### PR TITLE
fix(server): declare bulk-update before /:id so Express stops shadowing it

### DIFF
--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -277,6 +277,42 @@ router.post(
 );
 
 // PUT /api/products/:id
+// Declared before PUT /:id: Express matches in order, and a bare /:id would
+// otherwise capture "bulk-update" as an id and reject the body.
+// PUT /api/products/bulk-update
+const bulkUpdateSchema = z.object({
+  ids: z.array(z.number().int().positive()).min(1),
+  updates: z.object({
+    category_id: z.number().int().positive().optional(),
+    distributor_id: z.number().int().positive().nullable().optional(),
+    price_percent: z.number().min(-99).max(1000).optional(),
+    status: z.enum(['active', 'inactive', 'discontinued']).optional(),
+  }),
+});
+
+router.put(
+  '/bulk-update',
+  verifyToken,
+  requireRole('Admin'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = bulkUpdateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ success: false, error: parsed.error.errors[0].message });
+      }
+
+      const { ids, updates } = parsed.data;
+      const updated = bulkUpdateProducts(ids, updates);
+      res.json({ success: true, data: { updated } });
+    } catch (err: any) {
+      if (err.message === 'Category not found') {
+        return res.status(404).json({ success: false, error: err.message });
+      }
+      next(err);
+    }
+  }
+);
+
 router.put(
   '/:id',
   verifyToken,
@@ -380,40 +416,6 @@ router.post(
       const deleted = await bulkDeleteProducts(parsed.data.ids);
       res.json({ success: true, data: { deleted } });
     } catch (err) {
-      next(err);
-    }
-  }
-);
-
-// PUT /api/products/bulk-update
-const bulkUpdateSchema = z.object({
-  ids: z.array(z.number().int().positive()).min(1),
-  updates: z.object({
-    category_id: z.number().int().positive().optional(),
-    distributor_id: z.number().int().positive().nullable().optional(),
-    price_percent: z.number().min(-99).max(1000).optional(),
-    status: z.enum(['active', 'inactive', 'discontinued']).optional(),
-  }),
-});
-
-router.put(
-  '/bulk-update',
-  verifyToken,
-  requireRole('Admin'),
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const parsed = bulkUpdateSchema.safeParse(req.body);
-      if (!parsed.success) {
-        return res.status(400).json({ success: false, error: parsed.error.errors[0].message });
-      }
-
-      const { ids, updates } = parsed.data;
-      const updated = bulkUpdateProducts(ids, updates);
-      res.json({ success: true, data: { updated } });
-    } catch (err: any) {
-      if (err.message === 'Category not found') {
-        return res.status(404).json({ success: false, error: err.message });
-      }
       next(err);
     }
   }


### PR DESCRIPTION
Closes #23.

`PUT /api/v1/products/bulk-update` returned `400 "Required"` for every request. Bulk category, distributor, price and status changes have never worked.

## Cause

Express matches routes in declaration order. `PUT /:id` was declared at line 281 and `PUT /bulk-update` at line 400, so every bulk update was captured by `/:id` with `id="bulk-update"` and rejected by the single-product schema.

The repo already documents the rule this broke, in `CLAUDE.md`: *"Route ordering: Specific routes BEFORE /:id params (Express matches first)."*

## Fix

Moves the `bulkUpdateSchema` + route block above `PUT /:id`, with a comment stating why the position matters so it does not get reordered back.

## Verified against the running server

Before:
```
PUT /api/v1/products/bulk-update  {"ids":[30],"updates":{"status":"active"}}
→ {"success":false,"error":"Required"}
```

After:
```
→ {"success":true,"data":{"updated":1}}
```

And `PUT /api/v1/products/:id` still works — moving a route above it does not shadow it in turn:
```
PUT /api/v1/products/30  {"name":…,"sku":"MN-HJB-002","price":650,…}
→ {"success":true,"data":{"id":30,…}}
```

## Scope: this is the only instance

I scanned every route file for specific paths declared after a `/:id`, then verified each candidate against the running server rather than trusting the scan. Three looked suspicious and are actually fine:

| Route | Verdict |
|---|---|
| `POST /products/batch-generate-barcodes` | Fine — no single-segment `POST /:id` exists; `POST /:id/variants` is two segments |
| `GET /register/history` | Fine — returns data |
| `PUT /users/me/favorites` | Fine — `/:id` matches one segment, this is two |

Only `PUT /bulk-update` is genuinely shadowed.

## Post-Deploy Monitoring & Validation

- **Watch:** `PUT /api/v1/products/bulk-update` status codes. Healthy = 200s. The 400 rate on this route should go to zero — it is currently 100%.
- **Also watch:** `PUT /api/v1/products/:id` (single-product update) must stay at its current success rate. A rise in 400s there would mean the reorder shadowed it instead; verified above that it does not.
- **Failure signal:** any 404 on `/products/bulk-update`, which would mean the route did not register.
- **Rollback:** revert this commit; bulk update returns to being broken, which is the current state, so rollback is strictly safe.
- **Window:** first hour after deploy, and the first real bulk edit from the Inventory page.