### PR TITLE
fix(server): restore delivery shipping columns dropped by migration 022

### DIFF
--- a/server/db/migrations/068_delivery_shipping_columns.down.sql
+++ b/server/db/migrations/068_delivery_shipping_columns.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_delivery_orders_shipping_company;
+ALTER TABLE delivery_orders DROP COLUMN shipping_cost;
+ALTER TABLE delivery_orders DROP COLUMN shipping_company_id;

--- a/server/db/migrations/068_delivery_shipping_columns.sql
+++ b/server/db/migrations/068_delivery_shipping_columns.sql
@@ -1,0 +1,9 @@
+-- 021_shipping_companies.sql added shipping_company_id (a real FK) and
+-- shipping_cost. 022_delivery_overhaul.sql then rebuilt delivery_orders from a
+-- column list that omitted both, silently dropping them, while deliveryService
+-- kept selecting and inserting them. Every list, performance and create request
+-- has failed since.
+ALTER TABLE delivery_orders ADD COLUMN shipping_company_id INTEGER REFERENCES shipping_companies(id);
+ALTER TABLE delivery_orders ADD COLUMN shipping_cost REAL NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_delivery_orders_shipping_company ON delivery_orders(shipping_company_id);


### PR DESCRIPTION
Closes #25.

The entire Deliveries feature was returning **500**. `GET /api/v1/delivery`, `/delivery/analytics/performance` and delivery creation all failed with `no such column: d.shipping_company_id`.

## One migration silently undid another

`021_shipping_companies.sql` rebuilt `delivery_orders` with `shipping_company_id` (a real FK) and `shipping_cost`. `022_delivery_overhaul.sql` then rebuilt the table **again** from a column list that omitted both — and SQLite table-rebuild migrations copy only the columns named in the `INSERT ... SELECT`, so both were dropped without error. `deliveryService.ts` kept selecting and inserting them.

## The schema regressed, not the code

Both ends already expect the FK, so restoring the columns is the correct direction rather than rewriting the service:

- `DeliveryFormDialog.tsx` validates and submits `shipping_company_id`
- `deliveryService.ts` selects it (lines 119, 196, 213) and inserts it with `shipping_cost` (line 259)
- The `shipping_companies` table, route and management dialog all exist

The `shipping_company TEXT` column 022 introduced is **entirely unused** — `SELECT DISTINCT shipping_company` returns zero rows — so no backfill was needed and nothing depends on the denormalised form.

`068_delivery_shipping_columns.sql` adds both columns back plus the index 021 defined, with a matching `.down.sql`. Purely additive.

## Verified against the running server

| | Before | After |
|---|---|---|
| `GET /api/v1/delivery?limit=100` | 500 | **200** |
| `GET /api/v1/delivery/analytics/performance` | 500 | **200** |

And in a browser: the Deliveries page went from "no results" to listing all **8 orders**. A status transition round-tripped end to end — `PUT /api/v1/delivery/3/status` → 200, `In Transit` → `Delivered`, with the `delivery_status_history` row written (that endpoint is what dispatches the SMS/WhatsApp notification). Test data restored afterwards.

## Deliberately not included

`shipping_company TEXT` is now dead weight sitting beside `shipping_company_id` — the exact ambiguity that caused this. Removing it needs a full table rebuild, so it is left for a follow-up rather than folded into a fix that has to be safe.

Separately: there are **two migrations numbered 021**. Both applied, but the duplicate numbering makes ordering ambiguous and is worth cleaning up.

## Post-Deploy Monitoring & Validation

**Migration required on deploy** — `npm run migrate` must run. Both columns are additive with defaults, so old code continues to work either way.

- **Watch:** `GET /api/v1/delivery*` status codes. Healthy = 200s; the current 500 rate on these routes should go to zero.
- **Also watch:** `no such column: d.shipping_company_id` in server logs — should disappear entirely.
- **Then watch:** `POST /api/v1/delivery` (creation), which has been failing on the same missing columns, and `PUT /delivery/:id/status` for notification dispatch.
- **Failure signal:** any remaining 500 on a delivery route after the migration runs, or migration failure on startup.
- **Rollback:** `npm run migrate --down 1` drops both columns and returns the feature to its current broken state — strictly no worse than today.
- **Window:** first hour after deploy, plus the first real delivery created and first status change.