### PR TITLE
fix(server): add missing record_count column to exports table

### DIFF
--- a/server/db/migrations/067_exports_record_count.down.sql
+++ b/server/db/migrations/067_exports_record_count.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE exports DROP COLUMN record_count;

--- a/server/db/migrations/067_exports_record_count.sql
+++ b/server/db/migrations/067_exports_record_count.sql
@@ -1,0 +1,3 @@
+-- The exports route records how many rows an export produced, but the column
+-- was never created, so every generate request failed on the insert.
+ALTER TABLE exports ADD COLUMN record_count INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
Closes #18.

`POST /api/v1/exports/generate` returned 500 for every module, so Export Center's Download button never produced a file.

## Cause

`server/routes/exports.ts:171` inserts `record_count`, but no migration ever created that column:

```
SqliteError: table exports has no column named record_count
```

The rows were gathered fine — only the history-recording insert failed, and it runs before the response is sent, so the whole request failed.

## Which side was wrong

The insert was right and the migration was missing, not the other way round. `Exports.tsx` declares `record_count: number` and renders it in the Export History table, and the read is `SELECT e.*` so it picks the column up automatically. Adding the column makes the writer, the reader and the UI agree.

`067_exports_record_count.sql` adds `record_count INTEGER NOT NULL DEFAULT 0`, with a matching `.down.sql` per the repo convention.

## Verified

Ran the migration against the dev database, then drove the real UI:

- `POST /api/v1/exports/generate` → **200** (was 500)
- Export History gained its row: `Products XLSX 31 أحمد محمد 8/19/2026`
- The stored row is correct — `record_count: 31`, matching the 31 products in the database, `status: completed`
- The XLSX itself is generated client-side by `exportToExcel` and downloaded

Test row deleted afterwards; the `exports` table is back to empty as found.

## Not fixed here

The raw SQL error reached the browser as a toast reading `table exports has no column named record_count`. Echoing database errors to clients leaks schema detail and is a separate concern from this column — worth its own issue against the error handler rather than folding into this fix.

## Post-Deploy Monitoring & Validation

**Migration required on deploy** — `npm run migrate` must run before the new server code serves traffic, though the column is additive with a default so old code keeps working either way.

- Watch: `POST /api/v1/exports/generate` status codes. Healthy = 200s; the 500 rate for this route should go to zero.
- Also watch: `SqliteError: table exports has no column named record_count` in server logs — should disappear entirely.
- Failure signal: any 500 on that route after the migration has run, or migration failure on startup.
- Rollback: `npm run migrate --down 1` drops the column; the route returns to its previous (broken) state rather than a worse one.
- Window: first hour after deploy, or the first manual export, whichever comes first.