### PR TITLE
feat(client): migrate simple CRUD pages onto resource and the editor dialog

### DIFF
--- a/client/src/pages/Bundles.tsx
+++ b/client/src/pages/Bundles.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Gift, Plus, Pencil, Trash2, Package, ArrowRight, X, Percent } from 'lucide-react';
-import toast from 'react-hot-toast';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
@@ -15,91 +13,51 @@ import {
 } from '../components/ui/dialog';
 import { useTranslation } from '../i18n';
 import { formatCurrency } from '../lib/utils';
-import api from '../services/api';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse, Product } from '@/types';
+import { resource } from '../lib/resource';
+import { useEditorDialog } from '../lib/editorDialog';
+import { useApiQuery } from '../lib/apiQuery';
+import type { Bundle, BundleItem, Product } from '@/types';
 
-interface BundleItem {
-  id?: number;
-  product_id: number;
-  product_name: string;
-  product_price: number;
-  quantity: number;
-}
+const bundles = resource<Bundle>('bundles');
 
-interface Bundle {
-  id: number;
-  name: string;
-  description: string | null;
-  price: number;
-  status: string;
-  items: BundleItem[];
-  original_price: number;
-  savings: number;
-  savings_percent: number;
-  created_at: string;
-}
+const emptyBundle = { name: '', description: '', price: '', status: 'active' };
+
+const bundleToForm = (bundle: Bundle) => ({
+  name: bundle.name,
+  description: bundle.description || '',
+  price: String(bundle.price),
+  status: bundle.status,
+});
 
 export default function BundlesPage() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [form, setForm] = useState({
-    name: '',
-    description: '',
-    price: '',
-    status: 'active',
-  });
+  const editor = useEditorDialog(emptyBundle, bundleToForm);
+  const form = editor.values;
+  // The lines being composed beside the form, not a field of it.
   const [bundleItems, setBundleItems] = useState<BundleItem[]>([]);
   const [selectedBundle, setSelectedBundle] = useState<number | null>(null);
   const [addProductOpen, setAddProductOpen] = useState(false);
   const [productSearch, setProductSearch] = useState('');
 
