### PR TITLE
feat(client): migrate POS and cart cluster onto resource

### DIFF
--- a/client/src/components/CartPanel.test.tsx
+++ b/client/src/components/CartPanel.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '../lib/transport';
+import type { TransportRequest, TransportResult } from '../lib/transport';
+import { createMemoryTransport, type MemoryTransport } from '../lib/transport/memory';
+import { useSettingsStore } from '../store/settingsStore';
+import { useCartStore } from '../store/cartStore';
+import { useOfflineStore } from '../store/offlineStore';
+import CartPanel from './CartPanel';
+
+const SILK_DRESS = {
+  product_id: 7,
+  name: 'Silk Dress',
+  unit_price: 250,
+  quantity: 2,
+  stock: 5,
+  memo: 'gift wrap',
+};
+
+/**
+ * The memory transport echoes a POST body back as the created row, but a real
+ * sale returns server-side columns the receipt reads. Those are layered on so
+ * the success path completes; every assertion here is about the request.
+ */
+function withSaleReply(memory: MemoryTransport): MemoryTransport {
+  return {
+    ...memory,
+    async request<T>(req: TransportRequest): Promise<TransportResult<T>> {
+      const result = await memory.request<T>(req);
+      if (req.method === 'POST' && req.path === 'sales') {
+        return {
+          data: {
+            ...(result.data as Record<string, unknown>),
+            total: 480,
+            cashier_name: 'Sarah',
+            created_at: '2026-02-01T10:00:00.000Z',
+          } as T,
+        };
+      }
+      return result;
+    },
+  };
+}
+
+function makeTransport() {
+  return withSaleReply(
+    createMemoryTransport(
+      { customers: [] },
+      { reads: { settings: { tax_enabled: 'false', loyalty_enabled: 'false' } } }
+    )
+  );
+}
+
+function wrapperFor(transport: MemoryTransport) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+function openCheckout() {
+  fireEvent.click(screen.getByRole('button', { name: 'Checkout' }));
+  return screen.findByRole('button', { name: 'Confirm Sale' });
+}
+
+describe('CartPanel checkout', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    useCartStore.setState({
+      items: [SILK_DRESS],
+      discount: 10,
+      discountType: 'percentage',
+      notes: 'call before delivery',
+      tip: 5,
+      couponCode: 'SUMMER20',
+      couponDiscount: 20,
+    });
+  });
+
+  it('posts the sale exactly as the till composed it', async () => {
+    const transport = makeTransport();
+
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+    fireEvent.click(await openCheckout());
+
+    await waitFor(() =>
+      expect(
+        transport.calls().some((call) => call.method === 'POST' && call.path === 'sales')
+      ).toBe(true)
+    );
+
+    const sale = transport.calls().find((call) => call.path === 'sales');
+    expect(sale?.body).toEqual({
+      items: [{ product_id: 7, quantity: 2, unit_price: 250, memo: 'gift wrap' }],
+      discount: 10,
+      discount_type: 'percentage',
+      payment_method: 'Cash',
+      notes: 'call before delivery',
+      tip: 5,
+      coupon_code: 'SUMMER20',
+    });
+    // Optional fields stay off the body entirely rather than going up as null.
+    expect(sale?.body).not.toHaveProperty('customer_id');
+    expect(sale?.body).not.toHaveProperty('points_redeemed');
+    expect(sale?.body).not.toHaveProperty('payments');
+  });
+
+  it('clears the cart once the sale lands', async () => {
+    const transport = makeTransport();
+
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+    fireEvent.click(await openCheckout());
+
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    expect(useOfflineStore.getState().queue).toHaveLength(0);
+  });
+
+  it('queues the sale offline when the post fails with no connection', async () => {
+    const transport = makeTransport();
+    const online = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+
+    try {
+      render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+      transport.failNext('', 500);
+      fireEvent.click(await openCheckout());
+
+      await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(1));
+
+      // The queued payload is the reduced one the offline path builds, not the
+      // full checkout body: no notes, tip or coupon.
+      expect(useOfflineStore.getState().queue[0]).toMatchObject({
+        type: 'sale',
+        payload: {
+          items: [{ product_id: 7, quantity: 2, unit_price: 250 }],
+          discount: 10,
+          discount_type: 'percentage',
+          payment_method: 'Cash',
+        },
+      });
+      expect(useCartStore.getState().items).toHaveLength(0);
+    } finally {
+      if (online) Object.defineProperty(Navigator.prototype, 'onLine', online);
+    }
+  });
+});

