### PR TITLE
feat(client): resource module + transport seam, proven on Expenses and Vendors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,9 @@ Server routes:    verifyToken + requireRole('Admin') middleware
 DB queries:       db.query(sql, params) → { rows }  (pg-compat over SQLite)
 Transactions:     const rawDb = db.db; rawDb.transaction(...)()
 Pages:            React Query + react-hot-toast + shadcn Dialog/Sheet
+                  (migrating to resource() — see docs/CONVENTIONS.md)
+Client data:      resource<Row, Meta>('name') → useList/useOne/useRead/useSave/useRemove/useAction
+Transport seam:   client/src/lib/transport — http (axios) + memory (tests)
 i18n:             useTranslation() → { t, locale, isRtl }
 Stores:           Zustand with persist middleware
 Route ordering:   Specific routes BEFORE /:id params (Express matches first)

--- a/client/src/i18n/ar.json
+++ b/client/src/i18n/ar.json
@@ -40,6 +40,7 @@
   "common.clearFilters": "مسح الفلاتر",
   "common.all": "الكل",
   "common.loading": "جاري التحميل...",
+  "common.error": "حدث خطأ ما",
 
   "theme.light": "فاتح",
   "theme.dark": "داكن",
@@ -926,6 +927,8 @@
   "expenses.updated": "تم تحديث المصروف",
   "expenses.deleted": "تم حذف المصروف",
   "expenses.deleteConfirm": "هل تريد حذف هذا المصروف؟",
+  "expenses.saveFailed": "تعذر حفظ المصروف",
+  "expenses.deleteFailed": "تعذر حذف المصروف",
   "expenses.pnl": "الأرباح والخسائر",
   "expenses.revenue": "الإيرادات",
   "expenses.cogs": "تكلفة البضاعة المباعة",

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -40,6 +40,7 @@
   "common.clearFilters": "Clear filters",
   "common.all": "All",
   "common.loading": "Loading...",
+  "common.error": "Something went wrong",
 
   "theme.light": "Light",
   "theme.dark": "Dark",
@@ -926,6 +927,8 @@
   "expenses.updated": "Expense updated",
   "expenses.deleted": "Expense deleted",
   "expenses.deleteConfirm": "Delete this expense?",
+  "expenses.saveFailed": "Could not save the expense",
+  "expenses.deleteFailed": "Could not delete the expense",
   "expenses.pnl": "Profit & Loss",
   "expenses.revenue": "Revenue",
   "expenses.cogs": "Cost of Goods Sold",

