### PR TITLE
refactor(client): consolidate duplicated server shapes into shared types

### DIFF
--- a/client/src/components/BarcodeGenerator.tsx
+++ b/client/src/components/BarcodeGenerator.tsx
@@ -2,16 +2,11 @@ import { useEffect, useRef } from 'react';
 import JsBarcode from 'jsbarcode';
 import { useSettingsStore } from '../store/settingsStore';
 import { formatCurrency } from '../lib/utils';
-
-interface Product {
-  name: string;
-  sku: string;
-  price: string | number;
-}
+import type { Product } from '@/types';
 
 interface BarcodeGeneratorProps {
   value: string;
-  product?: Product | null;
+  product?: Pick<Product, 'name' | 'sku' | 'price'> | null;
 }
 
 export default function BarcodeGenerator({ value, product }: BarcodeGeneratorProps) {

--- a/client/src/components/CartPanel.tsx
+++ b/client/src/components/CartPanel.tsx
@@ -36,10 +36,12 @@ import HeldCartsDialog from './HeldCartsDialog';
 import api from '../services/api';
 import type { AxiosError } from 'axios';
 import type { ReceiptData } from './Receipt';
+import type { ApiErrorResponse, AppSettings, Customer } from '@/types';
 
 type PaymentMethod = 'Cash' | 'Card' | 'Other';
 
-interface SaleItem {
+/** Write payload for POST /api/v1/sales — not the read shape returned by GET /api/sales/:id */
+interface SaleItemInput {
   product_id: number;
   variant_id?: number | null;
   quantity: number;
@@ -53,7 +55,7 @@ interface PaymentEntry {
 }
 
 interface SaleData {
-  items: SaleItem[];
+  items: SaleItemInput[];
   discount: number;
   discount_type: string;
   payment_method: PaymentMethod;
@@ -66,28 +68,8 @@ interface SaleData {
   coupon_code?: string;
 }
 
-interface AppSettings {
-  tax_enabled: string;
-  tax_rate: string;
-  tax_mode: string;
-  loyalty_enabled: string;
-  loyalty_earn_rate: string;
-  loyalty_redeem_value: string;
-}
-
 interface CustomerLoyalty {
   points: number;
-}
-
-interface ApiErrorResponse {
-  error?: string;
-}
-
-interface CustomerRecord {
-  id: number;
-  name: string;
-  phone: string;
-  address: string | null;
 }
 
 interface CartPanelProps {
@@ -128,7 +110,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   const [splitPayment, setSplitPayment] = useState(false);
   const [payments, setPayments] = useState<PaymentEntry[]>([]);
   const [customerSearch, setCustomerSearch] = useState('');
-  const [selectedCustomer, setSelectedCustomer] = useState<CustomerRecord | null>(null);
+  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
   const [showCustomerDropdown, setShowCustomerDropdown] = useState(false);
   const [receiptOpen, setReceiptOpen] = useState(false);
   const [receiptData, setReceiptData] = useState<ReceiptData | null>(null);
@@ -205,7 +187,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     };
   }, [checkoutTriggerRef]);
 
-  const { data: customers } = useQuery<CustomerRecord[]>({
+  const { data: customers } = useQuery<Customer[]>({
     queryKey: ['customers', { search: debouncedCustomerSearch }],
     queryFn: () =>
       api
@@ -346,7 +328,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     }
   };
 
-  const handleSelectCustomer = (customer: CustomerRecord) => {
+  const handleSelectCustomer = (customer: Customer) => {
     setSelectedCustomer(customer);
     setCustomerSearch('');
     setShowCustomerDropdown(false);

--- a/client/src/components/CustomerDetail.tsx
+++ b/client/src/components/CustomerDetail.tsx
@@ -29,6 +29,7 @@ import { formatCurrency, formatDateTime, formatRelative } from '../lib/utils';
 import api from '../services/api';
 import { useTranslation } from '../i18n';
 import type { AxiosError } from 'axios';
+import type { AppSettings } from '@/types';
 
 interface CustomerDetailProps {
   customerId: number;
@@ -65,10 +66,6 @@ interface LoyaltyTransaction {
 interface LoyaltyData {
   points: number;
   transactions: LoyaltyTransaction[];
-}
-
-interface AppSettings {
-  loyalty_enabled: string;
 }
 
 export default function CustomerDetail({ customerId, customerName, onBack }: CustomerDetailProps) {

--- a/client/src/components/RefundDialog.tsx
+++ b/client/src/components/RefundDialog.tsx
@@ -10,13 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { formatCurrency } from '../lib/utils';
 import api from '../services/api';
 import { useTranslation } from '../i18n';
-
-interface SaleItem {
-  product_id: number;
-  product_name: string;
-  quantity: number;
-  unit_price: number;
-}
+import type { SaleItem } from '@/types';
 
 interface RefundDialogProps {
   open: boolean;

--- a/client/src/components/charts/RevenueChart.tsx
+++ b/client/src/components/charts/RevenueChart.tsx
@@ -13,11 +13,7 @@ import { useSettingsStore } from '../../store/settingsStore';
 import { useTranslation } from '../../i18n';
 import type { TooltipProps } from 'recharts';
 import type { ValueType, NameType } from 'recharts/types/component/DefaultTooltipContent';
-
-interface RevenueDataPoint {
-  date: string;
-  revenue: number;
-}
+import type { RevenueDataPoint } from '../../hooks/useDashboardData';
 
 interface CustomTooltipProps extends TooltipProps<ValueType, NameType> {
   isDark: boolean;

--- a/client/src/components/delivery/DeliveryFormDialog.tsx
+++ b/client/src/components/delivery/DeliveryFormDialog.tsx
@@ -17,13 +17,8 @@ import {
 } from '../ui/dialog';
 import { useTranslation, t as tStandalone } from '../../i18n';
 
-import type { Product } from '@/types';
-import type {
-  DeliveryOrder,
-  Customer,
-  ShippingCompany,
-  DeliveryPayload,
-} from '../../hooks/useDeliveryData';
+import type { Customer, Product } from '@/types';
+import type { DeliveryOrder, ShippingCompany, DeliveryPayload } from '../../hooks/useDeliveryData';
 
 const getDeliverySchema = () =>
   z.object({

--- a/client/src/components/inventory/ProductFormDialog.tsx
+++ b/client/src/components/inventory/ProductFormDialog.tsx
@@ -16,20 +16,8 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import api from '../../services/api';
 import { useTranslation } from '../../i18n';
-import type { Product, Category, Distributor } from '@/types';
+import type { Product, ProductFormData, Category, Distributor } from '@/types';
 import type { z } from 'zod';
-
-export interface ProductFormData {
-  name: string;
-  sku: string;
-  barcode?: string;
-  price: number;
-  cost_price: number;
-  stock: number;
-  category_id?: number | null;
-  distributor_id?: number | null;
-  min_stock: number;
-}
 
 interface ProductFormDialogProps {
   open: boolean;

--- a/client/src/hooks/useDeliveryData.ts
+++ b/client/src/hooks/useDeliveryData.ts
@@ -4,7 +4,7 @@ import api from '../services/api';
 import { useTranslation } from '../i18n';
 
 import type { AxiosError, AxiosResponse } from 'axios';
-import type { ApiErrorResponse, Product } from '@/types';
+import type { ApiErrorResponse, Customer, Product } from '@/types';
 
 export type DeliveryStatus = 'Pending' | 'Shipped' | 'Delivered' | 'Cancelled';
 
@@ -31,13 +31,6 @@ export interface DeliveryOrder {
   estimated_delivery: string | null;
   created_at: string;
   updated_at: string;
-}
-
-export interface Customer {
-  id: number;
-  name: string;
-  phone: string;
-  address: string | null;
 }
 
 export interface StatusHistoryEntry {

--- a/client/src/hooks/useInventoryData.ts
+++ b/client/src/hooks/useInventoryData.ts
@@ -3,7 +3,7 @@ import toast from 'react-hot-toast';
 import api from '../services/api';
 import { useTranslation } from '../i18n';
 import type { AxiosError, AxiosResponse } from 'axios';
-import type { ApiErrorResponse, Product, Category, Distributor } from '@/types';
+import type { ApiErrorResponse, Product, ProductFormData, Category, Distributor } from '@/types';
 
 export interface ImportResult {
   imported: number;
@@ -23,18 +23,6 @@ export interface CsvProduct {
 
 export interface LowStockProduct extends Product {
   deficit: number;
-}
-
-export interface ProductFormData {
-  name: string;
-  sku: string;
-  barcode?: string;
-  price: number;
-  cost_price: number;
-  stock: number;
-  category_id?: number | null;
-  distributor_id?: number | null;
-  min_stock: number;
 }
 
 interface UseInventoryDataOptions {

--- a/client/src/pages/Customers.tsx
+++ b/client/src/pages/Customers.tsx
@@ -33,18 +33,7 @@ import api from '../services/api';
 import { useTranslation, t as tStandalone } from '../i18n';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
-
-interface CustomerRecord {
-  id: number;
-  name: string;
-  phone: string;
-  address: string | null;
-  notes: string | null;
-  loyalty_points: number;
-  created_at: string;
-  updated_at: string;
-}
+import type { ApiErrorResponse, Customer } from '@/types';
 
 const getCustomerFormSchema = () =>
   z.object({
@@ -61,10 +50,10 @@ export default function CustomersPage() {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
-  const [editingCustomer, setEditingCustomer] = useState<CustomerRecord | null>(null);
-  const [viewingCustomer, setViewingCustomer] = useState<CustomerRecord | null>(null);
+  const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
+  const [viewingCustomer, setViewingCustomer] = useState<Customer | null>(null);
 
-  const { data: customers, isLoading } = useQuery<CustomerRecord[]>({
+  const { data: customers, isLoading } = useQuery<Customer[]>({
     queryKey: ['customers'],
     queryFn: () =>
       api.get('/api/v1/customers', { params: { limit: 1000 } }).then((r) => r.data.data),
@@ -124,7 +113,7 @@ export default function CustomersPage() {
     }
   };
 
-  const openEditDialog = (customer: CustomerRecord) => {
+  const openEditDialog = (customer: Customer) => {
     setEditingCustomer(customer);
     reset({
       name: customer.name,
@@ -141,7 +130,7 @@ export default function CustomersPage() {
     setDialogOpen(true);
   };
 
-  const columns: ColumnDef<CustomerRecord>[] = [
+  const columns: ColumnDef<Customer>[] = [
     { accessorKey: 'name', header: t('common.name') },
     {
       accessorKey: 'phone',

--- a/client/src/pages/Distributors.tsx
+++ b/client/src/pages/Distributors.tsx
@@ -31,19 +31,7 @@ import api from '../services/api';
 import { useTranslation, t as tStandalone } from '../i18n';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
-
-interface DistributorRecord {
-  id: number;
-  name: string;
-  contact_person: string | null;
-  phone: string | null;
-  email: string | null;
-  address: string | null;
-  notes: string | null;
-  created_at: string;
-  updated_at: string;
-}
+import type { ApiErrorResponse, Distributor } from '@/types';
 
 const getDistributorFormSchema = () =>
   z.object({
@@ -62,9 +50,9 @@ export default function DistributorsPage() {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
-  const [editingDistributor, setEditingDistributor] = useState<DistributorRecord | null>(null);
+  const [editingDistributor, setEditingDistributor] = useState<Distributor | null>(null);
 
-  const { data: distributors, isLoading } = useQuery<DistributorRecord[]>({
+  const { data: distributors, isLoading } = useQuery<Distributor[]>({
     queryKey: ['distributors'],
     queryFn: () => api.get('/api/v1/distributors').then((r) => r.data.data),
   });
@@ -123,7 +111,7 @@ export default function DistributorsPage() {
     }
   };
 
-  const openEditDialog = (distributor: DistributorRecord) => {
+  const openEditDialog = (distributor: Distributor) => {
     setEditingDistributor(distributor);
     reset({
       name: distributor.name,
@@ -142,7 +130,7 @@ export default function DistributorsPage() {
     setDialogOpen(true);
   };
 
-  const columns: ColumnDef<DistributorRecord>[] = [
+  const columns: ColumnDef<Distributor>[] = [
     { accessorKey: 'name', header: t('common.name') },
     {
       accessorKey: 'contact_person',

--- a/client/src/pages/Inventory.tsx
+++ b/client/src/pages/Inventory.tsx
@@ -47,7 +47,7 @@ import {
 import { Checkbox } from '../components/ui/checkbox';
 import DataTable from '../components/DataTable';
 import AdjustStockDialog from '../components/AdjustStockDialog';
-import ProductFormDialog, { type ProductFormData } from '../components/inventory/ProductFormDialog';
+import ProductFormDialog from '../components/inventory/ProductFormDialog';
 import BulkOperationDialogs from '../components/inventory/BulkOperationDialogs';
 import VariantManagerDialog from '../components/inventory/VariantManagerDialog';
 import { useInventoryData, type CsvProduct, type LowStockProduct } from '../hooks/useInventoryData';
@@ -58,7 +58,7 @@ import { useAuthStore } from '../store/authStore';
 import api from '../services/api';
 import { useTranslation, t as tStandalone } from '../i18n';
 import type { ColumnDef, RowSelectionState } from '@tanstack/react-table';
-import type { Product } from '@/types';
+import type { Product, ProductFormData } from '@/types';
 
 const getProductSchema = () =>
   z.object({

--- a/client/src/pages/Layaway.tsx
+++ b/client/src/pages/Layaway.tsx
@@ -25,13 +25,7 @@ import { useTranslation } from '../i18n';
 import { formatCurrency } from '../lib/utils';
 import api from '../services/api';
 import type { AxiosError } from 'axios';
-import type { ApiErrorResponse, Product } from '@/types';
-
-interface Customer {
-  id: number;
-  name: string;
-  phone: string | null;
-}
+import type { ApiErrorResponse, Customer, Product } from '@/types';
 
 interface LayawayItem {
   product_id: number;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -11,12 +11,11 @@ import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Checkbox } from '../components/ui/checkbox';
 import { useAuthStore } from '../store/authStore';
-import type { User } from '../store/authStore';
 import api from '../services/api';
 import moonLogo from '../assets/moon-logo.svg';
 import { useTranslation, t as tStandalone } from '../i18n';
 import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
+import type { ApiErrorResponse, AuthResponseData } from '@/types';
 
 const getLoginSchema = () =>
   z.object({
@@ -25,13 +24,6 @@ const getLoginSchema = () =>
   });
 
 type LoginFormData = z.infer<ReturnType<typeof getLoginSchema>>;
-
-interface LoginResponseData {
-  data: {
-    accessToken: string;
-    user: User;
-  };
-}
 
 export default function Login() {
   const navigate = useNavigate();
@@ -52,7 +44,7 @@ export default function Login() {
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true);
     try {
-      const response = await api.post<LoginResponseData>('/api/v1/auth/login', data);
+      const response = await api.post<AuthResponseData>('/api/v1/auth/login', data);
       const { accessToken, user } = response.data.data;
       login(user, accessToken);
       toast.success(t('login.welcomeBack', { name: user.name }));

--- a/client/src/pages/SalesHistory.tsx
+++ b/client/src/pages/SalesHistory.tsx
@@ -40,6 +40,7 @@ import { useTranslation } from '../i18n';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { DateRange } from '../components/ui/calendar';
 import type { ReceiptData } from '../components/Receipt';
+import type { SaleItem } from '@/types';
 
 interface Sale {
   id: number;
@@ -55,13 +56,6 @@ interface Sale {
   refunded_amount: number | null;
   customer_id: number | null;
   customer_name: string | null;
-}
-
-interface SaleItem {
-  product_id: number;
-  product_name: string;
-  quantity: number;
-  unit_price: number;
 }
 
 interface Refund {

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -16,15 +16,7 @@ import {
 import { useTranslation } from '../i18n';
 import api from '../services/api';
 import type { AxiosError } from 'axios';
-
-interface AllSettings {
-  tax_enabled: string;
-  tax_rate: string;
-  tax_mode: string;
-  loyalty_enabled: string;
-  loyalty_earn_rate: string;
-  loyalty_redeem_value: string;
-}
+import type { AppSettings } from '@/types';
 
 export default function Settings() {
   const { t } = useTranslation();
@@ -38,7 +30,7 @@ export default function Settings() {
   const [loyaltyEarnRate, setLoyaltyEarnRate] = useState('1');
   const [loyaltyRedeemValue, setLoyaltyRedeemValue] = useState('5');
 
-  const { data: settings, isLoading } = useQuery<AllSettings>({
+  const { data: settings, isLoading } = useQuery<AppSettings>({
     queryKey: ['settings'],
     queryFn: () => api.get('/api/v1/settings').then((r) => r.data.data),
   });

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -34,18 +34,7 @@ import api from '../services/api';
 import { useTranslation, t as tStandalone } from '../i18n';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
-
-type UserRole = 'Admin' | 'Cashier' | 'Delivery';
-
-interface UserRecord {
-  id: number;
-  name: string;
-  email: string;
-  role: UserRole;
-  last_login: string | null;
-  created_at: string;
-}
+import type { ApiErrorResponse, User, UserRole } from '@/types';
 
 const getCreateSchema = () =>
   z.object({
@@ -79,9 +68,9 @@ export default function UsersPage() {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
-  const [editingUser, setEditingUser] = useState<UserRecord | null>(null);
+  const [editingUser, setEditingUser] = useState<User | null>(null);
 
-  const { data: users, isLoading } = useQuery<UserRecord[]>({
+  const { data: users, isLoading } = useQuery<User[]>({
     queryKey: ['users'],
     queryFn: () => api.get('/api/v1/users').then((r) => r.data.data),
   });
@@ -143,7 +132,7 @@ export default function UsersPage() {
     }
   };
 
-  const openEditDialog = (user: UserRecord) => {
+  const openEditDialog = (user: User) => {
     setEditingUser(user);
     reset({ name: user.name, email: user.email, password: '', role: user.role });
     setDialogOpen(true);
@@ -155,7 +144,7 @@ export default function UsersPage() {
     setDialogOpen(true);
   };
 
-  const columns: ColumnDef<UserRecord>[] = [
+  const columns: ColumnDef<User>[] = [
     { accessorKey: 'name', header: t('common.name') },
     {
       accessorKey: 'email',

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,16 +1,10 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
-import { useAuthStore, type User } from '../store/authStore';
+import { useAuthStore } from '../store/authStore';
+import type { AuthResponseData } from '../types';
 
 interface QueueItem {
   resolve: (token: string) => void;
   reject: (error: AxiosError) => void;
-}
-
-interface RefreshResponseData {
-  data: {
-    accessToken: string;
-    user: User;
-  };
 }
 
 const api = axios.create({
@@ -71,7 +65,7 @@ const setupRefreshInterceptor = () => {
         isRefreshing = true;
 
         try {
-          const response = await axios.post<RefreshResponseData>(
+          const response = await axios.post<AuthResponseData>(
             `${import.meta.env.VITE_API_URL || 'http://localhost:3001'}/api/v1/auth/refresh`,
             {},
             { withCredentials: true }

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -3,22 +3,16 @@ import { persist } from 'zustand/middleware';
 import { queryClient } from '../lib/queryClient';
 import { useOfflineStore } from './offlineStore';
 import { useCartStore } from './cartStore';
-
-export interface User {
-  id: number;
-  name: string;
-  email: string;
-  role: 'Admin' | 'Cashier' | 'Delivery';
-}
+import type { AuthUser } from '../types';
 
 interface AuthState {
-  user: User | null;
+  user: AuthUser | null;
   accessToken: string | null;
   isAuthenticated: boolean;
-  login: (user: User, accessToken: string) => void;
+  login: (user: AuthUser, accessToken: string) => void;
   setAccessToken: (accessToken: string) => void;
   logout: () => void;
-  updateUser: (updates: Partial<User>) => void;
+  updateUser: (updates: Partial<AuthUser>) => void;
 }
 
 export const useAuthStore = create<AuthState>()(

--- a/client/src/store/cartStore.test.ts
+++ b/client/src/store/cartStore.test.ts
@@ -62,7 +62,9 @@ describe('Cart - Add Items', () => {
   });
 
   it('should parse string prices correctly', () => {
-    useCartStore.getState().addItem({ ...mockProduct, price: '499.99' });
+    // The API types price as a number; the cast guards the parseFloat fallback
+    // against legacy string payloads still sitting in the persisted cart.
+    useCartStore.getState().addItem({ ...mockProduct, price: '499.99' as unknown as number });
     expect(useCartStore.getState().items[0].unit_price).toBe(499.99);
   });
 });

--- a/client/src/store/cartStore.ts
+++ b/client/src/store/cartStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { Product as ServerProduct } from '../types';
 
 export interface CartItem {
   product_id: number;
@@ -11,14 +12,11 @@ export interface CartItem {
   memo?: string;
 }
 
-export interface Product {
-  id: number;
-  name: string;
-  price: string | number;
-  stock: number;
+/** addItem input: the product columns the cart needs, plus POS-side variant selection */
+export type Product = Pick<ServerProduct, 'id' | 'name' | 'price' | 'stock'> & {
   variant_id?: number | null;
   variant_attributes?: Record<string, string>;
-}
+};
 
 export interface BundleForCart {
   name: string;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -11,11 +11,11 @@ export interface Product {
   name: string;
   sku: string;
   barcode: string | null;
-  price: string | number;
+  price: number;
   cost_price: number;
   stock: number;
   min_stock: number;
-  category: string;
+  category: string | null;
   category_id: number | null;
   category_name: string | null;
   category_code: string | null;
@@ -42,11 +42,24 @@ export interface ProductVariant {
   attributes: Record<string, string>;
 }
 
-/** Category from GET /api/categories */
+/** Write payload for POST /api/products and PUT /api/products/:id */
+export interface ProductFormData {
+  name: string;
+  sku: string;
+  barcode?: string;
+  price: number;
+  cost_price: number;
+  stock: number;
+  category_id?: number | null;
+  distributor_id?: number | null;
+  min_stock: number;
+}
+
+/** Category summary from GET /api/products/categories (id/name/code projection) */
 export interface Category {
   id: number;
   name: string;
-  code?: string;
+  code: string;
 }
 
 /** Distributor from GET /api/distributors */
@@ -56,4 +69,64 @@ export interface Distributor {
   contact_person: string | null;
   phone: string | null;
   email: string | null;
+  address: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Customer from GET /api/customers */
+export interface Customer {
+  id: number;
+  name: string;
+  phone: string;
+  address: string | null;
+  notes: string | null;
+  loyalty_points: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type UserRole = 'Admin' | 'Cashier' | 'Delivery';
+
+/** User from GET /api/users */
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: UserRole;
+  last_login: string | null;
+  created_at: string;
+}
+
+/** Auth responses project only the identity columns, not the audit ones */
+export type AuthUser = Pick<User, 'id' | 'name' | 'email' | 'role'>;
+
+/** Body of POST /api/auth/login and POST /api/auth/refresh */
+export interface AuthResponseData {
+  data: {
+    accessToken: string;
+    user: AuthUser;
+  };
+}
+
+/** Sale line item from GET /api/sales/:id (read shape, not the write payload) */
+export interface SaleItem {
+  product_id: number;
+  product_name: string;
+  quantity: number;
+  unit_price: number;
+}
+
+/**
+ * Settings map from GET /api/settings. The route builds it from whatever rows
+ * exist, so every key is optional.
+ */
+export interface AppSettings {
+  tax_enabled?: 'true' | 'false';
+  tax_rate?: string;
+  tax_mode?: 'inclusive' | 'exclusive';
+  loyalty_enabled?: 'true' | 'false';
+  loyalty_earn_rate?: string;
+  loyalty_redeem_value?: string;
 }


### PR DESCRIPTION
Closes #3.

The shared types module was ~59 lines while pages declared their own view of the server contract, so an API change compiled cleanly almost everywhere and failed at runtime instead. Every shape declared in two or more places now has exactly one declaration.

Purely mechanical — **no runtime logic changed anywhere in this diff.** Every edit is a type annotation or an import; the only non-type change is one test cast, explained below.

## Discrepancies found

The issue asked for disagreements to be reconciled against the actual API and reported. Several copies turned out to disagree with the *server*, not just with each other. Each was verified against the migration and against the live database, not inferred:

| Shape | Was | Server truth |
|---|---|---|
| `Product.price` | `string \| number` in all 3 copies | `price REAL NOT NULL` (`003`) — returns a JS number. All three copies were wrong. |
| `Product.category` | `string` | `category TEXT`, nullable (`003`) |
| `Category.code` | `code?: string` | `code TEXT NOT NULL UNIQUE` (`008`); 0 nulls in live data |
| `Distributor` | 5 fields | `SELECT *` returns 9 — was missing `address`, `notes`, `created_at`, `updated_at` |
| `Customer.phone` | `string \| null` in `Layaway.tsx` | `phone TEXT NOT NULL` (`007`); 0 nulls in live data |
| `AppSettings` | every key required, in all 3 copies | `settings.ts` folds `SELECT key, value` into an object, so **no key is guaranteed**. `Settings.tsx` already defended with `\|\| '15'` fallbacks — dead code under the old type, correct under the new one. |

**`SaleItem` was two different contracts sharing one name.** `SalesHistory` and `RefundDialog` declared identical *read* rows; `CartPanel` declared the *write* payload for `POST /api/v1/sales` (has `variant_id`/`memo`, no `product_name`). Merging them would have made `product_name` required on a write. The write shape is now `SaleItemInput` and stays local to the cart panel.

`User` was likewise two honest projections — `/api/users` returns 6 columns, `/api/auth/*` returns 4 — so it is now `User` plus `AuthUser = Pick<User, 'id'|'name'|'email'|'role'>`.

## Left alone deliberately

- **Single-page shapes**, per the issue — they move later with their page.
- **`Category` vs `CategoryRecord`**: genuinely different projections (`/products/categories` selects exactly `id, name, code`; the admin page reads `created_at`/`updated_at`). Merging would force one to lie, so both stay.
- **`Bundle` vs `PosBundle`**: not verified as the same projection; out of the required list.
- **`resource.test.tsx`'s `Expense`**: a deliberate test fixture.

## Reported but not changed

`Expenses.tsx`'s local `Expense` is single-file so it stays, but for the record it is wrong in three ways: the route does `SELECT e.*` so the response also carries `user_id`, `created_at` and `updated_at`; `user_name` comes from a `LEFT JOIN` and is therefore nullable though declared `string`; and `category`/`recurring` could be narrowed to the `CHECK` constraint values. Whichever ticket migrates that page should fix it.

## One judgment call worth a look

`cartStore.test.ts`'s "should parse string prices correctly" passed `price: '499.99'`, which no longer typechecks. I kept the test with an explicit `as unknown as number` cast rather than deleting it, because **the cart is persisted** (`moon-cart-recovery`, 8-hour window) — a rehydrated cart really can hold a legacy string price, so the `parseFloat(String(...))` fallback in `addItem` is live defensive code, not dead. No `any`, no `@ts-ignore`. Happy to drop both the cast and the fallback if you would rather.

## Testing

- Typecheck: **26 errors, unchanged from baseline** — byte-identical pre-existing ones in `AiInsights.tsx` (13), `Storefront.tsx` (12), `RefundDialog.tsx` (1). None introduced.
- 44 tests pass. Lint 0 errors. Build succeeds.
- Smoke-tested in a browser against the running app: Customers (10 rows), Users (3), Distributors (5), Inventory (10), Sales History (10) and Settings all render real data with no console errors.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — types are erased at build time and this diff changes no runtime logic, no server code, and no schema.