-  const { data: bundles } = useQuery<Bundle[]>({
-    queryKey: ['bundles'],
-    queryFn: () => api.get('/api/v1/bundles').then((r) => r.data.data),
+  const { data: rows } = bundles.useList();
+  const { data: detail } = bundles.useOne(selectedBundle);
+
+  const { data: allProducts } = useApiQuery<Product[]>(
+    ['products-for-bundle', productSearch],
+    'products',
+    { search: productSearch, limit: 20 },
+    { enabled: addProductOpen }
+  );
+
+  const saver = bundles.useSave({
+    message: editor.isEditing ? t('bundles.updated') : t('bundles.created'),
+    fallbackMessage: 'Error',
+    onDone: editor.close,
   });
 
-  const { data: detail } = useQuery<Bundle>({
-    queryKey: ['bundle-detail', selectedBundle],
-    queryFn: () => api.get(`/api/v1/bundles/${selectedBundle}`).then((r) => r.data.data),
-    enabled: !!selectedBundle,
-  });
-
-  const { data: allProducts } = useQuery<Product[]>({
-    queryKey: ['products-for-bundle', productSearch],
-    queryFn: () =>
-      api
-        .get('/api/v1/products', { params: { search: productSearch, limit: 20 } })
-        .then((r) => r.data.data),
-    enabled: addProductOpen,
-  });
-
-  const saveMutation = useMutation({
-    mutationFn: (data: Record<string, unknown>) => {
-      if (editingId) return api.put(`/api/v1/bundles/${editingId}`, data);
-      return api.post('/api/v1/bundles', data);
-    },
-    onSuccess: () => {
-      toast.success(editingId ? t('bundles.updated') : t('bundles.created'));
-      queryClient.invalidateQueries({ queryKey: ['bundles'] });
-      if (selectedBundle) {
-        queryClient.invalidateQueries({ queryKey: ['bundle-detail', selectedBundle] });
-      }
-      setDialogOpen(false);
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Error'),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => api.delete(`/api/v1/bundles/${id}`),
-    onSuccess: () => {
-      toast.success(t('bundles.deleted'));
-      queryClient.invalidateQueries({ queryKey: ['bundles'] });
-      setSelectedBundle(null);
-    },
+  const remover = bundles.useRemove({
+    message: t('bundles.deleted'),
+    onDone: () => setSelectedBundle(null),
   });
 
   const originalPrice = bundleItems.reduce(
@@ -112,20 +70,12 @@ export default function BundlesPage() {
     originalPrice > 0 ? Math.round((formSavings / originalPrice) * 100) : 0;
 
   const openCreateDialog = () => {
-    setEditingId(null);
-    setForm({ name: '', description: '', price: '', status: 'active' });
+    editor.openNew();
     setBundleItems([]);
-    setDialogOpen(true);
   };
 
   const openEditDialog = (bundle: Bundle) => {
-    setEditingId(bundle.id);
-    setForm({
-      name: bundle.name,
-      description: bundle.description || '',
-      price: String(bundle.price),
-      status: bundle.status,
-    });
+    editor.openEdit(bundle);
     setBundleItems(
       bundle.items.map((item) => ({
         product_id: item.product_id,
@@ -134,12 +84,12 @@ export default function BundlesPage() {
         quantity: item.quantity,
       }))
     );
-    setDialogOpen(true);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    saveMutation.mutate({
+    saver.save({
+      id: editor.editingId,
       name: form.name,
       description: form.description || null,
       price: parseFloat(form.price),
@@ -281,13 +231,13 @@ export default function BundlesPage() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {!bundles?.length ? (
+        {!rows?.length ? (
           <div className="col-span-full text-center py-16">
             <Gift className="h-12 w-12 text-gold/40 mx-auto mb-3" />
             <p className="text-muted">{t('bundles.noBundles')}</p>
           </div>
         ) : (
-          bundles.map((bundle) => (
+          rows.map((bundle) => (
             <div
               key={bundle.id}
               className="p-4 rounded-md border border-border bg-card hover:border-gold/50 transition-colors cursor-pointer"
@@ -309,7 +259,7 @@ export default function BundlesPage() {
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7 text-destructive"
-                    onClick={() => deleteMutation.mutate(bundle.id)}
+                    onClick={() => remover.remove(bundle.id)}
                     aria-label={t('common.delete')}
                   >
                     <Trash2 className="h-3 w-3" />
@@ -348,10 +298,10 @@ export default function BundlesPage() {
       </div>
 
       {/* Create / Edit dialog */}
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog open={editor.open} onOpenChange={editor.setOpen}>
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>{editingId ? t('bundles.edit') : t('bundles.create')}</DialogTitle>
+            <DialogTitle>{editor.isEditing ? t('bundles.edit') : t('bundles.create')}</DialogTitle>
             <DialogDescription>{t('bundles.title')}</DialogDescription>
           </DialogHeader>
           <form onSubmit={handleSubmit} className="space-y-4">
@@ -359,7 +309,7 @@ export default function BundlesPage() {
               <Label>{t('bundles.name')}</Label>
               <Input
                 value={form.name}
-                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                onChange={(e) => editor.set('name', e.target.value)}
                 required
               />
             </div>
@@ -367,7 +317,7 @@ export default function BundlesPage() {
               <Label>{t('bundles.description')}</Label>
               <Input
                 value={form.description}
-                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                onChange={(e) => editor.set('description', e.target.value)}
               />
             </div>
             <div className="grid grid-cols-2 gap-3">
@@ -378,7 +328,7 @@ export default function BundlesPage() {
                   step="0.01"
                   min="0"
                   value={form.price}
-                  onChange={(e) => setForm({ ...form, price: e.target.value })}
+                  onChange={(e) => editor.set('price', e.target.value)}
                   required
                 />
               </div>
@@ -387,7 +337,7 @@ export default function BundlesPage() {
                 <select
                   className="w-full h-9 rounded-md border border-border bg-background px-3 text-sm"
                   value={form.status}
-                  onChange={(e) => setForm({ ...form, status: e.target.value })}
+                  onChange={(e) => editor.set('status', e.target.value)}
                 >
                   <option value="active">{t('bundles.active')}</option>
                   <option value="inactive">{t('bundles.inactive')}</option>
@@ -476,9 +426,9 @@ export default function BundlesPage() {
             <Button
               type="submit"
               className="w-full"
-              disabled={saveMutation.isPending || bundleItems.length === 0}
+              disabled={saver.isSaving || bundleItems.length === 0}
             >
-              {saveMutation.isPending ? t('common.loading') : t('common.save')}
+              {saver.isSaving ? t('common.loading') : t('common.save')}
             </Button>
           </form>
         </DialogContent>

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import toast from 'react-hot-toast';
 import { Plus, Pencil, Trash2 } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -27,19 +25,12 @@ import {
   AlertDialogTitle,
 } from '../components/ui/alert-dialog';
 import DataTable from '../components/DataTable';
-import api from '../services/api';
+import { resource } from '../lib/resource';
 import { useTranslation, t as tStandalone } from '../i18n';
 import type { ColumnDef } from '@tanstack/react-table';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
+import type { CategoryRecord } from '@/types';
 
-interface CategoryRecord {
-  id: number;
-  name: string;
-  code: string;
-  created_at: string;
-  updated_at: string;
-}
+const categoriesResource = resource<CategoryRecord>('categories');
 
 const getCategoryFormSchema = () =>
   z.object({
@@ -51,15 +42,11 @@ type CategoryFormData = z.infer<ReturnType<typeof getCategoryFormSchema>>;
 
 export default function CategoriesPage() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editingCategory, setEditingCategory] = useState<CategoryRecord | null>(null);
 
-  const { data: categories, isLoading } = useQuery<CategoryRecord[]>({
-    queryKey: ['categories'],
-    queryFn: () => api.get('/api/v1/categories').then((r) => r.data.data),
-  });
+  const { data: categories, isLoading } = categoriesResource.useList();
 
   const {
     register,
@@ -70,50 +57,23 @@ export default function CategoriesPage() {
     resolver: zodResolver(getCategoryFormSchema()),
   });
 
-  const createMutation = useMutation({
-    mutationFn: (data: CategoryFormData) => api.post('/api/v1/categories', data),
-    onSuccess: () => {
-      toast.success(t('categories.categoryCreated'));
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
-      setDialogOpen(false);
-      reset();
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('categories.createFailed')),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: number; data: CategoryFormData }) =>
-      api.put(`/api/v1/categories/${id}`, data),
-    onSuccess: () => {
-      toast.success(t('categories.categoryUpdated'));
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
+  const saver = categoriesResource.useSave({
+    message: editingCategory ? t('categories.categoryUpdated') : t('categories.categoryCreated'),
+    fallbackMessage: editingCategory ? t('categories.updateFailed') : t('categories.createFailed'),
+    onDone: () => {
       setDialogOpen(false);
       setEditingCategory(null);
       reset();
     },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('categories.updateFailed')),
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => api.delete(`/api/v1/categories/${id}`),
-    onSuccess: () => {
-      toast.success(t('categories.categoryDeleted'));
-      queryClient.invalidateQueries({ queryKey: ['categories'] });
-      setDeleteId(null);
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('categories.deleteFailed')),
+  const remover = categoriesResource.useRemove({
+    message: t('categories.categoryDeleted'),
+    fallbackMessage: t('categories.deleteFailed'),
+    onDone: () => setDeleteId(null),
   });
 
-  const onSubmit = (data: CategoryFormData) => {
-    if (editingCategory) {
-      updateMutation.mutate({ id: editingCategory.id, data });
-    } else {
-      createMutation.mutate(data);
-    }
-  };
+  const onSubmit = (data: CategoryFormData) => saver.save({ id: editingCategory?.id, ...data });
 
   const openEditDialog = (category: CategoryRecord) => {
     setEditingCategory(category);
@@ -213,7 +173,7 @@ export default function CategoriesPage() {
               </div>
             </div>
             <DialogFooter>
-              <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+              <Button type="submit" disabled={saver.isSaving}>
                 {editingCategory ? t('common.update') : t('common.create')}
               </Button>
             </DialogFooter>
@@ -231,7 +191,7 @@ export default function CategoriesPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => deleteId && deleteMutation.mutate(deleteId)}
+              onClick={() => deleteId && remover.remove(deleteId)}
               className="bg-destructive text-foreground hover:bg-destructive/90"
             >
               {t('common.delete')}

--- a/client/src/pages/Collections.tsx
+++ b/client/src/pages/Collections.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Palette, Plus, Pencil, Trash2, Package, ArrowRight, X } from 'lucide-react';
-import toast from 'react-hot-toast';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
@@ -15,138 +13,87 @@ import {
 } from '../components/ui/dialog';
 import { useTranslation } from '../i18n';
 import { formatCurrency } from '../lib/utils';
-import api from '../services/api';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse, Product } from '@/types';
+import { resource } from '../lib/resource';
+import { useEditorDialog } from '../lib/editorDialog';
+import { useApiQuery } from '../lib/apiQuery';
+import type { Collection, CollectionDetail, Product } from '@/types';
 
-interface Collection {
-  id: number;
-  name: string;
-  season: string | null;
-  year: number | null;
-  status: string;
-  description: string | null;
-  product_count: number;
-}
+const collections = resource<Collection>('collections');
 
-interface CollectionDetail extends Collection {
-  products: {
-    id: number;
-    name: string;
-    sku: string;
-    price: number;
-    stock: number;
-    image_url: string | null;
-  }[];
-}
+// One record of the same collection, read through its own type: the detail
+// endpoint hands back the products too, which the list rows never carry.
+const collectionDetail = resource<CollectionDetail>('collections');
 
 const seasons = ['Spring', 'Summer', 'Fall', 'Winter'] as const;
 const statuses = ['upcoming', 'active', 'on_sale', 'archived'] as const;
 
+// A factory, so a collection created next January defaults to next January.
+const emptyCollection = () => ({
+  name: '',
+  season: '',
+  year: String(new Date().getFullYear()),
+  status: 'upcoming',
+  description: '',
+});
+
+const collectionToForm = (col: Collection) => ({
+  name: col.name,
+  season: col.season || '',
+  year: String(col.year || ''),
+  status: col.status,
+  description: col.description || '',
+});
+
+// Membership has no endpoint of its own: a collection gains or loses a product
+// by being saved back with a different product list.
+const withProducts = (detail: CollectionDetail, productIds: number[]) => ({
+  id: detail.id,
+  name: detail.name,
+  season: detail.season || undefined,
+  year: detail.year || undefined,
+  status: detail.status,
+  description: detail.description || undefined,
+  product_ids: productIds,
+});
+
+const statusColors: Record<string, string> = {
+  upcoming: 'bg-blue-500/10 text-blue-600',
+  active: 'bg-emerald-500/10 text-emerald-600',
+  on_sale: 'bg-orange-500/10 text-orange-600',
+  archived: 'bg-gray-500/10 text-gray-600',
+};
+
 export default function CollectionsPage() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [form, setForm] = useState({
-    name: '',
-    season: '',
-    year: String(new Date().getFullYear()),
-    status: 'upcoming',
-    description: '',
-  });
+  const editor = useEditorDialog(emptyCollection, collectionToForm);
+  const form = editor.values;
   const [selectedCol, setSelectedCol] = useState<number | null>(null);
   const [addProductOpen, setAddProductOpen] = useState(false);
   const [productSearch, setProductSearch] = useState('');
 
-  const { data: collections } = useQuery<Collection[]>({
-    queryKey: ['collections'],
-    queryFn: () => api.get('/api/v1/collections').then((r) => r.data.data),
+  const { data: rows } = collections.useList();
+  const { data: detail } = collectionDetail.useOne(selectedCol);
+
+  const { data: allProducts } = useApiQuery<Product[]>(
+    ['products-for-collection', productSearch],
+    'products',
+    { search: productSearch, limit: 20 },
+    { enabled: addProductOpen }
+  );
+
+  const saver = collections.useSave({
+    message: t('collections.created'),
+    fallbackMessage: 'Error',
+    onDone: editor.close,
   });
 
-  const { data: detail } = useQuery<CollectionDetail>({
-    queryKey: ['collection-detail', selectedCol],
-    queryFn: () => api.get(`/api/v1/collections/${selectedCol}`).then((r) => r.data.data),
-    enabled: !!selectedCol,
+  const remover = collections.useRemove({
+    message: t('common.delete'),
+    onDone: () => setSelectedCol(null),
   });
 
-  const { data: allProducts } = useQuery<Product[]>({
-    queryKey: ['products-for-collection', productSearch],
-    queryFn: () =>
-      api
-        .get('/api/v1/products', { params: { search: productSearch, limit: 20 } })
-        .then((r) => r.data.data),
-    enabled: addProductOpen,
-  });
-
-  const saveMutation = useMutation({
-    mutationFn: (data: Record<string, unknown>) => {
-      if (editingId) return api.put(`/api/v1/collections/${editingId}`, data);
-      return api.post('/api/v1/collections', data);
-    },
-    onSuccess: () => {
-      toast.success(t('collections.created'));
-      queryClient.invalidateQueries({ queryKey: ['collections'] });
-      setDialogOpen(false);
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Error'),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => api.delete(`/api/v1/collections/${id}`),
-    onSuccess: () => {
-      toast.success(t('common.delete'));
-      queryClient.invalidateQueries({ queryKey: ['collections'] });
-      setSelectedCol(null);
-    },
-  });
-
-  const addProductMutation = useMutation({
-    mutationFn: (productId: number) => {
-      if (!detail) return Promise.reject();
-      const currentIds = detail.products.map((p) => p.id);
-      return api.put(`/api/v1/collections/${selectedCol}`, {
-        name: detail.name,
-        season: detail.season || undefined,
-        year: detail.year || undefined,
-        status: detail.status,
-        description: detail.description || undefined,
-        product_ids: [...currentIds, productId],
-      });
-    },
-    onSuccess: () => {
-      toast.success(t('common.save'));
-      queryClient.invalidateQueries({ queryKey: ['collection-detail', selectedCol] });
-      queryClient.invalidateQueries({ queryKey: ['collections'] });
-    },
-  });
-
-  const removeProductMutation = useMutation({
-    mutationFn: (productId: number) => {
-      if (!detail) return Promise.reject();
-      const currentIds = detail.products.map((p) => p.id).filter((id) => id !== productId);
-      return api.put(`/api/v1/collections/${selectedCol}`, {
-        name: detail.name,
-        season: detail.season || undefined,
-        year: detail.year || undefined,
-        status: detail.status,
-        description: detail.description || undefined,
-        product_ids: currentIds,
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['collection-detail', selectedCol] });
-      queryClient.invalidateQueries({ queryKey: ['collections'] });
-    },
-  });
-
-  const statusColors: Record<string, string> = {
-    upcoming: 'bg-blue-500/10 text-blue-600',
-    active: 'bg-emerald-500/10 text-emerald-600',
-    on_sale: 'bg-orange-500/10 text-orange-600',
-    archived: 'bg-gray-500/10 text-gray-600',
-  };
+  const addProduct = collections.useSave({ message: t('common.save') });
+  const removeProduct = collections.useSave();
 
   // Detail view
   if (selectedCol && detail) {
@@ -195,7 +142,14 @@ export default function CollectionsPage() {
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6 text-destructive shrink-0"
-                    onClick={() => removeProductMutation.mutate(p.id)}
+                    onClick={() =>
+                      removeProduct.save(
+                        withProducts(
+                          detail,
+                          detail.products.map((dp) => dp.id).filter((id) => id !== p.id)
+                        )
+                      )
+                    }
                     aria-label={t('common.delete')}
                   >
                     <X className="h-3 w-3" />
@@ -232,9 +186,11 @@ export default function CollectionsPage() {
                   <button
                     key={p.id}
                     className="w-full flex items-center justify-between p-2 rounded hover:bg-surface text-start"
-                    onClick={() => {
-                      addProductMutation.mutate(p.id);
-                    }}
+                    onClick={() =>
+                      addProduct.save(
+                        withProducts(detail, [...detail.products.map((dp) => dp.id), p.id])
+                      )
+                    }
                   >
                     <div>
                       <span className="text-sm font-medium">{p.name}</span>
@@ -260,32 +216,19 @@ export default function CollectionsPage() {
           </h1>
           <div className="gold-divider mt-2" />
         </div>
-        <Button
-          onClick={() => {
-            setEditingId(null);
-            setForm({
-              name: '',
-              season: '',
-              year: String(new Date().getFullYear()),
-              status: 'upcoming',
-              description: '',
-            });
-            setDialogOpen(true);
-          }}
-          className="gap-2"
-        >
+        <Button onClick={editor.openNew} className="gap-2">
           <Plus className="h-4 w-4" /> {t('collections.create')}
         </Button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {!collections?.length ? (
+        {!rows?.length ? (
           <div className="col-span-full text-center py-16">
             <Palette className="h-12 w-12 text-gold/40 mx-auto mb-3" />
             <p className="text-muted">{t('collections.noCollections')}</p>
           </div>
         ) : (
-          collections.map((col) => (
+          rows.map((col) => (
             <div
               key={col.id}
               className="p-4 rounded-md border border-border bg-card hover:border-gold/50 transition-colors cursor-pointer"
@@ -298,17 +241,7 @@ export default function CollectionsPage() {
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7"
-                    onClick={() => {
-                      setEditingId(col.id);
-                      setForm({
-                        name: col.name,
-                        season: col.season || '',
-                        year: String(col.year || ''),
-                        status: col.status,
-                        description: col.description || '',
-                      });
-                      setDialogOpen(true);
-                    }}
+                    onClick={() => editor.openEdit(col)}
                     aria-label={t('common.edit')}
                   >
                     <Pencil className="h-3 w-3" />
@@ -317,7 +250,7 @@ export default function CollectionsPage() {
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7 text-destructive"
-                    onClick={() => deleteMutation.mutate(col.id)}
+                    onClick={() => remover.remove(col.id)}
                     aria-label={t('common.delete')}
                   >
                     <Trash2 className="h-3 w-3" />
@@ -349,16 +282,19 @@ export default function CollectionsPage() {
         )}
       </div>
 
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog open={editor.open} onOpenChange={editor.setOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{editingId ? t('common.edit') : t('collections.create')}</DialogTitle>
+            <DialogTitle>
+              {editor.isEditing ? t('common.edit') : t('collections.create')}
+            </DialogTitle>
             <DialogDescription>{t('collections.title')}</DialogDescription>
           </DialogHeader>
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              saveMutation.mutate({
+              saver.save({
+                id: editor.editingId,
                 name: form.name,
                 season: form.season || undefined,
                 year: Number(form.year) || undefined,
@@ -372,7 +308,7 @@ export default function CollectionsPage() {
               <Label>{t('common.name')}</Label>
               <Input
                 value={form.name}
-                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                onChange={(e) => editor.set('name', e.target.value)}
                 required
               />
             </div>
@@ -380,7 +316,7 @@ export default function CollectionsPage() {
               <Label>{t('collections.description')}</Label>
               <Input
                 value={form.description}
-                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                onChange={(e) => editor.set('description', e.target.value)}
               />
             </div>
             <div className="grid grid-cols-3 gap-3">
@@ -389,7 +325,7 @@ export default function CollectionsPage() {
                 <select
                   className="w-full h-9 rounded-md border border-border bg-background px-3 text-sm"
                   value={form.season}
-                  onChange={(e) => setForm({ ...form, season: e.target.value })}
+                  onChange={(e) => editor.set('season', e.target.value)}
                 >
                   <option value="">—</option>
                   {seasons.map((s) => (
@@ -404,7 +340,7 @@ export default function CollectionsPage() {
                 <Input
                   type="number"
                   value={form.year}
-                  onChange={(e) => setForm({ ...form, year: e.target.value })}
+                  onChange={(e) => editor.set('year', e.target.value)}
                 />
               </div>
               <div className="space-y-1">
@@ -412,7 +348,7 @@ export default function CollectionsPage() {
                 <select
                   className="w-full h-9 rounded-md border border-border bg-background px-3 text-sm"
                   value={form.status}
-                  onChange={(e) => setForm({ ...form, status: e.target.value })}
+                  onChange={(e) => editor.set('status', e.target.value)}
                 >
                   {statuses.map((s) => (
                     <option key={s} value={s}>
@@ -422,8 +358,8 @@ export default function CollectionsPage() {
                 </select>
               </div>
             </div>
-            <Button type="submit" className="w-full" disabled={saveMutation.isPending}>
-              {saveMutation.isPending ? t('common.loading') : t('common.save')}
+            <Button type="submit" className="w-full" disabled={saver.isSaving}>
+              {saver.isSaving ? t('common.loading') : t('common.save')}
             </Button>
           </form>
         </DialogContent>

--- a/client/src/pages/Distributors.tsx
+++ b/client/src/pages/Distributors.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import toast from 'react-hot-toast';
 import { Plus, Pencil, Trash2 } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -27,11 +25,12 @@ import {
   AlertDialogTitle,
 } from '../components/ui/alert-dialog';
 import DataTable from '../components/DataTable';
-import api from '../services/api';
+import { resource } from '../lib/resource';
 import { useTranslation, t as tStandalone } from '../i18n';
 import type { ColumnDef } from '@tanstack/react-table';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse, Distributor } from '@/types';
+import type { Distributor } from '@/types';
+
+const distributorsResource = resource<Distributor>('distributors');
 
 const getDistributorFormSchema = () =>
   z.object({
@@ -47,15 +46,11 @@ type DistributorFormData = z.infer<ReturnType<typeof getDistributorFormSchema>>;
 
 export default function DistributorsPage() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [editingDistributor, setEditingDistributor] = useState<Distributor | null>(null);
 
-  const { data: distributors, isLoading } = useQuery<Distributor[]>({
-    queryKey: ['distributors'],
-    queryFn: () => api.get('/api/v1/distributors').then((r) => r.data.data),
-  });
+  const { data: distributors, isLoading } = distributorsResource.useList();
 
   const {
     register,
@@ -66,50 +61,28 @@ export default function DistributorsPage() {
     resolver: zodResolver(getDistributorFormSchema()),
   });
 
-  const createMutation = useMutation({
-    mutationFn: (data: DistributorFormData) => api.post('/api/v1/distributors', data),
-    onSuccess: () => {
-      toast.success(t('distributors.distributorCreated'));
-      queryClient.invalidateQueries({ queryKey: ['distributors'] });
-      setDialogOpen(false);
-      reset();
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('distributors.createFailed')),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: number; data: DistributorFormData }) =>
-      api.put(`/api/v1/distributors/${id}`, data),
-    onSuccess: () => {
-      toast.success(t('distributors.distributorUpdated'));
-      queryClient.invalidateQueries({ queryKey: ['distributors'] });
+  const saver = distributorsResource.useSave({
+    message: editingDistributor
+      ? t('distributors.distributorUpdated')
+      : t('distributors.distributorCreated'),
+    fallbackMessage: editingDistributor
+      ? t('distributors.updateFailed')
+      : t('distributors.createFailed'),
+    onDone: () => {
       setDialogOpen(false);
       setEditingDistributor(null);
       reset();
     },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('distributors.updateFailed')),
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => api.delete(`/api/v1/distributors/${id}`),
-    onSuccess: () => {
-      toast.success(t('distributors.distributorDeleted'));
-      queryClient.invalidateQueries({ queryKey: ['distributors'] });
-      setDeleteId(null);
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('distributors.deleteFailed')),
+  const remover = distributorsResource.useRemove({
+    message: t('distributors.distributorDeleted'),
+    fallbackMessage: t('distributors.deleteFailed'),
+    onDone: () => setDeleteId(null),
   });
 
-  const onSubmit = (data: DistributorFormData) => {
-    if (editingDistributor) {
-      updateMutation.mutate({ id: editingDistributor.id, data });
-    } else {
-      createMutation.mutate(data);
-    }
-  };
+  const onSubmit = (data: DistributorFormData) =>
+    saver.save({ id: editingDistributor?.id, ...data });
 
   const openEditDialog = (distributor: Distributor) => {
     setEditingDistributor(distributor);
@@ -240,7 +213,7 @@ export default function DistributorsPage() {
               <Input {...register('notes')} />
             </div>
             <DialogFooter>
-              <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+              <Button type="submit" disabled={saver.isSaving}>
                 {editingDistributor ? t('common.update') : t('common.create')}
               </Button>
             </DialogFooter>
@@ -258,7 +231,7 @@ export default function DistributorsPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => deleteId && deleteMutation.mutate(deleteId)}
+              onClick={() => deleteId && remover.remove(deleteId)}
               className="bg-destructive text-foreground hover:bg-destructive/90"
             >
               {t('common.delete')}

--- a/client/src/pages/Feedback.tsx
+++ b/client/src/pages/Feedback.tsx
@@ -1,32 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
 import { Star, TrendingUp, MessageSquare } from 'lucide-react';
 import { Card, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { useTranslation } from '../i18n';
-import api from '../services/api';
-
-interface FeedbackEntry {
-  id: number;
-  sale_id: number | null;
-  customer_name: string | null;
-  rating: number | null;
-  nps_score: number | null;
-  comment: string | null;
-  created_at: string;
-}
-interface FeedbackStats {
-  avg_rating: number | null;
-  total_responses: number;
-  nps_score: number | null;
-}
+import { useApiQuery } from '../lib/apiQuery';
+import type { FeedbackResponse } from '@/types';
 
 export default function FeedbackPage() {
   const { t } = useTranslation();
 
-  const { data } = useQuery<{ feedback: FeedbackEntry[]; stats: FeedbackStats }>({
-    queryKey: ['feedback'],
-    queryFn: () => api.get('/api/v1/feedback').then((r) => r.data.data),
-  });
+  // Not a CRUD collection: the list and its aggregate scores arrive together.
+  const { data } = useApiQuery<FeedbackResponse>(['feedback'], 'feedback');
 
   return (
     <div className="p-6 animate-fade-in">

--- a/client/src/pages/GiftCards.tsx
+++ b/client/src/pages/GiftCards.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { Plus, Gift, XCircle, Eye, CreditCard, MoreHorizontal } from 'lucide-react';
 import { Button } from '../components/ui/button';
@@ -33,106 +32,57 @@ import {
 } from '../components/ui/alert-dialog';
 import DataTable from '../components/DataTable';
 import { formatCurrency, formatDate } from '../lib/utils';
-import api from '../services/api';
 import { useTranslation } from '../i18n';
+import { resource } from '../lib/resource';
+import { useEditorDialog } from '../lib/editorDialog';
 import type { ColumnDef } from '@tanstack/react-table';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
+import type { GiftCard, GiftCardTransaction } from '@/types';
 
-interface GiftCard {
-  id: number;
-  code: string;
-  barcode: string | null;
-  initial_value: number;
-  balance: number;
-  status: 'active' | 'used' | 'cancelled';
-  customer_id: number | null;
-  customer_name: string | null;
-  expires_at: string | null;
-  created_at: string;
-}
+const giftCards = resource<GiftCard>('gift-cards');
 
-interface GiftCardTransaction {
-  id: number;
-  gift_card_id: number;
-  type: string;
-  amount: number;
-  reference_id: number | null;
-  created_at: string;
-}
+const emptyGiftCard = { initial_value: '', customer_id: '', expires_at: '' };
 
 export default function GiftCards() {
-  const queryClient = useQueryClient();
   const { t } = useTranslation();
 
-  const [createOpen, setCreateOpen] = useState(false);
+  // Neither of these holds form values: one names the card a confirmation is
+  // about, the other the card whose ledger is on screen.
   const [cancelId, setCancelId] = useState<number | null>(null);
   const [transactionsCard, setTransactionsCard] = useState<GiftCard | null>(null);
 
-  // Form state
-  const [initialValue, setInitialValue] = useState('');
-  const [customerId, setCustomerId] = useState('');
-  const [expiresAt, setExpiresAt] = useState('');
+  const editor = useEditorDialog(emptyGiftCard);
+  const form = editor.values;
 
-  // Queries
-  const { data: giftCards, isLoading } = useQuery<GiftCard[]>({
-    queryKey: ['gift-cards'],
-    queryFn: () =>
-      api.get('/api/v1/gift-cards', { params: { limit: 200 } }).then((r) => r.data.data),
+  const { data: cards, isLoading } = giftCards.useList({ limit: 200 });
+
+  const { data: transactions, isLoading: transactionsLoading } = giftCards.useRead<
+    GiftCardTransaction[]
+  >(`${transactionsCard?.id}/transactions`, undefined, !!transactionsCard);
+
+  const creator = giftCards.useSave({
+    message: t('giftCards.created'),
+    fallbackMessage: t('giftCards.createFailed'),
+    onDone: editor.close,
   });
 
-  const { data: transactions, isLoading: transactionsLoading } = useQuery<GiftCardTransaction[]>({
-    queryKey: ['gift-card-transactions', transactionsCard?.id],
-    queryFn: () =>
-      api.get(`/api/v1/gift-cards/${transactionsCard!.id}/transactions`).then((r) => r.data.data),
-    enabled: !!transactionsCard,
+  // Cancelling a card is a status change on it, so it goes through the same save.
+  const canceller = giftCards.useSave({
+    message: t('giftCards.cancelSuccess'),
+    fallbackMessage: t('giftCards.cancelFailed'),
+    onDone: () => setCancelId(null),
   });
-
-  // Mutations
-  const createMutation = useMutation({
-    mutationFn: (data: { initial_value: number; customer_id?: number; expires_at?: string }) =>
-      api.post('/api/v1/gift-cards', data),
-    onSuccess: () => {
-      toast.success(t('giftCards.created'));
-      queryClient.invalidateQueries({ queryKey: ['gift-cards'] });
-      resetForm();
-      setCreateOpen(false);
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('giftCards.createFailed')),
-  });
-
-  const cancelMutation = useMutation({
-    mutationFn: (id: number) => api.put(`/api/v1/gift-cards/${id}`, { status: 'cancelled' }),
-    onSuccess: () => {
-      toast.success(t('giftCards.cancelSuccess'));
-      queryClient.invalidateQueries({ queryKey: ['gift-cards'] });
-      setCancelId(null);
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || t('giftCards.cancelFailed')),
-  });
-
-  const resetForm = () => {
-    setInitialValue('');
-    setCustomerId('');
-    setExpiresAt('');
-  };
 
   const handleCreate = () => {
-    const value = parseFloat(initialValue);
+    const value = parseFloat(form.initial_value);
     if (!value || value <= 0) {
       toast.error(t('validation.pricePositive'));
       return;
     }
-    const payload: {
-      initial_value: number;
-      customer_id?: number;
-      expires_at?: string;
-    } = { initial_value: value };
-    if (customerId) payload.customer_id = Number(customerId);
-    if (expiresAt) payload.expires_at = expiresAt;
-    createMutation.mutate(payload);
+    creator.save({
+      initial_value: value,
+      customer_id: form.customer_id ? Number(form.customer_id) : undefined,
+      expires_at: form.expires_at || undefined,
+    });
   };
 
   const getStatusBadge = (status: string) => {
@@ -260,7 +210,7 @@ export default function GiftCards() {
           </h1>
           <div className="gold-divider mt-2" />
         </div>
-        <Button className="gap-2" onClick={() => setCreateOpen(true)}>
+        <Button className="gap-2" onClick={editor.openNew}>
           <Plus className="h-4 w-4" />
           {t('giftCards.create')}
         </Button>
@@ -269,19 +219,13 @@ export default function GiftCards() {
       {/* Table */}
       <DataTable
         columns={columns}
-        data={giftCards ?? []}
+        data={cards ?? []}
         isLoading={isLoading}
         searchPlaceholder={t('giftCards.searchPlaceholder')}
       />
 
       {/* Create Dialog */}
-      <Dialog
-        open={createOpen}
-        onOpenChange={(open) => {
-          setCreateOpen(open);
-          if (!open) resetForm();
-        }}
-      >
+      <Dialog open={editor.open} onOpenChange={editor.setOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t('giftCards.create')}</DialogTitle>
@@ -294,8 +238,8 @@ export default function GiftCards() {
                 type="number"
                 step="0.01"
                 min="0"
-                value={initialValue}
-                onChange={(e) => setInitialValue(e.target.value)}
+                value={form.initial_value}
+                onChange={(e) => editor.set('initial_value', e.target.value)}
                 placeholder="0.00"
               />
             </div>
@@ -306,8 +250,8 @@ export default function GiftCards() {
               </Label>
               <Input
                 type="number"
-                value={customerId}
-                onChange={(e) => setCustomerId(e.target.value)}
+                value={form.customer_id}
+                onChange={(e) => editor.set('customer_id', e.target.value)}
                 placeholder={t('giftCards.customerIdPlaceholder')}
               />
             </div>
@@ -316,11 +260,15 @@ export default function GiftCards() {
                 {t('giftCards.expiresAt')}{' '}
                 <span className="text-muted text-xs">({t('giftCards.optional')})</span>
               </Label>
-              <Input type="date" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} />
+              <Input
+                type="date"
+                value={form.expires_at}
+                onChange={(e) => editor.set('expires_at', e.target.value)}
+              />
             </div>
           </div>
           <DialogFooter>
-            <Button onClick={handleCreate} disabled={createMutation.isPending || !initialValue}>
+            <Button onClick={handleCreate} disabled={creator.isSaving || !form.initial_value}>
               <CreditCard className="h-4 w-4 me-2" />
               {t('common.create')}
             </Button>
@@ -338,7 +286,7 @@ export default function GiftCards() {
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => cancelId && cancelMutation.mutate(cancelId)}
+              onClick={() => cancelId && canceller.save({ id: cancelId, status: 'cancelled' })}
               className="bg-destructive text-foreground hover:bg-destructive/90"
             >
               {t('common.confirm')}

--- a/client/src/pages/Promotions.test.tsx
+++ b/client/src/pages/Promotions.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '../lib/transport';
+import { createMemoryTransport, type MemoryTransport } from '../lib/transport/memory';
+import { useSettingsStore } from '../store/settingsStore';
+import type { Coupon } from '@/types';
+import Promotions from './Promotions';
+
+const SUMMER: Coupon = {
+  id: 1,
+  code: 'SUMMER20',
+  type: 'percentage',
+  value: 20,
+  min_purchase: null,
+  max_discount: null,
+  starts_at: null,
+  expires_at: null,
+  max_uses: null,
+  max_uses_per_customer: null,
+  scope: 'all',
+  scope_ids: null,
+  stackable: 0,
+  status: 'active',
+  usage_count: 3,
+  created_at: '2026-01-01',
+};
+
+function wrapperFor(transport: MemoryTransport) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('Promotions', () => {
+  // The page renders whichever locale is set; pin it so assertions read in one.
+  beforeEach(() => useSettingsStore.setState({ locale: 'en' }));
+
+  it('shows the coupons the server holds', async () => {
+    const transport = createMemoryTransport({ coupons: [SUMMER] });
+
+    render(<Promotions />, { wrapper: wrapperFor(transport) });
+
+    expect(await screen.findByText('SUMMER20')).toBeInTheDocument();
+    expect(transport.calls()).toContainEqual(
+      expect.objectContaining({ method: 'GET', path: 'coupons' })
+    );
+  });
+
+  it('creates a coupon from the editor dialog', async () => {
+    const transport = createMemoryTransport({ coupons: [SUMMER] });
+
+    render(<Promotions />, { wrapper: wrapperFor(transport) });
+    await screen.findByText('SUMMER20');
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Coupon/i }));
+
+    fireEvent.change(await screen.findByRole('textbox'), { target: { value: 'WINTER10' } });
+    fireEvent.change(screen.getAllByRole('spinbutton')[0], { target: { value: '10' } });
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form') as HTMLFormElement);
+
+    await waitFor(() => expect(transport.peek('coupons')).toHaveLength(2));
+    expect(transport.calls()).toContainEqual(
+      expect.objectContaining({
+        method: 'POST',
+        path: 'coupons',
+        body: expect.objectContaining({ code: 'WINTER10', value: 10 }),
+      })
+    );
+    // The new row arrives without the page asking for a refetch.
+    expect(await screen.findByText('WINTER10')).toBeInTheDocument();
+  });
+
+  it('sends the search box straight to the server rather than filtering locally', async () => {
+    const transport = createMemoryTransport({ coupons: [SUMMER] });
+
+    render(<Promotions />, { wrapper: wrapperFor(transport) });
+    await screen.findByText('SUMMER20');
+
+    fireEvent.change(screen.getByPlaceholderText(/Search coupons/i), {
+      target: { value: 'WINTER' },
+    });
+
+    await waitFor(() =>
+      expect(transport.calls()).toContainEqual(
+        expect.objectContaining({ method: 'GET', path: 'coupons', params: { search: 'WINTER' } })
+      )
+    );
+  });
+});

--- a/client/src/pages/Promotions.tsx
+++ b/client/src/pages/Promotions.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Ticket, Plus, Search, Pencil, Trash2, MoreHorizontal } from 'lucide-react';
-import toast from 'react-hot-toast';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
@@ -22,28 +20,11 @@ import {
 } from '../components/ui/dialog';
 import { formatCurrency } from '../lib/utils';
 import { useTranslation } from '../i18n';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
-import api from '../services/api';
+import { resource } from '../lib/resource';
+import { useEditorDialog } from '../lib/editorDialog';
+import type { Coupon } from '@/types';
 
-interface Coupon {
-  id: number;
-  code: string;
-  type: 'percentage' | 'fixed';
-  value: number;
-  min_purchase: number | null;
-  max_discount: number | null;
-  starts_at: string | null;
-  expires_at: string | null;
-  max_uses: number | null;
-  max_uses_per_customer: number | null;
-  scope: 'all' | 'category' | 'product';
-  scope_ids: number[] | null;
-  stackable: number;
-  status: string;
-  usage_count: number;
-  created_at: string;
-}
+const coupons = resource<Coupon>('coupons');
 
 const emptyCoupon = {
   code: '',
@@ -58,66 +39,36 @@ const emptyCoupon = {
   stackable: false,
 };
 
+const couponToForm = (c: Coupon) => ({
+  code: c.code,
+  type: c.type,
+  value: c.value,
+  min_purchase: c.min_purchase,
+  max_discount: c.max_discount,
+  starts_at: c.starts_at,
+  expires_at: c.expires_at,
+  max_uses: c.max_uses,
+  scope: c.scope,
+  stackable: !!c.stackable,
+});
+
 export default function Promotions() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [form, setForm] = useState(emptyCoupon);
+  const editor = useEditorDialog(emptyCoupon, couponToForm);
+  const form = editor.values;
 
-  const { data: coupons, isLoading } = useQuery<Coupon[]>({
-    queryKey: ['coupons', search],
-    queryFn: () =>
-      api
-        .get('/api/v1/coupons', { params: { search: search || undefined } })
-        .then((r) => r.data.data),
+  const { data: rows, isLoading } = coupons.useList({ search: search || undefined });
+
+  const saver = coupons.useSave({
+    message: editor.isEditing ? t('promotions.updated') : t('promotions.created'),
+    fallbackMessage: 'Error',
+    onDone: editor.close,
   });
 
-  const saveMutation = useMutation({
-    mutationFn: (data: typeof form) => {
-      if (editingId) return api.put(`/api/v1/coupons/${editingId}`, data);
-      return api.post('/api/v1/coupons', data);
-    },
-    onSuccess: () => {
-      toast.success(editingId ? t('promotions.updated') : t('promotions.created'));
-      queryClient.invalidateQueries({ queryKey: ['coupons'] });
-      setDialogOpen(false);
-      resetForm();
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Error'),
+  const remover = coupons.useRemove({
+    message: t('promotions.deactivated'),
   });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => api.delete(`/api/v1/coupons/${id}`),
-    onSuccess: () => {
-      toast.success(t('promotions.deactivated'));
-      queryClient.invalidateQueries({ queryKey: ['coupons'] });
-    },
-  });
-
-  const resetForm = () => {
-    setForm(emptyCoupon);
-    setEditingId(null);
-  };
-
-  const openEdit = (c: Coupon) => {
-    setEditingId(c.id);
-    setForm({
-      code: c.code,
-      type: c.type,
-      value: c.value,
-      min_purchase: c.min_purchase,
-      max_discount: c.max_discount,
-      starts_at: c.starts_at,
-      expires_at: c.expires_at,
-      max_uses: c.max_uses,
-      scope: c.scope,
-      stackable: !!c.stackable,
-    });
-    setDialogOpen(true);
-  };
 
   return (
     <div className="p-6 animate-fade-in">
@@ -128,13 +79,7 @@ export default function Promotions() {
           </h1>
           <div className="gold-divider mt-2" />
         </div>
-        <Button
-          onClick={() => {
-            resetForm();
-            setDialogOpen(true);
-          }}
-          className="gap-2"
-        >
+        <Button onClick={editor.openNew} className="gap-2">
           <Plus className="h-4 w-4" /> {t('promotions.addCoupon')}
         </Button>
       </div>
@@ -151,7 +96,7 @@ export default function Promotions() {
 
       {isLoading ? (
         <p className="text-muted text-sm">{t('common.loading')}</p>
-      ) : !coupons?.length ? (
+      ) : !rows?.length ? (
         <div className="text-center py-16">
           <Ticket className="h-12 w-12 text-gold/40 mx-auto mb-3" />
           <p className="text-muted">{t('promotions.noCoupons')}</p>
@@ -173,7 +118,7 @@ export default function Promotions() {
               </tr>
             </thead>
             <tbody>
-              {coupons.map((c) => (
+              {rows.map((c) => (
                 <tr key={c.id} className="border-b border-border hover:bg-surface/50">
                   <td className="p-3 font-data font-semibold">{c.code}</td>
                   <td className="p-3">
@@ -201,7 +146,7 @@ export default function Promotions() {
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => openEdit(c)}>
+                        <DropdownMenuItem onClick={() => editor.openEdit(c)}>
                           <Pencil className="h-4 w-4 me-2 text-gold" />
                           {t('common.edit')}
                         </DropdownMenuItem>
@@ -210,7 +155,7 @@ export default function Promotions() {
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
                               className="text-destructive"
-                              onClick={() => deleteMutation.mutate(c.id)}
+                              onClick={() => remover.remove(c.id)}
                             >
                               <Trash2 className="h-4 w-4 me-2" />
                               {t('common.delete')}
@@ -227,18 +172,18 @@ export default function Promotions() {
         </div>
       )}
 
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog open={editor.open} onOpenChange={editor.setOpen}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
             <DialogTitle>
-              {editingId ? t('promotions.edit') : t('promotions.addCoupon')}
+              {editor.isEditing ? t('promotions.edit') : t('promotions.addCoupon')}
             </DialogTitle>
             <DialogDescription>{t('promotions.couponDetails')}</DialogDescription>
           </DialogHeader>
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              saveMutation.mutate(form);
+              saver.save({ id: editor.editingId, ...form });
             }}
             className="space-y-4"
           >
@@ -247,7 +192,7 @@ export default function Promotions() {
                 <Label>{t('promotions.code')}</Label>
                 <Input
                   value={form.code}
-                  onChange={(e) => setForm({ ...form, code: e.target.value })}
+                  onChange={(e) => editor.set('code', e.target.value)}
                   required
                 />
               </div>
@@ -256,9 +201,7 @@ export default function Promotions() {
                 <select
                   className="w-full h-9 rounded-md border border-border bg-background px-3 text-sm"
                   value={form.type}
-                  onChange={(e) =>
-                    setForm({ ...form, type: e.target.value as 'percentage' | 'fixed' })
-                  }
+                  onChange={(e) => editor.set('type', e.target.value as 'percentage' | 'fixed')}
                 >
                   <option value="percentage">{t('promotions.percentage')}</option>
                   <option value="fixed">{t('promotions.fixed')}</option>
@@ -271,7 +214,7 @@ export default function Promotions() {
                   min="0"
                   step="0.01"
                   value={form.value || ''}
-                  onChange={(e) => setForm({ ...form, value: parseFloat(e.target.value) || 0 })}
+                  onChange={(e) => editor.set('value', parseFloat(e.target.value) || 0)}
                   required
                 />
               </div>
@@ -282,9 +225,7 @@ export default function Promotions() {
                   min="0"
                   step="0.01"
                   value={form.min_purchase || ''}
-                  onChange={(e) =>
-                    setForm({ ...form, min_purchase: parseFloat(e.target.value) || null })
-                  }
+                  onChange={(e) => editor.set('min_purchase', parseFloat(e.target.value) || null)}
                 />
               </div>
               <div className="space-y-1">
@@ -294,9 +235,7 @@ export default function Promotions() {
                   min="0"
                   step="0.01"
                   value={form.max_discount || ''}
-                  onChange={(e) =>
-                    setForm({ ...form, max_discount: parseFloat(e.target.value) || null })
-                  }
+                  onChange={(e) => editor.set('max_discount', parseFloat(e.target.value) || null)}
                 />
               </div>
               <div className="space-y-1">
@@ -305,7 +244,7 @@ export default function Promotions() {
                   type="number"
                   min="1"
                   value={form.max_uses || ''}
-                  onChange={(e) => setForm({ ...form, max_uses: parseInt(e.target.value) || null })}
+                  onChange={(e) => editor.set('max_uses', parseInt(e.target.value) || null)}
                 />
               </div>
               <div className="space-y-1">
@@ -313,7 +252,7 @@ export default function Promotions() {
                 <Input
                   type="datetime-local"
                   value={form.starts_at || ''}
-                  onChange={(e) => setForm({ ...form, starts_at: e.target.value || null })}
+                  onChange={(e) => editor.set('starts_at', e.target.value || null)}
                 />
               </div>
               <div className="space-y-1">
@@ -321,7 +260,7 @@ export default function Promotions() {
                 <Input
                   type="datetime-local"
                   value={form.expires_at || ''}
-                  onChange={(e) => setForm({ ...form, expires_at: e.target.value || null })}
+                  onChange={(e) => editor.set('expires_at', e.target.value || null)}
                 />
               </div>
             </div>
@@ -330,15 +269,15 @@ export default function Promotions() {
                 type="checkbox"
                 id="stackable"
                 checked={form.stackable}
-                onChange={(e) => setForm({ ...form, stackable: e.target.checked })}
+                onChange={(e) => editor.set('stackable', e.target.checked)}
                 className="accent-gold h-4 w-4"
               />
               <Label htmlFor="stackable">{t('promotions.stackable')}</Label>
             </div>
-            <Button type="submit" className="w-full" disabled={saveMutation.isPending}>
-              {saveMutation.isPending
+            <Button type="submit" className="w-full" disabled={saver.isSaving}>
+              {saver.isSaving
                 ? t('common.saving')
-                : editingId
+                : editor.isEditing
                   ? t('common.save')
                   : t('promotions.addCoupon')}
             </Button>

--- a/client/src/pages/Segments.tsx
+++ b/client/src/pages/Segments.tsx
@@ -1,29 +1,10 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { Crown, Heart, Star, AlertTriangle, Moon, UserX, UserPlus } from 'lucide-react';
 import { Badge } from '../components/ui/badge';
 import { useTranslation } from '../i18n';
 import { formatCurrency } from '../lib/utils';
-import api from '../services/api';
-
-interface SegmentSummary {
-  segment: string;
-  count: number;
-  total_revenue: number;
-  avg_frequency: number;
-}
-
-interface CustomerRFM {
-  id: number;
-  name: string;
-  phone: string | null;
-  email: string | null;
-  recency_days: number;
-  frequency: number;
-  monetary: number;
-  segment: string;
-  loyalty_points: number;
-}
+import { useApiQuery } from '../lib/apiQuery';
+import type { SegmentsResponse } from '@/types';
 
 const segmentIcons: Record<string, React.ReactNode> = {
   champions: <Crown className="h-5 w-5 text-yellow-500" />,
@@ -58,10 +39,9 @@ const segmentKeys: Record<string, string> = {
 export default function SegmentsPage() {
   const { t } = useTranslation();
 
-  const { data, isLoading } = useQuery<{ customers: CustomerRFM[]; summary: SegmentSummary[] }>({
-    queryKey: ['segments'],
-    queryFn: () => api.get('/api/v1/segments').then((r) => r.data.data),
-  });
+  // Not a CRUD collection: one read returns the roll-up and the scored
+  // customers together, so it goes through the transport without `resource`.
+  const { data, isLoading } = useApiQuery<SegmentsResponse>(['segments'], 'segments');
 
   const [selectedSegment, setSelectedSegment] = useState<string | null>(null);
 

--- a/client/src/pages/Warranty.tsx
+++ b/client/src/pages/Warranty.tsx
@@ -1,7 +1,4 @@
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ShieldCheck, Plus } from 'lucide-react';
-import toast from 'react-hot-toast';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
@@ -14,20 +11,13 @@ import {
   DialogDescription,
 } from '../components/ui/dialog';
 import { useTranslation } from '../i18n';
-import api from '../services/api';
-import type { AxiosError } from 'axios';
-import type { ApiErrorResponse } from '@/types';
+import { resource } from '../lib/resource';
+import { useEditorDialog } from '../lib/editorDialog';
+import type { WarrantyClaim } from '@/types';
 
-interface Claim {
-  id: number;
-  sale_id: number;
-  product_name: string;
-  customer_name: string | null;
-  issue: string;
-  status: string;
-  resolution: string | null;
-  created_at: string;
-}
+const warranty = resource<WarrantyClaim>('warranty');
+
+const emptyClaim = { sale_id: '', product_id: '', issue: '' };
 
 const statusColors: Record<string, string> = {
   submitted: 'bg-blue-500/10 text-blue-600',
@@ -40,34 +30,18 @@ const statusColors: Record<string, string> = {
 
 export default function WarrantyPage() {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
-  const [createOpen, setCreateOpen] = useState(false);
-  const [form, setForm] = useState({ sale_id: '', product_id: '', issue: '' });
+  const editor = useEditorDialog(emptyClaim);
+  const form = editor.values;
 
-  const { data: claims } = useQuery<Claim[]>({
-    queryKey: ['warranty'],
-    queryFn: () => api.get('/api/v1/warranty').then((r) => r.data.data),
+  const { data: claims } = warranty.useList();
+
+  const saver = warranty.useSave({
+    message: t('warranty.create'),
+    fallbackMessage: 'Error',
+    onDone: editor.close,
   });
 
-  const createMutation = useMutation({
-    mutationFn: (data: { sale_id: number; product_id: number; issue: string }) =>
-      api.post('/api/v1/warranty', data),
-    onSuccess: () => {
-      toast.success(t('warranty.create'));
-      queryClient.invalidateQueries({ queryKey: ['warranty'] });
-      setCreateOpen(false);
-    },
-    onError: (err: AxiosError<ApiErrorResponse>) =>
-      toast.error(err.response?.data?.error || 'Error'),
-  });
-
-  const updateStatus = useMutation({
-    mutationFn: ({ id, status }: { id: number; status: string }) =>
-      api.put(`/api/v1/warranty/${id}/status`, { status }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['warranty'] });
-    },
-  });
+  const updateStatus = warranty.useAction('status', { method: 'PUT' });
 
   const statusKey = (s: string) => {
     const map: Record<string, string> = {
@@ -90,7 +64,7 @@ export default function WarrantyPage() {
           </h1>
           <div className="gold-divider mt-2" />
         </div>
-        <Button onClick={() => setCreateOpen(true)} className="gap-2">
+        <Button onClick={editor.openNew} className="gap-2">
           <Plus className="h-4 w-4" /> {t('warranty.create')}
         </Button>
       </div>
@@ -135,7 +109,9 @@ export default function WarrantyPage() {
                     <select
                       className="h-7 text-xs rounded border border-border bg-background px-2"
                       value={c.status}
-                      onChange={(e) => updateStatus.mutate({ id: c.id, status: e.target.value })}
+                      onChange={(e) =>
+                        updateStatus.run({ id: c.id, body: { status: e.target.value } })
+                      }
                     >
                       {[
                         'submitted',
@@ -158,7 +134,7 @@ export default function WarrantyPage() {
         </table>
       </div>
 
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog open={editor.open} onOpenChange={editor.setOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t('warranty.create')}</DialogTitle>
@@ -167,7 +143,8 @@ export default function WarrantyPage() {
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              createMutation.mutate({
+              saver.save({
+                id: editor.editingId,
                 sale_id: Number(form.sale_id),
                 product_id: Number(form.product_id),
                 issue: form.issue,
@@ -181,7 +158,7 @@ export default function WarrantyPage() {
                 <Input
                   type="number"
                   value={form.sale_id}
-                  onChange={(e) => setForm({ ...form, sale_id: e.target.value })}
+                  onChange={(e) => editor.set('sale_id', e.target.value)}
                   required
                 />
               </div>
@@ -190,7 +167,7 @@ export default function WarrantyPage() {
                 <Input
                   type="number"
                   value={form.product_id}
-                  onChange={(e) => setForm({ ...form, product_id: e.target.value })}
+                  onChange={(e) => editor.set('product_id', e.target.value)}
                   required
                 />
               </div>
@@ -199,12 +176,12 @@ export default function WarrantyPage() {
               <Label>{t('warranty.issue')}</Label>
               <Input
                 value={form.issue}
-                onChange={(e) => setForm({ ...form, issue: e.target.value })}
+                onChange={(e) => editor.set('issue', e.target.value)}
                 required
               />
             </div>
-            <Button type="submit" className="w-full" disabled={createMutation.isPending}>
-              {createMutation.isPending ? t('common.loading') : t('common.save')}
+            <Button type="submit" className="w-full" disabled={saver.isSaving}>
+              {saver.isSaving ? t('common.loading') : t('common.save')}
             </Button>
           </form>
         </DialogContent>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -62,6 +62,19 @@ export interface Category {
   code: string;
 }
 
+/**
+ * Category row from GET /api/categories — the collection's own full shape.
+ * Deliberately separate from `Category`, which is the trimmed projection the
+ * product routes hand out.
+ */
+export interface CategoryRecord {
+  id: number;
+  name: string;
+  code: string;
+  created_at: string;
+  updated_at: string;
+}
+
 /** Distributor from GET /api/distributors */
 export interface Distributor {
   id: number;
@@ -129,4 +142,163 @@ export interface AppSettings {
   loyalty_enabled?: 'true' | 'false';
   loyalty_earn_rate?: string;
   loyalty_redeem_value?: string;
+}
+
+/** One RFM segment's roll-up from GET /api/segments */
+export interface SegmentSummary {
+  segment: string;
+  count: number;
+  total_revenue: number;
+  avg_frequency: number;
+}
+
+/** A customer scored on recency/frequency/monetary, from GET /api/segments */
+export interface CustomerRFM {
+  id: number;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  recency_days: number;
+  frequency: number;
+  monetary: number;
+  segment: string;
+  loyalty_points: number;
+}
+
+/** Body of GET /api/segments */
+export interface SegmentsResponse {
+  customers: CustomerRFM[];
+  summary: SegmentSummary[];
+}
+
+/** One survey response from GET /api/feedback */
+export interface FeedbackEntry {
+  id: number;
+  sale_id: number | null;
+  customer_name: string | null;
+  rating: number | null;
+  nps_score: number | null;
+  comment: string | null;
+  created_at: string;
+}
+
+/** Aggregate satisfaction figures returned beside the feedback list */
+export interface FeedbackStats {
+  avg_rating: number | null;
+  total_responses: number;
+  nps_score: number | null;
+}
+
+/** Body of GET /api/feedback */
+export interface FeedbackResponse {
+  feedback: FeedbackEntry[];
+  stats: FeedbackStats;
+}
+
+/** Collection row from GET /api/collections */
+export interface Collection {
+  id: number;
+  name: string;
+  season: string | null;
+  year: number | null;
+  status: string;
+  description: string | null;
+  product_count: number;
+}
+
+/**
+ * A product as the collection detail endpoint projects it — fewer columns than
+ * `Product`, since a collection only shows what it takes to identify a line.
+ */
+export interface CollectionProduct {
+  id: number;
+  name: string;
+  sku: string;
+  price: number;
+  stock: number;
+  image_url: string | null;
+}
+
+/** GET /api/collections/:id — the list row plus the products it holds */
+export interface CollectionDetail extends Collection {
+  products: CollectionProduct[];
+}
+
+/** One product line inside a bundle */
+export interface BundleItem {
+  id?: number;
+  product_id: number;
+  product_name: string;
+  product_price: number;
+  quantity: number;
+}
+
+/** Bundle from GET /api/bundles, and from GET /api/bundles/:id */
+export interface Bundle {
+  id: number;
+  name: string;
+  description: string | null;
+  price: number;
+  status: string;
+  items: BundleItem[];
+  original_price: number;
+  savings: number;
+  savings_percent: number;
+  created_at: string;
+}
+
+/** Coupon from GET /api/coupons */
+export interface Coupon {
+  id: number;
+  code: string;
+  type: 'percentage' | 'fixed';
+  value: number;
+  min_purchase: number | null;
+  max_discount: number | null;
+  starts_at: string | null;
+  expires_at: string | null;
+  max_uses: number | null;
+  max_uses_per_customer: number | null;
+  scope: 'all' | 'category' | 'product';
+  scope_ids: number[] | null;
+  stackable: number;
+  status: string;
+  usage_count: number;
+  created_at: string;
+}
+
+/** Warranty claim from GET /api/warranty */
+export interface WarrantyClaim {
+  id: number;
+  sale_id: number;
+  product_name: string;
+  customer_name: string | null;
+  issue: string;
+  status: string;
+  resolution: string | null;
+  created_at: string;
+}
+
+/** Gift card from GET /api/gift-cards */
+export interface GiftCard {
+  id: number;
+  code: string;
+  barcode: string | null;
+  initial_value: number;
+  balance: number;
+  status: 'active' | 'used' | 'cancelled';
+  customer_id: number | null;
+  customer_name: string | null;
+  expires_at: string | null;
+  created_at: string;
+}
+
+/** One ledger entry from GET /api/gift-cards/:id/transactions */
+export interface GiftCardTransaction {
+  id: number;
+  gift_card_id: number;
+  type: string;
+  amount: number;
+  reference_id: number | null;
+  created_at: string;
 }


### PR DESCRIPTION
Closes #9.

All nine pages are off raw axios. Landed as two passes split by *kind of work*, which the issue anticipated — the split fell along form-handling, not page count.

## The batch was not uniform

The issue assumes all nine hand-roll the same dialog state. They don't, and three groups fell out:

**Five hand-roll form state → now use `useEditorDialog`.** Collections, Bundles, Promotions, Warranty, Gift Cards. Gift Cards had three separate `useState` fields collapsed into one editor; Warranty is create-only so it takes no `toValues`.

**Two use react-hook-form → deliberately keep their dialog state.** Categories and Distributors hand-roll only `dialogOpen` + `editingRecord`; RHF already owns the values and the `reset()`. Applying the hook would add a `values`/`set` surface nobody reads *and* still require a separate `reset()` call — three lines become two, plus dead interface. Not a win, so their data access changed and their dialog state didn't.

**Two have no dialog at all.** Segments and Feedback are read-only. They also aren't CRUD collections — each returns one aggregate object (`{customers, summary}`, `{feedback, stats}`), not a row array, so `useList`'s `Row[]` would be a lie. They read through `useApiQuery` instead.

So "all nine use the editor-dialog state machine" could not hold literally. Five do; the other four had nothing to replace.

## ⚠️ Two of the nine pages are dead code

**`Collections.tsx` and `Warranty.tsx` are not routed.** `App.tsx` has 31 lazy imports and 33 routes; neither page is among them, and nothing outside their own files references them. They are unreachable in the running app.

They were migrated anyway — leaving two files on the old pattern would block #13's lint rule. But they could not be verified in a browser, and they are worth deleting or wiring up as a follow-up. Flagging rather than deciding.

## Constraint held

`git diff --stat` lists nothing under `src/lib/` — `resource`, `editorDialog`, `apiQuery` and the transport gained no capability to absorb these pages.

Where something didn't fit, it went sideways rather than widening the core:
- **Collections has two projections of one collection** (`useList` gives `product_count`, `GET :id` gives `products[]`). The page holds two typed handles onto the same name rather than merging the shapes.
- **Gift-card transactions** are a record sub-path, served by the existing `useRead`.
- **Product pickers** in Collections/Bundles read a different collection → `useApiQuery`.
- **Second dialogs stay local** — Collections/Bundles' add-product, Gift Cards' cancel and transactions views. These name a *selected row* and carry no form values; they are not the editor machine, same call as the Vendors payout dialog in #6.

## Behaviour change worth knowing

`resource` always toasts a failed write. Five writes previously had **no `onError` at all and failed silently**: Collections delete, Collections add/remove-product, Bundles delete, Promotions deactivate, Warranty status change. These now surface the server's message. That is an improvement, but it is a visible change.

Two existing quirks were preserved rather than quietly fixed: Collections toasts `collections.created` even when updating, and its delete toasts `common.delete`.

## Testing

- **47 tests pass** (44 + 3 new). `Promotions.test.tsx` renders the real page through `createMemoryTransport`: asserts the list read reaches the transport, that submitting the dialog produces `POST coupons` with the right body and grows the store, and that the search box reaches the server as `params: {search}` rather than filtering client-side.
- Typecheck **13 errors, unchanged** (12 `Storefront.tsx`, 1 `RefundDialog.tsx` — both pre-existing, neither in scope). Lint 0 errors. Build succeeds.
- ~180 net lines removed across the nine pages.

**Browser-verified** against the running app — the seven routed pages all render real data with no console errors (Categories 10 rows, Distributors 5, Promotions 5, Gift Cards 1, Segments 16; Bundles and Feedback are genuinely empty tables). Full write path exercised on Promotions, which uses the editor hook: create added a row and auto-closed the dialog; edit loaded the record and saved as **`PUT /coupons/6`** with the row count holding at 6, confirming `editingId` routes to an update rather than a duplicate; delete fired and the row correctly flipped to Inactive — coupon deletion is a server-side soft delete, which is pre-existing behaviour. All test records removed; the database is back to its original counts.

## Post-Deploy Monitoring & Validation

Client-only; no server or schema change. Paths and query params are unchanged (verified against the server log during browser testing).

- Watch: 4xx/5xx on `/api/v1/{categories,distributors,collections,bundles,coupons,segments,warranty,gift-cards,feedback}`. Healthy = unchanged from baseline.
- Failure signal: a spike in 404s would indicate a dropped `/api/v1` prefix; a spike in *user-visible error toasts* on these pages is expected-but-new, since five writes that used to fail silently now report.
- Rollback trigger: any of the seven routed pages failing to render, or writes 404ing.
- Window: first hour after deploy.