--- a/client/src/lib/resource.test.tsx
+++ b/client/src/lib/resource.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ApiError, TransportProvider } from './transport';
+import { createMemoryTransport, type MemoryTransport } from './transport/memory';
+import { resource } from './resource';
+
+interface Expense {
+  id: number;
+  category: string;
+  amount: number;
+}
+
+const RENT: Expense = { id: 1, category: 'rent', amount: 1200 };
+const SALARIES: Expense = { id: 2, category: 'salaries', amount: 5000 };
+
+function wrapperFor(transport: MemoryTransport) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('resource', () => {
+  it('gives the caller rows, never the response envelope', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT, SALARIES] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useList(), {
+      wrapper: wrapperFor(transport),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual([RENT, SALARIES]);
+  });
+
+  it('saves a record with no id as a new one', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useSave(), {
+      wrapper: wrapperFor(transport),
+    });
+
+    result.current.save({ category: 'utilities', amount: 300 });
+
+    await waitFor(() => expect(transport.peek('expenses')).toHaveLength(2));
+    expect(transport.peek('expenses')[1]).toMatchObject({ category: 'utilities', amount: 300 });
+  });
+
+  it('saves a record carrying an id as a change to that record', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT, SALARIES] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useSave(), {
+      wrapper: wrapperFor(transport),
+    });
+
+    result.current.save({ id: 1, category: 'rent', amount: 1500 });
+
+    await waitFor(() => expect(transport.peek('expenses')[0]).toMatchObject({ amount: 1500 }));
+    expect(transport.peek('expenses')).toHaveLength(2);
+  });
+
+  it('removes a record', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT, SALARIES] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useRemove(), {
+      wrapper: wrapperFor(transport),
+    });
+
+    result.current.remove(1);
+
+    await waitFor(() => expect(transport.peek('expenses')).toEqual([SALARIES]));
+  });
+
+  it('refreshes the list after a save without the caller asking', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => ({ list: expenses.useList(), saver: expenses.useSave() }), {
+      wrapper: wrapperFor(transport),
+    });
+
+    await waitFor(() => expect(result.current.list.data).toHaveLength(1));
+
+    result.current.saver.save({ category: 'utilities', amount: 300 });
+
+    await waitFor(() => expect(result.current.list.data).toHaveLength(2));
+  });
+
+  it('refreshes the list after a removal without the caller asking', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT, SALARIES] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(
+      () => ({ list: expenses.useList(), remover: expenses.useRemove() }),
+      { wrapper: wrapperFor(transport) }
+    );
+
+    await waitFor(() => expect(result.current.list.data).toHaveLength(2));
+
+    result.current.remover.remove(1);
+
+    await waitFor(() => expect(result.current.list.data).toEqual([SALARIES]));
+  });
+
+  it('fetches a single record', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT, SALARIES] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useOne(2), {
+      wrapper: wrapperFor(transport),
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(SALARIES));
+  });
+
+  it('runs a sub-action against one record', async () => {
+    const transport = createMemoryTransport({
+      vendors: [{ id: 7, name: 'Acme', status: 'pending' }],
+    });
+    const vendors = resource<{ id: number; status: string }>('vendors');
+
+    const { result } = renderHook(() => vendors.useAction('status'), {
+      wrapper: wrapperFor(transport),
+    });
+
+    result.current.run({ id: 7, body: { status: 'active' } });
+
+    await waitFor(() => expect(transport.peek('vendors')[0]).toMatchObject({ status: 'active' }));
+  });
+
+  it('reads a named sub-path of the collection', async () => {
+    const transport = createMemoryTransport(
+      { expenses: [RENT] },
+      { reads: { 'expenses/pnl': { revenue: 10000, net_profit: 8800 } } }
+    );
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useRead<{ net_profit: number }>('pnl'), {
+      wrapper: wrapperFor(transport),
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual({ revenue: 10000, net_profit: 8800 }));
+  });
+
+  it('passes list params through to the transport', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT] });
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useList({ limit: 100, category: 'rent' }), {
+      wrapper: wrapperFor(transport),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(transport.calls()).toContainEqual(
+      expect.objectContaining({
+        method: 'GET',
+        path: 'expenses',
+        params: { limit: 100, category: 'rent' },
+      })
+    );
+  });
+
+  it('carries list meta alongside the rows', async () => {
+    const transport = createMemoryTransport(
+      { expenses: [RENT, SALARIES] },
+      { meta: { expenses: { total_amount: 6200 } } }
+    );
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useList(), {
+      wrapper: wrapperFor(transport),
+    });
+
+    await waitFor(() => expect(result.current.meta).toEqual({ total_amount: 6200 }));
+  });
+
+  it('surfaces a failure in one normalized shape', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT] });
+    transport.failNext('Amount must be positive', 400);
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useSave(), {
+      wrapper: wrapperFor(transport),
+    });
+
+    result.current.save({ category: 'rent', amount: -5 });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(ApiError));
+    expect(result.current.error).toMatchObject({
+      message: 'Amount must be positive',
+      status: 400,
+    });
+  });
+});

--- a/client/src/lib/resource.test.tsx
+++ b/client/src/lib/resource.test.tsx
@@ -137,6 +137,50 @@ describe('resource', () => {
     await waitFor(() => expect(transport.peek('vendors')[0]).toMatchObject({ status: 'active' }));
   });
 
