### PR TITLE
refactor(client): put checkout totals and split allocation behind a testable seam

### DIFF
--- a/client/src/components/CartPanel.tsx
+++ b/client/src/components/CartPanel.tsx
@@ -34,6 +34,7 @@ import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import ReceiptDialog from './ReceiptDialog';
 import HeldCartsDialog from './HeldCartsDialog';
 import { useApiQuery } from '../lib/apiQuery';
+import { calculateTotals, allocateSplit, type TaxMode } from '../lib/checkout';
 import { resource } from '../lib/resource';
 import { useTransport } from '../lib/transport';
 import type { ReceiptData } from './Receipt';
@@ -176,33 +177,45 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     return { enabled, earnRate, redeemValue, customerPoints };
   }, [appSettings, customerLoyalty]);
 
-  const cartTotal = getTotal();
   const taxInfo = useMemo(() => {
     const enabled = appSettings?.tax_enabled === 'true';
     const rate = parseFloat(appSettings?.tax_rate || '0');
-    const mode = appSettings?.tax_mode || 'exclusive';
-    if (!enabled || rate <= 0)
-      return { enabled: false, rate: 0, mode, amount: 0, totalWithTax: cartTotal };
+    const mode: TaxMode = appSettings?.tax_mode === 'inclusive' ? 'inclusive' : 'exclusive';
+    return { enabled: enabled && rate > 0, rate, mode };
+  }, [appSettings]);
 
-    const afterDiscount = cartTotal;
-    let taxAmount = 0;
-    let totalWithTax = afterDiscount;
+  // Every figure the sale is worth, decided in one place. What the footer, the
+  // checkout sheet and the split-payment allocation each show is now the same
+  // arithmetic rather than three near-misses.
+  const totals = useMemo(
+    () =>
+      calculateTotals({
+        items,
+        discount,
+        discountType,
+        couponDiscount,
+        tax: taxInfo,
+        pointsToRedeem: redeemPoints && loyaltyInfo.enabled ? pointsToRedeem : 0,
+        redeemValue: loyaltyInfo.redeemValue,
+        tip,
+      }),
+    [
+      items,
+      discount,
+      discountType,
+      couponDiscount,
+      taxInfo,
+      redeemPoints,
+      pointsToRedeem,
+      loyaltyInfo,
+      tip,
+    ]
+  );
 
-    if (mode === 'exclusive') {
-      taxAmount = Math.round(afterDiscount * (rate / 100) * 100) / 100;
-      totalWithTax = afterDiscount + taxAmount;
-    } else {
-      taxAmount = Math.round((afterDiscount - afterDiscount / (1 + rate / 100)) * 100) / 100;
-      totalWithTax = afterDiscount;
-    }
-
-    return { enabled: true, rate, mode, amount: taxAmount, totalWithTax };
-  }, [appSettings, cartTotal]);
-
-  const pointsDiscountAmount = useMemo(() => {
-    if (!redeemPoints || pointsToRedeem <= 0 || !loyaltyInfo.enabled) return 0;
-    return Math.round((pointsToRedeem / 100) * loyaltyInfo.redeemValue * 100) / 100;
-  }, [redeemPoints, pointsToRedeem, loyaltyInfo]);
+  // Split payments are balanced against what the customer actually owes, which
+  // includes tax and any points redeemed. Comparing against the bare cart total
+  // let a split under-collect whenever tax was switched on.
+  const split = useMemo(() => allocateSplit(payments, totals.amountDue), [payments, totals]);
 
   // Expose checkout trigger for keyboard shortcuts
   useEffect(() => {
@@ -652,12 +665,12 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                 {t('tax.vat')}
                 <span className="text-sm ms-1 opacity-70">({taxInfo.rate}%)</span>
               </span>
-              <span>{formatCurrency(taxInfo.amount)}</span>
+              <span>{formatCurrency(totals.taxAmount)}</span>
             </div>
           )}
           <div className="flex justify-between text-xl font-semibold font-data text-foreground">
             <span>{t('cart.total')}</span>
-            <span className="text-gold">{formatCurrency(taxInfo.totalWithTax)}</span>
+            <span className="text-gold">{formatCurrency(totals.totalWithTax)}</span>
           </div>
         </div>
 
@@ -721,7 +734,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                   <span>
                     {t('tax.vat')} ({taxInfo.rate}%)
                   </span>