--- a/client/src/components/CartPanel.tsx
+++ b/client/src/components/CartPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, type MutableRefObject } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Minus,
   Plus,
@@ -33,10 +33,13 @@ import { useTranslation } from '../i18n';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import ReceiptDialog from './ReceiptDialog';
 import HeldCartsDialog from './HeldCartsDialog';
-import api from '../services/api';
-import type { AxiosError } from 'axios';
+import { useApiQuery } from '../lib/apiQuery';
+import { resource } from '../lib/resource';
+import { useTransport } from '../lib/transport';
 import type { ReceiptData } from './Receipt';
-import type { ApiErrorResponse, AppSettings, Customer } from '@/types';
+import type { AppSettings, Customer } from '@/types';
+
+const customers = resource<Customer>('customers');
 
 type PaymentMethod = 'Cash' | 'Card' | 'Other';
 
@@ -72,6 +75,25 @@ interface CustomerLoyalty {
   points: number;
 }
 
+/** What POST /api/v1/sales hands back, as far as the receipt needs it. */
+interface SaleResponse {
+  id: number;
+  items?: { product_name: string; quantity: number; unit_price: number }[];
+  discount?: number;
+  discount_type?: string;
+  total: number;
+  tax_amount?: number;
+  payment_method: string;
+  cashier_name?: string;
+  created_at: string;
+}
+
+/** What POST /api/v1/coupons/validate hands back, as far as the cart needs it. */
+interface CouponValidation {
+  code: string;
+  discount: number;
+}
+
 interface CartPanelProps {
   checkoutTriggerRef?: MutableRefObject<(() => void) | null>;
 }
@@ -101,6 +123,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   const { addToQueue } = useOfflineStore();
   const { carts: heldCarts, holdCart } = useHeldCartsStore();
   const queryClient = useQueryClient();
+  const transport = useTransport();
   const { t, isRtl } = useTranslation();
   const [animateParent] = useAutoAnimate();
 
@@ -125,21 +148,25 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   const [redeemPoints, setRedeemPoints] = useState(false);
   const [pointsToRedeem, setPointsToRedeem] = useState(0);
 