+  it('runs a sub-action with the method that action requires', async () => {
+    const transport = createMemoryTransport({
+      vendors: [{ id: 7, name: 'Acme', status: 'pending' }],
+    });
+    const vendors = resource<{ id: number; status: string }>('vendors');
+
+    const { result } = renderHook(() => vendors.useAction('status', { method: 'PUT' }), {
+      wrapper: wrapperFor(transport),
+    });
+
+    result.current.run({ id: 7, body: { status: 'active' } });
+
+    await waitFor(() => expect(transport.peek('vendors')[0]).toMatchObject({ status: 'active' }));
+    expect(transport.calls()).toContainEqual(
+      expect.objectContaining({ method: 'PUT', path: 'vendors/7/status' })
+    );
+  });
+
+  it('creates a payout against one vendor', async () => {
+    const transport = createMemoryTransport({
+      vendors: [{ id: 7, name: 'Acme', status: 'active', balance: 5000 }],
+    });
+    const vendors = resource<{ id: number; balance: number }>('vendors');
+
+    const { result } = renderHook(() => vendors.useAction('payouts'), {
+      wrapper: wrapperFor(transport),
+    });
+
+    result.current.run({
+      id: 7,
+      body: { amount: 1200, method: 'bank_transfer', reference: 'TRX-1' },
+    });
+
+    await waitFor(() =>
+      expect(transport.calls()).toContainEqual(
+        expect.objectContaining({
+          method: 'POST',
+          path: 'vendors/7/payouts',
+          body: { amount: 1200, method: 'bank_transfer', reference: 'TRX-1' },
+        })
+      )
+    );
+  });
+
   it('reads a named sub-path of the collection', async () => {
     const transport = createMemoryTransport(
       { expenses: [RENT] },

--- a/client/src/lib/resource.ts
+++ b/client/src/lib/resource.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { t } from '../i18n';
-import { useTransport, type TransportRequest } from './transport';
+import { useTransport, type TransportMethod, type TransportRequest } from './transport';
 
 /** A record being saved. An `id` means update; its absence means create. */
 export type Draft = Record<string, unknown> & { id?: number | null };
@@ -13,6 +13,11 @@ export interface WriteOptions {
   message?: string;
   /** Toasted on failure when the server offers no message of its own. */
   fallbackMessage?: string;
+}
+
+export interface ActionOptions extends WriteOptions {
+  /** The verb this sub-action is served by. Defaults to POST. */
+  method?: TransportMethod;
 }
 
 /**
@@ -122,14 +127,17 @@ export function resource<Row, Meta = Record<string, unknown>>(name: string) {
     },
 
     /**
-     * A named sub-action on one record, e.g. `useAction('status')` posting to
-     * `vendors/7/status`. The record is named per call rather than bound here,
-     * so one hook serves every row in a list.
+     * A named sub-action on one record, e.g. `useAction('status', { method: 'PUT' })`
+     * for `vendors/7/status`. The record is named per call rather than bound
+     * here, so one hook serves every row in a list.
+     *
+     * The verb is part of the action: the same page can carry a PUT status
+     * change beside a POST payout, and the server decides which is which.
      */
-    useAction(action: string, options: WriteOptions = {}) {
+    useAction(action: string, { method = 'POST', ...options }: ActionOptions = {}) {
       const mutation = useWrite<{ id: number; body?: unknown }>(
         all,
-        ({ id, body }) => ({ method: 'POST', path: `${name}/${id}/${action}`, body }),
+        ({ id, body }) => ({ method, path: `${name}/${id}/${action}`, body }),
         options
       );
 

--- a/client/src/lib/resource.ts
+++ b/client/src/lib/resource.ts
@@ -1,0 +1,139 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { t } from '../i18n';
+import { useTransport, type TransportRequest } from './transport';
+
+/** A record being saved. An `id` means update; its absence means create. */
+export type Draft = Record<string, unknown> & { id?: number | null };
+
+export interface WriteOptions {
+  /** Runs after the write lands, e.g. to close a dialog. */
+  onDone?: () => void;
+  /** Toasted on success. Omit for a silent write. */
+  message?: string;
+  /** Toasted on failure when the server offers no message of its own. */
+  fallbackMessage?: string;
+}
+
+/**
+ * What every write does once it settles: refresh this resource's reads, tell
+ * the caller, and say something. Pages get all three without wiring any of it.
+ */
+function useWrite<Args>(
+  key: readonly unknown[],
+  toRequest: (args: Args) => TransportRequest,
+  { onDone, message, fallbackMessage }: WriteOptions
+) {
+  const transport = useTransport();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (args: Args) => transport.request(toRequest(args)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: key });
+      if (message) toast.success(message);
+      onDone?.();
+    },
+    onError: (error: Error) => {
+      // Empty when the failure was the transport's own (a dropped connection,
+      // a timeout). Callers get to phrase those; axios's wording never shows.
+      toast.error(error.message || fallbackMessage || t('common.error'));
+    },
+  });
+}
+
+/**
+ * A resource is one server collection, exposed to pages as a small set of hooks.
+ *
+ * Callers name the collection once and get reads and writes back. They never
+ * construct a URL, unwrap a response envelope, learn the error shape, or decide
+ * what to invalidate — that knowledge lives here, once, instead of at every
+ * call site.
+ *
+ * `Meta` types the aggregate figures the server sends beside a list, so pages
+ * read them without casting.
+ */
+export function resource<Row, Meta = Record<string, unknown>>(name: string) {
+  const all = [name] as const;
+
+  return {
+    useList(params?: Record<string, unknown>) {
+      const transport = useTransport();
+      const query = useQuery({
+        queryKey: [name, 'list', params ?? {}] as const,
+        queryFn: () => transport.request<Row[]>({ method: 'GET', path: name, params }),
+      });
+
+      return {
+        ...query,
+        data: query.data?.data,
+        meta: query.data?.meta as Meta | undefined,
+      };
+    },
+
+    useOne(id: number | null | undefined) {
+      const transport = useTransport();
+      const query = useQuery({
+        queryKey: [name, 'one', id] as const,
+        queryFn: () => transport.request<Row>({ method: 'GET', path: `${name}/${id}` }),
+        enabled: id !== null && id !== undefined,
+      });
+
+      return { ...query, data: query.data?.data };
+    },
+
+    /**
+     * A named read hanging off the collection rather than a record, e.g.
+     * `useRead('pnl')` for `expenses/pnl`. Returns whatever that endpoint
+     * yields, which is rarely the resource's own row type.
+     */
+    useRead<R>(segment: string, params?: Record<string, unknown>, enabled = true) {
+      const transport = useTransport();
+      const query = useQuery({
+        queryKey: [name, 'read', segment, params ?? {}] as const,
+        queryFn: () => transport.request<R>({ method: 'GET', path: `${name}/${segment}`, params }),
+        enabled,
+      });
+
+      return { ...query, data: query.data?.data };
+    },
+
+    useSave(options: WriteOptions = {}) {
+      const mutation = useWrite<Draft>(
+        all,
+        ({ id, ...values }) =>
+          id
+            ? { method: 'PUT', path: `${name}/${id}`, body: values }
+            : { method: 'POST', path: name, body: values },
+        options
+      );
+
+      return { ...mutation, save: mutation.mutate, isSaving: mutation.isPending };
+    },
+
+    useRemove(options: WriteOptions = {}) {
+      const mutation = useWrite<number>(
+        all,
+        (id) => ({ method: 'DELETE', path: `${name}/${id}` }),
+        options
+      );
+
+      return { ...mutation, remove: mutation.mutate, isRemoving: mutation.isPending };
+    },
+
+    /**
+     * A named sub-action on one record, e.g. `useAction('status')` posting to
+     * `vendors/7/status`. The record is named per call rather than bound here,
+     * so one hook serves every row in a list.
+     */
+    useAction(action: string, options: WriteOptions = {}) {
+      const mutation = useWrite<{ id: number; body?: unknown }>(
+        all,
+        ({ id, body }) => ({ method: 'POST', path: `${name}/${id}/${action}`, body }),
+        options
+      );
+
+      return { ...mutation, run: mutation.mutate, isRunning: mutation.isPending };
+    },
+  };
+}

--- a/client/src/lib/transport/context.ts
+++ b/client/src/lib/transport/context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext, useMemo } from 'react';
+import { createHttpTransport } from './http';
+import type { Transport } from './types';
+
+export const TransportContext = createContext<Transport | null>(null);
+
+/**
+ * The transport in force. Falls back to the real HTTP one so pages work
+ * without any wiring; tests supply an in-memory transport through the provider.
+ */
+export function useTransport(): Transport {
+  const provided = useContext(TransportContext);
+  const fallback = useMemo(() => createHttpTransport(), []);
+  return provided ?? fallback;
+}