-                  <span>{formatCurrency(taxInfo.amount)}</span>
+                  <span>{formatCurrency(totals.taxAmount)}</span>
                 </div>
               )}
               {couponDiscount > 0 && (
@@ -732,10 +745,10 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                   <span>-{formatCurrency(couponDiscount)}</span>
                 </div>
               )}
-              {pointsDiscountAmount > 0 && (
+              {totals.pointsDiscount > 0 && (
                 <div className="flex justify-between text-base text-gold font-data">
                   <span>{t('loyalty.pointsDiscount')}</span>
-                  <span>-{formatCurrency(pointsDiscountAmount)}</span>
+                  <span>-{formatCurrency(totals.pointsDiscount)}</span>
                 </div>
               )}
               {tip > 0 && (
@@ -746,9 +759,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
               )}
               <div className="flex justify-between text-lg font-semibold font-data">
                 <span>{t('cart.total')}</span>
-                <span className="text-gold">
-                  {formatCurrency(Math.max(0, taxInfo.totalWithTax - pointsDiscountAmount - tip))}
-                </span>
+                <span className="text-gold">{formatCurrency(totals.amountDue)}</span>
               </div>
             </div>
 
@@ -925,9 +936,9 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                         }}
                         className="h-8 text-sm font-data w-32"
                       />