-  // App settings (tax + loyalty)
-  const { data: appSettings } = useQuery<AppSettings>({
-    queryKey: ['settings'],
-    queryFn: () => api.get('/api/v1/settings').then((r) => r.data.data),
+  // App settings (tax + loyalty). Settings.tsx writes this key and
+  // CustomerDetail.tsx reads it, so the cache entry stays shared with them
+  // rather than moving under a resource-scoped key of its own.
+  const { data: appSettings } = useApiQuery<AppSettings>(['settings'], 'settings', undefined, {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Customer loyalty points
-  const { data: customerLoyalty } = useQuery<CustomerLoyalty>({
-    queryKey: ['customer-loyalty', selectedCustomer?.id],
-    queryFn: () =>
-      api.get(`/api/v1/customers/${selectedCustomer!.id}/loyalty`).then((r) => r.data.data),
-    enabled: !!selectedCustomer && appSettings?.loyalty_enabled === 'true',
-    staleTime: 30 * 1000,
-  });
+  // Customer loyalty points. Same story: CustomerDetail.tsx invalidates
+  // ['customer-loyalty', id] after adjusting points, and that has to keep
+  // reaching this copy.
+  const { data: customerLoyalty } = useApiQuery<CustomerLoyalty>(
+    ['customer-loyalty', selectedCustomer?.id],
+    `customers/${selectedCustomer?.id}/loyalty`,
+    undefined,
+    {
+      enabled: !!selectedCustomer && appSettings?.loyalty_enabled === 'true',
+      staleTime: 30 * 1000,
+    }
+  );
 
   const loyaltyInfo = useMemo(() => {
     const enabled = appSettings?.loyalty_enabled === 'true';
@@ -187,36 +214,45 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     };
   }, [checkoutTriggerRef]);
 
-  const { data: customers } = useQuery<Customer[]>({
-    queryKey: ['customers', { search: debouncedCustomerSearch }],
-    queryFn: () =>
-      api
-        .get('/api/v1/customers', { params: { search: debouncedCustomerSearch || undefined } })
-        .then((r) => r.data.data),
-    enabled: checkoutOpen && debouncedCustomerSearch.length > 0,
-    staleTime: 30 * 1000,
+  const { data: customerMatches } = useApiQuery<Customer[]>(
+    ['customers', { search: debouncedCustomerSearch }],
+    'customers',
+    { search: debouncedCustomerSearch || undefined },
+    {
+      enabled: checkoutOpen && debouncedCustomerSearch.length > 0,
+      staleTime: 30 * 1000,
+    }
+  );
+
+  // The created row is needed here to select it, so the caller reads it off
+  // this one write rather than the hook publishing it for everyone.
+  const customerCreator = customers.useSave({
+    message: t('cart.customerCreated'),
+    fallbackMessage: t('cart.customerCreateError'),
   });
 
-  const createCustomerMutation = useMutation({
-    mutationFn: (data: { name: string; phone: string }) => api.post('/api/v1/customers', data),
-    onSuccess: (response) => {
-      const customer = response.data.data;
-      setSelectedCustomer(customer);
-      setShowNewCustomer(false);
-      setNewCustomerName('');
-      setNewCustomerPhone('');
-      queryClient.invalidateQueries({ queryKey: ['customers'] });
-      toast.success(t('cart.customerCreated'));
-    },
-    onError: () => {
-      toast.error(t('cart.customerCreateError'));
-    },
-  });
+  const handleCreateCustomer = () => {
+    customerCreator.save(
+      { name: newCustomerName.trim(), phone: newCustomerPhone.trim() },
+      {
+        onSuccess: (result) => {
+          setSelectedCustomer(result.data as Customer);
+          setShowNewCustomer(false);
+          setNewCustomerName('');
+          setNewCustomerPhone('');
+        },
+      }
+    );
+  };
 
+  // The sale POST stays on the transport rather than `resource`: its failure
+  // path is not a toast but the offline queue, and `resource` toasts every
+  // failure it sees.
   const checkoutMutation = useMutation({
-    mutationFn: (saleData: SaleData) => api.post('/api/v1/sales', saleData),
+    mutationFn: (saleData: SaleData) =>
+      transport.request<SaleResponse>({ method: 'POST', path: 'sales', body: saleData }),
     onSuccess: (response) => {
-      const sale = response.data.data;
+      const sale = response.data;
       const receiptItems = (sale.items || []).map(
         (item: { product_name: string; quantity: number; unit_price: number }) => ({
           name: item.product_name,
@@ -259,7 +295,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
       setReceiptData(newReceipt);
       setReceiptOpen(true);
     },
-    onError: (err: AxiosError<ApiErrorResponse>) => {
+    onError: (error: Error) => {
       if (!navigator.onLine) {
         const saleData: SaleData = {
           items: items.map((i) => ({
@@ -280,7 +316,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
         setSelectedCustomer(null);
         setCustomerSearch('');
       } else {
-        toast.error(err.response?.data?.error || t('cart.saleFailed'));
+        toast.error(error.message || t('cart.saleFailed'));
       }
     },
   });
@@ -313,18 +349,22 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   const handleApplyCoupon = async () => {
     if (!couponInput.trim()) return;
     try {
-      const res = await api.post('/api/v1/coupons/validate', {
-        code: couponInput.trim(),
-        subtotal: getSubtotal(),
-        ...(selectedCustomer ? { customer_id: selectedCustomer.id } : {}),
-        item_product_ids: items.map((i) => i.product_id),
+      // Validation is a question about a code, not a write to one, so there is
+      // no record for `resource` to hang it off.
+      const { data } = await transport.request<CouponValidation>({
+        method: 'POST',
+        path: 'coupons/validate',
+        body: {
+          code: couponInput.trim(),
+          subtotal: getSubtotal(),
+          ...(selectedCustomer ? { customer_id: selectedCustomer.id } : {}),
+          item_product_ids: items.map((i) => i.product_id),
+        },
       });
-      const data = res.data.data;
       setCoupon(data.code, data.discount);
       toast.success(t('cart.couponApplied'));
     } catch (err: unknown) {
-      const axiosErr = err as AxiosError<ApiErrorResponse>;
-      toast.error(axiosErr.response?.data?.error || t('cart.couponInvalid'));
+      toast.error((err as Error).message || t('cart.couponInvalid'));
     }
   };
 
@@ -770,16 +810,11 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                       disabled={
                         !newCustomerName.trim() ||
                         !newCustomerPhone.trim() ||
-                        createCustomerMutation.isPending
+                        customerCreator.isSaving
                       }
-                      onClick={() =>
-                        createCustomerMutation.mutate({
-                          name: newCustomerName.trim(),
-                          phone: newCustomerPhone.trim(),
-                        })
-                      }
+                      onClick={handleCreateCustomer}
                     >
-                      {createCustomerMutation.isPending ? '...' : t('cart.saveCustomer')}
+                      {customerCreator.isSaving ? '...' : t('cart.saveCustomer')}
                     </Button>
                     <Button
                       variant="ghost"
@@ -811,8 +846,8 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                     />
                     {showCustomerDropdown && customerSearch.length > 0 && (
                       <div className="absolute z-20 top-full mt-1 w-full bg-card border border-border rounded-md shadow-lg max-h-40 overflow-y-auto">
-                        {customers && customers.length > 0 ? (
-                          customers.map((c) => (
+                        {customerMatches && customerMatches.length > 0 ? (
+                          customerMatches.map((c) => (
                             <button
                               key={c.id}
                               className="w-full text-start px-3 py-2 text-sm hover:bg-surface transition-colors"

--- a/client/src/components/RefundDialog.tsx
+++ b/client/src/components/RefundDialog.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
+import { useQueryClient } from '@tanstack/react-query';
 import { RotateCcw } from 'lucide-react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/dialog';
 import { Button } from './ui/button';
@@ -8,9 +7,12 @@ import { Label } from './ui/label';
 import { Checkbox } from './ui/checkbox';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { formatCurrency } from '../lib/utils';
-import api from '../services/api';
+import { resource } from '../lib/resource';
 import { useTranslation } from '../i18n';
 import type { SaleItem } from '@/types';
+
+/** Only the refund sub-action is reached from here, so no row shape surfaces. */
+const sales = resource<{ id: number }>('sales');
 
 interface RefundDialogProps {
   open: boolean;
@@ -58,25 +60,21 @@ export default function RefundDialog({
 
   const maxRefundable = saleTotal - refundedAmount;
 
-  const mutation = useMutation({
-    mutationFn: (data: {
-      items: { product_id: number; quantity: number; unit_price: number }[];
-      reason: string;
-      restock: boolean;
-    }) => api.post(`/api/v1/sales/${saleId}/refund`, data).then((r) => r.data),
-    onSuccess: () => {
-      toast.success(t('sales.refundSuccess'));
-      queryClient.invalidateQueries({ queryKey: ['sales'] });
+  // `useAction` refreshes the sales list itself; the open sale's detail row
+  // lives under its own key, so that one is still invalidated by hand.
+  const refunder = sales.useAction('refund', {
+    message: t('sales.refundSuccess'),
+    fallbackMessage: t('sales.refundFailed'),
+    onDone: () => {
       queryClient.invalidateQueries({ queryKey: ['sale-detail'] });
       onOpenChange(false);
       resetForm();
     },
-    onError: () => {
-      toast.error(t('sales.refundFailed'));
-    },
   });
 
   const handleSubmit = () => {
+    if (saleId === null) return;
+
     const refundItems = items
       .filter((item) => {
         const sel = selectedItems[item.product_id];
@@ -90,7 +88,7 @@ export default function RefundDialog({
 
     if (refundItems.length === 0) return;
 
-    mutation.mutate({ items: refundItems, reason, restock });
+    refunder.run({ id: saleId, body: { items: refundItems, reason, restock } });
   };
 
   const toggleItem = (productId: number, maxQty: number) => {
@@ -124,7 +122,7 @@ export default function RefundDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 font-display tracking-wider">
             <RotateCcw className="h-5 w-5 text-gold" />
-            {t('sales.refundSale', { id: saleId })}
+            {t('sales.refundSale', { id: saleId ?? '' })}
           </DialogTitle>
           <DialogDescription>{t('sales.refundDesc')}</DialogDescription>
         </DialogHeader>
@@ -231,13 +229,13 @@ export default function RefundDialog({
             onClick={handleSubmit}
             disabled={
               !hasSelection ||
-              mutation.isPending ||
+              refunder.isRunning ||
               refundAmount > maxRefundable ||
               refundAmount <= 0
             }
             className="w-full"
           >
-            {mutation.isPending ? t('sales.refundProcessing') : t('sales.refundSubmit')}
+            {refunder.isRunning ? t('sales.refundProcessing') : t('sales.refundSubmit')}
           </Button>
         </div>
       </DialogContent>

--- a/client/src/hooks/usePosData.ts
+++ b/client/src/hooks/usePosData.ts
@@ -1,7 +1,11 @@
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import api from '../services/api';
+import { useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useApiQuery } from '../lib/apiQuery';
+import { resource } from '../lib/resource';
+import { useTransport } from '../lib/transport';
 import type { Category, Product, ProductVariant } from '@/types';
+
+const products = resource<Product>('products');
 
 interface UsePosDataParams {
   debouncedSearch: string;
@@ -45,20 +49,30 @@ export function usePosData({
   selectedCategory,
 }: UsePosDataParams): UsePosDataReturn {
   const queryClient = useQueryClient();
+  const transport = useTransport();
 
   // We manage variant state here because queries depend on it
   const [variantDialogOpen, setVariantDialogOpen] = useState(false);
   const [variantProduct, setVariantProduct] = useState<Product | null>(null);
 
-  // Favorites
-  const { data: favorites } = useQuery<number[]>({
-    queryKey: ['favorites'],
-    queryFn: () => api.get('/api/v1/users/me/favorites').then((r) => r.data.data),
-    staleTime: 0,
-  });
+  // Every read on this screen keeps `staleTime: 0`. A till shows stock, and
+  // stock a few minutes old is wrong in the one place being wrong costs money,
+  // so these stay on `useApiQuery`, which takes a staleTime, rather than
+  // `resource.useList`, which always inherits the app's five-minute default.
 
+  // Favorites
+  const { data: favorites } = useApiQuery<number[]>(
+    ['favorites'],
+    'users/me/favorites',
+    undefined,
+    { staleTime: 0 }
+  );
+
+  // `me` is not a record id, so this write has no `resource` verb to hang off
+  // and goes straight to the transport.
   const favMutation = useMutation({
-    mutationFn: (favs: number[]) => api.put('/api/v1/users/me/favorites', { favorites: favs }),
+    mutationFn: (favs: number[]) =>
+      transport.request({ method: 'PUT', path: 'users/me/favorites', body: { favorites: favs } }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['favorites'] }),
   });
 
@@ -71,25 +85,25 @@ export function usePosData({
   };
 
   // Categories
-  const { data: categories } = useQuery<Category[]>({
-    queryKey: ['categories'],
-    queryFn: () => api.get('/api/v1/products/categories').then((r) => r.data.data),
-    staleTime: 0,
-  });
+  const { data: categories } = useApiQuery<Category[]>(
+    ['categories'],
+    'products/categories',
+    undefined,
+    { staleTime: 0 }
+  );
 
   // Active bundles for POS
-  const { data: bundles } = useQuery<PosBundle[]>({
-    queryKey: ['bundles-pos'],
-    queryFn: () =>
-      api
-        .get('/api/v1/bundles')
-        .then((r) => (r.data.data as PosBundle[]).filter((b) => b.status === 'active')),
+  const { data: allBundles } = useApiQuery<PosBundle[]>(['bundles-pos'], 'bundles', undefined, {
     staleTime: 0,
   });
+  const bundles = useMemo(
+    () => allBundles?.filter((bundle) => bundle.status === 'active'),
+    [allBundles]
+  );
 
   // Products with debounced search and category filter
-  const { data: products, isLoading: isLoadingProducts } = useQuery<Product[]>({
-    queryKey: [
+  const { data: productRows, isLoading: isLoadingProducts } = useApiQuery<Product[]>(
+    [
       'products',
       {
         search: debouncedSearch,
@@ -97,33 +111,28 @@ export function usePosData({
         limit: 100,
       },
     ],
-    queryFn: () =>
-      api
-        .get('/api/v1/products', {
-          params: {
-            search: debouncedSearch || undefined,
-            category_id: selectedCategory || undefined,
-            limit: 100,
-          },
-        })
-        .then((r) => r.data.data),
-    staleTime: 0,
-  });
+    'products',
+    {
+      search: debouncedSearch || undefined,
+      category_id: selectedCategory || undefined,
+      limit: 100,
+    },
+    { staleTime: 0 }
+  );
 
   // Variants for selected product
-  const { data: variants } = useQuery<ProductVariant[]>({
-    queryKey: ['product-variants', variantProduct?.id],
-    queryFn: () =>
-      api.get(`/api/v1/products/${variantProduct!.id}/variants`).then((r) => r.data.data),
-    enabled: !!variantProduct && variantDialogOpen,
-  });
+  const { data: variants } = products.useRead<ProductVariant[]>(
+    `${variantProduct?.id}/variants`,
+    undefined,
+    !!variantProduct && variantDialogOpen
+  );
 
   return {
     favorites,
     favMutation,
     toggleFavorite,
     categories,
-    products,
+    products: productRows,
     isLoadingProducts,
     bundles,
     variants,

--- a/client/src/pages/POS.tsx
+++ b/client/src/pages/POS.tsx
@@ -27,9 +27,15 @@ import { formatCurrency } from '../lib/utils';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { usePosShortcuts } from '../hooks/usePosShortcuts';
 import { usePosData, type PosBundle } from '../hooks/usePosData';
-import api from '../services/api';
+import { useTransport } from '../lib/transport';
 import { useTranslation } from '../i18n';
 import type { Product, ProductVariant } from '@/types';
+
+/**
+ * Where uploaded product images are served from. The transport owns request
+ * paths, not `<img src>`, so this reads the same env var the HTTP client does.
+ */
+const ASSET_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 export default function POS() {
   const [searchInput, setSearchInput] = useState('');
@@ -50,6 +56,7 @@ export default function POS() {
   } = useCartStore();
   const { holdCart, carts: heldCarts } = useHeldCartsStore();
   const { t } = useTranslation();
+  const transport = useTransport();
   const [animateGrid] = useAutoAnimate();
 
   const debouncedSearch = useDebouncedValue(searchInput, 300);
@@ -151,8 +158,12 @@ export default function POS() {
   const handleBarcodeDetected = useCallback(
     async (barcode: string) => {
       try {
-        const response = await api.get(`/api/v1/products/barcode/${barcode}`);
-        const product = response.data.data as Product;
+        // A one-shot lookup fired from a scanner callback rather than a render,
+        // so it goes through the transport directly instead of a query hook.
+        const { data: product } = await transport.request<Product>({
+          method: 'GET',
+          path: `products/barcode/${barcode}`,
+        });
         if (product) {
           addItem(product);
           setShowScanner(false);
@@ -162,7 +173,7 @@ export default function POS() {
         toast.error(t('pos.barcodeNotFound'));
       }
     },
-    [addItem, t]
+    [addItem, t, transport]
   );
 
   const handleProductClick = (product: Product) => {
@@ -424,7 +435,7 @@ export default function POS() {
                     <div className="flex items-start justify-between mb-2">
                       {product.image_url ? (
                         <img
-                          src={`${api.defaults.baseURL}${product.image_url}`}
+                          src={`${ASSET_BASE_URL}${product.image_url}`}
                           alt={product.name}
                           className="h-10 w-10 rounded object-cover"
                           loading="lazy"


### PR DESCRIPTION
Closes #8.

POS, the cart panel's data access, the refund dialog and `usePosData` are off raw axios. This is the highest-traffic path in the product, so it was verified by driving a real sale end to end in a browser, not by reading code.

**CartPanel's structure is untouched** — every hunk in its 157-line diff is a call site. No extraction, no state reorganisation. That is #12's job, and doing it here means doing it twice.

`usePosData` was kept, not deleted. Unlike the inventory and delivery hooks, it is 135 lines, takes 2 params, and returns mostly plain data — it is not inverted, so there was nothing to unwind.

## Verified in a browser — full money path

Real sale against the running app, database snapshotted before and restored after:

- **Variant selection** — clicking a variant product opened the picker; selecting added `(M)` to the cart at 100 EG.
- **Coupon, both directions** — `MOON10` on a 100 EG cart was correctly rejected (`POST coupons/validate` → 400) with the server's own message surfacing as a toast: *"Minimum purchase of 500 required"*. On a 1,650 EG cart it applied: 1,650 − 165 = **1,485**.
- **Sale submission** — `POST /api/v1/sales` → **201**. The persisted row is exactly right: `total: 1485`, `coupon_id: 1`, `coupon_discount: 165`, `payment_method: Cash`, two line items with `variant_id: 1` and `null` respectively.
- **Receipt** printed with correct lines; **cart cleared** to empty.
- **Refund** — `POST /api/v1/sales/42/refund` → 201, recorded as `refund_status: partial`, `refunded_amount: 100`, with `restock: 1`.
- **Token refresh** — a 401 mid-flow was transparently refreshed and the sale replayed as 201, so the interceptor's queue-and-replay still works through the transport.

Database restored precisely afterwards (sales 41, sale_items 77, variant stock 5, `integrity_check: ok`) — including the `coupon_usage` and `register_movements` rows the sale created, which a foreign key correctly refused to orphan.

## The sale request body is byte-identical

`handleCheckout` is unmodified, and `http.ts` passes `body` straight to axios `data` — exactly what `api.post(url, saleData)` did. `CartPanel.test.tsx` asserts the whole body with `toEqual`, including that `customer_id`, `points_redeemed` and `payments` stay *absent* rather than being sent as null.

## Typecheck: 13 → 12

Typing the refund dialog properly fixed the last non-`Storefront` error. All 12 remaining are pre-existing in `Storefront.tsx`, which no ticket in this sequence covers.

## Where `resource` didn't fit — four cases, none widened it

`git diff --stat` lists nothing under `src/lib/`.

1. **Sale POST** — `useSave` toasts every failure from its own `onError`. The sale's failure path is the *offline queue*, not a toast; a per-call handler would have run alongside it, showing an error toast next to "saved offline". Not acceptable on the money path.
2. **Coupon validation** — a question about a code, not a write to a record; `useAction` requires a record id.
3. **Favorites PUT** (`users/me/favorites`) — `useAction` takes `{id: number}`, and `me` is not a numeric id.
4. **Barcode lookup** — a one-shot imperative call from a scanner callback, not a render-driven read.

Reads with an explicit `staleTime: 0` went to `useApiQuery`, not `resource.useList`, which exposes no `staleTime`. The rule applied throughout: explicit `staleTime` → `useApiQuery`; none → `resource`. Query keys were preserved byte-for-byte so cross-page invalidation still lands.

## ⚠️ Pre-existing defects found (not fixed here)

**The total is computed three incompatible ways**, and the split-payment target is the odd one out — it uses `getTotal() - tip`, **excluding tax and points redemption entirely**. With tax enabled, the cashier is asked to balance against a number that is not what the customer owes.

**And nothing enforces the balance.** I confirmed this in the browser: with split payment on and **0 EG allocated against a 1,485 EG total, `Confirm Sale` is not disabled**. An unbalanced split submits.

Both pre-existing, both untouched here, filed separately. They are the strongest argument for #12a below.

Smaller: the field labelled "Quick Discount" and subtracted from the total is named and sent as `tip`; and `loyaltyInfo.earnRate` is computed and never read.

## Requested deliverable: CartPanel's shape, and how #12 should be split

The issue asked for this to inform #12. The file is ~270 lines of logic and ~765 of JSX.

The concerns are **not tangled with each other** — they are all tangled with *the total*. Coupons and loyalty barely touch: coupon discount is already folded into `cartStore.getTotal()`, and points redemption is a local overlay applied after tax. Splitting along "payment + split-payment" vs "loyalty + coupons" would put both tickets on the same lines and do the work twice.

**Recommend splitting by layer instead:**

- **12a — one total, computed once.** Extract a pure function taking `{items, discount, discountType, couponDiscount, taxSettings, pointsToRedeem, redeemValue, tip}` → `{subtotal, discountAmount, taxAmount, pointsDiscount, tip, amountDue}`. Replaces `taxInfo`, `pointsDiscountAmount` and all three ad-hoc totals; the split-payment bug falls out as a fix. ~120 lines, no markup restructuring, unit-testable without rendering. **This is where the value is.**
- **12b — checkout submission.** Extract `handleCheckout` + mutation + receipt construction + offline fallback into `useCheckout`. Depends on 12a's amounts, so it must come second.
- **12c — optional, lowest value.** Split the four large JSX blocks into child components. Safe, buys little.

## ⚠️ Blocks #13: the offline queue still uses raw axios

`CartPanel` enqueues the offline payload, but the **replay** lives in `src/hooks/useOffline.ts` and still does `api.post('/api/v1/sales', payload)`. That file was out of scope here, so the replay is byte-identical to before — but the sale POST now exists on two stacks. #13 cannot remove the axios export until this moves. Filed separately.

## Post-Deploy Monitoring & Validation

Client-only; no server or schema change. Request paths, query params and the sale body are unchanged.

- **Watch first:** `POST /api/v1/sales` success rate and volume — this is the money path. Healthy = unchanged 201 rate. Also `POST /sales/:id/refund` and `POST /coupons/validate`.
- **Failure signals:** any drop in sales volume, any rise in 4xx on `/sales`, or user reports of the cart failing to clear after checkout. A spike in `/api/v1/products/barcode/*` 404s would indicate the scanner path regressed.
- **Rollback trigger:** any non-zero rate of failed sale submissions that were succeeding before. Revert this PR; it is client-only so a redeploy of the previous bundle is sufficient.
- **Window:** first full trading day, watched actively for the first hour.