--- a/client/src/lib/transport/http.ts
+++ b/client/src/lib/transport/http.ts
@@ -1,0 +1,46 @@
+import type { AxiosError, AxiosInstance } from 'axios';
+import api from '../../services/api';
+import { ApiError, type Transport, type TransportRequest, type TransportResult } from './types';
+
+const API_PREFIX = '/api/v1';
+
+interface Envelope<T> {
+  success?: boolean;
+  data: T;
+  meta?: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * The real transport: axios underneath, plus the two contracts the server
+ * imposes — responses nested inside a `{ success, data, meta }` envelope, and
+ * failures carrying their message on `error`.
+ *
+ * This is the only module in the client that should know either of those.
+ */
+export function createHttpTransport(client: AxiosInstance = api): Transport {
+  return {
+    async request<T>({
+      method,
+      path,
+      params,
+      body,
+    }: TransportRequest): Promise<TransportResult<T>> {
+      try {
+        const response = await client.request<Envelope<T>>({
+          method,
+          url: `${API_PREFIX}/${path}`,
+          params,
+          data: body,
+        });
+        return { data: response.data.data, meta: response.data.meta };
+      } catch (caught) {
+        const error = caught as AxiosError<{ error?: string }>;
+        // Only the server's own wording is worth showing a user. Axios's
+        // ("Network Error", "timeout of 0ms exceeded") is left out, so callers
+        // fall back to something they phrased themselves.
+        throw new ApiError(error.response?.data?.error ?? '', error.response?.status ?? null);
+      }
+    },
+  };
+}

--- a/client/src/lib/transport/index.ts
+++ b/client/src/lib/transport/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export { createHttpTransport } from './http';
+export { useTransport } from './context';
+export { TransportProvider } from './provider';

--- a/client/src/lib/transport/memory.ts
+++ b/client/src/lib/transport/memory.ts
@@ -1,0 +1,119 @@
+import { ApiError, type Transport, type TransportRequest, type TransportResult } from './types';
+
+type Row = Record<string, unknown>;
+
+/** Seed data, keyed by resource name. Plain objects of any declared shape. */
+export type Collections = Record<string, readonly object[]>;
+
+export interface MemoryTransport extends Transport {
+  /** Current contents of a collection, for asserting on writes the UI made. */
+  peek(name: string): Row[];
+  /**
+   * Every request received, in order. Params are recorded rather than applied:
+   * filtering and pagination are the server's job, so a fake that invented its
+   * own version of them would let tests pass against behaviour HTTP would not
+   * reproduce. Assert on what was asked for instead.
+   */
+  calls(): TransportRequest[];
+  /** Make the next request fail, to exercise how callers handle errors. */
+  failNext(message: string, status?: number): void;
+}
+
+interface MemoryOptions {
+  /** Extra figures returned alongside a list, e.g. `{ total_amount: 6200 }`. */
+  meta?: Record<string, Record<string, unknown>>;
+  /** Canned responses for named sub-paths, keyed by full path, e.g. `expenses/pnl`. */
+  reads?: Record<string, unknown>;
+}
+
+/**
+ * An in-memory stand-in for the real server, satisfying the same Transport
+ * interface. Lets pages and the `resource` module be driven in tests without
+ * stubbing axios or standing up a request mocking layer.
+ */
+export function createMemoryTransport(
+  collections: Collections = {},
+  options: MemoryOptions = {}
+): MemoryTransport {
+  const store: Record<string, Row[]> = Object.fromEntries(
+    Object.entries(collections).map(([name, rows]) => [
+      name,
+      rows.map((row) => ({ ...row }) as Row),
+    ])
+  );
+
+  const nextId = (rows: Row[]): number =>
+    rows.reduce((highest, row) => Math.max(highest, Number(row.id) || 0), 0) + 1;
+
+  const collection = (name: string): Row[] => {
+    if (!store[name]) store[name] = [];
+    return store[name];
+  };
+
+  let pendingFailure: ApiError | null = null;
+  const received: TransportRequest[] = [];
+
+  return {
+    peek: (name) => collection(name).map((row) => ({ ...row })),
+
+    calls: () => received.map((call) => ({ ...call })),
+
+    failNext: (message, status = 400) => {
+      pendingFailure = new ApiError(message, status);
+    },
+
+    async request<T>(req: TransportRequest): Promise<TransportResult<T>> {
+      received.push(req);
+      const { method, path, body } = req;
+
+      if (pendingFailure) {
+        const failure = pendingFailure;
+        pendingFailure = null;
+        throw failure;
+      }
+
+      if (method === 'GET' && options.reads && path in options.reads) {
+        return { data: options.reads[path] as T };
+      }
+
+      const [name, id, action] = path.split('/');
+      const rows = collection(name);
+
+      if (method === 'GET' && id === undefined) {
+        return { data: rows.map((row) => ({ ...row })) as T, meta: options.meta?.[name] };
+      }
+
+      if (method === 'POST' && id === undefined) {
+        const created = { ...(body as Row), id: nextId(rows) };
+        rows.push(created);
+        return { data: { ...created } as T };
+      }
+
+      const index = rows.findIndex((row) => String(row.id) === id);
+      if (id !== undefined && index === -1) {
+        throw new ApiError(`No ${name} with id ${id}`, 404);
+      }
+
+      if (method === 'GET') {
+        return { data: { ...rows[index] } as T };
+      }
+
+      if (method === 'POST' && action) {
+        rows[index] = { ...rows[index], ...(body as Row) };
+        return { data: { ...rows[index] } as T };
+      }
+
+      if (method === 'PUT') {
+        rows[index] = { ...rows[index], ...(body as Row) };
+        return { data: { ...rows[index] } as T };
+      }
+
+      if (method === 'DELETE') {
+        const [removed] = rows.splice(index, 1);
+        return { data: { ...removed } as T };
+      }
+
+      throw new ApiError(`Unsupported request in memory transport: ${method} ${path}`, null);
+    },
+  };
+}

--- a/client/src/lib/transport/provider.tsx
+++ b/client/src/lib/transport/provider.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+import { TransportContext } from './context';
+import type { Transport } from './types';
+
+export function TransportProvider({
+  transport,
+  children,
+}: {
+  transport: Transport;
+  children: ReactNode;
+}) {
+  return <TransportContext.Provider value={transport}>{children}</TransportContext.Provider>;
+}

--- a/client/src/lib/transport/types.ts
+++ b/client/src/lib/transport/types.ts
@@ -1,0 +1,41 @@
+/**
+ * The transport seam: the one place that knows how to reach the server.
+ *
+ * Everything above this line (the `resource` module, and through it every page)
+ * deals in rows and errors. Everything below it deals in HTTP. Callers never
+ * see the response envelope, the API path prefix, or an AxiosError.
+ */
+
+export type TransportMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export interface TransportRequest {
+  method: TransportMethod;
+  /** Resource-relative path, e.g. `expenses` or `expenses/3/payouts`. No prefix. */
+  path: string;
+  params?: Record<string, unknown>;
+  body?: unknown;
+}
+
+export interface TransportResult<T> {
+  data: T;
+  /** Pagination and aggregate figures the server returns alongside a list. */
+  meta?: Record<string, unknown>;
+}
+
+export interface Transport {
+  request<T>(req: TransportRequest): Promise<TransportResult<T>>;
+}
+
+/**
+ * The single error shape every transport normalizes failures into, so callers
+ * never branch on whether a failure came from HTTP, the network, or a fake.
+ */
+export class ApiError extends Error {
+  readonly status: number | null;
+
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}

--- a/client/src/pages/Expenses.tsx
+++ b/client/src/pages/Expenses.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Receipt, Plus, Pencil, Trash2, TrendingUp, TrendingDown, DollarSign } from 'lucide-react';
-import toast from 'react-hot-toast';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
@@ -16,9 +14,7 @@ import {
 } from '../components/ui/dialog';
 import { useTranslation } from '../i18n';
 import { formatCurrency } from '../lib/utils';