-                      {pointsDiscountAmount > 0 && (
+                      {totals.pointsDiscount > 0 && (
                         <p className="text-xs text-gold font-data">
-                          = -{formatCurrency(pointsDiscountAmount)} {t('loyalty.pointsDiscount')}
+                          = -{formatCurrency(totals.pointsDiscount)} {t('loyalty.pointsDiscount')}
                         </p>
                       )}
                     </div>
@@ -1132,10 +1143,9 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                       <Plus className="h-3 w-3 me-1" /> {t('cart.addPayment')}
                     </Button>
                     <span
-                      className={`font-data ${Math.abs(payments.reduce((s, p) => s + p.amount, 0) - Math.max(0, getTotal() - tip)) < 0.01 ? 'text-green-500' : 'text-red-500'}`}
+                      className={`font-data ${split.isBalanced ? 'text-green-500' : 'text-red-500'}`}
                     >
-                      {formatCurrency(payments.reduce((s, p) => s + p.amount, 0))} /{' '}
-                      {formatCurrency(Math.max(0, getTotal() - tip))}
+                      {formatCurrency(split.allocated)} / {formatCurrency(totals.amountDue)}
                     </span>
                   </div>
                 </div>
@@ -1145,7 +1155,9 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
             <Button
               className="w-full"
               onClick={handleCheckout}
-              disabled={checkoutMutation.isPending}
+              // An unbalanced split used to submit, collecting whatever had been
+              // keyed in rather than what the sale was worth.
+              disabled={checkoutMutation.isPending || (splitPayment && !split.isBalanced)}
             >
               {checkoutMutation.isPending ? t('cart.processing') : t('cart.confirmSale')}
             </Button>

--- a/client/src/lib/checkout.test.ts
+++ b/client/src/lib/checkout.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateTotals,
+  allocateSplit,
+  refundTotal,
+  pointsEarned,
+  maxRedeemablePoints,
+  type TotalsInput,
+} from './checkout';
+
+const NO_TAX = { enabled: false, rate: 0, mode: 'exclusive' as const };
+
+function sale(over: Partial<TotalsInput> = {}): TotalsInput {
+  return {
+    items: [{ unit_price: 1000, quantity: 1 }],
+    discount: 0,
+    discountType: 'fixed',
+    couponDiscount: 0,
+    tax: NO_TAX,
+    pointsToRedeem: 0,
+    redeemValue: 5,
+    tip: 0,
+    ...over,
+  };
+}
+
+describe('totals', () => {
+  it('sums the lines', () => {
+    const t = calculateTotals(
+      sale({
+        items: [
+          { unit_price: 100, quantity: 2 },
+          { unit_price: 550, quantity: 1 },
+        ],
+      })
+    );
+
+    expect(t.subtotal).toBe(750);
+    expect(t.amountDue).toBe(750);
+  });
+
+  it('takes a fixed discount off the subtotal', () => {
+    const t = calculateTotals(sale({ discount: 150 }));
+
+    expect(t.discountAmount).toBe(150);
+    expect(t.amountDue).toBe(850);
+  });
+
+  it('takes a percentage discount off the subtotal', () => {
+    const t = calculateTotals(sale({ discount: 15, discountType: 'percentage' }));
+
+    expect(t.discountAmount).toBe(150);
+    expect(t.amountDue).toBe(850);
+  });
+
+  it('never lets discounts drive the sale below zero', () => {
+    const t = calculateTotals(sale({ discount: 5000 }));
+
+    expect(t.netOfDiscounts).toBe(0);
+    expect(t.amountDue).toBe(0);
+  });
+
+  it('adds exclusive tax on top of the discounted total', () => {
+    const t = calculateTotals(sale({ tax: { enabled: true, rate: 15, mode: 'exclusive' } }));
+
+    expect(t.taxAmount).toBe(150);
+    expect(t.totalWithTax).toBe(1150);
+    expect(t.amountDue).toBe(1150);
+  });
+
+  it('names inclusive tax without adding it', () => {
+    const t = calculateTotals(sale({ tax: { enabled: true, rate: 15, mode: 'inclusive' } }));
+
+    // 1000 already contains the tax: 1000 - 1000/1.15
+    expect(t.taxAmount).toBe(130.43);
+    expect(t.totalWithTax).toBe(1000);
+    expect(t.amountDue).toBe(1000);
+  });
+
+  it('taxes the discounted amount, not the sticker price', () => {
+    const t = calculateTotals(
+      sale({ discount: 200, tax: { enabled: true, rate: 10, mode: 'exclusive' } })
+    );
+
+    expect(t.taxAmount).toBe(80);
+    expect(t.amountDue).toBe(880);
+  });
+
+  it('ignores tax when the rate is zero even if tax is switched on', () => {
+    const t = calculateTotals(sale({ tax: { enabled: true, rate: 0, mode: 'exclusive' } }));
+
+    expect(t.taxAmount).toBe(0);
+    expect(t.amountDue).toBe(1000);
+  });
+});
+
+describe('coupon and loyalty applied together', () => {
+  it('subtracts the coupon before tax and the points after it', () => {
+    const t = calculateTotals(
+      sale({
+        couponDiscount: 100,
+        tax: { enabled: true, rate: 10, mode: 'exclusive' },
+        pointsToRedeem: 200,
+        redeemValue: 5,
+      })
+    );
+
+    expect(t.netOfDiscounts).toBe(900); // 1000 - 100 coupon
+    expect(t.taxAmount).toBe(90); // taxed on 900, not 1000
+    expect(t.totalWithTax).toBe(990);
+    expect(t.pointsDiscount).toBe(10); // 200 points at 5 per 100
+    expect(t.amountDue).toBe(980);
+  });
+
+  it('stacks a manual discount, a coupon, points and a tip', () => {
+    const t = calculateTotals(
+      sale({
+        discount: 10,
+        discountType: 'percentage',
+        couponDiscount: 50,
+        pointsToRedeem: 1000,
+        redeemValue: 5,
+        tip: 25,
+      })
+    );
+
+    expect(t.discountAmount).toBe(100);
+    expect(t.netOfDiscounts).toBe(850);
+    expect(t.pointsDiscount).toBe(50);
+    expect(t.amountDue).toBe(775); // 850 - 50 points - 25 tip
+  });
+
+  it('never lets points drive the amount due below zero', () => {
+    const t = calculateTotals(sale({ pointsToRedeem: 100000, redeemValue: 5 }));
+
+    expect(t.amountDue).toBe(0);
+  });
+
+  it('redeems nothing when no points are being spent', () => {
+    const t = calculateTotals(sale({ pointsToRedeem: 0 }));
+
+    expect(t.pointsDiscount).toBe(0);
+  });
+});
+
+describe('split payment allocation', () => {
+  const AMOUNT_DUE = 1150;
+
+  it('balances when the parts sum to the amount due', () => {
+    const a = allocateSplit([{ amount: 900 }, { amount: 250 }], AMOUNT_DUE);
+
+    expect(a.allocated).toBe(1150);
+    expect(a.remaining).toBe(0);
+    expect(a.isBalanced).toBe(true);
+    expect(a.isOverpaid).toBe(false);
+  });
+
+  it('does not balance when the parts fall short', () => {
+    const a = allocateSplit([{ amount: 900 }], AMOUNT_DUE);
+
+    expect(a.remaining).toBe(250);
+    expect(a.isBalanced).toBe(false);
+  });
+
+  it('does not balance when the parts overshoot, and says so', () => {
+    const a = allocateSplit([{ amount: 900 }, { amount: 400 }], AMOUNT_DUE);
+
+    expect(a.remaining).toBe(-150);
+    expect(a.isBalanced).toBe(false);
+    expect(a.isOverpaid).toBe(true);
+  });
+
+  it('treats sub-cent drift as balanced', () => {
+    const a = allocateSplit([{ amount: 383.33 }, { amount: 383.33 }, { amount: 383.34 }], 1150);
+
+    expect(a.isBalanced).toBe(true);
+  });
+
+  it('is unbalanced when nothing has been allocated yet', () => {
+    const a = allocateSplit([], AMOUNT_DUE);
+
+    expect(a.remaining).toBe(1150);
+    expect(a.isBalanced).toBe(false);
+  });
+
+  it('balances against tax and points, not the bare cart total', () => {
+    // The regression this module exists to prevent: the split target used to be
+    // the cart total less tip, so with tax on the cashier balanced to 1000
+    // while the customer owed 1090.
+    const t = calculateTotals(
+      sale({
+        tax: { enabled: true, rate: 10, mode: 'exclusive' },
+        pointsToRedeem: 200,
+        redeemValue: 5,
+      })
+    );
+
+    expect(t.amountDue).toBe(1090);
+    expect(allocateSplit([{ amount: 1000 }], t.amountDue).isBalanced).toBe(false);
+    expect(allocateSplit([{ amount: 1090 }], t.amountDue).isBalanced).toBe(true);
+  });
+});
+
+describe('refund totals', () => {
+  it('is worth the lines chosen', () => {
+    expect(
+      refundTotal([
+        { unit_price: 100, quantity: 1 },
+        { unit_price: 550, quantity: 2 },
+      ])
+    ).toBe(1200);
+  });
+
+  it('is nothing when no line is chosen', () => {
+    expect(refundTotal([])).toBe(0);
+  });
+
+  it('refunds part of a line', () => {
+    expect(refundTotal([{ unit_price: 333.33, quantity: 2 }])).toBe(666.66);
+  });
+});
+
+describe('loyalty accrual and redemption limits', () => {
+  it('earns whole points per hundred spent', () => {
+    expect(pointsEarned(1000, 1)).toBe(10);
+    expect(pointsEarned(1050, 2)).toBe(21);
+  });
+
+  it('earns nothing on a free sale', () => {
+    expect(pointsEarned(0, 1)).toBe(0);
+  });
+
+  it('caps redemption at the points the customer holds', () => {
+    expect(maxRedeemablePoints(300, 1000, 5)).toBe(300);
+  });
+
+  it('caps redemption at the value of the sale', () => {
+    // 1000 due, 5 per 100 points → 20,000 points would cover it exactly
+    expect(maxRedeemablePoints(99999, 1000, 5)).toBe(20000);
+  });
+
+  it('redeems nothing when the customer holds nothing', () => {
+    expect(maxRedeemablePoints(0, 1000, 5)).toBe(0);
+  });
+});

--- a/client/src/lib/checkout.ts
+++ b/client/src/lib/checkout.ts
@@ -1,0 +1,142 @@
+/**
+ * What a sale is worth, decided in one place.
+ *
+ * The cart panel used to compute the total three incompatible ways: the footer
+ * headline added tax but ignored points and tip, the checkout sheet subtracted
+ * both, and the split-payment allocation used neither — so with tax enabled a
+ * cashier was asked to balance payments against a figure that was not what the
+ * customer owed. Everything below is pure, so it can be exercised without
+ * rendering anything.
+ */
+
+export type DiscountType = 'fixed' | 'percentage';
+export type TaxMode = 'inclusive' | 'exclusive';
+
+export interface Priced {
+  unit_price: number;
+  quantity: number;
+}
+
+export interface TaxSettings {
+  enabled: boolean;
+  rate: number;
+  mode: TaxMode;
+}
+
+export interface TotalsInput {
+  items: Priced[];
+  discount: number;
+  discountType: DiscountType;
+  /** Already resolved to a currency amount by the coupon endpoint. */
+  couponDiscount: number;
+  tax: TaxSettings;
+  /** Loyalty points the customer is spending on this sale. */
+  pointsToRedeem: number;
+  /** Currency each 100 points is worth. */
+  redeemValue: number;
+  tip: number;
+}
+
+export interface Totals {
+  subtotal: number;
+  discountAmount: number;
+  couponDiscount: number;
+  /** Subtotal net of both discounts, before tax. What the cart store calls the total. */
+  netOfDiscounts: number;
+  taxAmount: number;
+  /** Net of discounts plus tax. Exclusive tax adds; inclusive tax is already inside. */
+  totalWithTax: number;
+  pointsDiscount: number;
+  tip: number;
+  /** The one figure the customer actually owes. */
+  amountDue: number;
+}
+
+/** Currency is only ever meaningful to the cent. */
+const money = (n: number) => Math.round(n * 100) / 100;
+
+export function calculateTotals({
+  items,
+  discount,
+  discountType,
+  couponDiscount,
+  tax,
+  pointsToRedeem,
+  redeemValue,
+  tip,
+}: TotalsInput): Totals {
+  const subtotal = items.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
+  const discountAmount = discountType === 'percentage' ? (subtotal * discount) / 100 : discount;
+  const netOfDiscounts = Math.max(0, subtotal - discountAmount - couponDiscount);
+
+  let taxAmount = 0;
+  let totalWithTax = netOfDiscounts;
+  if (tax.enabled && tax.rate > 0) {
+    if (tax.mode === 'exclusive') {
+      taxAmount = money(netOfDiscounts * (tax.rate / 100));
+      totalWithTax = netOfDiscounts + taxAmount;
+    } else {
+      // Inclusive: the tax is already inside the price, so only name it.
+      taxAmount = money(netOfDiscounts - netOfDiscounts / (1 + tax.rate / 100));
+    }
+  }
+
+  const pointsDiscount = pointsToRedeem > 0 ? money((pointsToRedeem / 100) * redeemValue) : 0;
+
+  return {
+    subtotal: money(subtotal),
+    discountAmount: money(discountAmount),
+    couponDiscount: money(couponDiscount),
+    netOfDiscounts: money(netOfDiscounts),
+    taxAmount,
+    totalWithTax: money(totalWithTax),
+    pointsDiscount,
+    tip: money(tip),
+    amountDue: Math.max(0, money(totalWithTax - pointsDiscount - tip)),
+  };
+}
+
+/** How many points a sale earns, given the rate per 100 spent. */
+export function pointsEarned(amountDue: number, earnRate: number): number {
+  if (earnRate <= 0 || amountDue <= 0) return 0;
+  return Math.floor((amountDue / 100) * earnRate);
+}
+
+/**
+ * The most a customer may spend on this sale: never more points than they hold,
+ * and never more value than the sale is worth.
+ */
+export function maxRedeemablePoints(
+  heldPoints: number,
+  totalWithTax: number,
+  redeemValue: number
+): number {
+  if (heldPoints <= 0 || redeemValue <= 0 || totalWithTax <= 0) return 0;
+  const pointsCoveringSale = Math.floor((totalWithTax / redeemValue) * 100);
+  return Math.min(heldPoints, pointsCoveringSale);
+}
+
+export interface Allocation {
+  allocated: number;
+  remaining: number;
+  /** Payments cover the amount due, to the cent. */
+  isBalanced: boolean;
+  /** More was allocated than the sale is worth. */
+  isOverpaid: boolean;
+}
+
+export function allocateSplit(payments: { amount: number }[], amountDue: number): Allocation {
+  const allocated = money(payments.reduce((sum, p) => sum + p.amount, 0));
+  const remaining = money(amountDue - allocated);
+  return {
+    allocated,
+    remaining,
+    isBalanced: Math.abs(remaining) < 0.01,
+    isOverpaid: remaining < -0.005,
+  };
+}
+
+/** What refunding a chosen set of lines is worth. */
+export function refundTotal(lines: Priced[]): number {
+  return money(lines.reduce((sum, l) => sum + l.unit_price * l.quantity, 0));
+}


### PR DESCRIPTION
Closes #12.

Totals, discount, coupon, tax, loyalty redemption and split-payment allocation now live in `lib/checkout.ts` as pure functions. The cart panel is a view over them.

**This found and fixed two real defects on the money path.**

## The seam

`calculateTotals(input) → { subtotal, discountAmount, couponDiscount, netOfDiscounts, taxAmount, totalWithTax, pointsDiscount, tip, amountDue }`, plus `allocateSplit`, `refundTotal`, `pointsEarned` and `maxRedeemablePoints`. All pure — **26 tests, no React, no DOM, no rendering.**

## Defect 1: the total was computed three incompatible ways

| Where | Formula | Missing |
|---|---|---|
| Footer headline | `getTotal() + tax` | points, tip |
| Checkout sheet | `totalWithTax − points − tip` | — |
| **Split-payment target** | **`getTotal() − tip`** | **tax and points** |

With tax enabled, the split-payment allocation asked the cashier to balance against a number that was **not what the customer owed**.

**Verified in a browser.** Cart of 1,550 with 14% VAT on:

- Footer and checkout sheet: subtotal 1,550, VAT 217, total **1,767** ✓
- Split-payment target now reads **`0 / 1,767`**. Before this change it read `0 / 1,550` — a cashier balancing that split would have **under-collected the entire 217 VAT on every split-payment sale**.

## Defect 2: an unbalanced split could be submitted

`Confirm Sale` was disabled only on `isPending`. I confirmed in the browser before the fix that with **0 EG allocated against a 1,485 EG total the button was live**.

Now gated on `split.isBalanced`. Verified both directions, which matters — blocking checkout would be worse than the bug:

- `0 / 1,767` → Confirm **disabled** ✓
- `1,767 / 1,767` → Confirm **enabled** ✓

## Recommendation for the rest of #12

#8 reported the file's shape and I followed its recommendation, which was to split by **layer** rather than by feature. The issue floated "payment + split-payment separately from loyalty + coupons"; that cut would have put both tickets on the same lines, because those concerns are not tangled with each other — they are all tangled with *the total*. Coupon discount is already folded into `getTotal()`, and points redemption is an overlay applied after tax.

**This PR is 12a — one total, computed once.** It is where the value was: both defects fell out of it.

Two follow-ups remain, deliberately not done here:

- **12b — checkout submission.** Extract `handleCheckout` + mutation + receipt construction + offline fallback into a `useCheckout` hook. Depends on 12a's amounts, so it had to come second.
- **12c — optional, lowest value.** Split the four large JSX blocks (customer picker 119 lines, split payment 115, loyalty 61, coupon 39) into child components. Pure markup move.

I stopped at 12a rather than bundling 12b, because this PR already changes money-path behaviour in two places and that is as much as should land in one reviewable step.

## Behaviour changes

Both are the bug fixes above, and both are intentional:

1. Split-payment target now includes tax and points redemption.
2. An unbalanced split can no longer be submitted.

Everything else is identical. **The sale request body is untouched** — the client never sent `tax_amount` (the server computes it; the client only reads it back for the receipt), and `points_redeemed` still comes straight from `pointsToRedeem`. The footer still shows `totalWithTax` and the checkout sheet still shows `amountDue`, exactly as before; they are simply now the same arithmetic rather than two near-misses.

## Also found, not fixed

- `loyaltyInfo.earnRate` is computed and never read — accrual is server-side. Left in place and now covered by `pointsEarned` for when it is wired up.
- The field labelled "Quick Discount", subtracted from the total, is named and sent to the server as `tip`.
- The settings table has `loyalty_points_per_egp` / `loyalty_egp_per_point`, but the cart reads `loyalty_earn_rate` / `loyalty_redeem_value` / `loyalty_enabled`. **Those keys do not exist**, so loyalty silently runs on hard-coded defaults and the redemption UI never appears. Pre-existing and worth its own issue.

## Testing

- **91 tests pass** (65 + 26 new). Typecheck 12 errors, all pre-existing in `Storefront.tsx`. Lint 0 errors. Build succeeds.
- Test coverage matches what the issue asked for: split payments that do and do not sum to the total (including sub-cent drift and overpayment), coupon plus loyalty applied together, and refund totals. One test pins the exact regression — a split balancing to 1,000 when 1,090 is owed.

## Post-Deploy Monitoring & Validation

Client-only; no server or schema change; sale request body unchanged.

- **Watch:** `POST /api/v1/sales` volume and success rate, and specifically the share of sales with a `payments` array. A drop in split-payment sales would suggest the new balance gate is blocking cashiers — that is the main risk of this change.
- **Also watch:** total revenue per sale for split payments should tick **up** where tax is enabled, since those sales were previously under-collecting.
- **Failure signal:** cashiers reporting that Confirm Sale will not enable. Verified enabled at exact balance and with sub-cent drift, but real tills will find edge cases faster than I can.
- **Rollback trigger:** any inability to complete a split-payment sale. Client-only, so redeploying the previous bundle restores the old behaviour (including the under-collection).
- **Window:** first full trading day, with split-payment sales checked specifically.