### PR TITLE
feat(client): move analytics surfaces onto the transport adapter

### DIFF
--- a/client/src/hooks/useDashboardData.ts
+++ b/client/src/hooks/useDashboardData.ts
@@ -1,5 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
-import api from '../services/api';
+import { useApiQuery } from '../lib/apiQuery';
 
 export interface KpiData {
   today_revenue: number;
@@ -64,12 +63,12 @@ interface DashboardAllData {
 }
 
 export function useDashboardData(dateParams: Record<string, string>) {
-  const query = useQuery<DashboardAllData>({
-    queryKey: ['dashboard-all', dateParams],
-    queryFn: () =>
-      api.get('/api/v1/analytics/dashboard-all', { params: dateParams }).then((r) => r.data.data),
-    staleTime: 10 * 60 * 1000,
-  });
+  const query = useApiQuery<DashboardAllData>(
+    ['dashboard-all', dateParams],
+    'analytics/dashboard-all',
+    dateParams,
+    { staleTime: 10 * 60 * 1000 }
+  );
 
   const d = query.data;
 

--- a/client/src/lib/apiQuery.ts
+++ b/client/src/lib/apiQuery.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTransport } from './transport';
+
+/**
+ * A read that does not belong to a resource collection.
+ *
+ * Roughly fifteen percent of the API is not CRUD — analytics aggregates, AI
+ * endpoints, report generation, export payloads. Those go through the same
+ * transport as `resource`, so they get the envelope unwrapped and errors
+ * normalized on the same terms, without `resource` growing a capability to
+ * serve them. Widening `resource` until it covered these is exactly how a
+ * small interface becomes a large one.
+ */
+export interface ApiQueryOptions {
+  /** Hold the read until the tab or filter it belongs to is actually showing. */
+  enabled?: boolean;
+  /** How long the answer stays fresh, for reads too expensive to repeat. */
+  staleTime?: number;
+}
+
+export function useApiQuery<T>(
+  key: readonly unknown[],
+  path: string,
+  params?: Record<string, unknown>,
+  { enabled = true, staleTime }: ApiQueryOptions = {}
+) {
+  const transport = useTransport();
+  const query = useQuery({
+    queryKey: key,
+    queryFn: () => transport.request<T>({ method: 'GET', path, params }),
+    enabled,
+    staleTime,
+  });
+
+  return { ...query, data: query.data?.data, meta: query.data?.meta };
+}

--- a/client/src/pages/AdvancedAnalytics.tsx
+++ b/client/src/pages/AdvancedAnalytics.tsx
@@ -1,14 +1,79 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from '../i18n';
 import { formatCurrency, formatDate } from '../lib/utils';
-import api from '../services/api';
+import { useApiQuery } from '../lib/apiQuery';
 import { Card, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import AbcChart from '../components/charts/AbcChart';
 import HeatmapChart from '../components/charts/HeatmapChart';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { useSettingsStore } from '../store/settingsStore';
+
+// --- Server payloads ---
+
+/** GET analytics/abc-classification */
+interface AbcResponse {
+  products: Array<{
+    id: number;
+    name: string;
+    sku: string;
+    stock: number;
+    price: number;
+    abc_class: string;
+    revenue: number;
+    units_sold: number;
+    revenue_pct: number;
+    cumulative_pct: number;
+  }>;
+  summary: {
+    total_revenue: number;
+    a_count: number;
+    b_count: number;
+    c_count: number;
+  };
+}
+
+/** GET analytics/dead-stock */
+interface DeadStockResponse {
+  products: Array<{
+    id: number;
+    name: string;
+    sku: string;
+    category: string;
+    stock: number;
+    price: number;
+    cost_price: number;
+    tied_up_capital: number;
+    last_sold_date: string | null;
+    days_inactive: number;
+  }>;
+  summary: { total_products: number; total_tied_up_capital: number };
+}
+
+/** GET analytics/customer-ltv */
+interface CustomerLtvResponse {
+  customers: Array<{
+    id: number;
+    name: string;
+    phone: string;
+    order_count: number;
+    lifetime_revenue: number;
+    avg_order_value: number;
+    first_purchase: string;
+    last_purchase: string;
+    tenure_days: number;
+    recency_days: number;
+  }>;
+  summary: { total_customers: number; avg_ltv: number; top10_revenue_share: number };
+}
+
+/** GET analytics/hourly-heatmap */
+type HourlyHeatmapResponse = Array<{
+  day_of_week: number;
+  hour: number;
+  order_count: number;
+  revenue: number;
+}>;
 
 // --- Tab Button ---
 
@@ -96,32 +161,10 @@ function DaysSelector({
 function AbcTab() {
   const { t } = useTranslation();
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['analytics', 'abc-classification'],
-    queryFn: async () => {
-      const res = await api.get('/api/v1/analytics/abc-classification');
-      return res.data.data as {
-        products: Array<{
-          id: number;
-          name: string;
-          sku: string;
-          stock: number;
-          price: number;
-          abc_class: string;
-          revenue: number;
-          units_sold: number;
-          revenue_pct: number;
-          cumulative_pct: number;
-        }>;
-        summary: {
-          total_revenue: number;
-          a_count: number;
-          b_count: number;
-          c_count: number;
-        };
-      };
-    },
-  });
+  const { data, isLoading } = useApiQuery<AbcResponse>(
+    ['analytics', 'abc-classification'],
+    'analytics/abc-classification'
+  );
 
   if (isLoading) return <div className="p-8 text-center text-muted">{t('common.loading')}</div>;
   if (!data) return null;
@@ -202,27 +245,11 @@ function DeadStockTab() {
   const { t } = useTranslation();
   const [days, setDays] = useState(90);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['analytics', 'dead-stock', days],
-    queryFn: async () => {
-      const res = await api.get(`/api/v1/analytics/dead-stock?days=${days}`);
-      return res.data.data as {
-        products: Array<{
-          id: number;
-          name: string;
-          sku: string;
-          category: string;
-          stock: number;
-          price: number;
-          cost_price: number;
-          tied_up_capital: number;
-          last_sold_date: string | null;
-          days_inactive: number;
-        }>;
-        summary: { total_products: number; total_tied_up_capital: number };
-      };
-    },
-  });
+  const { data, isLoading } = useApiQuery<DeadStockResponse>(
+    ['analytics', 'dead-stock', days],
+    'analytics/dead-stock',
+    { days }
+  );
 
   return (
     <div className="space-y-6">
@@ -307,27 +334,10 @@ function ClvTab() {
   const theme = useSettingsStore((s) => s.theme);
   const isDark = theme === 'dark';
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['analytics', 'customer-ltv'],
-    queryFn: async () => {
-      const res = await api.get('/api/v1/analytics/customer-ltv');
-      return res.data.data as {
-        customers: Array<{
-          id: number;
-          name: string;
-          phone: string;
-          order_count: number;
-          lifetime_revenue: number;
-          avg_order_value: number;
-          first_purchase: string;
-          last_purchase: string;
-          tenure_days: number;
-          recency_days: number;
-        }>;
-        summary: { total_customers: number; avg_ltv: number; top10_revenue_share: number };
-      };
-    },
-  });
+  const { data, isLoading } = useApiQuery<CustomerLtvResponse>(
+    ['analytics', 'customer-ltv'],
+    'analytics/customer-ltv'
+  );
 
   if (isLoading) return <div className="p-8 text-center text-muted">{t('common.loading')}</div>;
   if (!data) return null;
@@ -488,18 +498,11 @@ function HeatmapTab() {
   const { t } = useTranslation();
   const [days, setDays] = useState(30);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['analytics', 'hourly-heatmap', days],
-    queryFn: async () => {
-      const res = await api.get(`/api/v1/analytics/hourly-heatmap?days=${days}`);
-      return res.data.data as Array<{
-        day_of_week: number;
-        hour: number;
-        order_count: number;
-        revenue: number;
-      }>;
-    },
-  });
+  const { data, isLoading } = useApiQuery<HourlyHeatmapResponse>(
+    ['analytics', 'hourly-heatmap', days],
+    'analytics/hourly-heatmap',
+    { days }
+  );
 
   // Calculate peaks
   const peakHour = data?.reduce((best, cur) => (cur.revenue > best.revenue ? cur : best), {

--- a/client/src/pages/AiInsights.tsx
+++ b/client/src/pages/AiInsights.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Brain, TrendingUp, RefreshCw, BookOpen, Plus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { formatCurrency } from '../lib/utils';
@@ -15,36 +15,64 @@ import {
   DialogDescription,
 } from '../components/ui/dialog';
 import { useTranslation } from '../i18n';
-import api from '../services/api';
+import { useApiQuery } from '../lib/apiQuery';
+import { useTransport } from '../lib/transport';
+
+/** GET ai/predictions — sales_predictions joined onto its product */
+interface SalesPrediction {
+  id: number;
+  product_id: number | null;
+  product_name: string | null;
+  sku: string | null;
+  category: string | null;
+  period: string;
+  predicted_units: number;
+  predicted_revenue: number;
+  confidence: number;
+}
+
+/** GET ai/knowledge-base */
+interface KnowledgeEntry {
+  id: number;
+  category: string;
+  question: string;
+  answer: string;
+  keywords: string | null;
+}
 
 export default function AiInsightsPage() {
   const { t } = useTranslation();
   const qc = useQueryClient();
+  const transport = useTransport();
   const [tab, setTab] = useState<'predictions' | 'chatbot' | 'knowledge'>('predictions');
   const [kbOpen, setKbOpen] = useState(false);
   const [kbForm, setKbForm] = useState({ category: '', question: '', answer: '', keywords: '' });
 
-  const { data: predictions } = useQuery<Record<string, unknown>[]>({
-    queryKey: ['predictions'],
-    queryFn: () => api.get('/api/v1/ai/predictions').then((r) => r.data.data),
-    enabled: tab === 'predictions',
-  });
-  const { data: knowledgeBase } = useQuery<Record<string, unknown>[]>({
-    queryKey: ['knowledge-base'],
-    queryFn: () => api.get('/api/v1/ai/knowledge-base').then((r) => r.data.data),
-    enabled: tab === 'knowledge',
-  });
+  const { data: predictions } = useApiQuery<SalesPrediction[]>(
+    ['predictions'],
+    'ai/predictions',
+    undefined,
+    { enabled: tab === 'predictions' }
+  );
+  const { data: knowledgeBase } = useApiQuery<KnowledgeEntry[]>(
+    ['knowledge-base'],
+    'ai/knowledge-base',
+    undefined,
+    { enabled: tab === 'knowledge' }
+  );
 
   const generatePredictions = useMutation({
-    mutationFn: () => api.post('/api/v1/ai/predictions/generate'),
+    mutationFn: () =>
+      transport.request<SalesPrediction[]>({ method: 'POST', path: 'ai/predictions/generate' }),
     onSuccess: (res) => {
-      toast.success(`${res.data.data.length} ${t('aiInsights.predictionsGenerated')}`);
+      toast.success(`${res.data.length} ${t('aiInsights.predictionsGenerated')}`);
       qc.invalidateQueries({ queryKey: ['predictions'] });
     },
   });
 
   const addKbEntry = useMutation({
-    mutationFn: (data: typeof kbForm) => api.post('/api/v1/ai/knowledge-base', data),
+    mutationFn: (data: typeof kbForm) =>
+      transport.request({ method: 'POST', path: 'ai/knowledge-base', body: data }),
     onSuccess: () => {
       toast.success(t('aiInsights.kbAdded'));
       qc.invalidateQueries({ queryKey: ['knowledge-base'] });
@@ -124,7 +152,7 @@ export default function AiInsightsPage() {
                     </td>
                   </tr>
                 ) : (
-                  predictions.map((p: Record<string, unknown>) => (
+                  predictions.map((p) => (
                     <tr key={p.id} className="border-b border-border hover:bg-surface/50">
                       <td className="p-3">
                         <div className="font-medium">{p.product_name}</div>
@@ -156,7 +184,7 @@ export default function AiInsightsPage() {
             <Plus className="h-4 w-4" /> {t('aiInsights.addEntry')}
           </Button>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {knowledgeBase?.map((entry: Record<string, unknown>) => (
+            {knowledgeBase?.map((entry) => (
               <div key={entry.id} className="p-4 rounded-md border border-border bg-card">
                 <Badge variant="gold" className="text-[10px] mb-2">
                   {entry.category}

--- a/client/src/pages/Exports.tsx
+++ b/client/src/pages/Exports.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Download, FileSpreadsheet } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Button } from '../components/ui/button';
@@ -7,9 +7,8 @@ import { Label } from '../components/ui/label';
 import { Badge } from '../components/ui/badge';
 import { useTranslation } from '../i18n';
 import { exportToExcel } from '../lib/exportUtils';
-import type { AxiosError } from 'axios';
-import api from '../services/api';
-import type { ApiErrorResponse } from '@/types';
+import { useApiQuery } from '../lib/apiQuery';
+import { useTransport } from '../lib/transport';
 
 interface ExportRecord {
   id: number;
@@ -20,32 +19,42 @@ interface ExportRecord {
   created_at: string;
 }
 
+/** POST exports/generate */
+interface ExportPayload {
+  module: string;
+  columns: string[];
+  rows: Record<string, unknown>[];
+}
+
 const MODULES = ['products', 'sales', 'customers', 'inventory', 'deliveries'] as const;
 
 export default function ExportsPage() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const transport = useTransport();
   const [selectedModule, setSelectedModule] = useState<string>('products');
 
-  const { data: history } = useQuery<ExportRecord[]>({
-    queryKey: ['exports'],
-    queryFn: () => api.get('/api/v1/exports').then((r) => r.data.data),
-  });
+  const { data: history } = useApiQuery<ExportRecord[]>(['exports'], 'exports');
 
   const generateMutation = useMutation({
     mutationFn: () =>
-      api.post('/api/v1/exports/generate', { module: selectedModule, format: 'xlsx' }),
+      transport.request<ExportPayload>({
+        method: 'POST',
+        path: 'exports/generate',
+        body: { module: selectedModule, format: 'xlsx' },
+      }),
     onSuccess: (res) => {
-      const { columns, rows, module: mod } = res.data.data;
-      const exportData = rows as Record<string, unknown>[];
-      const cols = (columns as string[]).map((c) => ({ key: c, label: c }));
+      const { columns, rows, module: mod } = res.data;
+      const exportData = rows;
+      const cols = columns.map((c) => ({ key: c, label: c }));
       const filename = `moon-${mod}-${new Date().toISOString().slice(0, 10)}.xlsx`;
       exportToExcel(filename, exportData, cols);
       toast.success(t('exports.downloaded', { count: String(rows.length) }));
       queryClient.invalidateQueries({ queryKey: ['exports'] });
     },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Export failed'),
+    // ApiError carries the server's wording, and nothing when the failure was
+    // the transport's own — so the page keeps its own fallback.
+    onError: (err: Error) => toast.error(err.message || 'Export failed'),
   });
 
   const moduleLabels: Record<string, string> = {

--- a/client/src/pages/ReportBuilder.tsx
+++ b/client/src/pages/ReportBuilder.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { BarChart3, Plus, Play, Trash2, Clock, FileText } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { formatCurrency } from '../lib/utils';
@@ -15,7 +15,10 @@ import {
   DialogDescription,
 } from '../components/ui/dialog';
 import { useTranslation } from '../i18n';
-import api from '../services/api';
+import { resource } from '../lib/resource';
+import { useTransport } from '../lib/transport';
+
+type ReportRow = Record<string, unknown>;
 
 interface SavedReport {
   id: number;
@@ -39,12 +42,15 @@ const reportTypeColors: Record<string, string> = {
   custom: 'bg-gray-500/20 text-gray-600',
 };
 
+const reports = resource<SavedReport>('reports');
+
 export default function ReportBuilderPage() {
   const { t } = useTranslation();
   const qc = useQueryClient();
+  const transport = useTransport();
   const [tab, setTab] = useState<'saved' | 'builder' | 'quick'>('saved');
   const [createOpen, setCreateOpen] = useState(false);
-  const [resultData, setResultData] = useState<Record<string, unknown>[] | null>(null);
+  const [resultData, setResultData] = useState<ReportRow[] | null>(null);
   const [form, setForm] = useState({
     name: '',
     description: '',
@@ -59,30 +65,20 @@ export default function ReportBuilderPage() {
     date_to: '',
   });
 
-  const { data: reports } = useQuery<SavedReport[]>({
-    queryKey: ['reports'],
-    queryFn: () => api.get('/api/v1/reports').then((r) => r.data.data),
+  const { data: savedReports } = reports.useList();
+
+  const createReport = reports.useSave({
+    message: t('reportBuilder.created'),
+    onDone: () => setCreateOpen(false),
   });
 
-  const createReport = useMutation({
-    mutationFn: (data: typeof form) => api.post('/api/v1/reports', data),
-    onSuccess: () => {
-      toast.success(t('reportBuilder.created'));
-      qc.invalidateQueries({ queryKey: ['reports'] });
-      setCreateOpen(false);
-    },
-  });
-
-  const deleteReport = useMutation({
-    mutationFn: (id: number) => api.delete(`/api/v1/reports/${id}`),
-    onSuccess: () => {
-      toast.success(t('reportBuilder.deleted'));
-      qc.invalidateQueries({ queryKey: ['reports'] });
-    },
-  });
+  const deleteReport = reports.useRemove({ message: t('reportBuilder.deleted') });
 
   const runReport = useMutation({
-    mutationFn: (id: number) => api.post(`/api/v1/reports/${id}/run`).then((r) => r.data.data),
+    mutationFn: (id: number) =>
+      transport
+        .request<ReportRow[]>({ method: 'POST', path: `reports/${id}/run` })
+        .then((r) => r.data),
     onSuccess: (data) => {
       setResultData(data);
       toast.success(t('reportBuilder.runSuccess'));
@@ -92,7 +88,9 @@ export default function ReportBuilderPage() {
 
   const runQuick = useMutation({
     mutationFn: (data: typeof quickForm) =>
-      api.post('/api/v1/reports/quick', data).then((r) => r.data.data),
+      transport
+        .request<ReportRow[]>({ method: 'POST', path: 'reports/quick', body: data })
+        .then((r) => r.data),
     onSuccess: (data) => {
       setResultData(data);
       toast.success(t('reportBuilder.runSuccess'));
@@ -133,13 +131,13 @@ export default function ReportBuilderPage() {
 
       {tab === 'saved' && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {!reports?.length ? (
+          {!savedReports?.length ? (
             <div className="col-span-full text-center py-16">
               <BarChart3 className="h-12 w-12 text-gold/40 mx-auto mb-3" />
               <p className="text-muted">{t('reportBuilder.noReports')}</p>
             </div>
           ) : (
-            reports.map((r) => (
+            savedReports.map((r) => (
               <div
                 key={r.id}
                 className="p-4 rounded-md border border-border bg-card hover:border-gold/50 transition-colors"
@@ -159,7 +157,7 @@ export default function ReportBuilderPage() {
                       variant="ghost"
                       size="icon"
                       className="h-7 w-7 text-destructive"
-                      onClick={() => deleteReport.mutate(r.id)}
+                      onClick={() => deleteReport.remove(r.id)}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>
@@ -257,7 +255,7 @@ export default function ReportBuilderPage() {
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              createReport.mutate(form);
+              createReport.save(form);
             }}
             className="space-y-3"
           >
@@ -304,8 +302,8 @@ export default function ReportBuilderPage() {
                 </select>
               </div>
             </div>
-            <Button type="submit" className="w-full" disabled={createReport.isPending}>
-              {createReport.isPending ? t('common.saving') : t('common.save')}
+            <Button type="submit" className="w-full" disabled={createReport.isSaving}>
+              {createReport.isSaving ? t('common.saving') : t('common.save')}
             </Button>
           </form>
         </DialogContent>


### PR DESCRIPTION
Closes #7.

Dashboard, Advanced Analytics, AI Insights, Report Builder and Exports no longer import the shared axios instance. Independent of the CRUD work, so this ran in parallel with the other batches.

## Approach

Roughly fifteen percent of the API is not CRUD, and the issue is explicit that `resource` must not grow to cover it. So reads go through **`useApiQuery`** — a new peer to `resource` in `lib/`, not part of it:

```ts
const { data } = useApiQuery<AbcResponse>(['analytics', 'abc-classification'], 'analytics/abc-classification');
```

**`resource.ts` and `lib/transport/*` are byte-identical in this PR** — `git diff --stat` does not list them. That was the constraint and it held.

`useApiQuery` takes exactly two options, both needed to preserve existing behaviour: `enabled` (AI Insights gates two reads on the active tab) and `staleTime` (the dashboard caches for 10 minutes). Nothing else was added.

## Where it didn't fit

Three calls do not go through either abstraction, and use `useTransport()` directly:

- **`POST reports/:id/run`** and **`POST reports/quick`** — both need the *response rows* to render. `resource.useAction` deliberately does not hand the response back to the caller, and widening it to do so is precisely what this issue forbids.
- **`POST reports/quick`** is also collection-level with no record id, which `useAction`'s `name/:id/action` shape cannot express at all.

Report Builder's saved reports *are* a genuine CRUD collection, so those use `resource('reports')` for list/save/remove.

## Typecheck errors: 26 → 13

AI Insights held 13 of the repo's 26 pre-existing errors, all from `api.get(...).then(r => r.data.data)` typed as `Record<string, unknown>` — every field access yielded `unknown`. Typing the two endpoints against the actual schema (`sales_predictions` joined onto its product, and `knowledge_base`) removed all 13. The remaining 13 are in `Storefront.tsx`, which no ticket in this sequence covers.

Report Builder's result rows stay `Record<string, unknown>[]` deliberately — a saved report returns arbitrary columns rendered via `Object.keys`, so that one is honestly dynamic.

## Verified in a browser

Against the running app, logged in as admin:

- **Dashboard** — real KPIs (41 sales, 4 pending deliveries).
- **Advanced Analytics** — all four tabs, each a separately migrated query: ABC (12 A / 9 B / 10 C, revenue 239,680), dead stock (31 products, 623,410 tied up), customer LTV (12 customers, 96.63% top-10 share), hourly heatmap. I converted `?days=${days}` into transport `params`, so I confirmed against the server log that changing the filter really sends `dead-stock?days=180`.
- **AI Insights** — predictions render real rows; the `enabled` gating holds (`ai/knowledge-base` is only requested after switching tabs). The knowledge base displays empty because the table genuinely has 0 rows, not because of this change.
- **Report Builder** — a quick report returned 23 rows and rendered its dynamic columns, exercising the direct-transport path.
- **Exports** — see below.

No console errors on any surface.

## ⚠️ Pre-existing server bug found — export generation is broken

`POST /api/v1/exports/generate` returns **500**. `server/routes/exports.ts:171` inserts a `record_count` column that does not exist on the `exports` table:

```
SqliteError: table exports has no column named record_count
```

**This predates this work** — it is on `main`, in server code this branch does not touch (`git diff main -- server/` is empty). So #7's "file export still works" criterion cannot be met, for reasons unrelated to this migration. Filed separately.

It did, however, verify the error criterion nicely: the failure surfaced through the new normalized path as a toast carrying the server's own message, exactly as intended. Worth noting separately that the server echoing a raw SQL error to the UI is its own problem.

## Post-Deploy Monitoring & Validation

Client-only change; no server or schema modification. After deploy, watch for `GET /api/v1/analytics/*`, `/ai/*`, `/reports*` and `/exports` 4xx/5xx rates — healthy is unchanged from current baseline, since paths and query params are identical (verified against the server log). The one known failure signal, `POST /exports/generate` → 500, is the pre-existing bug above and is not a regression from this PR. Rollback trigger: any analytics endpoint that starts 404ing, which would indicate the `/api/v1` prefix was dropped.