-import api from '../services/api';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
+import { resource } from '../lib/resource';
 
 interface Expense {
   id: number;
@@ -43,9 +39,10 @@ interface PnLData {
 const categories = ['rent', 'salaries', 'utilities', 'marketing', 'supplies', 'other'] as const;
 const recurrences = ['one_time', 'daily', 'weekly', 'monthly', 'yearly'] as const;
 
+const expenses = resource<Expense, { total: number; total_amount: number }>('expenses');
+
 export default function ExpensesPage() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [tab, setTab] = useState<'list' | 'pnl'>('list');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -57,44 +54,21 @@ export default function ExpensesPage() {
     recurring: 'one_time',
   });
 
-  const { data: expensesData } = useQuery<{
-    data: Expense[];
-    meta: { total: number; total_amount: number };
-  }>({
-    queryKey: ['expenses'],
-    queryFn: () =>
-      api.get('/api/v1/expenses?limit=100').then((r) => ({ data: r.data.data, meta: r.data.meta })),
-  });
+  const { data: rows, meta } = expenses.useList({ limit: 100 });
+  const { data: pnl } = expenses.useRead<PnLData>('pnl', undefined, tab === 'pnl');
 
-  const { data: pnl } = useQuery<PnLData>({
-    queryKey: ['expenses', 'pnl'],
-    queryFn: () => api.get('/api/v1/expenses/pnl').then((r) => r.data.data),
-    enabled: tab === 'pnl',
-  });
-
-  const saveMutation = useMutation({
-    mutationFn: (data: Record<string, unknown>) => {
-      if (editingId) return api.put(`/api/v1/expenses/${editingId}`, data);
-      return api.post('/api/v1/expenses', data);
-    },
-    onSuccess: () => {
-      toast.success(editingId ? t('expenses.updated') : t('expenses.created'));
-      queryClient.invalidateQueries({ queryKey: ['expenses'] });
+  const saver = expenses.useSave({
+    message: editingId ? t('expenses.updated') : t('expenses.created'),
+    fallbackMessage: t('expenses.saveFailed'),
+    onDone: () => {
       setDialogOpen(false);
       resetForm();
     },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Error'),
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => api.delete(`/api/v1/expenses/${id}`),
-    onSuccess: () => {
-      toast.success(t('expenses.deleted'));
-      queryClient.invalidateQueries({ queryKey: ['expenses'] });
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Error'),
+  const remover = expenses.useRemove({
+    message: t('expenses.deleted'),
+    fallbackMessage: t('expenses.deleteFailed'),
   });
 
   const resetForm = () => {
@@ -168,7 +142,7 @@ export default function ExpensesPage() {
                   {t('expenses.totalExpenses')}
                 </span>
                 <p className="text-2xl font-data font-bold text-red-500">
-                  {formatCurrency(expensesData?.meta.total_amount || 0)}
+                  {formatCurrency(meta?.total_amount ?? 0)}
                 </p>
               </div>
               <Receipt className="h-8 w-8 text-gold/40" />
@@ -195,14 +169,14 @@ export default function ExpensesPage() {
                 </tr>
               </thead>
               <tbody>
-                {!expensesData?.data.length ? (
+                {!rows?.length ? (
                   <tr>
                     <td colSpan={6} className="text-center py-12 text-muted">
                       {t('common.noResults')}
                     </td>
                   </tr>
                 ) : (
-                  expensesData.data.map((exp) => (
+                  rows.map((exp) => (
                     <tr key={exp.id} className="border-b border-border hover:bg-surface/50">
                       <td className="p-3 font-data text-xs">{exp.date}</td>
                       <td className="p-3">
@@ -236,7 +210,7 @@ export default function ExpensesPage() {
                             className="h-7 w-7 text-destructive"
                             onClick={() => {
                               if (window.confirm(t('expenses.deleteConfirm')))
-                                deleteMutation.mutate(exp.id);
+                                remover.remove(exp.id);
                             }}
                             aria-label={t('common.delete')}
                           >
@@ -348,7 +322,8 @@ export default function ExpensesPage() {
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              saveMutation.mutate({
+              saver.save({
+                id: editingId,
                 category: form.category,
                 amount: Number(form.amount),
                 description: form.description || undefined,
@@ -416,8 +391,8 @@ export default function ExpensesPage() {
                 </select>
               </div>
             </div>
-            <Button type="submit" className="w-full" disabled={saveMutation.isPending}>
-              {saveMutation.isPending ? t('common.loading') : t('common.save')}
+            <Button type="submit" className="w-full" disabled={saver.isSaving}>
+              {saver.isSaving ? t('common.loading') : t('common.save')}
             </Button>
           </form>
         </DialogContent>

--- a/client/src/pages/Vendors.tsx
+++ b/client/src/pages/Vendors.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Plus, Pencil, DollarSign, CheckCircle, Ban } from 'lucide-react';
-import toast from 'react-hot-toast';
 import { formatCurrency } from '../lib/utils';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -15,9 +13,7 @@ import {
   DialogDescription,
 } from '../components/ui/dialog';
 import { useTranslation } from '../i18n';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
-import api from '../services/api';
+import { resource } from '../lib/resource';
 
 interface Vendor {
   id: number;
@@ -33,6 +29,16 @@ interface Vendor {
   created_at: string;
 }
 
+/** GET vendors/dashboard/stats */
+interface VendorStats {
+  active_vendors: number;
+  pending_vendors: number;
+  total_unpaid: number;
+  pending_commissions: number;
+}
+
+const vendorsResource = resource<Vendor>('vendors');
+
 const statusColors: Record<string, string> = {
   pending: 'bg-yellow-500/20 text-yellow-600',
   active: 'bg-green-500/20 text-green-600',
@@ -42,7 +48,6 @@ const statusColors: Record<string, string> = {
 
 export default function VendorsPage() {
   const { t } = useTranslation();
-  const qc = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [payoutOpen, setPayoutOpen] = useState(false);
   const [statusFilter, setStatusFilter] = useState('');
@@ -68,48 +73,25 @@ export default function VendorsPage() {
     notes: '',
   });
 
-  const { data: vendors } = useQuery<Vendor[]>({
-    queryKey: ['vendors', statusFilter],
-    queryFn: () =>
-      api
-        .get('/api/v1/vendors', { params: { status: statusFilter || undefined } })
-        .then((r) => r.data.data),
-  });
-  const { data: stats } = useQuery<Record<string, unknown>>({
-    queryKey: ['vendor-stats'],
-    queryFn: () => api.get('/api/v1/vendors/dashboard/stats').then((r) => r.data.data),
-  });
+  const { data: vendors } = vendorsResource.useList({ status: statusFilter || undefined });
+  const { data: stats } = vendorsResource.useRead<VendorStats>('dashboard/stats');
 
-  const saveVendor = useMutation({
-    mutationFn: (data: typeof form) =>
-      editingId ? api.put(`/api/v1/vendors/${editingId}`, data) : api.post('/api/v1/vendors', data),
-    onSuccess: () => {
-      toast.success(t('vendors.saved'));
-      qc.invalidateQueries({ queryKey: ['vendors'] });
+  const saveVendor = vendorsResource.useSave({
+    message: t('vendors.saved'),
+    onDone: () => {
       setDialogOpen(false);
       setEditingId(null);
     },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Error'),
   });
 
-  const updateStatus = useMutation({
-    mutationFn: ({ id, status }: { id: number; status: string }) =>
-      api.put(`/api/v1/vendors/${id}/status`, { status }),
-    onSuccess: () => {
-      toast.success(t('vendors.statusUpdated'));
-      qc.invalidateQueries({ queryKey: ['vendors'] });
-    },
+  const updateStatus = vendorsResource.useAction('status', {
+    method: 'PUT',
+    message: t('vendors.statusUpdated'),
   });
 
-  const createPayout = useMutation({
-    mutationFn: (data: typeof payoutForm) =>
-      api.post(`/api/v1/vendors/${selectedVendor?.id}/payouts`, data),
-    onSuccess: () => {
-      toast.success(t('vendors.payoutCreated'));
-      qc.invalidateQueries({ queryKey: ['vendors'] });
-      setPayoutOpen(false);
-    },
+  const createPayout = vendorsResource.useAction('payouts', {
+    message: t('vendors.payoutCreated'),
+    onDone: () => setPayoutOpen(false),
   });
 
   const openEdit = (v: Vendor) => {
@@ -246,7 +228,7 @@ export default function VendorsPage() {
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7 text-green-500"
-                          onClick={() => updateStatus.mutate({ id: v.id, status: 'active' })}
+                          onClick={() => updateStatus.run({ id: v.id, body: { status: 'active' } })}
                           aria-label={t('common.confirm')}
                         >
                           <CheckCircle className="h-3.5 w-3.5" />
@@ -271,7 +253,9 @@ export default function VendorsPage() {
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7 text-red-500"
-                          onClick={() => updateStatus.mutate({ id: v.id, status: 'suspended' })}
+                          onClick={() =>
+                            updateStatus.run({ id: v.id, body: { status: 'suspended' } })
+                          }
                           aria-label={t('common.delete')}
                         >
                           <Ban className="h-3.5 w-3.5" />
@@ -298,7 +282,7 @@ export default function VendorsPage() {
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              saveVendor.mutate(form);
+              saveVendor.save({ id: editingId, ...form });
             }}
             className="space-y-3"
           >
@@ -378,8 +362,8 @@ export default function VendorsPage() {
                 />
               </div>
             </div>
-            <Button type="submit" className="w-full" disabled={saveVendor.isPending}>
-              {saveVendor.isPending ? t('common.saving') : t('common.save')}
+            <Button type="submit" className="w-full" disabled={saveVendor.isSaving}>
+              {saveVendor.isSaving ? t('common.saving') : t('common.save')}
             </Button>
           </form>
         </DialogContent>
@@ -397,7 +381,7 @@ export default function VendorsPage() {
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              createPayout.mutate(payoutForm);
+              createPayout.run({ id: selectedVendor!.id, body: payoutForm });
             }}
             className="space-y-3"
           >
@@ -431,8 +415,8 @@ export default function VendorsPage() {
                 onChange={(e) => setPayoutForm({ ...payoutForm, notes: e.target.value })}
               />
             </div>
-            <Button type="submit" className="w-full" disabled={createPayout.isPending}>
-              {createPayout.isPending ? t('common.saving') : t('vendors.processPayout')}
+            <Button type="submit" className="w-full" disabled={createPayout.isRunning}>
+              {createPayout.isRunning ? t('common.saving') : t('vendors.processPayout')}
             </Button>
           </form>
         </DialogContent>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ moon-store/
 │       ├── services/          # Axios API client with interceptors
 │       ├── hooks/             # useOffline, useScanner, usePosShortcuts, useDebouncedValue
 │       ├── i18n/              # AR/EN translations + useTranslation hook
-│       ├── lib/               # utils.ts, queryClient.ts
+│       ├── lib/               # utils.ts, queryClient.ts, resource.ts, transport/
 │       ├── App.tsx            # Router + route config
 │       ├── main.tsx           # Entry: providers + Toaster
 │       └── index.css          # Tailwind + CSS variables (light/dark)

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -15,7 +15,51 @@
 ## Component Patterns
 
 ### Page Components
-Every page follows this pattern:
+
+> **Migration in progress.** New and migrated pages use `resource()` (below).
+> The legacy pattern that follows still describes most pages and stays valid
+> until they are migrated. See issue #4 for the seam and #13 for the cutover.
+
+#### Current pattern — `resource()`
+
+A page names its server collection once and gets reads and writes back. It
+never constructs a URL, unwraps the `{ success, data, meta }` envelope, learns
+the error shape, or decides what to invalidate:
+
+```tsx
+import { resource } from '../lib/resource';
+
+const expenses = resource<Expense, { total_amount: number }>('expenses');
+
+export default function ExpensesPage() {
+  const { data: rows, meta } = expenses.useList({ limit: 100 });
+  const pnl = expenses.useRead<PnLData>('pnl', undefined, tab === 'pnl');
+
+  const saver = expenses.useSave({
+    message: t('expenses.created'),        // toasted on success
+    fallbackMessage: t('expenses.saveFailed'),  // used when the server says nothing
+    onDone: () => setDialogOpen(false),
+  });
+
+  const remover = expenses.useRemove({ message: t('expenses.deleted') });
+
+  saver.save({ id: editingId, ...form });  // no id → create, id → update
+}
+```
+
+Hooks: `useList(params)`, `useOne(id)`, `useRead(segment, params, enabled)`,
+`useSave(opts)`, `useRemove(opts)`, `useAction(name, opts)`. Writes invalidate
+the resource's own reads automatically — never call `invalidateQueries` in a page.
+
+Endpoints that are not CRUD collections (analytics, AI, reports, exports) should
+use the transport adapter directly rather than widening `resource`.
+
+In tests, inject `createMemoryTransport()` via `<TransportProvider>` — no axios
+stubbing and no request-mocking library.
+
+#### Legacy pattern — being migrated away from
+
+Pages not yet migrated follow this:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';


### PR DESCRIPTION
Lands the foundation for the resource migration sequence: closes out #4 and #5, which were completed locally but never pushed.

## What's here

- `client/src/lib/resource.ts` — one server collection exposed to pages as `useList`/`useOne`/`useRead`/`useSave`/`useRemove`/`useAction`. Pages never construct a URL, unwrap an envelope, or learn the error shape.
- `client/src/lib/transport/` — the seam. `http.ts` (axios) for the app, `memory.ts` for tests. Everything above the seam deals in rows and errors; everything below deals in HTTP.
- Expenses and Vendors migrated as the proving pages, plus `useAction` gaining an explicit verb so a PUT status change and a POST payout can coexist on one page.

## Testing

`resource.test.tsx` — 14 tests driving reads, writes and sub-actions through the in-memory transport. Full suite green (34 tests).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is client-only refactoring with no server or schema change, and the two migrated pages are low-traffic admin surfaces. Parity on Expenses and Vendors is covered by the browser verification pass in the follow-up work.