### PR TITLE
fix(pos): make POS financial mutations concurrency-safe and idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  server:
+    name: Server (lint, typecheck, test)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: moon_store_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      # Presence of this URL is what un-skips the concurrency and idempotency suites.
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/moon_store_test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/moon_store_test
+      JWT_SECRET: ci-jwt-secret-key-at-least-32-characters-long
+      JWT_REFRESH_SECRET: ci-jwt-refresh-secret-key-at-least-32-chars
+
+    defaults:
+      run:
+        working-directory: server
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run typecheck
+
+      - name: Test (with real PostgreSQL)
+        run: npm test -- --reporter=default --reporter=json --outputFile=vitest-report.json
+
+      - name: Fail if the real-PostgreSQL suites did not actually run
+        # A silently-skipped concurrency suite is the failure mode this guard exists for.
+        if: always()
+        run: node scripts/assertRealPostgresSuitesRan.mjs vitest-report.json
+
+  client:
+    name: Client (lint, typecheck, test)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: client
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      # No typecheck step here yet: `tsc --noEmit` on client/ currently reports
+      # pre-existing errors unrelated to this workflow. Add the step once they are cleared.
+
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ nul
 .playwright-mcp/
 .tanstack/
 *.tsbuildinfo
+
+# vitest JSON report, written by CI to check the real-PostgreSQL suites actually ran
+vitest-report.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,28 @@ on teardown, so files cannot contaminate each other. The target database only ne
 privileges. CI (`.github/workflows/ci.yml`) always sets `TEST_DATABASE_URL` and fails the
 build if these suites were skipped.
 
+## Idempotency compatibility window
+
+Retry-prone mutations (`POST /api/v1/sales` and the other wrapped endpoints) accept an
+`Idempotency-Key` request header. A repeated key returns the original outcome
+byte-identically with `Idempotent-Replay: true`; the same key with a different payload,
+endpoint, or user returns `409` with the code `IDEMPOTENCY_KEY_REUSED`. Keys live 24h and
+identify a *committed outcome* — a failed mutation releases its key, so a corrected retry
+under the same key runs normally.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `IDEMPOTENCY_REQUIRED` | `false` | While false, a request with no key behaves exactly as it did before idempotency existed. Set to `true` to require the header. |
+
+**Rollout order is server first, then client** — neither half breaks the other at any
+point in between, because the header is optional on both sides for the whole window.
+
+**Flip criterion, not a date:** set `IDEMPOTENCY_REQUIRED=true` only once every deployed
+till is confirmed to be sending the header. The observable is that
+`SELECT COUNT(*) FROM idempotency_keys WHERE created_at > NOW() - INTERVAL '1 day'`
+matches the day's sale count. Flipping is a config change, not a deploy, so it is
+reversible in seconds.
+
 ## Git Workflow
 
 - **Always branch from `main`** before starting a feature (`feature/xxx`, `fix/xxx`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,35 @@ Full checklist detail, the global string-coupling contract (persist keys, shared
 duplicated Sidebar route strings, global i18n files), and slice split/merge criteria:
 `docs/CONVENTIONS.md`.
 
+## Testing
+
+```bash
+cd server && npm test          # pg-mem suites; real-PostgreSQL suites report as skipped
+cd client && npm test
+```
+
+### Real-PostgreSQL suites
+
+Concurrency and idempotency invariants (guarded relative writes, `FOR UPDATE`, unique-claim
+races) cannot be proven on pg-mem — they need two genuinely concurrent connections. Those
+suites use `describeWithPostgres` from `server/tests/support/realPostgres.ts` and run only
+when `TEST_DATABASE_URL` is set. Without it they **skip loudly**; they never pass silently.
+
+```bash
+# Option A — a PostgreSQL you already run locally: point at a throwaway database
+createdb moon_store_test
+TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/moon_store_test npm test
+
+# Option B — a disposable container (port 5433, so it clears a local 5432)
+docker compose -f docker-compose.test.yml up -d
+TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5433/moon_store_test npm test
+```
+
+Each test file gets its own schema, migrated through the real migration runner and dropped
+on teardown, so files cannot contaminate each other. The target database only needs `CREATE`
+privileges. CI (`.github/workflows/ci.yml`) always sets `TEST_DATABASE_URL` and fails the
+build if these suites were skipped.
+
 ## Git Workflow
 
 - **Always branch from `main`** before starting a feature (`feature/xxx`, `fix/xxx`)

--- a/client/src/features/pos/components/CartPanel.test.tsx
+++ b/client/src/features/pos/components/CartPanel.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { TransportProvider } from '../../../shared/lib/transport/index';
+import { TransportProvider, isValidIdempotencyKey } from '../../../shared/lib/transport/index';
 import type { TransportRequest, TransportResult } from '../../../shared/lib/transport/index';
 import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
 import { useSettingsStore } from '../../../shared/store/settingsStore';
@@ -138,6 +138,68 @@ describe('CartPanel checkout', () => {
     expect(sale?.body).not.toHaveProperty('payments');
   });
 
+  it('stamps the sale with a well-formed idempotency key', async () => {
+    const transport = makeTransport();
+
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+    fireEvent.click(await openCheckout());
+
+    await waitFor(() => expect(transport.idempotencyKeys()).toHaveLength(1));
+
+    const [key] = transport.idempotencyKeys();
+    // The server 400s anything outside its format, so a key the fallback
+    // generator produced has to satisfy the same rule as `crypto.randomUUID`.
+    expect(isValidIdempotencyKey(key)).toBe(true);
+    // It travels as a header, not as part of the sale the cashier rang up.
+    expect(transport.calls().find((call) => call.path === 'sales')?.body).not.toHaveProperty(
+      'idempotencyKey'
+    );
+  });
+
+  it('gives a second, different sale its own key', async () => {
+    const transport = makeTransport();
+
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+    fireEvent.click(await openCheckout());
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+
+    // The receipt modal owns the screen until it is dismissed.
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Close' }))[0]);
+
+    useCartStore.setState({ items: [{ ...SILK_DRESS, product_id: 9, quantity: 1 }] });
+    fireEvent.click(await screen.findByRole('button', { name: 'Checkout' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm Sale' }));
+
+    await waitFor(() => expect(transport.idempotencyKeys()).toHaveLength(2));
+    const [first, second] = transport.idempotencyKeys();
+    expect(second).not.toBe(first);
+  });
+
+  it('reuses the same key when the cashier immediately retries the same cart', async () => {
+    const transport = makeTransport();
+
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+    const confirm = await openCheckout();
+    transport.failNext('Gateway timeout', 502, undefined, undefined, 'sales');
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    // The failure left the cart and the drawer alone, so the cashier can retry.
+    expect(useCartStore.getState().items).toHaveLength(1);
+
+    fireEvent.click(confirm);
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+
+    // Same key on both attempts: the first POST may have committed before the
+    // response was lost, and the server has to recognise the second as its replay.
+    const keys = transport.idempotencyKeys();
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toBe(keys[1]);
+  });
+
   it('clears the cart once the sale lands', async () => {
     const transport = makeTransport();
 
@@ -184,6 +246,11 @@ describe('CartPanel checkout', () => {
 
       await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(1));
       expect(useOfflineStore.getState().queue[0].contractVersion).toBe('v1');
+      // The queued entry carries the very key the failed POST went out under,
+      // so a replay of a request that did land is deduped rather than doubled.
+      const [attemptKey] = transport.idempotencyKeys();
+      expect(useOfflineStore.getState().queue[0].idempotencyKey).toBe(attemptKey);
+      expect(isValidIdempotencyKey(attemptKey)).toBe(true);
     } finally {
       // `defineProperty` above created an OWN property on the `navigator`
       // instance, shadowing the prototype's real getter -- restoring a

--- a/client/src/features/pos/components/CartPanel.test.tsx
+++ b/client/src/features/pos/components/CartPanel.test.tsx
@@ -200,6 +200,44 @@ describe('CartPanel checkout', () => {
     expect(keys[0]).toBe(keys[1]);
   });
 
+  it('reuses the same key after a reload, because the cart survives one too', async () => {
+    const transport = makeTransport();
+
+    const first = render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    const confirm = await openCheckout();
+    transport.failNext('Gateway timeout', 502, undefined, undefined, 'sales');
+    fireEvent.click(confirm);
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    // A reload tears the component down; the persisted cart (and its attempt) remain.
+    first.unmount();
+    const attempt = useCartStore.getState().checkoutAttempt;
+    expect(attempt).not.toBeNull();
+
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    const confirmAgain = await openCheckout();
+    fireEvent.click(confirmAgain);
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+
+    // If the key had lived only in a ref, the remount would have minted a new one and
+    // the server would have rung this sale up twice.
+    const keys = transport.idempotencyKeys();
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toBe(keys[1]);
+    expect(keys[1]).toBe(attempt!.key);
+  });
+
+  it('drops the stored attempt once the sale lands, so the next sale gets a new key', async () => {
+    const transport = makeTransport();
+
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    const confirm = await openCheckout();
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    expect(useCartStore.getState().checkoutAttempt).toBeNull();
+  });
+
   it('clears the cart once the sale lands', async () => {
     const transport = makeTransport();
 

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef, type MutableRefObject } from 'react';
+import { useState, useEffect, useMemo, type MutableRefObject } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -177,6 +177,8 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     clearCart,
     needsReview,
     acknowledgeReview,
+    checkoutAttempt,
+    setCheckoutAttempt,
   } = useCartStore();
   const { addToQueue } = useOfflineStore();
   const { carts: heldCarts, holdCart } = useHeldCartsStore();
@@ -367,21 +369,25 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   };
 
   /**
-   * The idempotency key identifies one rung-up sale, not one HTTP request. It
-   * is keyed on the composed payload so a cashier who hits Confirm again after
-   * a failure retries under the SAME key (letting the server return the
-   * original outcome rather than committing a second sale), while a cart that
-   * has changed gets a fresh one. Cleared once a sale is committed or queued,
-   * so the next sale never inherits a key -- even an identical repeat order.
+   * The idempotency key identifies one rung-up sale, not one HTTP request. It is keyed on
+   * the composed payload so a cashier who hits Confirm again after a failure retries under
+   * the SAME key (letting the server return the original outcome rather than committing a
+   * second sale), while a cart that has changed gets a fresh one. Cleared once a sale is
+   * committed or queued, so the next sale never inherits a key — even an identical repeat
+   * order.
+   *
+   * It lives in the persisted cart store rather than a ref: the cart survives a reload, so
+   * the key protecting it has to as well. A till that refreshes while a checkout is in
+   * flight would otherwise mint a new key and ring the same sale up twice.
    */
-  const checkoutAttemptRef = useRef<{ fingerprint: string; key: string } | null>(null);
-
   const idempotencyKeyFor = (saleData: SaleData): string => {
     const fingerprint = JSON.stringify(saleData);
-    if (checkoutAttemptRef.current?.fingerprint !== fingerprint) {
-      checkoutAttemptRef.current = { fingerprint, key: createIdempotencyKey() };
+    if (checkoutAttempt?.fingerprint === fingerprint) {
+      return checkoutAttempt.key;
     }
-    return checkoutAttemptRef.current.key;
+    const attempt = { fingerprint, key: createIdempotencyKey() };
+    setCheckoutAttempt(attempt);
+    return attempt.key;
   };
 
   const checkoutMutation = useMutation({
@@ -393,7 +399,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
         idempotencyKey,
       }),
     onSuccess: (response) => {
-      checkoutAttemptRef.current = null;
+      setCheckoutAttempt(null);
       const sale = response.data;
       const calc = sale.calculation;
 
@@ -487,7 +493,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
           idempotencyKey: attempt.idempotencyKey,
         });
         toast.success(t('cart.savedOffline'));
-        checkoutAttemptRef.current = null;
+        setCheckoutAttempt(null);
         clearCart();
         setCheckoutOpen(false);
         setSelectedCustomer(null);

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, type MutableRefObject } from 'react';
+import { useState, useEffect, useMemo, useRef, type MutableRefObject } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -46,7 +46,7 @@ import {
   type TaxMode,
 } from '../../../shared/lib/checkout';
 import { resource } from '../../../shared/lib/resource';
-import { useTransport } from '../../../shared/lib/transport/index';
+import { useTransport, createIdempotencyKey } from '../../../shared/lib/transport/index';
 import { ApiError } from '../../../shared/lib/transport/types';
 import type { ReceiptData, ReceiptItem, ReceiptPayment } from '../../../shared/components/Receipt';
 import type { AppSettings, Customer } from '../../../shared/types/index';
@@ -81,6 +81,12 @@ interface SaleData {
   notes?: string;
   tip?: number;
   coupon_code?: string;
+}
+
+/** One checkout attempt: the composed body plus the key that dedupes its retries. */
+interface CheckoutAttempt {
+  saleData: SaleData;
+  idempotencyKey: string;
 }
 
 interface CustomerLoyalty {
@@ -360,10 +366,34 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     );
   };
 
+  /**
+   * The idempotency key identifies one rung-up sale, not one HTTP request. It
+   * is keyed on the composed payload so a cashier who hits Confirm again after
+   * a failure retries under the SAME key (letting the server return the
+   * original outcome rather than committing a second sale), while a cart that
+   * has changed gets a fresh one. Cleared once a sale is committed or queued,
+   * so the next sale never inherits a key -- even an identical repeat order.
+   */
+  const checkoutAttemptRef = useRef<{ fingerprint: string; key: string } | null>(null);
+
+  const idempotencyKeyFor = (saleData: SaleData): string => {
+    const fingerprint = JSON.stringify(saleData);
+    if (checkoutAttemptRef.current?.fingerprint !== fingerprint) {
+      checkoutAttemptRef.current = { fingerprint, key: createIdempotencyKey() };
+    }
+    return checkoutAttemptRef.current.key;
+  };
+
   const checkoutMutation = useMutation({
-    mutationFn: (saleData: SaleData) =>
-      transport.request<SaleResponse>({ method: 'POST', path: 'sales', body: saleData }),
+    mutationFn: ({ saleData, idempotencyKey }: CheckoutAttempt) =>
+      transport.request<SaleResponse>({
+        method: 'POST',
+        path: 'sales',
+        body: saleData,
+        idempotencyKey,
+      }),
     onSuccess: (response) => {
+      checkoutAttemptRef.current = null;
       const sale = response.data;
       const calc = sale.calculation;
 
@@ -429,7 +459,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
       setReceiptData(newReceipt);
       setReceiptOpen(true);
     },
-    onError: (error: Error) => {
+    onError: (error: Error, attempt: CheckoutAttempt) => {
       if (!navigator.onLine) {
         const saleData: SaleData = {
           items: items.map((i) => ({
@@ -451,8 +481,13 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
           // it. A legacy entry already sitting in a user's queue from before
           // this deploy has no such field and is left for manual review.
           contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          // The same key the failed POST carried: if that request did reach
+          // the server after all, the replay is recognised as a duplicate
+          // instead of ringing the sale up twice.
+          idempotencyKey: attempt.idempotencyKey,
         });
         toast.success(t('cart.savedOffline'));
+        checkoutAttemptRef.current = null;
         clearCart();
         setCheckoutOpen(false);
         setSelectedCustomer(null);
@@ -501,7 +536,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
       ...(couponCode ? { coupon_code: couponCode } : {}),
     };
 
-    checkoutMutation.mutate(saleData);
+    checkoutMutation.mutate({ saleData, idempotencyKey: idempotencyKeyFor(saleData) });
   };
 
   const handleApplyCoupon = async () => {

--- a/client/src/features/pos/store/cartStore.ts
+++ b/client/src/features/pos/store/cartStore.ts
@@ -67,6 +67,15 @@ interface CartState {
    * financial preview is still unconfirmed until the cashier acts.
    */
   needsReview: boolean;
+  /**
+   * The idempotency key for the checkout currently being attempted, paired with a
+   * fingerprint of the payload it was minted for. Persisted with the cart because a till
+   * that reloads mid-checkout must retry under the SAME key — otherwise the server sees
+   * an unrelated request and rings the sale up twice, which is the exact failure the key
+   * exists to prevent. Null whenever no attempt is in flight.
+   */
+  checkoutAttempt: { fingerprint: string; key: string } | null;
+  setCheckoutAttempt: (attempt: { fingerprint: string; key: string } | null) => void;
   addItem: (product: Product) => void;
   addBundle: (bundle: BundleForCart) => void;
   removeItem: (productId: number, variantId?: number | null) => void;
@@ -232,6 +241,9 @@ export const useCartStore = create<CartState>()(
       couponDiscount: 0,
       lastUpdated: Date.now(),
       needsReview: false,
+      checkoutAttempt: null,
+
+      setCheckoutAttempt: (attempt) => set({ checkoutAttempt: attempt }),
 
       addItem: (product) =>
         set((state) => {
@@ -362,6 +374,8 @@ export const useCartStore = create<CartState>()(
           couponDiscount: 0,
           lastUpdated: Date.now(),
           needsReview: false,
+          // A committed or queued sale must never lend its key to the next one.
+          checkoutAttempt: null,
         }),
 
       isRecoveredCart: () => {
@@ -382,6 +396,8 @@ export const useCartStore = create<CartState>()(
           couponDiscount: 0,
           needsReview: true,
           lastUpdated: Date.now(),
+          // A restored held cart is a different checkout attempt.
+          checkoutAttempt: null,
         }),
 
       acknowledgeReview: () => set({ needsReview: false }),
@@ -399,6 +415,9 @@ export const useCartStore = create<CartState>()(
         couponDiscount: state.couponDiscount,
         lastUpdated: state.lastUpdated,
         needsReview: state.needsReview,
+        // Additive and safely absent: a blob persisted before this shipped simply has no
+        // key and falls back to the initial null, so no schema migration is needed.
+        checkoutAttempt: state.checkoutAttempt,
       }),
       migrate: (persistedState) => {
         // Any stored version below CART_SCHEMA_VERSION is v0 -- this is the

--- a/client/src/shared/hooks/useOffline.test.tsx
+++ b/client/src/shared/hooks/useOffline.test.tsx
@@ -88,6 +88,44 @@ describe('offline sale replay', () => {
     expect(transport.calls()[0].body).toBe(QUEUED_SALE);
   });
 
+  it('replays a queued sale under the idempotency key it was stamped with', async () => {
+    const transport: MemoryTransport = createMemoryTransport({ sales: [] });
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 1,
+          createdAt: '2026-02-01T10:00:00.000Z',
+          type: 'sale',
+          payload: QUEUED_SALE,
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          idempotencyKey: 'checkout-attempt-key',
+        },
+      ],
+      isSyncing: false,
+    });
+
+    renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(0));
+
+    // The key the till stamped at ring-up, unchanged -- a replay under a fresh
+    // key would let the server commit the sale a second time.
+    expect(transport.idempotencyKeys()).toEqual(['checkout-attempt-key']);
+  });
+
+  it('replays a legacy entry that predates idempotency keys with no key at all', async () => {
+    const transport: MemoryTransport = createMemoryTransport({ sales: [] });
+    // Versioned (so not quarantined) but queued before keys existed.
+    queueOneSale();
+
+    renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(0));
+
+    expect(transport.idempotencyKeys()).toEqual([]);
+    expect(transport.calls()[0]).not.toHaveProperty('idempotencyKey');
+  });
+
   it('leaves a sale queued when the replay fails', async () => {
     const { transport, attempts } = failingTransport();
     queueOneSale();

--- a/client/src/shared/hooks/useOffline.ts
+++ b/client/src/shared/hooks/useOffline.ts
@@ -64,7 +64,15 @@ export function useOffline(): UseOfflineReturn {
           // "revalidates against the current authoritative total before
           // submission" the plan calls for -- the check happens server-side,
           // not by recomputing the total here first.
-          await transport.request({ method: 'POST', path: 'sales', body: item.payload });
+          await transport.request({
+            method: 'POST',
+            path: 'sales',
+            body: item.payload,
+            // Omitted entirely for an entry queued before keys existed, so it
+            // replays exactly as it did before rather than under a key the
+            // server never saw.
+            ...(item.idempotencyKey ? { idempotencyKey: item.idempotencyKey } : {}),
+          });
           removeFromQueue(item.id);
           synced++;
         }

--- a/client/src/shared/lib/transport/client.test.ts
+++ b/client/src/shared/lib/transport/client.test.ts
@@ -263,4 +263,50 @@ describe('HTTP transport contract', () => {
       transport.request<Blob>({ method: 'GET', path: 'exports/1', responseType: 'blob' })
     ).resolves.toEqual({ data: blob });
   });
+
+  it('sends an idempotency key as the Idempotency-Key header', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 200, data: { data: { id: 1 } } });
+    const { createHttpTransport } = await import('./http');
+    const transport = createHttpTransport({ request } as never);
+
+    await transport.request({
+      method: 'POST',
+      path: 'sales',
+      body: { total: 10 },
+      idempotencyKey: 'a1b2c3',
+    });
+
+    expect(request.mock.calls[0][0].headers).toEqual({ 'Idempotency-Key': 'a1b2c3' });
+  });
+
+  it('sends no headers at all when no key is supplied', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 200, data: { data: { id: 1 } } });
+    const { createHttpTransport } = await import('./http');
+    const transport = createHttpTransport({ request } as never);
+
+    await transport.request({ method: 'POST', path: 'sales', body: { total: 10 } });
+
+    // The shared client's own JSON headers must stay in force -- an empty
+    // per-request `headers` object would be harmless, but asserting its
+    // absence keeps the no-key path byte-identical to pre-idempotency behaviour.
+    expect(request.mock.calls[0][0]).not.toHaveProperty('headers');
+  });
+
+  it('still clears Content-Type for a FormData body, alongside a key', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 200, data: { data: {} } });
+    const { createHttpTransport } = await import('./http');
+    const transport = createHttpTransport({ request } as never);
+
+    await transport.request({
+      method: 'POST',
+      path: 'products/import',
+      body: new FormData(),
+      idempotencyKey: 'k-1',
+    });
+
+    expect(request.mock.calls[0][0].headers).toEqual({
+      'Content-Type': undefined,
+      'Idempotency-Key': 'k-1',
+    });
+  });
 });

--- a/client/src/shared/lib/transport/http.ts
+++ b/client/src/shared/lib/transport/http.ts
@@ -33,7 +33,16 @@ export function createHttpTransport(client: AxiosInstance = api): Transport {
       params,
       body,
       responseType = 'json',
+      idempotencyKey,
     }: TransportRequest): Promise<TransportResult<T>> {
+      const headers: Record<string, string | undefined> = {};
+      if (idempotencyKey) headers['Idempotency-Key'] = idempotencyKey;
+      // The shared client pins JSON, which makes axios serialise a FormData
+      // body to "{}" instead of uploading it. Clearing the header lets the
+      // browser set multipart/form-data with its own boundary. Encoding is
+      // this adapter's business, so callers still just hand over a body.
+      if (body instanceof FormData) headers['Content-Type'] = undefined;
+
       try {
         const response = await client.request<Envelope<T>>({
           method,
@@ -41,11 +50,7 @@ export function createHttpTransport(client: AxiosInstance = api): Transport {
           params,
           data: body,
           ...(responseType === 'blob' ? { responseType: 'blob' as const } : {}),
-          // The shared client pins JSON, which makes axios serialise a FormData
-          // body to "{}" instead of uploading it. Clearing the header lets the
-          // browser set multipart/form-data with its own boundary. Encoding is
-          // this adapter's business, so callers still just hand over a body.
-          ...(body instanceof FormData ? { headers: { 'Content-Type': undefined } } : {}),
+          ...(Object.keys(headers).length > 0 ? { headers } : {}),
         });
         if (response.status === 204) return { data: undefined as T };
         // A streamed file has no envelope to unwrap; the blob is the answer.

--- a/client/src/shared/lib/transport/idempotency.ts
+++ b/client/src/shared/lib/transport/idempotency.ts
@@ -1,0 +1,35 @@
+/**
+ * The `Idempotency-Key` contract, kept beside the transport that sends it.
+ *
+ * The server accepts a non-empty, printable-ASCII key of at most 255
+ * characters and answers anything else with a 400, so both the generator and
+ * the in-memory fake read the rule from here rather than restating it.
+ */
+
+const MAX_KEY_LENGTH = 255;
+const PRINTABLE_ASCII = /^[\x20-\x7e]+$/;
+
+export function isValidIdempotencyKey(key: string): boolean {
+  return key.length > 0 && key.length <= MAX_KEY_LENGTH && PRINTABLE_ASCII.test(key);
+}
+
+function randomHex(byteCount: number): string {
+  const bytes = new Uint8Array(byteCount);
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * `crypto.randomUUID` exists only in a secure context, and a till served over
+ * plain HTTP on a shop LAN is exactly the deployment this key has to survive.
+ * The fallback is not a UUID and does not need to be — the server treats the
+ * key as an opaque printable-ASCII string, and uniqueness is all that matters.
+ */
+export function createIdempotencyKey(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID();
+  return `${Date.now().toString(36)}-${randomHex(16)}`;
+}

--- a/client/src/shared/lib/transport/index.ts
+++ b/client/src/shared/lib/transport/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export { createHttpTransport } from './http';
+export { createIdempotencyKey, isValidIdempotencyKey } from './idempotency';
 export { useTransport } from './context';
 export { TransportProvider } from './provider';
 export { setAuthPort, type AuthPort } from './authPort';

--- a/client/src/shared/lib/transport/memory.ts
+++ b/client/src/shared/lib/transport/memory.ts
@@ -1,3 +1,4 @@
+import { isValidIdempotencyKey } from './idempotency';
 import { ApiError, type Transport, type TransportRequest, type TransportResult } from './types';
 
 type Row = Record<string, unknown>;
@@ -15,6 +16,12 @@ export interface MemoryTransport extends Transport {
    * reproduce. Assert on what was asked for instead.
    */
   calls(): TransportRequest[];
+  /**
+   * Idempotency keys seen so far, in order, for the requests that carried one.
+   * Recorded separately from `calls()` so a test can assert on stability
+   * across a retry without reconstructing which call was which.
+   */
+  idempotencyKeys(): string[];
   /**
    * Make a request fail, to exercise how callers handle errors. `code`/
    * `details` let a test simulate a structured server error such as the
@@ -76,13 +83,24 @@ export function createMemoryTransport(
 
     calls: () => received.map((call) => ({ ...call })),
 
+    idempotencyKeys: () =>
+      received.map((call) => call.idempotencyKey).filter((key): key is string => key !== undefined),
+
     failNext: (message, status = 400, code, details, matchPath) => {
       pendingFailure = { error: new ApiError(message, status, code, details), matchPath };
     },
 
     async request<T>(req: TransportRequest): Promise<TransportResult<T>> {
       received.push(req);
-      const { method, path, body } = req;
+      const { method, path, body, idempotencyKey } = req;
+
+      // The server rejects a malformed key with a 400 before doing any work.
+      // Reproducing that here means a test exercising the offline/retry paths
+      // fails on a key the real endpoint would refuse, rather than passing
+      // against a fake that accepts anything.
+      if (idempotencyKey !== undefined && !isValidIdempotencyKey(idempotencyKey)) {
+        throw new ApiError('Invalid Idempotency-Key', 400, 'VALIDATION_ERROR');
+      }
 
       if (pendingFailure && (!pendingFailure.matchPath || pendingFailure.matchPath === path)) {
         const failure = pendingFailure.error;

--- a/client/src/shared/lib/transport/types.ts
+++ b/client/src/shared/lib/transport/types.ts
@@ -21,6 +21,13 @@ export interface TransportRequest {
    * reach past it to `fetch` and lose the token-refresh retry.
    */
   responseType?: 'json' | 'blob';
+  /**
+   * Sent as the `Idempotency-Key` header. Stamped once per checkout attempt
+   * rather than per request, so a transport-level retry (after a token
+   * refresh) and an offline replay collapse onto the same key and the server
+   * returns the original outcome instead of creating a second sale.
+   */
+  idempotencyKey?: string;
 }
 
 export interface TransportResult<T> {

--- a/client/src/shared/store/offlineStore.test.ts
+++ b/client/src/shared/store/offlineStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { OFFLINE_QUEUE_STORAGE_KEY } from '@/shared/lib/storageKeys';
 import { useOfflineStore, isQuarantined, SALE_QUEUE_CONTRACT_VERSION } from './offlineStore';
 
 beforeEach(() => {
@@ -18,6 +19,41 @@ describe('offlineStore - addToQueue', () => {
     useOfflineStore.getState().addToQueue({ type: 'sale', payload: {} });
 
     expect(useOfflineStore.getState().queue[0].contractVersion).toBeUndefined();
+  });
+
+  it('carries an idempotency key when the caller passes one, and leaves it unset otherwise', () => {
+    const { addToQueue } = useOfflineStore.getState();
+    addToQueue({ type: 'sale', payload: {}, idempotencyKey: 'key-abc' });
+    addToQueue({ type: 'sale', payload: {} });
+
+    expect(useOfflineStore.getState().queue[0].idempotencyKey).toBe('key-abc');
+    // A legacy entry has no key at all -- not an empty string, which would be
+    // sent as a malformed header on replay.
+    expect(useOfflineStore.getState().queue[1].idempotencyKey).toBeUndefined();
+  });
+});
+
+describe('offlineStore - persistence', () => {
+  it('preserves the idempotency key across a reload between queueing and replay', async () => {
+    useOfflineStore.getState().addToQueue({
+      type: 'sale',
+      payload: { items: [] },
+      contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+      idempotencyKey: 'key-survives-reload',
+    });
+
+    // What the persist middleware actually wrote is the only thing a reloaded
+    // till gets to see, so assert on storage rather than on live state.
+    const raw = localStorage.getItem(OFFLINE_QUEUE_STORAGE_KEY);
+    expect(JSON.parse(raw ?? '{}').state.queue[0].idempotencyKey).toBe('key-survives-reload');
+
+    // A reload starts from empty in-memory state plus whatever storage holds.
+    // (Clearing the state also rewrites storage, so put the snapshot back.)
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    localStorage.setItem(OFFLINE_QUEUE_STORAGE_KEY, raw as string);
+    await useOfflineStore.persist.rehydrate();
+
+    expect(useOfflineStore.getState().queue[0].idempotencyKey).toBe('key-survives-reload');
   });
 });
 

--- a/client/src/shared/store/offlineStore.ts
+++ b/client/src/shared/store/offlineStore.ts
@@ -18,6 +18,14 @@ export interface OfflineAction {
   /** Present on any 'sale' entry queued under the current checkout contract. */
   contractVersion?: string;
   /**
+   * The `Idempotency-Key` the checkout attempt was stamped with, replayed
+   * verbatim by useOffline.ts so a sale that reaches the server twice (queued
+   * offline, then also delivered by a late-succeeding request) is committed
+   * once. Optional: entries persisted before this shipped carry no key and
+   * replay keyless, exactly as they did before.
+   */
+  idempotencyKey?: string;
+  /**
    * Set once a sync attempt is rejected with SPLIT_PAYMENT_MISMATCH: the
    * catalog/tax/coupon/loyalty state changed since this sale was queued and
    * its split no longer balances. A mismatched entry is quarantined the same

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,27 @@
+# Local PostgreSQL for the concurrency and idempotency suites.
+#
+#   docker compose -f docker-compose.test.yml up -d
+#   TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5433/moon_store_test \
+#     npm test --prefix server
+#
+# Port 5433 keeps this clear of a PostgreSQL already listening on 5432. If you already
+# have a local PostgreSQL, you do not need this file — point TEST_DATABASE_URL at a
+# throwaway database on it instead. The suites create and drop their own schemas, so the
+# target database only needs CREATE privileges.
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: moon_store_test
+    ports:
+      - '5433:5432'
+    tmpfs:
+      # Test data is disposable; keeping it off disk makes the suite meaningfully faster.
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 20

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -211,17 +211,65 @@ router.get('/stats/summary', handler);  // never reached
 
 ### Database Queries
 
-```typescript
-// pg-compatible wrapper (async, returns { rows })
-const { rows } = await db.query('SELECT * FROM users WHERE id = $1', [userId]);
+PostgreSQL via `pg`. Every mutation routes through `withTransaction`, which accepts an
+already-open client so a service can join its caller's transaction rather than opening a
+second one.
 
-// Raw better-sqlite3 for transactions
-const rawDb = db.db;
-rawDb.transaction(() => {
-  rawDb.prepare('INSERT INTO ...').run(...);
-  rawDb.prepare('UPDATE ...').run(...);
-})();
+```typescript
+const { rows } = await pool.query('SELECT * FROM users WHERE id = $1', [userId]);
+
+await withTransaction(async (client) => {
+  await repo.createSale(data, client);
+  await repo.createSaleItem(item, client);
+});
 ```
+
+### Concurrency and idempotency
+
+The pool runs at `READ COMMITTED`. That is atomic against torn writes but **not** against
+lost updates, so these three rules are what keep quantities and balances correct. The next
+read-then-write is the next oversell.
+
+**1. Never write a quantity or balance you read earlier in the same request.**
+
+```typescript
+// WRONG — two concurrent callers both read 5, both write 3, and four units vanish.
+const product = await repo.getProductById(id, client);
+if (product.stock < qty) throw new Error('Insufficient stock');
+await repo.updateProductStock(id, product.stock - qty, client);
+
+// RIGHT — one statement decides. rowCount 0 means it did not fit.
+// Cast the parameter: pg-mem inverts `column - $1` unless it is typed.
+const newStock = await repo.decrementProductStock(id, qty, client);
+if (newStock === null) throw new InsufficientStockError(...);
+```
+
+An earlier check may stay as a fail-fast courtesy — a better error, sooner — but it is
+advisory. The guarded write is the authority, and the audit trail derives from its
+`RETURNING` value, not from the earlier read.
+
+**2. Reach for `SELECT ... FOR UPDATE` only when the invariant spans rows.** Coupon
+`max_uses` counts rows in `coupon_usage`; a cumulative refund compares against sibling
+refunds. Neither fits in one conditional write, so lock the parent row (`coupons`,
+`sales`) and let it serialize the counters. Consuming paths only — a preview that takes a
+lock blocks live checkouts for no benefit.
+
+**3. Touch resources in one canonical order:** `idempotency_keys` → `products` /
+`product_variants` (ascending by id) → `coupons` → `customers` → `gift_cards` → `sales` →
+`register_sessions`. Two concurrent multi-line checkouts naming the same products in
+opposite request order would otherwise deadlock; sorting the write phase removes the
+cycle. `withTransaction` also accepts an opt-in bounded retry on SQLSTATE `40001`/`40P01`,
+but only for callbacks with no non-transactional side effect — it re-runs them.
+
+**Retry-prone mutations take an `Idempotency-Key`.** Wrap them in `withIdempotency`
+(`server/src/http/idempotency.ts`), which claims the key as the first statement inside the
+business transaction so the claim shares its fate: a commit makes the outcome replayable,
+a failure releases the key. Keep slow work (notifications, audit writes, external calls)
+outside the transaction, and suppress it on a replay — see `SalesController.createSale`.
+
+The header is optional while `IDEMPOTENCY_REQUIRED` is false. See `CLAUDE.md` for the
+compatibility window and for running the real-PostgreSQL suites, which are the only place
+these invariants can actually be proven.
 
 ### Response Format
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -254,12 +254,33 @@ refunds. Neither fits in one conditional write, so lock the parent row (`coupons
 `sales`) and let it serialize the counters. Consuming paths only — a preview that takes a
 lock blocks live checkouts for no benefit.
 
-**3. Touch resources in one canonical order:** `idempotency_keys` → `products` /
-`product_variants` (ascending by id) → `coupons` → `customers` → `gift_cards` → `sales` →
-`register_sessions`. Two concurrent multi-line checkouts naming the same products in
-opposite request order would otherwise deadlock; sorting the write phase removes the
-cycle. `withTransaction` also accepts an opt-in bounded retry on SQLSTATE `40001`/`40P01`,
-but only for callbacks with no non-transactional side effect — it re-runs them.
+**3. Take locks in an order that cannot cycle against any other path.**
+
+The rule that is mechanically enforced: **all product and variant rows a transaction
+touches are locked in one pass, sorted by `sortForStockWrites`**
+(`server/src/modules/pos/stockWriteOrder.ts`). Every path that mutates stock must route
+through that one comparator — two concurrent checkouts naming the same products in
+opposite request order would otherwise deadlock. A path with more than one stock phase
+(an exchange restocks returns and deducts new items) must sort the **combined** set;
+sorting each phase separately still lets two callers interleave them in opposite order.
+
+The order the paths actually take across resource *kinds* is per-path, not global:
+
+| Path | Order |
+| --- | --- |
+| checkout | `idempotency_keys` → `coupons` (FOR UPDATE) → `sales` → `products`/`variants` → `customers` → `register_sessions` |
+| refund | `idempotency_keys` → `sales` (FOR UPDATE) → `products` → `register_sessions` |
+| exchange | `idempotency_keys` → `exchanges` → `products`/`variants` |
+| gift card | `idempotency_keys` → `gift_cards` |
+
+These do not cycle against each other today, because no two of them take the same pair of
+kinds in opposite order. That is a weaker invariant than a single global order, so when
+adding a path, check it against this table rather than assuming one exists.
+
+`withTransaction` accepts an opt-in bounded retry on SQLSTATE `40001`/`40P01`, enabled by
+`withIdempotency` for the whole business transaction. It re-runs the callback, so it is
+only safe while every non-transactional side effect stays in the controller, after the
+transaction — which is also why notifications and audit writes live there.
 
 **Retry-prone mutations take an `Idempotency-Key`.** Wrap them in `withIdempotency`
 (`server/src/http/idempotency.ts`), which claims the key as the first statement inside the

--- a/docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md
+++ b/docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md
@@ -1,0 +1,946 @@
+---
+title: 'fix: Make POS financial mutations concurrency-safe and idempotent'
+type: fix
+status: completed
+date: 2026-08-30
+origin: https://github.com/zhamdy/moon-store/issues/42
+---
+
+# fix: Make POS financial mutations concurrency-safe and idempotent
+
+## Overview
+
+Every financial mutation in this server reads a quantity or balance, computes a new absolute
+value in JavaScript, and writes it back. Inside a transaction this is atomic against torn
+writes but **not** against lost updates: two concurrent checkouts both read `stock = 5`, both
+write `stock = 3`, and four units vanish. Nothing in the codebase takes a row lock
+(`grep 'FOR UPDATE'` over `server/src` returns nothing) and nothing dedupes a retried request
+(`grep -i idempot` over the server returns only an unrelated seed test).
+
+This plan adds two server-side invariants and proves them against a real PostgreSQL instance:
+
+1. **Concurrency safety** — quantities and balances change through conditional, relative SQL
+   writes (`SET stock = stock - $1 WHERE stock >= $1`) or an explicit row lock, never through a
+   read-then-write of an absolute value.
+2. **Idempotency** — a caller-supplied `Idempotency-Key` makes a retried mutation return the
+   original outcome instead of creating a second one, with a deterministic 409 when the same key
+   arrives with a different payload.
+
+The response envelope (`{ data, meta }` / `{ error: { code, message, details } }`) and every
+existing field on every existing response are unchanged.
+
+## Problem Frame
+
+`SalesService.executeSale` (`server/src/modules/pos/sales/service.ts`) resolves each line in
+`resolveLines`, capturing `previousStock` and computing `newStock = previousStock - quantity`.
+Much later in the same transaction it calls
+`repo.updateProductStock(item.product_id, item.newStock, client)`, which issues
+`UPDATE products SET stock = $1 WHERE id = $2` — an absolute write derived from a stale read.
+The stock sufficiency check (`if (Number(product.stock) < item.quantity)`) runs against the same
+stale read. Under `READ COMMITTED` (the pool default; see `server/src/database/pool.ts`) two
+concurrent checkouts of the last unit both pass the check and both commit.
+
+The same shape appears in:
+
+| Site | Read-then-write | Consequence |
+|---|---|---|
+| `pos/sales/service.ts` `executeSale` | `previousStock` → `updateProductStock` / `updateVariantStock` | Oversell, lost stock update |
+| `pos/sales/service.ts` `executeRefund` | `sale.refunded_amount` → `updateSaleRefundStatus`; `product.stock` → `updateProductStock` | Over-refund past sale total, lost restock |
+| `commerce/giftCards/service.ts` `redeem` | `card.balance` → `updateBalance` | Gift card spent twice, balance goes negative |
+| `commerce/coupons/service.ts` `validate` | `getUsageCount` → later `createCouponUsage` | `max_uses` / `max_uses_per_customer` exceeded |
+| `pos/sales/service.ts` loyalty | balance checked in `buildBreakdown`, debited via relative SQL | Balance can go negative (check is stale) |
+| `pos/exchanges/service.ts` | relative SQL already, but unguarded | Stock can go negative |
+
+Retry duplication is the second half. The client's offline queue
+(`client/src/shared/hooks/useOffline.ts`) replays a queued sale body verbatim, and the transport
+(`client/src/shared/lib/transport/http.ts`) retries after a token refresh. Neither carries
+anything that lets the server recognize a replay, so a network failure after commit but before
+the response reaches the till produces a second sale, a second stock deduction, a second coupon
+use, and a second loyalty award.
+
+Related client-side risk is tracked separately in #30; this plan makes the server authoritative
+regardless of how the client behaves.
+
+## Requirements Trace
+
+- **R1.** Concurrent purchases cannot reduce stock below zero or lose a stock update.
+- **R2.** Repeating an identical request with the same idempotency key creates one transaction
+  and returns the original outcome.
+- **R3.** Reusing a key with a different payload returns a deterministic conflict response.
+- **R4.** A failed mutation leaves all related records unchanged (sale, items, payments, coupon
+  usage, loyalty, stock adjustments, register movement).
+- **R5.** Concurrency and retry behavior is tested against real PostgreSQL.
+- **R6.** Existing clients continue working during an explicitly documented compatibility window.
+- **R7.** The same invariant covers refunds, gift-card redemption, and coupon consumption.
+- **R8.** Response envelopes and existing response fields are unchanged.
+
+## Scope Boundaries
+
+- **Not** fixing the client offline queue's replay/quarantine logic — that is #30. This plan
+  touches the client only to stamp and persist a stable idempotency key (decided with the user).
+- **Not** general authentication or observability work.
+- **Not** introducing a reservation/hold system for cart stock. `stock_reservations` exists in the
+  schema (`server/src/database/migrations/001_initial_schema.sql:307`) but does not participate in
+  checkout today, and wiring it in is a behavior change, not a concurrency fix.
+- **Not** changing the checkout financial contract established by
+  `docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md`. Amounts, rounding, and the
+  `sale_calculations` snapshot stay exactly as they are.
+- **Not** raising the transaction isolation level globally. `READ COMMITTED` plus conditional
+  writes and explicit locks is the chosen mechanism (see Key Technical Decisions).
+- **Not** rewriting `server/services/*.ts` legacy shims beyond what compiles.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `server/src/database/transaction.ts` — `withTransaction(callback, poolOrClient)`; accepts an
+  already-open client for nesting. Every service mutation already routes through it. This is where
+  a bounded deadlock/serialization retry belongs.
+- `server/src/database/pool.ts` — single `pg.Pool`, `max` 10 (dev) / 20 (prod), `setPool()` exists
+  for tests to swap in pg-mem.
+- `server/src/database/migrate.ts` — file-ordered `NNN_name.sql` + `NNN_name.down.sql`, each
+  applied inside `withTransaction`. Next number is `004`.
+- `server/src/database/migrations/003_sale_calculation_snapshot.sql` — the house style for a new
+  migration: long header comment explaining *why*, `CREATE TABLE IF NOT EXISTS`, `TIMESTAMPTZ`,
+  paired `.down.sql`.
+- `server/src/http/errors.ts` — `PublicError`, `PublicErrorCode` already includes `CONFLICT` → 409,
+  and `ValidationDetail { field, code, message }` is the established way to attach a machine
+  code. `SPLIT_PAYMENT_MISMATCH_CODE` in `server/src/modules/pos/sales/types.ts` is the precedent
+  for a named, client-consumed error code.
+- `server/src/modules/pos/sales/repository.ts` — `ISalesRepository` is an explicit interface with a
+  hand-written fake in tests; new repository methods must be added to the interface.
+- `server/src/modules/pos/exchanges/repository.ts:125-152` — already uses relative SQL
+  (`SET stock = stock + $1`). Good shape, missing the `WHERE stock >= $1` guard.
+- `server/src/modules/pos/sales/controller.ts` — maps domain errors to `PublicError` by string
+  matching. New failures should be typed (like `SalesValidationError`) rather than string-matched.
+- `client/src/shared/lib/transport/types.ts` — `TransportRequest` has no header channel; adding one
+  is the minimal client seam.
+- `client/src/shared/store/offlineStore.ts` — `OfflineAction.payload` is persisted verbatim and
+  replayed verbatim, so a key stamped into the queued entry survives reloads and replays.
+
+### Institutional Learnings
+
+`docs/solutions/` does not exist in this repo, so there are no recorded prior solutions to carry
+forward. The nearest institutional context is
+`docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md`, whose central lesson —
+*the server computes the authoritative value; the client is never trusted* — this plan extends
+from **amounts** to **quantities and retries**.
+
+### External References
+
+- Stripe's idempotency contract (`Idempotency-Key` header, stored response replay, 409 on payload
+  mismatch, 24h retention) is the model for the semantics chosen here.
+- PostgreSQL `READ COMMITTED` re-evaluates a `WHERE` clause after a concurrent update releases its
+  row lock, which is precisely what makes `UPDATE ... SET stock = stock - $1 WHERE stock >= $1`
+  correct without a higher isolation level.
+- SQLSTATE `40001` (serialization failure) and `40P01` (deadlock detected) are the two retryable
+  transaction errors; `23505` (unique violation) is the idempotency-claim collision signal.
+
+## Key Technical Decisions
+
+- **Conditional relative writes over row locks, where a single row carries the invariant.**
+  `UPDATE products SET stock = stock - $1 WHERE id = $2 AND stock >= $1 RETURNING stock` is atomic,
+  needs no lock ordering of its own, and reports insufficiency through `rowCount === 0`. Rationale:
+  it removes the stale-read window entirely instead of narrowing it, and it is a smaller change
+  than restructuring `resolveLines` around a lock phase.
+
+- **`SELECT ... FOR UPDATE` only where the invariant spans rows.** Coupon `max_uses` counts rows in
+  `coupon_usage`, and refund cumulative amount compares against sibling refunds; neither can be
+  expressed as a single conditional write. Locking the parent row (`coupons`, `sales`) serializes
+  the counters. Rationale: the narrowest correct tool per invariant, rather than one blanket
+  mechanism.
+
+- **Canonical lock order, enforced by sorting.** Within a transaction, resources are touched in a
+  fixed order: `idempotency_keys` → `products`/`product_variants` (sorted ascending by kind then
+  id) → `coupons` → `customers` → `gift_cards` → `sales` → `register_sessions`. Rationale: two
+  concurrent multi-line checkouts sharing two products in opposite request order would otherwise
+  deadlock. Sorting the resolved lines before the write phase removes the cycle. The write phase is
+  therefore decoupled from the request's line order (the persisted `sale_items` order changes; no
+  consumer depends on it — verify in Unit 4).
+
+- **Bounded retry on `40001`/`40P01` in `withTransaction`.** Ordering makes deadlock unlikely, not
+  impossible. Two retries with a short jittered backoff. Rationale: the whole transaction rolls
+  back, including the idempotency claim, so a retry is genuinely a fresh attempt with no partial
+  side effects. Non-transactional side effects (`notifySale`, `logAuditFromReq`) already live in the
+  controller *after* the transaction, so they cannot double-fire.
+
+- **The idempotency claim is the first statement inside the business transaction** (chosen with the
+  user over a two-phase claim + lease). A duplicate blocks on the unique index until the first
+  transaction ends, then either sees a unique violation (winner committed → replay the stored
+  response) or acquires the claim itself (winner rolled back → proceed normally). Rationale:
+  exactly-once by construction, no `in_progress` state, no lease expiry, no stale-claim reaper. The
+  accepted cost is that a duplicate holds a pooled connection for the duration of a checkout —
+  bounded and small for a POS, and only for genuine duplicates.
+
+- **A rolled-back mutation releases its key.** Because the claim lives inside the transaction, a
+  failure removes it, and the client may retry the same key. Rationale: this is what makes R4 and R2
+  compose — the key identifies a *committed outcome*, never a *failed attempt*. Consequence to
+  document: a deterministic 400 (bad payload) is not cached and will be recomputed on retry.
+
+- **Key uniqueness is global; scope is validated, not keyed.** `UNIQUE (key)` with `endpoint`,
+  `user_id`, and `request_fingerprint` stored alongside. A key that arrives on a different endpoint,
+  from a different user, or with a different fingerprint gets the same 409 with code
+  `IDEMPOTENCY_KEY_REUSED`. Rationale: prevents cross-endpoint key confusion and never discloses
+  what the original request was.
+
+- **Fingerprint = SHA-256 over canonical JSON of the *validated* (post-Zod) body.** Key-sorted,
+  computed after parsing so that key order, whitespace, and stripped unknown fields do not produce
+  false conflicts. Node's built-in `crypto` — no new dependency.
+
+- **`Idempotency-Key` is optional during a documented compatibility window**, gated by a new
+  `IDEMPOTENCY_REQUIRED` env flag defaulting to `false`. Without the header, behavior is exactly
+  today's (minus the concurrency bugs). Rationale: satisfies R6 without stranding an unpatched till,
+  and gives a single switch to close the window later.
+
+- **Non-negative invariants as `CHECK ... NOT VALID` constraints.** `products.stock >= 0`,
+  `product_variants.stock >= 0`, `gift_cards.balance >= 0`, `customers.loyalty_points >= 0` as
+  defense-in-depth behind the application logic. `NOT VALID` because existing rows may already be
+  negative (nothing has been guarding exchanges) and the migration must not fail on legacy data.
+  Rationale: a future code path that forgets the guard fails loudly at the database instead of
+  silently corrupting inventory.
+
+- **Replay is signalled additively.** A replayed response carries an `Idempotent-Replay: true`
+  response header and is otherwise byte-identical to the original body and status. Rationale: R8
+  — no envelope or field changes; a header is invisible to every existing consumer.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Real-Postgres harness scope** — `TEST_DATABASE_URL`-gated tests plus a new
+  `.github/workflows/ci.yml` with a `postgres:16` service container and a local
+  `docker-compose.test.yml`. No CI exists in the repo today, so the criterion "tested against real
+  PostgreSQL" cannot be met without adding one. *(user decision)*
+- **Client scope** — minimal stamping only: an `idempotencyKey` field on `TransportRequest`, a
+  stable UUID generated at ring-up and persisted with the queued sale, sent as `Idempotency-Key`.
+  #30's queue logic is untouched. *(user decision)*
+- **Claim placement** — inside the business transaction. *(user decision)*
+- **Isolation level** — stays `READ COMMITTED`. `REPEATABLE READ` would convert the lost update
+  into a `40001` the caller must retry, which is strictly more machinery than a conditional write.
+- **Key TTL** — 24 hours, enforced by `expires_at` plus opportunistic deletion of the expired row
+  during a claim collision. No background reaper in this plan.
+
+### Deferred to Implementation
+
+- **Whether pg-mem supports the new SQL** (`ON CONFLICT DO NOTHING`, `RETURNING` on a guarded
+  `UPDATE`, `FOR UPDATE`). If a construct is unsupported, the affected existing tests move to the
+  real-PG harness rather than the SQL being weakened. Knowable only by running the suite.
+- **Exact repository method names and signatures** for the new atomic primitives.
+- **Whether any consumer depends on `sale_items` insertion order** — confirmed by reading callers
+  during Unit 4, not assumed here.
+- **Whether `register.recordSaleMovement`'s `findOpenSessionByCashierId` needs its own lock.** A
+  cashier is single-session by construction; concurrency across a single cashier's two devices is
+  the only exposure, and it is assessed against the real-PG suite in Unit 9.
+- **Backfill/repair of already-negative stock rows**, if the `NOT VALID` constraint reveals any.
+  Surfaced by a validation query in Unit 2; remediation is an operational decision.
+
+## High-Level Technical Design
+
+*Directional only — signatures, error wording, and SQL are for the implementer to finalize.*
+
+### Idempotent mutation flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client (retry)
+    participant H as withIdempotency
+    participant TX as Business transaction
+    participant DB as PostgreSQL
+
+    C->>H: POST /sales, Idempotency-Key: K, body B
+    H->>H: fingerprint = sha256(canonical(validated B))
+    H->>TX: BEGIN
+    TX->>DB: INSERT INTO idempotency_keys (key=K, fingerprint, endpoint, user) 
+    alt claim acquired
+        TX->>DB: ...execute sale (stock, coupon, loyalty, register)...
+        TX->>DB: UPDATE idempotency_keys SET response_status, response_body WHERE key=K
+        TX->>DB: COMMIT
+        H-->>C: 201 + body
+    else 23505 unique violation (a committed twin exists)
+        TX->>DB: ROLLBACK
+        H->>DB: SELECT * FROM idempotency_keys WHERE key = K
+        alt row present and fingerprint matches
+            H-->>C: original status + body, Idempotent-Replay: true
+        else row present, fingerprint differs
+            H-->>C: 409 CONFLICT / IDEMPOTENCY_KEY_REUSED
+        else row gone (winner rolled back)
+            H->>TX: retry once from BEGIN
+        end
+    end
+```
+
+### Stock write, before and after
+
+```
+before:  read stock -> check in JS -> compute newStock -> UPDATE stock = newStock
+         └─ stale between read and write; two writers both "win"
+
+after:   UPDATE products
+            SET stock = stock - :qty
+          WHERE id = :id AND stock >= :qty
+      RETURNING stock AS new_stock            -- previous = new_stock + :qty
+         └─ rowCount 0 => insufficient stock => throw, transaction rolls back
+```
+
+The early check in `resolveLines` is kept but demoted to a fail-fast courtesy; the guarded
+`UPDATE` is the authority. `stock_adjustments` rows derive `previous_qty`/`new_qty` from the
+`RETURNING` value, not from the earlier read.
+
+### Invariant → mechanism map
+
+| Invariant | Mechanism |
+|---|---|
+| Product / variant stock never negative | Guarded relative `UPDATE` + `CHECK` |
+| Gift-card balance never negative | Guarded relative `UPDATE` + status/expiry in the `WHERE` |
+| Loyalty balance never negative | Guarded relative `UPDATE` |
+| Coupon `max_uses` / per-customer limit | `SELECT ... FOR UPDATE` on the coupon row before counting |
+| Cumulative refund ≤ sale total | `SELECT ... FOR UPDATE` on the sale row |
+| One outcome per idempotency key | `UNIQUE (key)` claimed inside the transaction |
+
+## Implementation Units
+
+### Phase 1 — Foundations
+
+- [x] **Unit 1: Real-PostgreSQL test harness and CI**
+
+**Goal:** Give the suite a way to run against real PostgreSQL, so every later unit can be proven
+rather than argued. Existing pg-mem tests keep running unchanged.
+
+**Requirements:** R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `server/tests/support/realPostgres.ts` (connect via `TEST_DATABASE_URL`, run migrations
+  into a per-run schema or database, truncate between tests, expose a `describeWithPostgres` guard
+  that skips with a clear message when the URL is absent)
+- Create: `docker-compose.test.yml` (a `postgres:16` service for local runs)
+- Create: `.github/workflows/ci.yml` (lint + typecheck + `npm test` for `server/` and `client/`,
+  with a `postgres:16` service container and `TEST_DATABASE_URL` exported)
+- Modify: `server/tests/setup.ts` (leave existing env stubs; do not force a DB connection)
+- Modify: `CLAUDE.md` (how to run the real-PG tests locally)
+
+**Approach:**
+- The guard must *skip loudly*, never silently pass, when `TEST_DATABASE_URL` is unset — a
+  concurrency suite that quietly no-ops is worse than no suite.
+- Each real-PG test file gets an isolated schema (or database) created and dropped around the file,
+  so parallel vitest files cannot see each other's rows.
+- Migrations run through the existing `runMigrationsUp` so the harness exercises the real schema
+  path rather than a hand-written DDL copy.
+- CI runs the full suite once with `TEST_DATABASE_URL` set; there is no separate "unit vs
+  integration" split to maintain.
+
+**Patterns to follow:**
+- `server/tests/sales.test.ts` head — pg-mem construction, `setPool`/`closePool`, `runMigrationsUp`.
+- `server/src/database/migrate.ts` — `runMigrationsUp(pool, migrationsDir)` accepts an explicit pool.
+
+**Test scenarios:**
+- Happy path: with `TEST_DATABASE_URL` set, the harness applies all migrations and a trivial
+  `SELECT 1` round-trips.
+- Happy path: two concurrent clients obtained from the harness can hold overlapping transactions
+  (proves it is real PG, not pg-mem).
+- Edge case: with `TEST_DATABASE_URL` unset, guarded suites report as skipped and the rest of the
+  suite still passes.
+- Edge case: two harness-using test files run in the same vitest run without cross-contaminating
+  rows.
+
+**Verification:**
+- `npm test` in `server/` passes both with and without `TEST_DATABASE_URL`, with the guarded suites
+  visibly skipped in the latter case.
+- A pushed branch shows a green CI run in which the guarded suites actually executed.
+
+---
+
+- [x] **Unit 2: Migration 004 — idempotency keys and non-negative invariants**
+
+**Goal:** Add the `idempotency_keys` table and the database-level floors that back the application
+guards.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Unit 1 (to test the migration against real PG)
+
+**Files:**
+- Create: `server/src/database/migrations/004_concurrency_and_idempotency.sql`
+- Create: `server/src/database/migrations/004_concurrency_and_idempotency.down.sql`
+- Test: `server/tests/database/migrate.test.ts` (extend)
+
+**Approach:**
+- `idempotency_keys`: `key TEXT PRIMARY KEY`, `endpoint TEXT NOT NULL`,
+  `user_id INTEGER REFERENCES users(id)`, `request_fingerprint TEXT NOT NULL`,
+  `response_status INTEGER`, `response_body JSONB`, `resource_type TEXT`, `resource_id INTEGER`,
+  `created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP`, `expires_at TIMESTAMPTZ NOT NULL`.
+  Index on `expires_at` for cleanup.
+- `CHECK` constraints added `NOT VALID`: `products.stock >= 0`, `product_variants.stock >= 0`,
+  `gift_cards.balance >= 0`, `customers.loyalty_points >= 0`. New and updated rows are enforced;
+  legacy rows are not retroactively rejected.
+- Include, as a comment in the migration, the query an operator can run to find pre-existing
+  violating rows, and note that `VALIDATE CONSTRAINT` is a follow-up once they are cleaned.
+- The `.down.sql` drops the table and the four constraints.
+
+**Patterns to follow:**
+- `server/src/database/migrations/003_sale_calculation_snapshot.sql` — header comment explaining
+  the *why*, `IF NOT EXISTS`, `TIMESTAMPTZ`, paired down file.
+
+**Test scenarios:**
+- Happy path: `runMigrationsUp` on a fresh real-PG database creates `idempotency_keys` with the
+  expected columns and the primary key on `key`.
+- Happy path: `runMigrationsDown(1)` removes the table and the constraints; a subsequent up
+  re-applies cleanly.
+- Error path: inserting two rows with the same `key` raises SQLSTATE `23505`.
+- Error path: `UPDATE products SET stock = -1` is rejected by the check constraint.
+- Edge case: a pre-existing row with negative stock does not block the migration (`NOT VALID`).
+- Integration: the migration applies on top of the existing 001–003 chain, in order, through the
+  real `runMigrationsUp`.
+
+**Verification:**
+- Migration up/down/up is idempotent against real PG and leaves `_migrations` consistent.
+- The existing pg-mem-based suites still pass (or, where a construct is unsupported, the affected
+  file is moved to the real-PG harness rather than the SQL being softened).
+
+---
+
+- [x] **Unit 3: Shared idempotency helper and conflict semantics**
+
+**Goal:** One reusable helper that wraps a business transaction with claim, replay, and conflict
+handling — so no module reimplements the protocol.
+
+**Requirements:** R2, R3, R4, R6, R8
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `server/src/http/idempotency.ts` (fingerprint canonicalization, `withIdempotency`,
+  `IdempotencyConflictError`, the `IDEMPOTENCY_KEY_REUSED` code constant, header name constant)
+- Create: `server/src/http/idempotency.test.ts` (colocated per `docs/CONVENTIONS.md`)
+- Modify: `server/src/config/env.ts` (add `IDEMPOTENCY_REQUIRED`, boolean, default `false`)
+- Modify: `server/src/database/transaction.ts` (bounded retry on `40001` / `40P01`, opt-in via an
+  options argument so existing callers are untouched)
+- Test: `server/tests/database/transaction.test.ts` (extend for the retry behavior)
+
+**Approach:**
+- `withIdempotency({ key, endpoint, userId, payload, run })`:
+  - No `key` and `IDEMPOTENCY_REQUIRED` false → call `run` directly; today's behavior, no table row.
+  - No `key` and `IDEMPOTENCY_REQUIRED` true → `PublicError('VALIDATION_ERROR', …)` naming the
+    missing header.
+  - With a `key` → open a transaction, `INSERT` the claim as the first statement, call `run(client)`,
+    then write `response_status` / `response_body` before commit.
+  - `23505` → rollback, re-read the row on the pool, and branch: fingerprint+endpoint+user all match
+    → return the stored outcome flagged as a replay; any mismatch → `IdempotencyConflictError`; row
+    absent (winner rolled back, or the key had expired and was cleaned) → one retry of the whole
+    flow, then give up with a 409 rather than looping.
+- Fingerprint canonicalization sorts object keys recursively and rejects non-finite numbers, so
+  `{a:1,b:2}` and `{b:2,a:1}` fingerprint identically.
+- Key format validation: non-empty, ≤ 255 chars, printable ASCII. A malformed key is a 400, not a
+  silent bypass.
+- The retry in `withTransaction` must be opt-in and must never wrap a callback that has already
+  performed a non-transactional side effect.
+
+**Technical design:** see the sequence diagram above; the helper owns every branch in it, and the
+calling service supplies only `run`.
+
+**Execution note:** implement test-first. The interleavings here are the whole point of the unit,
+and the tests are cheaper to write than the debugging is.
+
+**Patterns to follow:**
+- `server/src/http/errors.ts` — `PublicError` with `CONFLICT`, and `ValidationDetail` for the
+  machine code.
+- `server/src/modules/pos/sales/types.ts` — `SalesValidationError` + `SPLIT_PAYMENT_MISMATCH_CODE`
+  as the precedent for a typed, coded domain error.
+- `server/src/config/env.ts` — Zod-parsed env with defaults.
+
+**Test scenarios:**
+- Happy path: first call with key K runs the callback once and returns its result.
+- Happy path: second call with K and the identical payload does not run the callback and returns the
+  stored status and body.
+- Happy path: no key supplied, flag off → callback runs, no row is written.
+- Edge case: payload with the same fields in a different key order fingerprints identically and
+  replays rather than conflicting.
+- Edge case: a key whose row has passed `expires_at` is treated as fresh — the callback runs again.
+- Error path: same key, different payload → `IdempotencyConflictError` carrying
+  `IDEMPOTENCY_KEY_REUSED`; the callback does not run.
+- Error path: same key, different endpoint or different `user_id` → the same conflict, and the
+  original response body is not disclosed.
+- Error path: the callback throws → the transaction rolls back, no key row survives, and an
+  immediate retry with the same key runs the callback again.
+- Error path: no key supplied, flag on → 400 naming the missing header; the callback does not run.
+- Error path: malformed key (empty, over-long, control characters) → 400.
+- Integration: two concurrent calls with the same key against real PG produce exactly one callback
+  execution and two identical successful responses.
+- Integration: a callback that raises `40P01` is retried by `withTransaction` and ultimately
+  commits once.
+
+**Verification:**
+- The concurrent-duplicate test passes repeatedly against real PG without flaking.
+- `idempotency_keys` holds exactly one row per committed outcome and none for failed attempts.
+
+---
+
+### Phase 2 — Checkout
+
+- [x] **Unit 4: Atomic stock mutation in checkout**
+
+**Goal:** Replace `executeSale`'s read-then-write stock path with guarded relative writes applied in
+a canonical order.
+
+**Requirements:** R1, R4, R8
+
+**Dependencies:** Units 1, 2
+
+**Files:**
+- Modify: `server/src/modules/pos/sales/repository.ts` (add guarded decrement/increment methods to
+  `ISalesRepository` and `SalesRepository`; keep the existing absolute setters only if a
+  non-checkout caller still needs them, otherwise remove them from the interface)
+- Modify: `server/src/modules/pos/sales/service.ts` (`executeSale` write phase: sort resolved lines
+  canonically; derive `previousStock`/`newStock` from `RETURNING`; throw a typed insufficient-stock
+  error on `rowCount === 0`)
+- Modify: `server/src/modules/pos/sales/types.ts` (a typed `InsufficientStockError` carrying the
+  offending product/variant id, so the controller stops string-matching)
+- Modify: `server/src/modules/pos/sales/controller.ts` (map the typed error; keep the existing
+  message text so client-facing wording is unchanged)
+- Test: `server/tests/sales.test.ts` (extend)
+- Test: `server/tests/concurrency/checkout.concurrency.test.ts` (new, real-PG guarded)
+
+**Approach:**
+- The `resolveLines` pre-check stays (fail fast, better error before any write) but is explicitly
+  documented as advisory; the guarded `UPDATE` is authoritative.
+- Sort the write phase by `(isVariant, variant_id ?? product_id)` ascending before applying, to fix
+  lock order. Confirm no consumer depends on `sale_items` insertion order before landing this.
+- `stock_adjustments.previous_qty` / `new_qty` derive from the `RETURNING` value so the audit trail
+  records what actually happened, not what was predicted.
+- Pricing reads in `resolveLines` are unchanged — price staleness is not a lost-update problem, and
+  the financial contract from the previous plan must not shift.
+
+**Technical design:** see "Stock write, before and after" above.
+
+**Execution note:** add the failing concurrent-oversell test first; it is the unit's definition of
+done and it will fail loudly against the current code.
+
+**Patterns to follow:**
+- `server/src/modules/pos/exchanges/repository.ts:125-152` — relative-SQL shape to mirror (plus the
+  guard it is missing).
+- `server/src/modules/pos/sales/types.ts` — `SalesValidationError` as the typed-error precedent.
+
+**Test scenarios:**
+- Happy path: a single-line sale of qty 2 against stock 5 leaves stock 3 and writes one
+  `stock_adjustments` row with `previous_qty` 5 / `new_qty` 3.
+- Happy path: a variant line decrements `product_variants.stock`, not `products.stock`.
+- Happy path: a multi-line sale decrements every line exactly once.
+- Edge case: a sale of exactly the remaining stock succeeds and leaves stock at 0.
+- Edge case: a bundle group deducts each member product by its allocated quantity, with financial
+  amounts unchanged from the existing bundle fixtures.
+- Error path: qty exceeding stock throws the typed insufficient-stock error, the controller returns
+  the existing 400 wording, and no sale, items, payments, or adjustments are written.
+- Error path: a line whose product row was deleted between resolve and write fails the transaction
+  rather than writing a partial sale.
+- Integration: 10 concurrent checkouts of 1 unit each against stock 5 → exactly 5 succeed, 5 fail
+  with insufficient stock, final stock is 0, and `sale_items` count equals 5 (R1).
+- Integration: 2 concurrent 2-line checkouts requesting the same two products in opposite order
+  both complete without a deadlock error surfacing to the caller.
+- Integration: a checkout that fails at the register-movement step leaves stock, coupon usage, and
+  loyalty untouched (R4).
+
+**Verification:**
+- The 10-way oversell test passes on real PG across repeated runs.
+- Final stock never goes negative in any concurrency scenario, with the `CHECK` constraint as the
+  backstop that would have caught it.
+
+---
+
+- [x] **Unit 5: Serialize coupon consumption and loyalty redemption**
+
+**Goal:** Make coupon usage limits and loyalty balances hold under concurrency, inside the checkout
+transaction.
+
+**Requirements:** R1, R4, R7
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `server/src/modules/commerce/coupons/repository.ts` (a lock-taking `findByCodeForUpdate`
+  used only on the consuming path)
+- Modify: `server/src/modules/commerce/coupons/service.ts` (`validate` gains an explicit
+  "for consumption" mode that locks the coupon row before counting usage; the preview/read path
+  stays lock-free)
+- Modify: `server/src/modules/pos/sales/repository.ts` (guarded loyalty debit:
+  `SET loyalty_points = loyalty_points - $1 WHERE id = $2 AND loyalty_points >= $1`)
+- Modify: `server/src/modules/pos/sales/service.ts` (call the consuming variant from `executeSale`
+  only; `calculateSaleTotals` keeps the non-locking path)
+- Test: `server/tests/commerce-contracts.test.ts` (extend)
+- Test: `server/tests/concurrency/checkout.concurrency.test.ts` (extend)
+
+**Approach:**
+- Lock order matters: the coupon row is taken *after* the stock rows and *before* the customer row,
+  matching the canonical order in Key Technical Decisions.
+- The preview path (`calculateSaleTotals`, and the standalone coupon-validate endpoint) must not take
+  locks — a preview that blocks a checkout would be a self-inflicted contention source.
+- The loyalty debit becomes authoritative at the write; the balance check in `buildBreakdown` stays
+  as the source of the user-facing error message.
+- Earned-points credit is already a relative write and stays as-is.
+
+**Patterns to follow:**
+- `server/src/modules/commerce/coupons/service.ts` `validate` — already accepts a `Queryable` so it
+  can run inside the checkout transaction; extend that seam rather than adding a parallel path.
+
+**Test scenarios:**
+- Happy path: a coupon with `max_uses = 1` applies to one sale and records one `coupon_usage` row.
+- Happy path: loyalty redemption of 100 points debits exactly 100 and writes one `redeemed`
+  transaction row.
+- Edge case: a coupon with no `max_uses` never takes the counting path.
+- Edge case: `max_uses_per_customer` is enforced per customer while a different customer still
+  succeeds concurrently.
+- Error path: redeeming more points than the balance fails the transaction and leaves the balance
+  and `loyalty_transactions` unchanged.
+- Error path: a coupon at its usage limit yields the existing `CouponError` wording and 400.
+- Integration: 5 concurrent sales using a `max_uses = 1` coupon → exactly 1 succeeds, 4 fail with
+  the usage-limit error, and `coupon_usage` holds exactly 1 row.
+- Integration: 3 concurrent sales each redeeming 100 points from a 150-point balance → exactly 1
+  succeeds, balance is 50, never negative.
+- Integration: a coupon-limit failure rolls back the stock decrement from the same transaction.
+
+**Verification:**
+- Coupon `max_uses` and loyalty balances hold under concurrent load on real PG.
+- The preview endpoints take no row locks (verified by a concurrent preview-during-checkout test
+  that does not block).
+
+---
+
+- [x] **Unit 6: Wire idempotency into sale creation**
+
+**Goal:** `POST /api/v1/sales` honours `Idempotency-Key` end to end.
+
+**Requirements:** R2, R3, R4, R6, R8
+
+**Dependencies:** Units 3, 4, 5
+
+**Files:**
+- Modify: `server/src/modules/pos/sales/controller.ts` (read the header, compute the fingerprint from
+  `parsed.data`, wrap `executeSale` in `withIdempotency`, set `Idempotent-Replay` on a replay, map
+  `IdempotencyConflictError` to a 409)
+- Modify: `server/src/modules/pos/sales/service.ts` (`executeSale` accepts the caller's transaction
+  client so the claim and the sale share one transaction)
+- Modify: `server/src/docs/openapi.ts` (document the header, the 409, and the replay header on the
+  sales endpoints)
+- Test: `server/tests/sales.test.ts` (extend)
+- Test: `server/tests/concurrency/sales.idempotency.test.ts` (new, real-PG guarded)
+
+**Approach:**
+- Non-transactional side effects stay where they are, *after* the transaction:
+  `logAuditFromReq` and `notifySale` must not fire on a replay — a replayed request should not send
+  a second SMS. Gate them on the "was this a replay?" flag the helper returns.
+- The stored `response_body` is exactly the `success(...)` payload the first request returned,
+  including `cashier_name`, `calculation`, `items`, and `payments`, so a replay is byte-identical.
+- `resource_type` / `resource_id` are set to `'sale'` / the sale id, so an operator can trace a key
+  to its sale without parsing the stored body.
+
+**Patterns to follow:**
+- `server/src/modules/pos/sales/controller.ts` `createSale` — the existing parse → execute → audit →
+  notify → respond shape; the wrapper slots between parse and execute.
+
+**Test scenarios:**
+- Happy path: a request with a key returns 201 and persists one `idempotency_keys` row linked to the
+  sale.
+- Happy path: replaying that request returns the same 201 status and an identical body, with
+  `Idempotent-Replay: true`.
+- Happy path: a request with no key behaves exactly as before, writes no key row, and returns the
+  unchanged response shape (R6, R8).
+- Edge case: two *different* keys with identical bodies create two distinct sales — identical
+  payloads are not treated as duplicates.
+- Edge case: a replay does not re-send the sale notification or write a second audit entry.
+- Error path: the same key with a changed cart returns 409 with `IDEMPOTENCY_KEY_REUSED` and creates
+  no second sale.
+- Error path: a request that fails validation (split-payment mismatch) with a key returns the
+  existing 400 and leaves no key row, so a corrected retry with the same key succeeds.
+- Error path: a request that fails on insufficient stock leaves no key row and no sale.
+- Integration: 20 concurrent identical requests with one key → exactly 1 `sales` row, 1 stock
+  decrement, 1 coupon usage, 1 loyalty award, and 20 identical 201 responses (R2, R4).
+- Integration: with `IDEMPOTENCY_REQUIRED=true`, a keyless request is rejected and a keyed one
+  succeeds (R6 window closure).
+
+**Verification:**
+- 20-way concurrent replay produces exactly one sale and twenty identical bodies on real PG.
+- Every existing sales test passes unmodified, proving the envelope and fields are untouched.
+
+---
+
+### Phase 3 — The remaining retry-prone mutations
+
+- [x] **Unit 7: Concurrency-safe and idempotent refunds**
+
+**Goal:** Refunds cannot over-refund a sale or lose a restock, and a retried refund does not refund
+twice.
+
+**Requirements:** R1, R2, R4, R7
+
+**Dependencies:** Units 3, 4
+
+**Files:**
+- Modify: `server/src/modules/pos/sales/repository.ts` (`findByIdForUpdate`; guarded restock)
+- Modify: `server/src/modules/pos/sales/service.ts` (`executeRefund` locks the sale row before
+  reading `refunded_amount`; restock uses the relative guarded write)
+- Modify: `server/src/modules/pos/sales/controller.ts` (wrap `executeRefund` in `withIdempotency`;
+  move `recordRefundMovement` inside the transaction so a rolled-back refund cannot leave a register
+  movement behind)
+- Test: `server/tests/sales.test.ts` (extend)
+- Test: `server/tests/concurrency/refunds.concurrency.test.ts` (new, real-PG guarded)
+
+**Approach:**
+- `recordRefundMovement` is currently called from the controller *after* the transaction and
+  swallows its own errors — that violates R4. Moving it inside the refund transaction mirrors what
+  Unit 4 of the previous plan already did for sale movements.
+- The cumulative check (`previouslyRefunded + refundAmount > sale.total`) becomes correct once the
+  sale row is locked for the duration.
+- Refund amounts still come from the request's `unit_price`; tightening that to server-authoritative
+  pricing is a separate concern and explicitly not in this plan.
+
+**Patterns to follow:**
+- `server/src/modules/pos/sales/service.ts` `executeSale`'s in-transaction register movement — the
+  established shape for "this side effect commits with the mutation".
+
+**Test scenarios:**
+- Happy path: a partial refund sets `refund_status = 'partial'` and increments `refunded_amount`.
+- Happy path: a refund with `restock: true` increments product stock by the refunded quantity.
+- Edge case: a refund bringing the cumulative total exactly to the sale total sets `'full'`.
+- Error path: a refund exceeding the remaining refundable amount is rejected and changes nothing.
+- Error path: refunding an already fully-refunded sale returns the existing error.
+- Integration: 3 concurrent partial refunds that together exceed the sale total → only the ones that
+  fit succeed, `refunded_amount` never exceeds `total`.
+- Integration: a retried refund with the same idempotency key produces one refund row, one restock,
+  and one register movement.
+- Integration: a refund that fails after the refund row is created leaves no register movement (R4).
+
+**Verification:**
+- Cumulative refunds never exceed the sale total under concurrent load.
+- No register movement exists for any refund that did not commit.
+
+---
+
+- [x] **Unit 8: Gift cards, exchanges, and manual stock adjustments**
+
+**Goal:** Apply the same two invariants to the remaining balance- and stock-mutating endpoints named
+in the issue.
+
+**Requirements:** R1, R2, R4, R7
+
+**Dependencies:** Units 3, 4
+
+**Files:**
+- Modify: `server/src/modules/commerce/giftCards/repository.ts` (guarded balance debit that also
+  asserts `status = 'active'` and non-expiry in the `WHERE`)
+- Modify: `server/src/modules/commerce/giftCards/service.ts` (`redeem` uses it; `rowCount === 0`
+  distinguishes insufficient balance from inactive/expired via a follow-up read for the message)
+- Modify: `server/src/modules/commerce/giftCards/controller.ts` (idempotency wrapper on redeem)
+- Modify: `server/src/modules/pos/exchanges/repository.ts` (add the missing `AND stock >= $1` guard
+  to `deductProductStock` / `deductVariantStock`)
+- Modify: `server/src/modules/pos/exchanges/service.ts` (sort item writes canonically; surface the
+  guard failure as a typed error)
+- Modify: `server/src/modules/pos/exchanges/controller.ts` (idempotency wrapper)
+- Modify: `server/src/modules/inventory/stockAdjustments/repository.ts` and `service.ts` (relative
+  guarded writes for manual adjustments)
+- Test: `server/tests/exchanges.test.ts`, `server/tests/commerce-contracts.test.ts`,
+  `server/tests/inventory-bounded.test.ts` (extend)
+- Test: `server/tests/concurrency/balances.concurrency.test.ts` (new, real-PG guarded)
+
+**Approach:**
+- Gift-card redemption is the clearest double-spend surface: the status, expiry, and balance
+  conditions all move into the `WHERE` clause so a single statement decides eligibility.
+- Exchanges already use relative SQL; this is a small guard plus lock ordering, not a rewrite.
+- Manual stock adjustments that *set* an absolute value (a stock count reconciliation) are a
+  legitimately absolute operation — leave `stockCounts` alone and note why in the code comment.
+
+**Patterns to follow:**
+- Unit 4's guarded-`UPDATE` + `rowCount` shape, reused verbatim.
+
+**Test scenarios:**
+- Happy path: redeeming 50 from a 100 balance leaves 50 and writes one transaction row.
+- Edge case: redeeming the exact remaining balance succeeds and leaves 0.
+- Error path: redeeming from an inactive, expired, or insufficient card fails with the existing
+  message and changes no balance.
+- Error path: an exchange whose new items exceed available stock fails wholly — no returned-item
+  restock survives.
+- Integration: 5 concurrent redemptions of 100 against a 100 balance → exactly 1 succeeds, balance
+  is 0, never negative.
+- Integration: a retried gift-card redemption with the same key debits once.
+- Integration: concurrent exchanges on the same product never drive stock negative.
+
+**Verification:**
+- No balance or stock column can be driven negative by any concurrent combination in the suite.
+- The `CHECK` constraints from Unit 2 are never the thing that catches a bug in these paths — they
+  stay a silent backstop.
+
+---
+
+- [x] **Unit 9: Client idempotency key stamping**
+
+**Goal:** Give the till a stable key per rung-up sale that survives a reload and every offline
+replay, so the server-side guarantee is actually reachable.
+
+**Requirements:** R2, R6
+
+**Dependencies:** Unit 6
+
+**Files:**
+- Modify: `client/src/shared/lib/transport/types.ts` (optional `idempotencyKey` on
+  `TransportRequest`)
+- Modify: `client/src/shared/lib/transport/http.ts` (send it as the `Idempotency-Key` header)
+- Modify: `client/src/shared/lib/transport/memory.ts` (honour it in the fake so tests exercise the
+  same seam)
+- Modify: `client/src/features/pos/components/CartPanel.tsx` (generate one `crypto.randomUUID()` per
+  checkout attempt, pass it on the online POST, and store it on the queued entry for the offline
+  fallback)
+- Modify: `client/src/shared/store/offlineStore.ts` (carry `idempotencyKey` on `OfflineAction`)
+- Modify: `client/src/shared/hooks/useOffline.ts` (send the stored key on replay)
+- Test: `client/src/shared/lib/transport/client.test.ts`,
+  `client/src/shared/store/offlineStore.test.ts`, `client/src/shared/hooks/useOffline.test.tsx`,
+  `client/src/features/pos/components/CartPanel.test.tsx` (extend)
+
+**Approach:**
+- The key is generated once per *checkout attempt*, not per HTTP request — that is what makes a
+  transport-level retry and an offline replay collapse onto the same key.
+- A new key is generated when the cashier changes the cart and rings up again; a genuinely new sale
+  must not inherit the previous key.
+- The queued-entry field is additive and optional, so entries persisted before this ships still
+  replay (keyless, exactly as today). This is deliberately the *only* offline-queue change; #30's
+  quarantine and replay logic is untouched.
+- `crypto.randomUUID()` needs a secure context; note the fallback if the till is ever served over
+  plain HTTP.
+
+**Patterns to follow:**
+- `client/src/shared/store/offlineStore.ts` `contractVersion` — the established precedent for an
+  optional additive field on a persisted queue entry, with older entries handled explicitly.
+
+**Test scenarios:**
+- Happy path: a successful checkout sends an `Idempotency-Key` header.
+- Happy path: an offline checkout stores the key on the queue entry and the replay sends the same
+  value.
+- Edge case: two consecutive distinct checkouts send two different keys.
+- Edge case: a queue entry persisted without a key still replays, with no header.
+- Edge case: a reload between queueing and replay preserves the key (it round-trips through the
+  persist middleware).
+- Error path: a failed checkout that the cashier immediately retries with the same cart reuses the
+  same key, so the server can dedupe.
+- Integration: a checkout whose response is lost and then retried results in one sale server-side
+  (exercised against the real-PG server suite, not only the client fake).
+
+**Verification:**
+- The client sends a stable key across a retry of the same rung-up sale, and a distinct key for a
+  distinct sale.
+- Existing client tests pass unchanged where they do not assert on headers.
+
+---
+
+- [x] **Unit 10: Contract documentation and the compatibility window**
+
+**Goal:** Write down what callers can rely on, and when the optional header stops being optional.
+
+**Requirements:** R3, R6, R8
+
+**Dependencies:** Units 6, 7, 8
+
+**Files:**
+- Modify: `server/src/docs/openapi.ts` (the `Idempotency-Key` request header, the `Idempotent-Replay`
+  response header, and the 409 response with `IDEMPOTENCY_KEY_REUSED`, on every wrapped endpoint)
+- Modify: `docs/CONVENTIONS.md` (a short "concurrency and idempotency" contract: never write an
+  absolute quantity read earlier in the same request; the canonical lock order; when to reach for
+  `FOR UPDATE`)
+- Modify: `CLAUDE.md` (running the real-PG suite; the `IDEMPOTENCY_REQUIRED` flag)
+- Modify: `server/.env.example` if present, otherwise the env table in `CLAUDE.md`
+- Create: `docs/reports/` entry or issue comment recording the compatibility window's dates and the
+  flip criteria
+
+**Approach:**
+- The compatibility window is stated concretely: the header is optional while
+  `IDEMPOTENCY_REQUIRED=false`; it flips to required only once telemetry (or a manual check of the
+  deployed client version) shows every till sending a key. Name the observable that gates the flip
+  rather than only a date.
+- The convention entry is what stops this regressing — the next read-then-write is the next
+  oversell.
+
+**Test scenarios:**
+- Test expectation: none — documentation and OpenAPI metadata only. The OpenAPI document's own
+  structural assertions in `server/tests/api-contract-conformance.test.ts` cover that the added
+  header and response definitions parse and conform.
+
+**Verification:**
+- `server/tests/api-contract-conformance.test.ts` passes with the enriched spec.
+- The Scalar reference renders the header and the 409 on the sales, refunds, exchanges, and
+  gift-card endpoints.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `executeSale` reaches `bundlesRepository`, `couponsService`,
+  `registerService`, and the settings reads — all of which now run inside a transaction that also
+  holds an idempotency claim and (transiently) row locks. Lengthening that transaction increases
+  contention, so nothing slow (notifications, audit writes, external calls) may move into it.
+  `notifySale` and `logAuditFromReq` stay outside and must be suppressed on replay.
+- **Error propagation:** three new typed errors cross the service→controller boundary
+  (`InsufficientStockError`, `IdempotencyConflictError`, and the gift-card/exchange guard failures).
+  The controller's existing string-matching remains for the errors it already handles; new errors
+  are typed so the string list stops growing.
+- **State lifecycle risks:** the claim row and the mutation share a fate by construction. The
+  residual risk is a *committed* mutation whose response never reaches the client and whose client
+  never retries — unchanged from today, and outside this plan.
+- **API surface parity:** the same wrapper must be applied to every retry-prone mutation named in
+  the issue, not just sales. Units 7 and 8 exist for exactly that reason; layaway payments and
+  online-order transitions are adjacent surfaces worth a follow-up issue but are not in the issue's
+  enumerated scope.
+- **Integration coverage:** none of the core claims (oversell, lost update, duplicate suppression,
+  usage-limit enforcement) can be proven by unit tests with a fake repository. Every one of them
+  needs two real concurrent connections; that is what Unit 1 buys.
+- **Connection pool:** a blocked duplicate holds a pooled connection for the duration of the winning
+  checkout. With `max` 10 in dev, a pathological retry storm could saturate the pool. The real-PG
+  suite should include a modest storm to confirm the pool recovers.
+- **Unchanged invariants:** the `{ data, meta }` / `{ error }` envelope; every existing field on
+  every existing response; the checkout financial contract and `sale_calculations` snapshot from
+  `docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md`; the split-payment validation
+  policy and its `SPLIT_PAYMENT_MISMATCH` code; the offline queue's quarantine semantics; and the
+  behavior of every request that sends no `Idempotency-Key`.
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| pg-mem does not support `ON CONFLICT` / guarded `UPDATE ... RETURNING` / `FOR UPDATE`, breaking existing tests | Med | Med | Verify in Unit 2 before building on it. Where unsupported, move that test file to the real-PG harness rather than weakening the SQL. Unit 1 lands first precisely so this escape hatch exists. |
+| Longer checkout transactions increase lock contention at a busy till | Med | Med | Keep every slow operation outside the transaction; sort writes to a canonical lock order; include a pool-saturation scenario in the real-PG suite. |
+| Deadlock between checkout and exchange/refund paths touching the same rows in different orders | Low | High | One documented lock order across all units, enforced by sorting; bounded `40001`/`40P01` retry in `withTransaction`; explicit cross-path concurrency test. |
+| `CHECK (stock >= 0)` fails to apply because legacy rows are already negative | Med | Low | Added `NOT VALID`; the migration ships the query to find violators and `VALIDATE CONSTRAINT` is left as an operational follow-up. |
+| A blocked duplicate exhausts the connection pool under a retry storm | Low | Med | Duplicates block only for the winner's duration; test the storm; the two-phase alternative is documented in Key Technical Decisions should this prove real. |
+| Client ships a key but the server has not deployed yet, or vice versa | Med | Low | The header is optional on both sides for the whole compatibility window; neither order of deployment breaks. |
+| No CI exists, so the concurrency suite could silently stop running | Med | High | Unit 1 adds the workflow, and the harness skips *loudly* rather than passing silently when `TEST_DATABASE_URL` is missing. |
+| Scope creep into #30's offline-queue logic | Med | Med | Unit 9 is deliberately bounded to one additive field and the header; the queue's replay and quarantine behavior is not touched. |
+
+## Documentation / Operational Notes
+
+- **Rollout order:** server first (idempotency optional), then client. Neither half breaks the other
+  at any point in between.
+- **Compatibility window:** `IDEMPOTENCY_REQUIRED` defaults to `false`. It flips to `true` only once
+  every deployed till is confirmed to send the header; the flip is a config change, not a deploy.
+- **Migration:** `004` is additive and online — a new table plus four `NOT VALID` constraints. No
+  table rewrite, no lock on a large table, and the `.down.sql` is a clean reversal.
+- **Operational follow-up:** `idempotency_keys` grows with sale volume. TTL is 24h and expired rows
+  are cleaned opportunistically on collision; if volume warrants it, a scheduled
+  `DELETE FROM idempotency_keys WHERE expires_at < NOW()` is the intended next step.
+- **Monitoring worth adding later (not in this plan):** counts of 409 `IDEMPOTENCY_KEY_REUSED`,
+  replay hits, insufficient-stock rejections, and deadlock retries. Each is a leading indicator of a
+  misbehaving till.
+- **Stale docs found during research:** `C:\Users\opggh\CLAUDE.md` still describes this server as
+  SQLite/better-sqlite3 with a JavaScript `routes/` layout. The server is PostgreSQL + TypeScript +
+  modular monolith. Worth correcting alongside Unit 10, though it is outside this issue.
+
+## Sources & References
+
+- **Origin issue:** [zhamdy/moon-store#42](https://github.com/zhamdy/moon-store/issues/42) —
+  "fix: Make POS financial mutations concurrency-safe and idempotent" (P0, backend)
+- Related issue: #30 (client offline queue) — explicitly out of scope
+- Prior plan (financial contract this must not disturb):
+  `docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md`
+- Prior plan (backend architecture this builds on):
+  `docs/plans/2026-08-21-003-refactor-backend-postgresql-modular-monolith-plan.md`
+- Core code: `server/src/modules/pos/sales/service.ts`,
+  `server/src/modules/pos/sales/repository.ts`, `server/src/database/transaction.ts`,
+  `server/src/http/errors.ts`, `server/src/modules/commerce/giftCards/service.ts`,
+  `server/src/modules/commerce/coupons/service.ts`, `server/src/modules/pos/exchanges/service.ts`
+- Client seam: `client/src/shared/lib/transport/http.ts`,
+  `client/src/shared/store/offlineStore.ts`, `client/src/shared/hooks/useOffline.ts`

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,3 +8,8 @@ TWILIO_PHONE=+1234567890
 TWILIO_WHATSAPP_FROM=whatsapp:+14155238886
 CLIENT_URL=http://localhost:5173
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
+
+# Closes the idempotency compatibility window. While false, a mutation without an
+# Idempotency-Key behaves exactly as it did before idempotency existed, so an unpatched
+# till keeps working. See CLAUDE.md for the flip criterion.
+IDEMPOTENCY_REQUIRED=false

--- a/server/eslint.config.mjs
+++ b/server/eslint.config.mjs
@@ -1,4 +1,5 @@
 import js from '@eslint/js';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
 
@@ -7,6 +8,12 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
+  {
+    files: ['**/*.mjs'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
   {
     files: ['**/*.ts'],
     rules: {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -34,6 +34,7 @@
         "@types/pg": "^8.23.1",
         "eslint": "^9.39.3",
         "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.11.0",
         "pg-mem": "^3.0.14",
         "prettier": "^3.8.1",
         "tsx": "^4.21.0",
@@ -632,6 +633,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ms": {
@@ -3289,9 +3303,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.ts\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@scalar/express-api-reference": "^0.8.48",
@@ -42,6 +43,7 @@
     "@types/pg": "^8.23.1",
     "eslint": "^9.39.3",
     "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.11.0",
     "pg-mem": "^3.0.14",
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",

--- a/server/scripts/assertRealPostgresSuitesRan.mjs
+++ b/server/scripts/assertRealPostgresSuitesRan.mjs
@@ -1,0 +1,56 @@
+/**
+ * CI guard: fail the build if the real-PostgreSQL suites were skipped.
+ *
+ * `describeWithPostgres` skips when TEST_DATABASE_URL is unset. That is correct locally
+ * but catastrophic in CI, where a misconfigured service container would turn the entire
+ * concurrency and idempotency proof into a green no-op. This asserts they actually ran.
+ */
+import fs from 'fs';
+
+const REQUIRED_SUITE_PATTERN = /tests[/\\](support[/\\]realPostgres|concurrency[/\\])/;
+
+const reportPath = process.argv[2];
+
+if (!reportPath || !fs.existsSync(reportPath)) {
+  console.error(`[ci-guard] vitest JSON report not found at "${reportPath}".`);
+  process.exit(1);
+}
+
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+const suites = (report.testResults ?? []).filter((s) => REQUIRED_SUITE_PATTERN.test(s.name));
+
+if (suites.length === 0) {
+  console.error('[ci-guard] No real-PostgreSQL suite files were found in the vitest report.');
+  process.exit(1);
+}
+
+let executed = 0;
+const skipped = [];
+
+for (const suite of suites) {
+  for (const test of suite.assertionResults ?? []) {
+    if (test.status === 'passed' || test.status === 'failed') {
+      executed += 1;
+    } else {
+      skipped.push(`${suite.name} › ${test.fullName ?? test.title}`);
+    }
+  }
+}
+
+if (executed === 0) {
+  console.error(
+    '[ci-guard] Every real-PostgreSQL test was skipped. TEST_DATABASE_URL is almost certainly ' +
+      'unset or the postgres service is unreachable.'
+  );
+  process.exit(1);
+}
+
+if (skipped.length > 0) {
+  console.error(`[ci-guard] ${skipped.length} real-PostgreSQL test(s) were skipped:`);
+  for (const name of skipped) {
+    console.error(`  - ${name}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[ci-guard] ${executed} real-PostgreSQL test(s) executed across ${suites.length} file(s).`);

--- a/server/scripts/assertRealPostgresSuitesRan.mjs
+++ b/server/scripts/assertRealPostgresSuitesRan.mjs
@@ -6,8 +6,26 @@
  * concurrency and idempotency proof into a green no-op. This asserts they actually ran.
  */
 import fs from 'fs';
+import path from 'path';
 
-const REQUIRED_SUITE_PATTERN = /tests[/\\](support[/\\]realPostgres|concurrency[/\\])/;
+/**
+ * Discovered rather than pattern-matched against a couple of directories: a guard that
+ * only knows about `concurrency/` silently stops covering the next real-PostgreSQL suite
+ * someone adds elsewhere, which is exactly the failure it exists to prevent.
+ */
+function findGuardedSuites(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findGuardedSuites(full, found);
+    } else if (entry.name.endsWith('.test.ts')) {
+      if (fs.readFileSync(full, 'utf8').includes('describeWithPostgres')) {
+        found.push(path.resolve(full));
+      }
+    }
+  }
+  return found;
+}
 
 const reportPath = process.argv[2];
 
@@ -17,12 +35,24 @@ if (!reportPath || !fs.existsSync(reportPath)) {
 }
 
 const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
-const suites = (report.testResults ?? []).filter((s) => REQUIRED_SUITE_PATTERN.test(s.name));
 
-if (suites.length === 0) {
-  console.error('[ci-guard] No real-PostgreSQL suite files were found in the vitest report.');
+const expected = findGuardedSuites(path.resolve('tests'));
+if (expected.length === 0) {
+  console.error('[ci-guard] No describeWithPostgres suites found under tests/.');
   process.exit(1);
 }
+
+const reported = new Map((report.testResults ?? []).map((s) => [path.resolve(s.name), s]));
+const missing = expected.filter((f) => !reported.has(f));
+if (missing.length > 0) {
+  console.error('[ci-guard] These real-PostgreSQL suites are absent from the vitest report:');
+  for (const f of missing) {
+    console.error(`  - ${path.relative(process.cwd(), f)}`);
+  }
+  process.exit(1);
+}
+
+const suites = expected.map((f) => reported.get(f));
 
 let executed = 0;
 const skipped = [];

--- a/server/services/productService.ts
+++ b/server/services/productService.ts
@@ -2,6 +2,7 @@ import db from '../src/database/pool';
 import { withTransaction, Queryable } from '../src/database/transaction';
 import { productSchema } from '../validators/productSchema';
 import { notifyLowStock } from './notifications';
+import { stockAdjustmentsService } from '../src/modules/inventory/stockAdjustments/service';
 
 // --- Types ---
 
@@ -416,28 +417,27 @@ export async function adjustStock(
       throw new Error('Cannot adjust stock on a discontinued product');
     }
 
-    const previousQty = product.stock;
-    const newQty = previousQty + delta;
+    // The read above only decides eligibility (exists, not discontinued). The quantity
+    // it saw is deliberately not used to compute the new total: the guarded relative
+    // write below is the authority, so two concurrent adjustments cannot lose one
+    // another's delta or drive stock negative.
+    const applied = await stockAdjustmentsService.applyDelta(
+      productId,
+      delta,
+      reason,
+      userId,
+      client
+    );
 
-    if (newQty < 0) {
+    if (applied === null) {
       throw new Error('Stock cannot go below zero');
     }
 
-    await client.query('UPDATE products SET stock = $1, updated_at = NOW() WHERE id = $2', [
-      newQty,
-      productId,
-    ]);
-
-    await client.query(
-      'INSERT INTO stock_adjustments (product_id, previous_qty, new_qty, delta, reason, user_id) VALUES ($1, $2, $3, $4, $5, $6)',
-      [productId, previousQty, newQty, delta, reason, userId]
-    );
-
-    if (newQty <= product.min_stock) {
-      notifyLowStock(product.name, newQty, productId);
+    if (applied.newQty <= product.min_stock) {
+      notifyLowStock(product.name, applied.newQty, productId);
     }
 
-    return { previous_qty: previousQty, new_qty: newQty, delta };
+    return { previous_qty: applied.previousQty, new_qty: applied.newQty, delta };
   });
 }
 

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -12,6 +12,16 @@ const envSchema = z.object({
     .default('postgresql://postgres:postgres@localhost:5432/moon_store'),
   JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 characters'),
   JWT_REFRESH_SECRET: z.string().min(32, 'JWT_REFRESH_SECRET must be at least 32 characters'),
+  /**
+   * Closes the idempotency compatibility window. While false (the default), a mutation
+   * without an `Idempotency-Key` behaves exactly as it did before idempotency existed,
+   * so an unpatched till keeps working. Flip to true only once every deployed client is
+   * confirmed to send the header — it is a config change, not a deploy.
+   */
+  IDEMPOTENCY_REQUIRED: z
+    .enum(['true', 'false', '1', '0'])
+    .default('false')
+    .transform((v) => v === 'true' || v === '1'),
   CLIENT_URL: z.string().optional().default('http://localhost:5173'),
   ALLOWED_ORIGINS: z.string().optional(),
   TWILIO_ACCOUNT_SID: z.string().optional(),

--- a/server/src/database/migrations/004_concurrency_and_idempotency.down.sql
+++ b/server/src/database/migrations/004_concurrency_and_idempotency.down.sql
@@ -1,0 +1,7 @@
+-- 004_concurrency_and_idempotency.down.sql
+ALTER TABLE products DROP CONSTRAINT IF EXISTS products_stock_non_negative;
+ALTER TABLE product_variants DROP CONSTRAINT IF EXISTS product_variants_stock_non_negative;
+ALTER TABLE gift_cards DROP CONSTRAINT IF EXISTS gift_cards_balance_non_negative;
+ALTER TABLE customers DROP CONSTRAINT IF EXISTS customers_loyalty_points_non_negative;
+
+DROP TABLE IF EXISTS idempotency_keys;

--- a/server/src/database/migrations/004_concurrency_and_idempotency.sql
+++ b/server/src/database/migrations/004_concurrency_and_idempotency.sql
@@ -47,7 +47,12 @@ CREATE TABLE IF NOT EXISTS idempotency_keys (
   user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
   request_fingerprint TEXT NOT NULL,
   response_status INTEGER,
-  response_body JSONB,
+  -- JSON, not JSONB, and deliberately so: jsonb normalizes an object's key order, so a
+  -- replayed body would serialize differently from the one the first caller received.
+  -- A replay must be byte-identical to the original response, and json preserves the
+  -- stored text exactly. Nothing queries inside this column -- resource_type/resource_id
+  -- exist so an operator can trace a key without needing to.
+  response_body JSON,
   resource_type TEXT,
   resource_id INTEGER,
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/server/src/database/migrations/004_concurrency_and_idempotency.sql
+++ b/server/src/database/migrations/004_concurrency_and_idempotency.sql
@@ -1,0 +1,79 @@
+-- 004_concurrency_and_idempotency.sql
+-- Unit 2 of the POS concurrency/idempotency fix (see
+-- docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md, "Unit 2").
+--
+-- Two additions, both additive and online — a new table plus four NOT VALID
+-- check constraints. No table rewrite, no lock on a large table.
+--
+-- 1. `idempotency_keys` — a caller-supplied Idempotency-Key claims a row as the
+--    FIRST statement inside the business transaction. The unique primary key on
+--    `key` is what makes "exactly one committed outcome per key" true by
+--    construction: a duplicate blocks on the index until the first transaction
+--    ends, then either sees 23505 (winner committed -> replay the stored
+--    response) or acquires the claim itself (winner rolled back -> proceed).
+--    Because the claim shares the transaction's fate, a FAILED mutation leaves
+--    no row and the client may retry the same key. A key therefore identifies a
+--    committed outcome, never an attempt.
+--
+--    Uniqueness is global, and `endpoint` / `user_id` / `request_fingerprint`
+--    are validated rather than keyed, so a key replayed against a different
+--    endpoint or user is a deterministic conflict instead of a cross-endpoint
+--    collision. The stored `response_body` is replayed byte-identically, so a
+--    retried request never observes a different outcome than the first.
+--
+-- 2. Non-negative floors as CHECK ... NOT VALID. The application guards
+--    (guarded relative UPDATEs, row locks) are the real mechanism; these are
+--    defense-in-depth so that a future code path which forgets the guard fails
+--    loudly at the database instead of silently corrupting inventory or a
+--    balance.
+--
+--    NOT VALID because existing rows may already be negative — nothing has been
+--    guarding exchanges — and this migration must not fail on legacy data. New
+--    and updated rows ARE enforced; only the retroactive full-table scan is
+--    skipped. To find pre-existing violators before promoting these:
+--
+--      SELECT 'products' AS t, id, stock AS v FROM products WHERE stock < 0
+--      UNION ALL SELECT 'product_variants', id, stock FROM product_variants WHERE stock < 0
+--      UNION ALL SELECT 'gift_cards', id, balance FROM gift_cards WHERE balance < 0
+--      UNION ALL SELECT 'customers', id, loyalty_points FROM customers WHERE loyalty_points < 0;
+--
+--    Once that returns no rows, `ALTER TABLE <t> VALIDATE CONSTRAINT <c>` is the
+--    operational follow-up. It takes only a SHARE UPDATE EXCLUSIVE lock and does
+--    not block reads or writes.
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+  key TEXT PRIMARY KEY,
+  endpoint TEXT NOT NULL,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  request_fingerprint TEXT NOT NULL,
+  response_status INTEGER,
+  response_body JSONB,
+  resource_type TEXT,
+  resource_id INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
+-- Supports both the opportunistic delete of an expired row during a claim
+-- collision and a future scheduled DELETE ... WHERE expires_at < NOW().
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires_at ON idempotency_keys (expires_at);
+
+-- Lets an operator trace a key back to the row it produced without parsing JSON.
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_resource
+  ON idempotency_keys (resource_type, resource_id);
+
+-- ADD CONSTRAINT has no IF NOT EXISTS. It does not need one: the migration
+-- runner applies each file at most once, and the paired .down.sql drops these,
+-- so up/down/up is clean. A plpgsql DO guard would only cost pg-mem support.
+ALTER TABLE products
+  ADD CONSTRAINT products_stock_non_negative CHECK (stock >= 0) NOT VALID;
+
+ALTER TABLE product_variants
+  ADD CONSTRAINT product_variants_stock_non_negative CHECK (stock >= 0) NOT VALID;
+
+ALTER TABLE gift_cards
+  ADD CONSTRAINT gift_cards_balance_non_negative CHECK (balance >= 0) NOT VALID;
+
+-- loyalty_points is nullable; a CHECK passes on NULL, which is the intent.
+ALTER TABLE customers
+  ADD CONSTRAINT customers_loyalty_points_non_negative CHECK (loyalty_points >= 0) NOT VALID;

--- a/server/src/database/migrations/004_concurrency_and_idempotency.sql
+++ b/server/src/database/migrations/004_concurrency_and_idempotency.sql
@@ -2,8 +2,18 @@
 -- Unit 2 of the POS concurrency/idempotency fix (see
 -- docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md, "Unit 2").
 --
--- Two additions, both additive and online — a new table plus four NOT VALID
--- check constraints. No table rewrite, no lock on a large table.
+-- Two additions: a new table plus four NOT VALID check constraints. Neither
+-- rewrites a table, and NOT VALID skips the full-table validation scan.
+--
+-- It is NOT, however, a lock-free operation. ADD CONSTRAINT still takes an
+-- ACCESS EXCLUSIVE lock on the target table to write the catalog entry --
+-- NOT VALID removes the scan, and therefore how LONG the lock is held, but not
+-- the lock itself. On a live POS these four tables are exactly the ones
+-- checkout, refund, and redemption hold open transactions against, and a
+-- waiting ACCESS EXCLUSIVE queues every later reader behind it. So each ALTER
+-- runs under a short lock_timeout: if a till is mid-checkout, this migration
+-- fails fast and can be re-run, instead of stalling the shop. Prefer a quiet
+-- window anyway.
 --
 -- 1. `idempotency_keys` — a caller-supplied Idempotency-Key claims a row as the
 --    FIRST statement inside the business transaction. The unique primary key on
@@ -44,6 +54,11 @@
 CREATE TABLE IF NOT EXISTS idempotency_keys (
   key TEXT PRIMARY KEY,
   endpoint TEXT NOT NULL,
+  -- Known narrow gap: deleting a user nulls this column, and a replay compares it
+  -- against the live caller's id, so a retry of that user's own claim inside the 24h
+  -- TTL would be answered with a conflict instead of the stored outcome. Deleting a
+  -- user mid-TTL while their token is still valid is rare enough to accept; the
+  -- alternative (RESTRICT) would block user deletion on unrelated key rows.
   user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
   request_fingerprint TEXT NOT NULL,
   response_status INTEGER,
@@ -66,6 +81,10 @@ CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires_at ON idempotency_keys (
 -- Lets an operator trace a key back to the row it produced without parsing JSON.
 CREATE INDEX IF NOT EXISTS idx_idempotency_keys_resource
   ON idempotency_keys (resource_type, resource_id);
+
+-- Bounds only the catalog lock each ALTER waits for. The whole file already runs
+-- in one transaction, so SET LOCAL reverts at COMMIT.
+SET LOCAL lock_timeout = '3s';
 
 -- ADD CONSTRAINT has no IF NOT EXISTS. It does not need one: the migration
 -- runner applies each file at most once, and the paired .down.sql drops these,

--- a/server/src/database/transaction.ts
+++ b/server/src/database/transaction.ts
@@ -9,25 +9,39 @@ export interface Queryable {
   ): Promise<QueryResult<T>>;
 }
 
-/**
- * Executes a callback within a PostgreSQL transaction.
- * Automatically handles BEGIN, COMMIT, ROLLBACK, and client release.
- *
- * @param callback The function to execute inside the transaction
- * @param poolOrClient Optional Pool or PoolClient instance. If omitted, uses getPool().
- */
-export async function withTransaction<T>(
-  callback: (client: PoolClient) => Promise<T>,
-  poolOrClient?: Pool | PoolClient
-): Promise<T> {
-  const isClientProvided = poolOrClient && 'release' in poolOrClient;
+/** Serialization failure and deadlock detected — the two errors a fresh attempt can fix. */
+const RETRYABLE_SQLSTATES = new Set(['40001', '40P01']);
 
-  if (isClientProvided) {
-    // If a client is already provided (e.g. nested transaction), execute directly
-    return callback(poolOrClient as PoolClient);
+export interface TransactionOptions {
+  /**
+   * Retry the whole transaction on SQLSTATE 40001/40P01. Opt-in, because it re-runs the
+   * callback: it is only safe when the callback performs no non-transactional side
+   * effect (no notification, no external call, no write outside this client).
+   */
+  retryOnSerializationFailure?: boolean;
+  /** Additional attempts after the first. Defaults to 2. */
+  maxRetries?: number;
+}
+
+function sqlState(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
   }
+  return undefined;
+}
 
-  const pool = (poolOrClient as Pool) || getPool();
+export function isRetryableTransactionError(error: unknown): boolean {
+  const code = sqlState(error);
+  return code !== undefined && RETRYABLE_SQLSTATES.has(code);
+}
+
+/** Short jittered backoff, so two deadlocked callers do not retry in lockstep. */
+function backoffMs(attempt: number): number {
+  return attempt * 10 + Math.floor(Math.random() * 10);
+}
+
+async function runOnce<T>(pool: Pool, callback: (client: PoolClient) => Promise<T>): Promise<T> {
   const client = await pool.connect();
 
   try {
@@ -46,5 +60,51 @@ export async function withTransaction<T>(
     throw error;
   } finally {
     client.release();
+  }
+}
+
+/**
+ * Executes a callback within a PostgreSQL transaction.
+ * Automatically handles BEGIN, COMMIT, ROLLBACK, and client release.
+ *
+ * @param callback The function to execute inside the transaction
+ * @param poolOrClient Optional Pool or PoolClient instance. If omitted, uses getPool().
+ * @param options Optional retry behavior. Defaults to no retry, matching prior behavior.
+ */
+export async function withTransaction<T>(
+  callback: (client: PoolClient) => Promise<T>,
+  poolOrClient?: Pool | PoolClient,
+  options: TransactionOptions = {}
+): Promise<T> {
+  const isClientProvided = poolOrClient && 'release' in poolOrClient;
+
+  if (isClientProvided) {
+    // If a client is already provided (e.g. nested transaction), execute directly
+    return callback(poolOrClient as PoolClient);
+  }
+
+  const pool = (poolOrClient as Pool) || getPool();
+
+  if (!options.retryOnSerializationFailure) {
+    return runOnce(pool, callback);
+  }
+
+  const maxRetries = options.maxRetries ?? 2;
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await runOnce(pool, callback);
+    } catch (error) {
+      // The whole transaction rolled back, so a retry is a genuinely fresh attempt
+      // with no partial side effects to undo.
+      if (attempt >= maxRetries || !isRetryableTransactionError(error)) {
+        throw error;
+      }
+      logger.warn('Retrying transaction after a serialization failure', {
+        sqlState: sqlState(error),
+        attempt: attempt + 1,
+      });
+      await new Promise((resolve) => setTimeout(resolve, backoffMs(attempt + 1)));
+    }
   }
 }

--- a/server/src/docs/openapi.ts
+++ b/server/src/docs/openapi.ts
@@ -1702,7 +1702,7 @@ export const openApiSpec = {
         },
         responses: {
           '409': { $ref: '#/components/responses/IdempotencyKeyReused' },
-          '200': {
+          '201': {
             description: 'Successful operation',
             headers: {
               'Idempotent-Replay': { $ref: '#/components/headers/IdempotentReplay' },
@@ -1872,7 +1872,7 @@ export const openApiSpec = {
         },
         responses: {
           '409': { $ref: '#/components/responses/IdempotencyKeyReused' },
-          '200': {
+          '201': {
             description: 'Successful operation',
             headers: {
               'Idempotent-Replay': { $ref: '#/components/headers/IdempotentReplay' },
@@ -2650,7 +2650,14 @@ export const openApiSpec = {
       post: {
         tags: ['POS Exchanges'],
         summary: 'Create / Submit Exchanges (Admin, Cashier)',
-        description: 'Endpoint classification: M. Allowed Roles: Admin, Cashier.',
+        description:
+          'Endpoint classification: M. Allowed Roles: Admin, Cashier.\n\n' +
+          '**Stock is now guarded.** A `new_items` line exceeding available stock is rejected with ' +
+          '`400 VALIDATION_ERROR` and persists nothing — no exchange, no returned-item restock. ' +
+          'Previously such a request succeeded and drove stock negative.\n\n' +
+          '**Idempotency:** supply an `Idempotency-Key` header to make a retry return the original ' +
+          'exchange instead of processing a second one. A replayed response is byte-identical and ' +
+          'carries `Idempotent-Replay: true`.',
         parameters: [{ $ref: '#/components/parameters/IdempotencyKey' }],
         security: [
           {
@@ -2670,7 +2677,7 @@ export const openApiSpec = {
         },
         responses: {
           '409': { $ref: '#/components/responses/IdempotencyKeyReused' },
-          '200': {
+          '201': {
             description: 'Successful operation',
             headers: {
               'Idempotent-Replay': { $ref: '#/components/headers/IdempotentReplay' },

--- a/server/src/docs/openapi.ts
+++ b/server/src/docs/openapi.ts
@@ -212,6 +212,36 @@ export const openApiSpec = {
           },
         },
       },
+      IdempotencyConflict: {
+        type: 'object',
+        description:
+          'Returned when an Idempotency-Key is reused with a different payload, on a different ' +
+          'endpoint, or by a different user. Deliberately discloses nothing about the original ' +
+          'request: the caller replaying a key is not necessarily the caller that created it.',
+        properties: {
+          error: {
+            type: 'object',
+            properties: {
+              code: { type: 'string', example: 'CONFLICT' },
+              message: {
+                type: 'string',
+                example: 'This Idempotency-Key was already used for a different request.',
+              },
+              details: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    field: { type: 'string', example: 'idempotency-key' },
+                    code: { type: 'string', example: 'IDEMPOTENCY_KEY_REUSED' },
+                    message: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
       ApiError: {
         type: 'object',
         properties: {
@@ -231,6 +261,39 @@ export const openApiSpec = {
                 example: 'Invalid input data',
               },
             },
+          },
+        },
+      },
+    },
+    parameters: {
+      IdempotencyKey: {
+        name: 'Idempotency-Key',
+        in: 'header',
+        required: false,
+        description:
+          'Makes a retried request return the ORIGINAL outcome instead of creating a second one. ' +
+          'Non-empty printable ASCII, at most 255 characters; generate one per rung-up sale, not ' +
+          'per HTTP request, so a transport retry and an offline replay share it. A key identifies ' +
+          'a COMMITTED outcome and lives 24 hours: a failed mutation releases its key, so a ' +
+          'corrected retry under the same key runs normally. Optional while IDEMPOTENCY_REQUIRED ' +
+          'is false; a request without one behaves exactly as it did before idempotency existed.',
+        schema: { type: 'string', maxLength: 255, example: '0f6a2b1c-1d3e-4f50-9a7b-2c8d9e0f1a2b' },
+      },
+    },
+    headers: {
+      IdempotentReplay: {
+        description:
+          'Present and "true" when this response was replayed from a previous request with the ' +
+          'same Idempotency-Key. The status and body are byte-identical to the original.',
+        schema: { type: 'string', example: 'true' },
+      },
+    },
+    responses: {
+      IdempotencyKeyReused: {
+        description: 'Idempotency-Key reused for a different request',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/IdempotencyConflict' },
           },
         },
       },
@@ -1591,7 +1654,13 @@ export const openApiSpec = {
           'entries) are allowed. Omitting `payments` is the unchanged single-tender compatibility path: ' +
           'no `sale_payments` rows are created and no sum check applies. A mismatched/invalid split is ' +
           'rejected with `400 VALIDATION_ERROR` and a `details[].code` of `SPLIT_PAYMENT_MISMATCH`, and ' +
-          'persists nothing (no sale, items, payments, or register movement).',
+          'persists nothing (no sale, items, payments, or register movement).\n\n' +
+          '**Idempotency:** supply an `Idempotency-Key` header to make a retry return the original ' +
+          'sale instead of ringing up a second one. A replayed response is byte-identical and carries ' +
+          '`Idempotent-Replay: true`; it also suppresses the sale notification and the audit entry, so ' +
+          'a retry never sends a second SMS. Reusing a key with a different cart returns 409 ' +
+          '`IDEMPOTENCY_KEY_REUSED` and creates no sale.',
+        parameters: [{ $ref: '#/components/parameters/IdempotencyKey' }],
         security: [
           {
             BearerAuth: [],
@@ -1632,8 +1701,12 @@ export const openApiSpec = {
           },
         },
         responses: {
+          '409': { $ref: '#/components/responses/IdempotencyKeyReused' },
           '200': {
             description: 'Successful operation',
+            headers: {
+              'Idempotent-Replay': { $ref: '#/components/headers/IdempotentReplay' },
+            },
             content: {
               'application/json': {
                 schema: {
@@ -1775,6 +1848,7 @@ export const openApiSpec = {
           },
         ],
         parameters: [
+          { $ref: '#/components/parameters/IdempotencyKey' },
           {
             name: 'id',
             in: 'path',
@@ -1797,8 +1871,12 @@ export const openApiSpec = {
           },
         },
         responses: {
+          '409': { $ref: '#/components/responses/IdempotencyKeyReused' },
           '200': {
             description: 'Successful operation',
+            headers: {
+              'Idempotent-Replay': { $ref: '#/components/headers/IdempotentReplay' },
+            },
             content: {
               'application/json': {
                 schema: {
@@ -2573,6 +2651,7 @@ export const openApiSpec = {
         tags: ['POS Exchanges'],
         summary: 'Create / Submit Exchanges (Admin, Cashier)',
         description: 'Endpoint classification: M. Allowed Roles: Admin, Cashier.',
+        parameters: [{ $ref: '#/components/parameters/IdempotencyKey' }],
         security: [
           {
             BearerAuth: [],
@@ -2590,8 +2669,12 @@ export const openApiSpec = {
           },
         },
         responses: {
+          '409': { $ref: '#/components/responses/IdempotencyKeyReused' },
           '200': {
             description: 'Successful operation',
+            headers: {
+              'Idempotent-Replay': { $ref: '#/components/headers/IdempotentReplay' },
+            },
             content: {
               'application/json': {
                 schema: {
@@ -7364,6 +7447,7 @@ export const openApiSpec = {
           },
         ],
         parameters: [
+          { $ref: '#/components/parameters/IdempotencyKey' },
           {
             name: 'code',
             in: 'path',
@@ -7386,8 +7470,12 @@ export const openApiSpec = {
           },
         },
         responses: {
+          '409': { $ref: '#/components/responses/IdempotencyKeyReused' },
           '200': {
             description: 'Successful operation',
+            headers: {
+              'Idempotent-Replay': { $ref: '#/components/headers/IdempotentReplay' },
+            },
             content: {
               'application/json': {
                 schema: {

--- a/server/src/http/idempotency.ts
+++ b/server/src/http/idempotency.ts
@@ -1,0 +1,313 @@
+/**
+ * Idempotency protocol for retry-prone mutations.
+ *
+ * A caller-supplied `Idempotency-Key` makes a retried mutation return the ORIGINAL
+ * outcome instead of creating a second one. The claim is inserted as the first statement
+ * inside the business transaction, so it shares that transaction's fate:
+ *
+ *   - the mutation commits   -> the claim commits with it, and every later request with
+ *                               that key replays the stored response
+ *   - the mutation fails     -> the claim rolls back with it, and the client may retry
+ *                               the same key against a fresh attempt
+ *
+ * That is what makes "exactly one committed outcome per key" true by construction: there
+ * is no in-progress state, no lease to expire, and no stale-claim reaper. The accepted
+ * cost is that a duplicate arriving mid-flight blocks on the unique index for the
+ * duration of the winner's transaction — bounded, and only for genuine duplicates.
+ *
+ * A key therefore identifies a COMMITTED OUTCOME, never an attempt. One consequence
+ * worth knowing: a deterministic 400 is not cached, so a corrected retry with the same
+ * key runs normally.
+ */
+import { createHash } from 'crypto';
+import type { PoolClient } from 'pg';
+import { withTransaction } from '../database/transaction';
+import { getPool } from '../database/pool';
+import { getEnv } from '../config/env';
+import { PublicError } from './errors';
+import logger from '../../lib/logger';
+
+/** Request header carrying the key. Lowercased, as Express normalizes header names. */
+export const IDEMPOTENCY_HEADER = 'idempotency-key';
+
+/**
+ * Response header flagging a replay. Signalling additively keeps the response envelope
+ * and every existing field unchanged — a header is invisible to existing consumers.
+ */
+export const IDEMPOTENCY_REPLAY_HEADER = 'Idempotent-Replay';
+
+/** Stable, client-matchable code for a key reused with different request details. */
+export const IDEMPOTENCY_KEY_REUSED = 'IDEMPOTENCY_KEY_REUSED';
+
+export const IDEMPOTENCY_KEY_TTL_HOURS = 24;
+
+const MAX_KEY_LENGTH = 255;
+const PRINTABLE_ASCII = /^[\x20-\x7E]+$/;
+const UNIQUE_VIOLATION = '23505';
+
+/**
+ * Raised when a key arrives with a different payload, endpoint, or user than the one it
+ * already identifies. Deliberately carries nothing about the original request: the
+ * caller of a reused key is not necessarily the caller that created it.
+ */
+export class IdempotencyConflictError extends Error {
+  constructor(
+    message = 'This Idempotency-Key was already used for a different request.',
+    public readonly code: string = IDEMPOTENCY_KEY_REUSED,
+    public readonly statusCode: number = 409
+  ) {
+    super(message);
+    this.name = 'IdempotencyConflictError';
+  }
+}
+
+/**
+ * Deterministic JSON with recursively sorted object keys, so `{a,b}` and `{b,a}` produce
+ * one fingerprint. Array order is preserved because it is semantically meaningful.
+ * Non-finite numbers throw rather than silently serializing to `null`, which would make
+ * two different payloads collide.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new PublicError('VALIDATION_ERROR', 'Request contains a non-finite number.');
+  }
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      sorted[key] = canonicalize(source[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * SHA-256 over the canonical JSON of the payload. Callers pass the VALIDATED (post-Zod)
+ * body, so key order, whitespace, and stripped unknown fields cannot raise a false
+ * conflict between two requests that mean the same thing.
+ */
+export function fingerprintPayload(payload: unknown): string {
+  return createHash('sha256').update(canonicalJson(payload)).digest('hex');
+}
+
+/** A malformed key is a 400, never a silent bypass of the guarantee the caller asked for. */
+export function assertValidIdempotencyKey(key: string): void {
+  if (key.trim().length === 0) {
+    throw new PublicError('VALIDATION_ERROR', `${IDEMPOTENCY_HEADER} must not be empty.`);
+  }
+  if (key.length > MAX_KEY_LENGTH) {
+    throw new PublicError(
+      'VALIDATION_ERROR',
+      `${IDEMPOTENCY_HEADER} must be at most ${MAX_KEY_LENGTH} characters.`
+    );
+  }
+  if (!PRINTABLE_ASCII.test(key)) {
+    throw new PublicError(
+      'VALIDATION_ERROR',
+      `${IDEMPOTENCY_HEADER} must contain only printable ASCII characters.`
+    );
+  }
+}
+
+/** What the wrapped mutation produced, and how it should be replayed later. */
+export interface IdempotentRun<T> {
+  status: number;
+  body: unknown;
+  result: T;
+  /** Lets an operator trace a key to its row without parsing the stored body. */
+  resourceType?: string;
+  resourceId?: number;
+}
+
+export interface IdempotentOutcome<T> {
+  status: number;
+  body: unknown;
+  /** True when this response came from storage. Suppress side effects when it is. */
+  replayed: boolean;
+  /** The callback's return value, or null on a replay (the callback did not run). */
+  result: T | null;
+}
+
+export interface WithIdempotencyOptions<T> {
+  /** The caller's key, if any. Absent is allowed while IDEMPOTENCY_REQUIRED is false. */
+  key?: string | null;
+  /** Scope label, e.g. `POST /api/v1/sales`. Validated on replay, not part of the key. */
+  endpoint: string;
+  userId?: number | null;
+  /** The validated request body. */
+  payload: unknown;
+  run: (client: PoolClient) => Promise<IdempotentRun<T>>;
+}
+
+/** Internal signal: the claim INSERT lost the race. Never escapes this module. */
+class ClaimCollision extends Error {
+  constructor() {
+    super('Idempotency key already claimed');
+    this.name = 'ClaimCollision';
+  }
+}
+
+interface KeyRow {
+  endpoint: string;
+  user_id: number | null;
+  request_fingerprint: string;
+  response_status: number | null;
+  response_body: unknown;
+  expired: boolean;
+}
+
+export async function withIdempotency<T>(
+  options: WithIdempotencyOptions<T>
+): Promise<IdempotentOutcome<T>> {
+  const { key, endpoint, userId = null, payload, run } = options;
+
+  if (key === undefined || key === null) {
+    if (getEnv().IDEMPOTENCY_REQUIRED) {
+      throw new PublicError(
+        'VALIDATION_ERROR',
+        `An ${IDEMPOTENCY_HEADER} header is required for this request.`
+      );
+    }
+    // Exactly today's behavior, minus the concurrency bugs: no row, no claim.
+    const outcome = await withTransaction(run);
+    return { status: outcome.status, body: outcome.body, replayed: false, result: outcome.result };
+  }
+
+  assertValidIdempotencyKey(key);
+  const fingerprint = fingerprintPayload(payload);
+
+  // At most one retry. The only reason to retry is that the winner rolled back and
+  // released the key; looping on that would be unbounded for no extra correctness.
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await claimAndRun({ key, endpoint, userId, fingerprint, run });
+    } catch (error) {
+      if (!(error instanceof ClaimCollision)) {
+        throw error;
+      }
+
+      const existing = await readKeyRow(key);
+
+      if (!existing) {
+        // The winner rolled back and released the key. Try to claim it ourselves.
+        continue;
+      }
+
+      if (existing.expired) {
+        // Past its TTL, so it no longer identifies a live outcome. Clear it opportunistically
+        // (this is the only reaper) and treat the key as fresh.
+        await getPool().query(
+          'DELETE FROM idempotency_keys WHERE key = $1 AND expires_at <= NOW()',
+          [key]
+        );
+        continue;
+      }
+
+      if (
+        existing.request_fingerprint !== fingerprint ||
+        existing.endpoint !== endpoint ||
+        existing.user_id !== userId
+      ) {
+        throw new IdempotencyConflictError();
+      }
+
+      if (existing.response_status === null) {
+        // A committed claim with no stored outcome should be unreachable: the outcome is
+        // written before COMMIT in the same transaction. Treat it as a conflict rather
+        // than inventing a response.
+        logger.error('Idempotency key committed without a stored response', { key, endpoint });
+        throw new IdempotencyConflictError();
+      }
+
+      return {
+        status: existing.response_status,
+        body: existing.response_body,
+        replayed: true,
+        result: null,
+      };
+    }
+  }
+
+  // Two claim collisions in a row where the row then vanished each time. Refusing beats
+  // looping: the caller can retry the request itself.
+  throw new IdempotencyConflictError(
+    'Could not resolve this Idempotency-Key against a stable outcome. Please retry.'
+  );
+}
+
+async function claimAndRun<T>(args: {
+  key: string;
+  endpoint: string;
+  userId: number | null;
+  fingerprint: string;
+  run: (client: PoolClient) => Promise<IdempotentRun<T>>;
+}): Promise<IdempotentOutcome<T>> {
+  const { key, endpoint, userId, fingerprint, run } = args;
+
+  const outcome = await withTransaction(async (client) => {
+    // FIRST statement in the transaction. A concurrent duplicate blocks here until this
+    // transaction ends, then either sees 23505 (we committed) or claims it (we rolled back).
+    try {
+      await client.query(
+        `INSERT INTO idempotency_keys (key, endpoint, user_id, request_fingerprint, expires_at)
+         VALUES ($1, $2, $3, $4, NOW() + ($5 || ' hours')::interval)`,
+        [key, endpoint, userId, fingerprint, String(IDEMPOTENCY_KEY_TTL_HOURS)]
+      );
+    } catch (error) {
+      // Only THIS statement's unique violation means "a twin already holds the key".
+      // A 23505 raised later by the business callback (a duplicate SKU, say) is a real
+      // failure and must surface as itself, not be mistaken for a replay.
+      if (isUniqueViolation(error)) {
+        throw new ClaimCollision();
+      }
+      throw error;
+    }
+
+    const produced = await run(client);
+
+    await client.query(
+      `UPDATE idempotency_keys
+          SET response_status = $2, response_body = $3, resource_type = $4, resource_id = $5
+        WHERE key = $1`,
+      [
+        key,
+        produced.status,
+        JSON.stringify(produced.body),
+        produced.resourceType ?? null,
+        produced.resourceId ?? null,
+      ]
+    );
+
+    return produced;
+  });
+
+  return { status: outcome.status, body: outcome.body, replayed: false, result: outcome.result };
+}
+
+async function readKeyRow(key: string): Promise<KeyRow | null> {
+  const { rows } = await getPool().query<KeyRow>(
+    `SELECT endpoint, user_id, request_fingerprint, response_status, response_body,
+            (expires_at <= NOW()) AS expired
+       FROM idempotency_keys
+      WHERE key = $1`,
+    [key]
+  );
+  return rows[0] ?? null;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === UNIQUE_VIOLATION
+  );
+}

--- a/server/src/http/idempotency.ts
+++ b/server/src/http/idempotency.ts
@@ -39,11 +39,35 @@ export const IDEMPOTENCY_REPLAY_HEADER = 'Idempotent-Replay';
 /** Stable, client-matchable code for a key reused with different request details. */
 export const IDEMPOTENCY_KEY_REUSED = 'IDEMPOTENCY_KEY_REUSED';
 
+/**
+ * Distinct from {@link IDEMPOTENCY_KEY_REUSED}: nothing conflicts, we simply could not
+ * resolve the key against a settled outcome. Separate because the two demand opposite
+ * client behavior — a reused key must NOT be retried, this one should be.
+ */
+export const IDEMPOTENCY_UNRESOLVED = 'IDEMPOTENCY_UNRESOLVED';
+
+/**
+ * Bounds how long a duplicate blocks on the claim's unique index. Without it the wait is
+ * the winner's entire transaction, and each waiter holds a pooled connection meanwhile —
+ * so a storm of duplicates on one key could starve the pool for every other till. Failing
+ * fast turns that into a retryable error for the duplicate alone.
+ */
+const CLAIM_LOCK_TIMEOUT = '3s';
+
+/**
+ * The transaction rolls back wholesale on a deadlock, claim included, so a retry is a
+ * genuinely fresh attempt. Safe here specifically because the non-transactional side
+ * effects (notifications, audit) live in the controller, after this returns.
+ */
+const RETRY_DEADLOCKS = { retryOnSerializationFailure: true } as const;
+
 export const IDEMPOTENCY_KEY_TTL_HOURS = 24;
 
 const MAX_KEY_LENGTH = 255;
 const PRINTABLE_ASCII = /^[\x20-\x7E]+$/;
 const UNIQUE_VIOLATION = '23505';
+/** Raised when `lock_timeout` expires while waiting to acquire a lock. */
+const LOCK_NOT_AVAILABLE = '55P03';
 
 /**
  * Raised when a key arrives with a different payload, endpoint, or user than the one it
@@ -117,6 +141,40 @@ export function assertValidIdempotencyKey(key: string): void {
   }
 }
 
+/**
+ * Reads the caller's key off the request. Returns null when absent, which is what keeps
+ * every wrapped endpoint working unchanged for a till that has not been updated yet.
+ *
+ * Shared rather than per-controller: the header name, the repeated-header rule, and the
+ * absent-means-null contract have to be identical everywhere or the guarantee is uneven.
+ */
+export function readIdempotencyKey(req: {
+  headers: Record<string, string | string[] | undefined>;
+}): string | null {
+  const raw = req.headers[IDEMPOTENCY_HEADER];
+  if (Array.isArray(raw)) {
+    // A repeated header has no single unambiguous key; refusing beats guessing.
+    throw new PublicError('VALIDATION_ERROR', `Only one ${IDEMPOTENCY_HEADER} header is allowed.`);
+  }
+  return raw ?? null;
+}
+
+/**
+ * Translates an idempotency conflict into the public error every wrapped endpoint
+ * returns. Shared so the code, field, and status stay identical across them — a client
+ * branching on `details[].code` must not have to learn per-endpoint variants.
+ *
+ * Returns null when the error is not a conflict, so a controller can fall through.
+ */
+export function toIdempotencyPublicError(error: unknown): PublicError | null {
+  if (!(error instanceof IdempotencyConflictError)) {
+    return null;
+  }
+  return new PublicError('CONFLICT', error.message, [
+    { field: IDEMPOTENCY_HEADER, code: error.code, message: error.message },
+  ]);
+}
+
 /** What the wrapped mutation produced, and how it should be replayed later. */
 export interface IdempotentRun<T> {
   status: number;
@@ -177,7 +235,7 @@ export async function withIdempotency<T>(
       );
     }
     // Exactly today's behavior, minus the concurrency bugs: no row, no claim.
-    const outcome = await withTransaction(run);
+    const outcome = await withTransaction(run, undefined, RETRY_DEADLOCKS);
     return { status: outcome.status, body: outcome.body, replayed: false, result: outcome.result };
   }
 
@@ -237,9 +295,12 @@ export async function withIdempotency<T>(
   }
 
   // Two claim collisions in a row where the row then vanished each time. Refusing beats
-  // looping: the caller can retry the request itself.
+  // looping. This is transient and carries no conflicting request, so it must NOT reuse
+  // the reused-key code: a client that treats that code as permanent would give up on a
+  // request it should simply send again.
   throw new IdempotencyConflictError(
-    'Could not resolve this Idempotency-Key against a stable outcome. Please retry.'
+    'Could not resolve this Idempotency-Key against a stable outcome. Please retry.',
+    IDEMPOTENCY_UNRESOLVED
   );
 }
 
@@ -252,42 +313,62 @@ async function claimAndRun<T>(args: {
 }): Promise<IdempotentOutcome<T>> {
   const { key, endpoint, userId, fingerprint, run } = args;
 
-  const outcome = await withTransaction(async (client) => {
-    // FIRST statement in the transaction. A concurrent duplicate blocks here until this
-    // transaction ends, then either sees 23505 (we committed) or claims it (we rolled back).
-    try {
-      await client.query(
-        `INSERT INTO idempotency_keys (key, endpoint, user_id, request_fingerprint, expires_at)
+  const outcome = await withTransaction(
+    async (client) => {
+      // Bounds only the claim's own wait; cleared immediately after so the business
+      // callback's own statements are not held to a lock budget meant for the claim.
+      await client.query(`SET LOCAL lock_timeout = '${CLAIM_LOCK_TIMEOUT}'`);
+
+      // FIRST statement in the transaction. A concurrent duplicate blocks here until this
+      // transaction ends, then either sees 23505 (we committed) or claims it (we rolled back).
+      try {
+        await client.query(
+          `INSERT INTO idempotency_keys (key, endpoint, user_id, request_fingerprint, expires_at)
          VALUES ($1, $2, $3, $4, NOW() + ($5 || ' hours')::interval)`,
-        [key, endpoint, userId, fingerprint, String(IDEMPOTENCY_KEY_TTL_HOURS)]
-      );
-    } catch (error) {
-      // Only THIS statement's unique violation means "a twin already holds the key".
-      // A 23505 raised later by the business callback (a duplicate SKU, say) is a real
-      // failure and must surface as itself, not be mistaken for a replay.
-      if (isUniqueViolation(error)) {
-        throw new ClaimCollision();
+          [key, endpoint, userId, fingerprint, String(IDEMPOTENCY_KEY_TTL_HOURS)]
+        );
+      } catch (error) {
+        // Only THIS statement's unique violation means "a twin already holds the key".
+        // A 23505 raised later by the business callback (a duplicate SKU, say) is a real
+        // failure and must surface as itself, not be mistaken for a replay.
+        if (isUniqueViolation(error)) {
+          throw new ClaimCollision();
+        }
+        // The winner is taking longer than the claim's lock budget. Nothing is wrong and
+        // nothing conflicts — tell the caller to try again rather than holding a pooled
+        // connection for the rest of the winner's transaction.
+        if (sqlState(error) === LOCK_NOT_AVAILABLE) {
+          throw new IdempotencyConflictError(
+            'This request is still being processed. Please retry.',
+            IDEMPOTENCY_UNRESOLVED
+          );
+        }
+        throw error;
       }
-      throw error;
-    }
 
-    const produced = await run(client);
+      // The claim is held; the business callback takes as long as it legitimately needs.
+      await client.query(`SET LOCAL lock_timeout = 0`);
 
-    await client.query(
-      `UPDATE idempotency_keys
+      const produced = await run(client);
+
+      await client.query(
+        `UPDATE idempotency_keys
           SET response_status = $2, response_body = $3, resource_type = $4, resource_id = $5
         WHERE key = $1`,
-      [
-        key,
-        produced.status,
-        JSON.stringify(produced.body),
-        produced.resourceType ?? null,
-        produced.resourceId ?? null,
-      ]
-    );
+        [
+          key,
+          produced.status,
+          JSON.stringify(produced.body),
+          produced.resourceType ?? null,
+          produced.resourceId ?? null,
+        ]
+      );
 
-    return produced;
-  });
+      return produced;
+    },
+    undefined,
+    RETRY_DEADLOCKS
+  );
 
   return { status: outcome.status, body: outcome.body, replayed: false, result: outcome.result };
 }
@@ -303,11 +384,14 @@ async function readKeyRow(key: string): Promise<KeyRow | null> {
   return rows[0] ?? null;
 }
 
+function sqlState(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
 function isUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error as { code?: unknown }).code === UNIQUE_VIOLATION
-  );
+  return sqlState(error) === UNIQUE_VIOLATION;
 }

--- a/server/src/modules/commerce/coupons/repository.ts
+++ b/server/src/modules/commerce/coupons/repository.ts
@@ -6,6 +6,7 @@ export interface ICouponsRepository {
   list(filters: CouponFilters, queryable?: Queryable): Promise<CouponListResult>;
   findById(id: number | string, queryable?: Queryable): Promise<Record<string, any> | null>;
   findByCode(code: string, queryable?: Queryable): Promise<Record<string, any> | null>;
+  findByCodeForUpdate(code: string, queryable: Queryable): Promise<Record<string, any> | null>;
   create(data: CouponData, queryable?: Queryable): Promise<Record<string, any>>;
   update(
     id: string | number,
@@ -117,6 +118,25 @@ export class CouponsRepository implements ICouponsRepository {
   async findByCode(code: string, queryable?: Queryable): Promise<Record<string, any> | null> {
     const res = await this.q(queryable).query(
       `SELECT * FROM coupons WHERE code = $1 AND status = 'active'`,
+      [code.toUpperCase().trim()]
+    );
+    return res.rows[0] ? this.parseScopeIds(res.rows[0]) : null;
+  }
+
+  /**
+   * `findByCode` that also takes a row lock on the coupon.
+   *
+   * `max_uses` counts rows in `coupon_usage`, so the invariant spans rows and cannot be
+   * expressed as one conditional write the way a stock decrement can. Locking the parent
+   * coupon row serializes everyone counting against the same limit. Consuming path only:
+   * a preview that took this lock would block live checkouts for no benefit.
+   */
+  async findByCodeForUpdate(
+    code: string,
+    queryable: Queryable
+  ): Promise<Record<string, any> | null> {
+    const res = await queryable.query(
+      `SELECT * FROM coupons WHERE code = $1 AND status = 'active' FOR UPDATE`,
       [code.toUpperCase().trim()]
     );
     return res.rows[0] ? this.parseScopeIds(res.rows[0]) : null;

--- a/server/src/modules/commerce/coupons/service.ts
+++ b/server/src/modules/commerce/coupons/service.ts
@@ -75,14 +75,24 @@ export class CouponsService {
    * `server/src/database/transaction.ts`) so callers such as
    * `SalesService.executeSale` can run this validation inside the checkout
    * transaction instead of maintaining a weaker, parallel coupon lookup.
+   *
+   * `forConsumption` marks the path that is about to record a `coupon_usage` row. It
+   * locks the coupon before counting usage, which is what makes `max_uses` hold under
+   * concurrency: without it, N concurrent checkouts all read the same count and all pass.
+   * The preview paths (`calculateSaleTotals`, the standalone validate endpoint) leave it
+   * false and take no lock — a preview that blocked a checkout would be a self-inflicted
+   * contention source.
    */
   async validate(
     input: ValidateCouponInput,
-    queryable: Queryable = pool
+    queryable: Queryable = pool,
+    options: { forConsumption?: boolean } = {}
   ): Promise<ValidateCouponResult> {
     const { code, subtotal, customer_id, item_product_ids } = input;
 
-    const coupon = await this.repo.findByCode(code, queryable);
+    const coupon = options.forConsumption
+      ? await this.repo.findByCodeForUpdate(code, queryable)
+      : await this.repo.findByCode(code, queryable);
     if (!coupon) {
       throw new CouponError('Coupon not found or inactive', 404);
     }

--- a/server/src/modules/commerce/giftCards/controller.ts
+++ b/server/src/modules/commerce/giftCards/controller.ts
@@ -8,24 +8,11 @@ import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
 import {
-  IDEMPOTENCY_HEADER,
   IDEMPOTENCY_REPLAY_HEADER,
-  IdempotencyConflictError,
+  readIdempotencyKey,
+  toIdempotencyPublicError,
   withIdempotency,
 } from '../../../http/idempotency';
-
-/**
- * Express lowercases header names. Returns null when absent, which is what keeps the
- * endpoint working unchanged for a till that has not been updated yet.
- */
-function readIdempotencyKey(req: Request): string | null {
-  const raw = req.headers[IDEMPOTENCY_HEADER];
-  if (Array.isArray(raw)) {
-    // A repeated header has no single unambiguous key; refusing beats guessing.
-    throw new PublicError('VALIDATION_ERROR', `Only one ${IDEMPOTENCY_HEADER} header is allowed.`);
-  }
-  return raw ?? null;
-}
 
 export const createGiftCardSchema = z.object({
   code: z.string().min(4).max(50).optional(),
@@ -157,12 +144,9 @@ export class GiftCardsController {
 
       res.status(outcome.status).json(outcome.body);
     } catch (err) {
-      if (err instanceof IdempotencyConflictError) {
-        next(
-          new PublicError('CONFLICT', err.message, [
-            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
-          ])
-        );
+      const conflict = toIdempotencyPublicError(err);
+      if (conflict) {
+        next(conflict);
         return;
       }
       next(err);

--- a/server/src/modules/commerce/giftCards/controller.ts
+++ b/server/src/modules/commerce/giftCards/controller.ts
@@ -7,6 +7,25 @@ import { parseGiftCardListQuery, parseGiftCardTransactionQuery } from './types';
 import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
+import {
+  IDEMPOTENCY_HEADER,
+  IDEMPOTENCY_REPLAY_HEADER,
+  IdempotencyConflictError,
+  withIdempotency,
+} from '../../../http/idempotency';
+
+/**
+ * Express lowercases header names. Returns null when absent, which is what keeps the
+ * endpoint working unchanged for a till that has not been updated yet.
+ */
+function readIdempotencyKey(req: Request): string | null {
+  const raw = req.headers[IDEMPOTENCY_HEADER];
+  if (Array.isArray(raw)) {
+    // A repeated header has no single unambiguous key; refusing beats guessing.
+    throw new PublicError('VALIDATION_ERROR', `Only one ${IDEMPOTENCY_HEADER} header is allowed.`);
+  }
+  return raw ?? null;
+}
 
 export const createGiftCardSchema = z.object({
   code: z.string().min(4).max(50).optional(),
@@ -90,9 +109,26 @@ export class GiftCardsController {
       const authReq = req as AuthRequest;
       const code = req.params.code as string;
 
-      let result;
+      let outcome;
       try {
-        result = await giftCardsService.redeem(code, amount, sale_id, authReq.user!.id);
+        outcome = await withIdempotency({
+          // Stable per endpoint: the card code is fingerprinted through the payload
+          // instead, so one key cannot straddle two different cards.
+          endpoint: 'POST /api/v1/gift-cards/:code/redeem',
+          key: readIdempotencyKey(req),
+          userId: authReq.user!.id,
+          payload: { ...parsed.data, code },
+          run: async (client) => {
+            const redeemed = await giftCardsService.redeem(
+              code,
+              amount,
+              sale_id,
+              authReq.user!.id,
+              client
+            );
+            return { status: 200, body: success(redeemed), result: redeemed };
+          },
+        });
       } catch (err: any) {
         if (
           err.message === 'Gift card not found' ||
@@ -106,15 +142,29 @@ export class GiftCardsController {
         throw err;
       }
 
-      logAuditFromReq(req, 'redeem', 'gift_card', undefined, {
-        code: result.code,
-        amount,
-        sale_id,
-        new_balance: result.new_balance,
-      });
+      if (outcome.replayed) {
+        // A replay must not write a second audit entry.
+        res.setHeader(IDEMPOTENCY_REPLAY_HEADER, 'true');
+      } else {
+        const result = outcome.result!;
+        logAuditFromReq(req, 'redeem', 'gift_card', undefined, {
+          code: result.code,
+          amount,
+          sale_id,
+          new_balance: result.new_balance,
+        });
+      }
 
-      res.json(success(result));
+      res.status(outcome.status).json(outcome.body);
     } catch (err) {
+      if (err instanceof IdempotencyConflictError) {
+        next(
+          new PublicError('CONFLICT', err.message, [
+            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
+          ])
+        );
+        return;
+      }
       next(err);
     }
   }

--- a/server/src/modules/commerce/giftCards/repository.ts
+++ b/server/src/modules/commerce/giftCards/repository.ts
@@ -18,7 +18,11 @@ export interface IGiftCardsRepository {
     },
     queryable?: Queryable
   ): Promise<Record<string, any>>;
-  updateBalance(id: number, newBalance: number, queryable?: Queryable): Promise<void>;
+  redeemBalance(
+    id: number,
+    amount: number,
+    queryable?: Queryable
+  ): Promise<{ balanceBefore: number; balanceAfter: number } | null>;
   createTransaction(
     data: {
       gift_card_id: number;
@@ -149,11 +153,39 @@ export class GiftCardsRepository implements IGiftCardsRepository {
     return result.rows[0];
   }
 
-  async updateBalance(id: number, newBalance: number, queryable?: Queryable): Promise<void> {
-    await this.q(queryable).query(
-      'UPDATE gift_cards SET balance = $1, updated_at = NOW() WHERE id = $2',
-      [newBalance, id]
+  /**
+   * Every condition that makes a redemption legal — active, unexpired, sufficient
+   * balance — lives in the WHERE clause, so one statement decides eligibility and
+   * performs the debit. A read-then-write let two concurrent redemptions both pass the
+   * balance check and spend the same money twice.
+   *
+   * `$1::numeric` is cast because pg-mem evaluates `column - $param` with the operands
+   * inverted unless the parameter carries a type.
+   *
+   * Both balances come from RETURNING rather than from the earlier read, so the
+   * transaction row records what actually happened and cannot drift by a rounding step.
+   *
+   * @returns the balances around the debit, or null when the card was not eligible.
+   */
+  async redeemBalance(
+    id: number,
+    amount: number,
+    queryable?: Queryable
+  ): Promise<{ balanceBefore: number; balanceAfter: number } | null> {
+    const res = await this.q(queryable).query<{ balance: number; balance_before: number }>(
+      `UPDATE gift_cards
+          SET balance = balance - $1::numeric, updated_at = NOW()
+        WHERE id = $2
+          AND balance >= $1::numeric
+          AND status = 'active'
+          AND (expires_at IS NULL OR expires_at > NOW())
+        RETURNING balance, balance + $1::numeric AS balance_before`,
+      [amount, id]
     );
+    const row = res.rows[0];
+    return row
+      ? { balanceBefore: Number(row.balance_before), balanceAfter: Number(row.balance) }
+      : null;
   }
 
   async createTransaction(

--- a/server/src/modules/commerce/giftCards/service.ts
+++ b/server/src/modules/commerce/giftCards/service.ts
@@ -1,4 +1,4 @@
-import { withTransaction } from '../../../database/transaction';
+import { Queryable, withTransaction } from '../../../database/transaction';
 import { IGiftCardsRepository, giftCardsRepository as defaultRepo } from './repository';
 import {
   CreateGiftCardInput,
@@ -110,53 +110,72 @@ export class GiftCardsService {
     };
   }
 
+  /**
+   * @param client joins an existing transaction (the idempotency claim's) instead of
+   * opening one, so the claim and the debit commit or roll back together.
+   */
   async redeem(
     code: string,
     amount: number,
     saleId: number,
-    performedByUserId: number
+    performedByUserId: number,
+    client?: Queryable
   ): Promise<RedeemResult> {
-    return withTransaction(async (client) => {
-      const card = await this.repo.findByCode(code, client);
+    if (client) {
+      return this.executeRedeem(code, amount, saleId, performedByUserId, client);
+    }
+    return withTransaction((tx) => this.executeRedeem(code, amount, saleId, performedByUserId, tx));
+  }
 
-      if (!card) {
+  private async executeRedeem(
+    code: string,
+    amount: number,
+    saleId: number,
+    performedByUserId: number,
+    client: Queryable
+  ): Promise<RedeemResult> {
+    const card = await this.repo.findByCode(code, client);
+
+    if (!card) {
+      throw new Error('Gift card not found');
+    }
+
+    const debited = await this.repo.redeemBalance(card.id, amount, client);
+
+    if (!debited) {
+      // The guarded UPDATE decided the card was ineligible but cannot say why. This
+      // read exists only to pick the message, in the same precedence as before.
+      const current = await this.repo.findById(card.id, client);
+
+      if (!current) {
         throw new Error('Gift card not found');
       }
-
-      if (card.status !== 'active') {
+      if (current.status !== 'active') {
         throw new Error('Gift card is not active');
       }
-
-      if (card.expires_at && new Date(card.expires_at) < new Date()) {
+      if (current.expires_at && new Date(current.expires_at) < new Date()) {
         throw new Error('Gift card has expired');
       }
+      throw new Error(`Insufficient balance. Available: ${Number(current.balance)}`);
+    }
 
-      const currentBalance = Number(card.balance);
-      if (currentBalance < amount) {
-        throw new Error(`Insufficient balance. Available: ${currentBalance}`);
-      }
+    const transaction = await this.repo.createTransaction(
+      {
+        gift_card_id: card.id,
+        sale_id: saleId,
+        amount,
+        balance_before: debited.balanceBefore,
+        balance_after: debited.balanceAfter,
+        performed_by: performedByUserId,
+      },
+      client
+    );
 
-      const newBalance = currentBalance - amount;
-      await this.repo.updateBalance(card.id, newBalance, client);
-
-      const transaction = await this.repo.createTransaction(
-        {
-          gift_card_id: card.id,
-          sale_id: saleId,
-          amount,
-          balance_before: currentBalance,
-          balance_after: newBalance,
-          performed_by: performedByUserId,
-        },
-        client
-      );
-
-      return {
-        transaction,
-        new_balance: newBalance,
-        code: card.code,
-      };
-    });
+    return {
+      transaction,
+      new_balance: debited.balanceAfter,
+      code: card.code,
+    };
   }
 
   async getTransactions(

--- a/server/src/modules/inventory/stockAdjustments/repository.ts
+++ b/server/src/modules/inventory/stockAdjustments/repository.ts
@@ -7,6 +7,18 @@ export interface IStockAdjustmentsRepository {
     filters: StockAdjustmentFilters,
     queryable?: Queryable
   ): Promise<{ rows: StockAdjustmentRecord[]; total: number }>;
+  applyDelta(productId: number, delta: number, queryable: Queryable): Promise<number | null>;
+  record(
+    data: {
+      product_id: number;
+      previous_qty: number;
+      new_qty: number;
+      delta: number;
+      reason: string;
+      user_id: number;
+    },
+    queryable: Queryable
+  ): Promise<void>;
 }
 
 export class StockAdjustmentsRepository implements IStockAdjustmentsRepository {
@@ -40,6 +52,48 @@ export class StockAdjustmentsRepository implements IStockAdjustmentsRepository {
     );
 
     return { rows: result.rows, total };
+  }
+
+  /**
+   * A manual adjustment is a DELTA, so it is applied relatively and guarded in one
+   * statement: reading the stock and writing back an absolute total let two concurrent
+   * adjustments lose one another's change. `stock + $1::int >= 0` covers both signs, so
+   * a decrement can never drive the column negative.
+   *
+   * A stock-COUNT reconciliation is a different operation — it asserts an observed
+   * absolute quantity, so `stockCounts` writes `SET stock = $1` and is correct as is.
+   *
+   * `$1::int` is cast because pg-mem evaluates `column <op> $param` with the operands
+   * inverted unless the parameter carries a type.
+   *
+   * @returns the resulting stock, or null when the delta would go below zero.
+   */
+  async applyDelta(productId: number, delta: number, queryable: Queryable): Promise<number | null> {
+    const res = await queryable.query<{ stock: number }>(
+      `UPDATE products SET stock = stock + $1::int, updated_at = NOW()
+        WHERE id = $2 AND stock + $1::int >= 0
+        RETURNING stock`,
+      [delta, productId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  async record(
+    data: {
+      product_id: number;
+      previous_qty: number;
+      new_qty: number;
+      delta: number;
+      reason: string;
+      user_id: number;
+    },
+    queryable: Queryable
+  ): Promise<void> {
+    await queryable.query(
+      `INSERT INTO stock_adjustments (product_id, previous_qty, new_qty, delta, reason, user_id)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [data.product_id, data.previous_qty, data.new_qty, data.delta, data.reason, data.user_id]
+    );
   }
 }
 

--- a/server/src/modules/inventory/stockAdjustments/service.ts
+++ b/server/src/modules/inventory/stockAdjustments/service.ts
@@ -3,6 +3,7 @@ import {
   stockAdjustmentsRepository as defaultRepo,
 } from './repository';
 import { StockAdjustmentFilters, StockAdjustmentRecord } from './types';
+import { Queryable } from '../../../database/transaction';
 
 export class StockAdjustmentsService {
   constructor(private repo: IStockAdjustmentsRepository = defaultRepo) {}
@@ -13,6 +14,41 @@ export class StockAdjustmentsService {
 
   list(filters: StockAdjustmentFilters): Promise<{ rows: StockAdjustmentRecord[]; total: number }> {
     return this.repo.list(filters);
+  }
+
+  /**
+   * Applies a manual delta and records it. Both quantities on the audit row come from
+   * the guarded UPDATE's RETURNING, so the trail records what actually happened rather
+   * than what an earlier read predicted.
+   *
+   * @returns the before/after quantities, or null when the delta would go below zero.
+   */
+  async applyDelta(
+    productId: number,
+    delta: number,
+    reason: string,
+    userId: number,
+    client: Queryable
+  ): Promise<{ previousQty: number; newQty: number } | null> {
+    const newQty = await this.repo.applyDelta(productId, delta, client);
+    if (newQty === null) {
+      return null;
+    }
+
+    const previousQty = newQty - delta;
+    await this.repo.record(
+      {
+        product_id: productId,
+        previous_qty: previousQty,
+        new_qty: newQty,
+        delta,
+        reason,
+        user_id: userId,
+      },
+      client
+    );
+
+    return { previousQty, newQty };
   }
 }
 

--- a/server/src/modules/pos/exchanges/controller.ts
+++ b/server/src/modules/pos/exchanges/controller.ts
@@ -2,8 +2,14 @@ import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { AuthRequest } from '../../../../middleware/auth';
 import { logAuditFromReq } from '../../../../middleware/auditLogger';
-import { exchangesService, IExchangesService } from './service';
+import { exchangesService, ExchangeStockError, IExchangesService } from './service';
 import { PublicError } from '../../../http/errors';
+import {
+  IDEMPOTENCY_HEADER,
+  IDEMPOTENCY_REPLAY_HEADER,
+  IdempotencyConflictError,
+  withIdempotency,
+} from '../../../http/idempotency';
 import { paginationMeta } from '../../../http/pagination';
 import { success } from '../../../http/responses';
 import { parseExchangeListQuery } from './types';
@@ -36,6 +42,19 @@ const exchangeSchema = z.object({
   notes: z.string().max(500).optional(),
 });
 
+/**
+ * Express lowercases header names. Returns null when absent, which is what keeps the
+ * endpoint working unchanged for a till that has not been updated yet.
+ */
+function readIdempotencyKey(req: Request): string | null {
+  const raw = req.headers[IDEMPOTENCY_HEADER];
+  if (Array.isArray(raw)) {
+    // A repeated header has no single unambiguous key; refusing beats guessing.
+    throw new PublicError('VALIDATION_ERROR', `Only one ${IDEMPOTENCY_HEADER} header is allowed.`);
+  }
+  return raw ?? null;
+}
+
 export class ExchangesController {
   constructor(private service: IExchangesService = exchangesService) {}
 
@@ -44,15 +63,48 @@ export class ExchangesController {
       const authReq = req as AuthRequest;
       const parsed = exchangeSchema.parse(req.body);
 
-      const result = await this.service.createExchange(parsed, authReq.user!.id);
-
-      logAuditFromReq(req, 'create', 'exchange', result.id, {
-        exchange_number: result.exchange_number,
-        difference: result.difference,
+      const outcome = await withIdempotency({
+        endpoint: 'POST /api/v1/exchanges',
+        key: readIdempotencyKey(req),
+        userId: authReq.user!.id,
+        payload: parsed,
+        run: async (client) => {
+          const exchange = await this.service.createExchange(parsed, authReq.user!.id, client);
+          return {
+            status: 201,
+            body: success(exchange),
+            result: exchange,
+            resourceType: 'exchange',
+            resourceId: Number(exchange.id),
+          };
+        },
       });
 
-      res.status(201).json(success(result));
+      if (outcome.replayed) {
+        // A replay must not write a second audit entry.
+        res.setHeader(IDEMPOTENCY_REPLAY_HEADER, 'true');
+      } else {
+        const result = outcome.result!;
+        logAuditFromReq(req, 'create', 'exchange', result.id, {
+          exchange_number: result.exchange_number,
+          difference: result.difference,
+        });
+      }
+
+      res.status(outcome.status).json(outcome.body);
     } catch (err) {
+      if (err instanceof IdempotencyConflictError) {
+        next(
+          new PublicError('CONFLICT', err.message, [
+            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
+          ])
+        );
+        return;
+      }
+      if (err instanceof ExchangeStockError) {
+        next(new PublicError('VALIDATION_ERROR', err.message));
+        return;
+      }
       next(
         err instanceof z.ZodError || err instanceof PublicError
           ? err

--- a/server/src/modules/pos/exchanges/controller.ts
+++ b/server/src/modules/pos/exchanges/controller.ts
@@ -5,9 +5,9 @@ import { logAuditFromReq } from '../../../../middleware/auditLogger';
 import { exchangesService, ExchangeStockError, IExchangesService } from './service';
 import { PublicError } from '../../../http/errors';
 import {
-  IDEMPOTENCY_HEADER,
   IDEMPOTENCY_REPLAY_HEADER,
-  IdempotencyConflictError,
+  readIdempotencyKey,
+  toIdempotencyPublicError,
   withIdempotency,
 } from '../../../http/idempotency';
 import { paginationMeta } from '../../../http/pagination';
@@ -41,19 +41,6 @@ const exchangeSchema = z.object({
   payment_method: z.enum(['cash', 'card', 'store_credit']).optional(),
   notes: z.string().max(500).optional(),
 });
-
-/**
- * Express lowercases header names. Returns null when absent, which is what keeps the
- * endpoint working unchanged for a till that has not been updated yet.
- */
-function readIdempotencyKey(req: Request): string | null {
-  const raw = req.headers[IDEMPOTENCY_HEADER];
-  if (Array.isArray(raw)) {
-    // A repeated header has no single unambiguous key; refusing beats guessing.
-    throw new PublicError('VALIDATION_ERROR', `Only one ${IDEMPOTENCY_HEADER} header is allowed.`);
-  }
-  return raw ?? null;
-}
 
 export class ExchangesController {
   constructor(private service: IExchangesService = exchangesService) {}
@@ -93,12 +80,9 @@ export class ExchangesController {
 
       res.status(outcome.status).json(outcome.body);
     } catch (err) {
-      if (err instanceof IdempotencyConflictError) {
-        next(
-          new PublicError('CONFLICT', err.message, [
-            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
-          ])
-        );
+      const conflict = toIdempotencyPublicError(err);
+      if (conflict) {
+        next(conflict);
         return;
       }
       if (err instanceof ExchangeStockError) {

--- a/server/src/modules/pos/exchanges/repository.ts
+++ b/server/src/modules/pos/exchanges/repository.ts
@@ -26,8 +26,16 @@ export interface IExchangesRepository {
   createNewItem(exchangeId: number, item: NewItemInput, queryable: Queryable): Promise<void>;
   restockVariant(variantId: number, quantity: number, queryable: Queryable): Promise<void>;
   restockProduct(productId: number, quantity: number, queryable: Queryable): Promise<void>;
-  deductVariantStock(variantId: number, quantity: number, queryable: Queryable): Promise<void>;
-  deductProductStock(productId: number, quantity: number, queryable: Queryable): Promise<void>;
+  deductVariantStock(
+    variantId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
+  deductProductStock(
+    productId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
   listExchanges(
     filters: {
       search?: string;
@@ -129,26 +137,41 @@ export class ExchangesRepository implements IExchangesRepository {
     );
   }
 
+  /**
+   * `AND stock >= $1::int` is what stops an exchange driving stock negative; without it
+   * the relative write was atomic but unbounded. `$1::int` is cast because pg-mem
+   * evaluates `column - $param` with the operands inverted unless the parameter is typed
+   * — which is why the unguarded subtraction here never misbehaved on the addition side.
+   *
+   * @returns the remaining stock, or null when there was not enough.
+   */
   async deductVariantStock(
     variantId: number,
     quantity: number,
     queryable: Queryable
-  ): Promise<void> {
-    await this.q(queryable).query(`UPDATE product_variants SET stock = stock - $1 WHERE id = $2`, [
-      quantity,
-      variantId,
-    ]);
+  ): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      `UPDATE product_variants SET stock = stock - $1::int
+        WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
+      [quantity, variantId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
   }
 
+  /** @returns the remaining stock, or null when there was not enough. */
   async deductProductStock(
     productId: number,
     quantity: number,
     queryable: Queryable
-  ): Promise<void> {
-    await this.q(queryable).query(
-      `UPDATE products SET stock = stock - $1, updated_at = NOW() WHERE id = $2`,
+  ): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      `UPDATE products SET stock = stock - $1::int, updated_at = NOW()
+        WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
       [quantity, productId]
     );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
   }
 
   async listExchanges(

--- a/server/src/modules/pos/exchanges/service.ts
+++ b/server/src/modules/pos/exchanges/service.ts
@@ -1,6 +1,36 @@
-import { withTransaction } from '../../../database/transaction';
+import { Queryable, withTransaction } from '../../../database/transaction';
 import { IExchangesRepository, exchangesRepository as defaultRepo } from './repository';
 import { CreateExchangeDTO, ExchangeFilters, ExchangeRow, ExchangeDetail } from './types';
+
+/** A new exchange line could not be taken out of stock. Rolls the whole exchange back. */
+export class ExchangeStockError extends Error {
+  constructor(
+    message: string,
+    public readonly productId: number,
+    public readonly variantId: number | null
+  ) {
+    super(message);
+    this.name = 'ExchangeStockError';
+  }
+}
+
+/**
+ * Canonical order for the stock write phase: products before variants, then ascending by
+ * id — the same ordering the checkout path uses, so an exchange and a sale touching the
+ * same rows cannot lock them in opposite orders and deadlock.
+ */
+function sortForStockWrites<T extends { product_id: number; variant_id?: number | null }>(
+  lines: T[]
+): T[] {
+  return [...lines].sort((a, b) => {
+    const aVariant = a.variant_id ?? 0;
+    const bVariant = b.variant_id ?? 0;
+    if (aVariant !== bVariant) {
+      return aVariant - bVariant;
+    }
+    return a.product_id - b.product_id;
+  });
+}
 
 export function generateExchangeNumber(): string {
   const now = new Date();
@@ -12,7 +42,11 @@ export function generateExchangeNumber(): string {
 }
 
 export interface IExchangesService {
-  createExchange(data: CreateExchangeDTO, cashierId: number): Promise<ExchangeRow>;
+  createExchange(
+    data: CreateExchangeDTO,
+    cashierId: number,
+    client?: Queryable
+  ): Promise<ExchangeRow>;
   listExchanges(filters: ExchangeFilters): Promise<{ rows: ExchangeRow[]; total: number }>;
   getExchangeById(id: number | string): Promise<ExchangeDetail | null>;
 }
@@ -24,57 +58,86 @@ export class ExchangesService implements IExchangesService {
     return this.repo;
   }
 
-  async createExchange(data: CreateExchangeDTO, cashierId: number): Promise<ExchangeRow> {
+  /**
+   * @param client joins an existing transaction (the idempotency claim's) instead of
+   * opening one, so the claim and the exchange commit or roll back together.
+   */
+  async createExchange(
+    data: CreateExchangeDTO,
+    cashierId: number,
+    client?: Queryable
+  ): Promise<ExchangeRow> {
     const originalSale = await this.repo.findSaleById(data.original_sale_id);
     if (!originalSale) {
       throw new Error('Original sale not found');
     }
 
+    if (client) {
+      return this.writeExchange(data, cashierId, originalSale, client);
+    }
+    return withTransaction((tx) => this.writeExchange(data, cashierId, originalSale, tx));
+  }
+
+  private async writeExchange(
+    data: CreateExchangeDTO,
+    cashierId: number,
+    originalSale: Record<string, any>,
+    client: Queryable
+  ): Promise<ExchangeRow> {
     const returnTotal = data.returned_items.reduce((s, i) => s + i.price * i.quantity, 0);
     const newTotal = data.new_items.reduce((s, i) => s + i.price * i.quantity, 0);
     const difference = newTotal - returnTotal;
-    const exchangeNumber = generateExchangeNumber();
 
-    return withTransaction(async (client) => {
-      const exchange = await this.repo.createExchange(
-        {
-          exchange_number: exchangeNumber,
-          original_sale_id: data.original_sale_id,
-          customer_id: originalSale.customer_id || null,
-          cashier_id: cashierId,
-          return_total: returnTotal,
-          new_total: newTotal,
-          difference,
-          payment_method: data.payment_method || (difference >= 0 ? 'cash' : 'store_credit'),
-          notes: data.notes || null,
-        },
-        client
-      );
+    const exchange = await this.repo.createExchange(
+      {
+        exchange_number: generateExchangeNumber(),
+        original_sale_id: data.original_sale_id,
+        customer_id: originalSale.customer_id || null,
+        cashier_id: cashierId,
+        return_total: returnTotal,
+        new_total: newTotal,
+        difference,
+        payment_method: data.payment_method || (difference >= 0 ? 'cash' : 'store_credit'),
+        notes: data.notes || null,
+      },
+      client
+    );
 
-      for (const item of data.returned_items) {
-        await this.repo.createReturnedItem(exchange.id, item, client);
+    // Both loops walk the canonical order rather than the request's, so two concurrent
+    // exchanges naming the same rows in opposite order cannot deadlock against each other.
+    for (const item of sortForStockWrites(data.returned_items)) {
+      await this.repo.createReturnedItem(exchange.id, item, client);
 
-        if (item.condition === 'good') {
-          if (item.variant_id) {
-            await this.repo.restockVariant(item.variant_id, item.quantity, client);
-          } else {
-            await this.repo.restockProduct(item.product_id, item.quantity, client);
-          }
-        }
-      }
-
-      for (const item of data.new_items) {
-        await this.repo.createNewItem(exchange.id, item, client);
-
+      if (item.condition === 'good') {
         if (item.variant_id) {
-          await this.repo.deductVariantStock(item.variant_id, item.quantity, client);
+          await this.repo.restockVariant(item.variant_id, item.quantity, client);
         } else {
-          await this.repo.deductProductStock(item.product_id, item.quantity, client);
+          await this.repo.restockProduct(item.product_id, item.quantity, client);
         }
       }
+    }
 
-      return exchange;
-    });
+    for (const item of sortForStockWrites(data.new_items)) {
+      await this.repo.createNewItem(exchange.id, item, client);
+
+      const remaining = item.variant_id
+        ? await this.repo.deductVariantStock(item.variant_id, item.quantity, client)
+        : await this.repo.deductProductStock(item.product_id, item.quantity, client);
+
+      if (remaining === null) {
+        // The guarded UPDATE matched nothing: not enough stock, or the row is gone.
+        // Throwing rolls the whole exchange back, so no returned-item restock survives.
+        throw new ExchangeStockError(
+          item.variant_id
+            ? `Insufficient stock for variant ID ${item.variant_id}`
+            : `Insufficient stock for product ID ${item.product_id}`,
+          item.product_id,
+          item.variant_id ?? null
+        );
+      }
+    }
+
+    return exchange;
   }
 
   async listExchanges(filters: ExchangeFilters): Promise<{ rows: ExchangeRow[]; total: number }> {

--- a/server/src/modules/pos/exchanges/service.ts
+++ b/server/src/modules/pos/exchanges/service.ts
@@ -1,35 +1,25 @@
 import { Queryable, withTransaction } from '../../../database/transaction';
 import { IExchangesRepository, exchangesRepository as defaultRepo } from './repository';
 import { CreateExchangeDTO, ExchangeFilters, ExchangeRow, ExchangeDetail } from './types';
+import { sortForStockWrites } from '../stockWriteOrder';
+import { INSUFFICIENT_STOCK_CODE } from '../sales/types';
 
-/** A new exchange line could not be taken out of stock. Rolls the whole exchange back. */
+/**
+ * A new exchange line could not be taken out of stock. Rolls the whole exchange back.
+ * Carries the same code and status as the checkout path's `InsufficientStockError`: it is
+ * the same event, and a client should not have to special-case it per endpoint.
+ */
 export class ExchangeStockError extends Error {
   constructor(
     message: string,
     public readonly productId: number,
-    public readonly variantId: number | null
+    public readonly variantId: number | null,
+    public readonly code: string = INSUFFICIENT_STOCK_CODE,
+    public readonly statusCode: number = 400
   ) {
     super(message);
     this.name = 'ExchangeStockError';
   }
-}
-
-/**
- * Canonical order for the stock write phase: products before variants, then ascending by
- * id — the same ordering the checkout path uses, so an exchange and a sale touching the
- * same rows cannot lock them in opposite orders and deadlock.
- */
-function sortForStockWrites<T extends { product_id: number; variant_id?: number | null }>(
-  lines: T[]
-): T[] {
-  return [...lines].sort((a, b) => {
-    const aVariant = a.variant_id ?? 0;
-    const bVariant = b.variant_id ?? 0;
-    if (aVariant !== bVariant) {
-      return aVariant - bVariant;
-    }
-    return a.product_id - b.product_id;
-  });
 }
 
 export function generateExchangeNumber(): string {
@@ -67,15 +57,23 @@ export class ExchangesService implements IExchangesService {
     cashierId: number,
     client?: Queryable
   ): Promise<ExchangeRow> {
-    const originalSale = await this.repo.findSaleById(data.original_sale_id);
-    if (!originalSale) {
-      throw new Error('Original sale not found');
-    }
-
     if (client) {
+      // Read on the caller's connection, not a second one from the pool: holding two
+      // connections per request halves the pool's effective capacity under load.
+      const originalSale = await this.repo.findSaleById(data.original_sale_id, client);
+      if (!originalSale) {
+        throw new Error('Original sale not found');
+      }
       return this.writeExchange(data, cashierId, originalSale, client);
     }
-    return withTransaction((tx) => this.writeExchange(data, cashierId, originalSale, tx));
+
+    return withTransaction(async (tx) => {
+      const originalSale = await this.repo.findSaleById(data.original_sale_id, tx);
+      if (!originalSale) {
+        throw new Error('Original sale not found');
+      }
+      return this.writeExchange(data, cashierId, originalSale, tx);
+    });
   }
 
   private async writeExchange(
@@ -103,36 +101,52 @@ export class ExchangesService implements IExchangesService {
       client
     );
 
-    // Both loops walk the canonical order rather than the request's, so two concurrent
-    // exchanges naming the same rows in opposite order cannot deadlock against each other.
-    for (const item of sortForStockWrites(data.returned_items)) {
+    // Line rows first. They touch the exchange's own child tables, never a product row,
+    // so their order is irrelevant to locking and can stay the request's.
+    for (const item of data.returned_items) {
       await this.repo.createReturnedItem(exchange.id, item, client);
-
-      if (item.condition === 'good') {
-        if (item.variant_id) {
-          await this.repo.restockVariant(item.variant_id, item.quantity, client);
-        } else {
-          await this.repo.restockProduct(item.product_id, item.quantity, client);
-        }
-      }
+    }
+    for (const item of data.new_items) {
+      await this.repo.createNewItem(exchange.id, item, client);
     }
 
-    for (const item of sortForStockWrites(data.new_items)) {
-      await this.repo.createNewItem(exchange.id, item, client);
+    // Stock writes second, as ONE canonically ordered pass over the union of both sides.
+    // Sorting each side separately would not be enough: an exchange returning product 5
+    // and taking product 2 would lock 5 then 2, while one returning 2 and taking 5 locks
+    // 2 then 5 — opposite orders on the same pair, which is a deadlock. It also has to
+    // agree with the checkout path, hence the shared comparator.
+    const stockWrites = sortForStockWrites([
+      ...data.returned_items
+        // A damaged return never re-enters sellable stock.
+        .filter((item) => item.condition === 'good')
+        .map((item) => ({ ...item, delta: item.quantity })),
+      ...data.new_items.map((item) => ({ ...item, delta: -item.quantity })),
+    ]);
 
-      const remaining = item.variant_id
-        ? await this.repo.deductVariantStock(item.variant_id, item.quantity, client)
-        : await this.repo.deductProductStock(item.product_id, item.quantity, client);
+    for (const write of stockWrites) {
+      if (write.delta > 0) {
+        if (write.variant_id) {
+          await this.repo.restockVariant(write.variant_id, write.delta, client);
+        } else {
+          await this.repo.restockProduct(write.product_id, write.delta, client);
+        }
+        continue;
+      }
+
+      const quantity = -write.delta;
+      const remaining = write.variant_id
+        ? await this.repo.deductVariantStock(write.variant_id, quantity, client)
+        : await this.repo.deductProductStock(write.product_id, quantity, client);
 
       if (remaining === null) {
         // The guarded UPDATE matched nothing: not enough stock, or the row is gone.
         // Throwing rolls the whole exchange back, so no returned-item restock survives.
         throw new ExchangeStockError(
-          item.variant_id
-            ? `Insufficient stock for variant ID ${item.variant_id}`
-            : `Insufficient stock for product ID ${item.product_id}`,
-          item.product_id,
-          item.variant_id ?? null
+          write.variant_id
+            ? `Insufficient stock for variant ID ${write.variant_id}`
+            : `Insufficient stock for product ID ${write.product_id}`,
+          write.product_id,
+          write.variant_id ?? null
         );
       }
     }

--- a/server/src/modules/pos/register/service.ts
+++ b/server/src/modules/pos/register/service.ts
@@ -41,7 +41,7 @@ export interface IRegisterService {
     cashAmount: number,
     queryable?: Queryable
   ): Promise<void>;
-  recordRefundMovement(cashierId: number, amount: number): Promise<void>;
+  recordRefundMovement(cashierId: number, amount: number, queryable?: Queryable): Promise<void>;
 }
 
 export class RegisterService implements IRegisterService {
@@ -196,17 +196,24 @@ export class RegisterService implements IRegisterService {
     await this.repo.updateSaleRegisterSession(saleId, sessionId, queryable);
   }
 
-  async recordRefundMovement(cashierId: number, amount: number): Promise<void> {
-    try {
-      const session = await this.repo.findOpenSessionByCashierId(cashierId);
-      if (!session) return;
+  /**
+   * Refund counterpart of {@link recordSaleMovement}, with the same contract: when
+   * `queryable` is the refund transaction's client, the movement commits or rolls back
+   * with the refund. It previously ran after the transaction and swallowed its own
+   * errors, so a rolled-back refund could leave a drawer movement behind and a failed
+   * movement could silently desync the drawer. Both are now impossible.
+   */
+  async recordRefundMovement(
+    cashierId: number,
+    amount: number,
+    queryable?: Queryable
+  ): Promise<void> {
+    const session = await this.repo.findOpenSessionByCashierId(cashierId, queryable);
+    if (!session) return;
 
-      const sessionId = session.id;
-      await this.repo.createMovement(sessionId, 'refund', amount);
-      await this.repo.updateSessionExpectedCash(sessionId, -amount);
-    } catch {
-      // Don't fail the refund if register tracking fails
-    }
+    const sessionId = session.id;
+    await this.repo.createMovement(sessionId, 'refund', amount, null, null, queryable);
+    await this.repo.updateSessionExpectedCash(sessionId, -amount, queryable);
   }
 }
 
@@ -236,5 +243,5 @@ export const recordSaleMovement = (
   cashAmount: number,
   queryable?: Queryable
 ) => registerService.recordSaleMovement(cashierId, saleId, cashAmount, queryable);
-export const recordRefundMovement = (cashierId: number, amount: number) =>
-  registerService.recordRefundMovement(cashierId, amount);
+export const recordRefundMovement = (cashierId: number, amount: number, queryable?: Queryable) =>
+  registerService.recordRefundMovement(cashierId, amount, queryable);

--- a/server/src/modules/pos/sales/controller.ts
+++ b/server/src/modules/pos/sales/controller.ts
@@ -6,7 +6,7 @@ import { recordRefundMovement } from '../register';
 import { saleSchema, refundSchema } from '../../../../validators/saleSchema';
 import { salesService } from './service';
 import { salesRepository } from './repository';
-import { parseSaleListQuery, SalesValidationError } from './types';
+import { parseSaleListQuery, SalesValidationError, InsufficientStockError } from './types';
 import { CouponError } from '../../commerce/coupons/types';
 import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
@@ -89,6 +89,12 @@ export class SalesController {
             { field: 'payments', code: err.code, message: err.message },
           ])
         );
+        return;
+      }
+      if (err instanceof InsufficientStockError) {
+        // Same 400 and same wording as before; the error is merely typed now, so the
+        // string-matching list below stops growing.
+        next(new PublicError('VALIDATION_ERROR', err.message));
         return;
       }
       if (err instanceof CouponError) {

--- a/server/src/modules/pos/sales/controller.ts
+++ b/server/src/modules/pos/sales/controller.ts
@@ -2,7 +2,6 @@ import { Request, Response, NextFunction } from 'express';
 import { AuthRequest } from '../../../../middleware/auth';
 import { logAuditFromReq } from '../../../../middleware/auditLogger';
 import { notifySale } from '../../../../services/notifications';
-import { recordRefundMovement } from '../register';
 import { saleSchema, refundSchema } from '../../../../validators/saleSchema';
 import { salesService } from './service';
 import { salesRepository } from './repository';
@@ -11,6 +10,25 @@ import { CouponError } from '../../commerce/coupons/types';
 import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
+import {
+  IDEMPOTENCY_HEADER,
+  IDEMPOTENCY_REPLAY_HEADER,
+  IdempotencyConflictError,
+  withIdempotency,
+} from '../../../http/idempotency';
+
+/**
+ * Express lowercases header names. Returns null when absent, which is what keeps the
+ * endpoint working unchanged for a till that has not been updated yet.
+ */
+function readIdempotencyKey(req: Request): string | null {
+  const raw = req.headers[IDEMPOTENCY_HEADER];
+  if (Array.isArray(raw)) {
+    // A repeated header has no single unambiguous key; refusing beats guessing.
+    throw new PublicError('VALIDATION_ERROR', `Only one ${IDEMPOTENCY_HEADER} header is allowed.`);
+  }
+  return raw ?? null;
+}
 
 export class SalesController {
   async getSales(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -64,25 +82,59 @@ export class SalesController {
       const cashierId = authReq.user!.id;
       const cashierName = authReq.user!.name;
 
-      // Cash-register movement is now recorded INSIDE executeSale's checkout
-      // transaction (Unit 4), derived from the confirmed/validated split --
-      // not here, and not from unchecked request values.
-      const sale = await salesService.executeSale(parsed.data, cashierId);
+      const outcome = await withIdempotency({
+        key: readIdempotencyKey(req),
+        endpoint: 'POST /api/v1/sales',
+        userId: cashierId,
+        // The VALIDATED body, so key order, whitespace, and stripped unknown
+        // fields cannot make two identical requests look different.
+        payload: parsed.data,
+        run: async (client) => {
+          // Cash-register movement is recorded INSIDE executeSale's checkout
+          // transaction (Unit 4), derived from the confirmed/validated split --
+          // not here, and not from unchecked request values. Passing the client
+          // makes the sale and the idempotency claim share one transaction, so
+          // they commit or roll back together.
+          const sale = await salesService.executeSale(parsed.data, cashierId, client);
 
-      logAuditFromReq(req, 'create', 'sale', sale.id, {
-        total: sale.total,
-        payment_method: sale.payment_method,
-        item_count: parsed.data.items.length,
+          // Additive cashier metadata (R6): `sale` from `repo.createSale`'s
+          // RETURNING * has no join, so attach the display name the request
+          // already carries; every other confirmed-response field (calculation,
+          // items, payments) is attached by SalesService itself.
+          return {
+            status: 201,
+            body: success({ ...sale, cashier_name: cashierName }),
+            result: sale,
+            resourceType: 'sale',
+            resourceId: Number(sale.id),
+          };
+        },
       });
 
-      notifySale(Number(sale.total), sale.id, cashierName);
+      if (outcome.replayed) {
+        // A replay must not fire the side effects again -- no second audit
+        // entry, and no second SMS to the customer.
+        res.setHeader(IDEMPOTENCY_REPLAY_HEADER, 'true');
+      } else {
+        const sale = outcome.result!;
+        logAuditFromReq(req, 'create', 'sale', sale.id, {
+          total: sale.total,
+          payment_method: sale.payment_method,
+          item_count: parsed.data.items.length,
+        });
+        notifySale(Number(sale.total), sale.id, cashierName);
+      }
 
-      // Additive cashier metadata (R6): `sale` from `repo.createSale`'s
-      // RETURNING * has no join, so attach the display name the request
-      // already carries; every other confirmed-response field (calculation,
-      // items, payments) is attached by SalesService itself.
-      res.status(201).json(success({ ...sale, cashier_name: cashierName }));
+      res.status(outcome.status).json(outcome.body);
     } catch (err: any) {
+      if (err instanceof IdempotencyConflictError) {
+        next(
+          new PublicError('CONFLICT', err.message, [
+            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
+          ])
+        );
+        return;
+      }
       if (err instanceof SalesValidationError) {
         next(
           new PublicError('VALIDATION_ERROR', err.message, [
@@ -129,21 +181,55 @@ export class SalesController {
       const authReq = req as AuthRequest;
       const cashierId = authReq.user!.id;
 
-      const result = await salesService.executeRefund(saleId, parsed.data, cashierId);
+      const outcome = await withIdempotency({
+        key: readIdempotencyKey(req),
+        // Stable label. The key's scope is validated rather than keyed, so the sale id
+        // must NOT be interpolated here; it goes into the fingerprinted payload below so
+        // that one key reused across two different sales conflicts instead of replaying
+        // the wrong refund.
+        endpoint: 'POST /api/v1/sales/:id/refund',
+        userId: cashierId,
+        payload: { saleId, body: parsed.data },
+        run: async (client) => {
+          // The cash-register movement is recorded INSIDE executeRefund's transaction,
+          // not here: a refund that rolls back must leave no drawer movement behind.
+          // Passing the client makes the refund and the idempotency claim share one
+          // transaction, so they commit or roll back together.
+          const result = await salesService.executeRefund(saleId, parsed.data, cashierId, client);
 
-      logAuditFromReq(req, 'refund', 'sale', req.params.id as string, {
-        refund_amount: result.refund.amount,
+          return {
+            status: 201,
+            body: success({
+              refund: result.refund,
+              refund_status: result.refundStatus,
+              refunded_amount: result.newRefundedTotal,
+            }),
+            result,
+            resourceType: 'refund',
+            resourceId: Number(result.refund.id),
+          };
+        },
       });
-      recordRefundMovement(cashierId, Number(result.refund.amount));
 
-      res.status(201).json(
-        success({
-          refund: result.refund,
-          refund_status: result.refundStatus,
-          refunded_amount: result.newRefundedTotal,
-        })
-      );
+      if (outcome.replayed) {
+        // A replay must not write a second audit entry.
+        res.setHeader(IDEMPOTENCY_REPLAY_HEADER, 'true');
+      } else {
+        logAuditFromReq(req, 'refund', 'sale', req.params.id as string, {
+          refund_amount: outcome.result!.refund.amount,
+        });
+      }
+
+      res.status(outcome.status).json(outcome.body);
     } catch (err: any) {
+      if (err instanceof IdempotencyConflictError) {
+        next(
+          new PublicError('CONFLICT', err.message, [
+            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
+          ])
+        );
+        return;
+      }
       if (
         err.message === 'Sale not found' ||
         err.message === 'Sale already fully refunded' ||

--- a/server/src/modules/pos/sales/controller.ts
+++ b/server/src/modules/pos/sales/controller.ts
@@ -11,24 +11,11 @@ import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
 import {
-  IDEMPOTENCY_HEADER,
   IDEMPOTENCY_REPLAY_HEADER,
-  IdempotencyConflictError,
+  readIdempotencyKey,
+  toIdempotencyPublicError,
   withIdempotency,
 } from '../../../http/idempotency';
-
-/**
- * Express lowercases header names. Returns null when absent, which is what keeps the
- * endpoint working unchanged for a till that has not been updated yet.
- */
-function readIdempotencyKey(req: Request): string | null {
-  const raw = req.headers[IDEMPOTENCY_HEADER];
-  if (Array.isArray(raw)) {
-    // A repeated header has no single unambiguous key; refusing beats guessing.
-    throw new PublicError('VALIDATION_ERROR', `Only one ${IDEMPOTENCY_HEADER} header is allowed.`);
-  }
-  return raw ?? null;
-}
 
 export class SalesController {
   async getSales(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -127,12 +114,9 @@ export class SalesController {
 
       res.status(outcome.status).json(outcome.body);
     } catch (err: any) {
-      if (err instanceof IdempotencyConflictError) {
-        next(
-          new PublicError('CONFLICT', err.message, [
-            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
-          ])
-        );
+      const conflict = toIdempotencyPublicError(err);
+      if (conflict) {
+        next(conflict);
         return;
       }
       if (err instanceof SalesValidationError) {
@@ -222,12 +206,9 @@ export class SalesController {
 
       res.status(outcome.status).json(outcome.body);
     } catch (err: any) {
-      if (err instanceof IdempotencyConflictError) {
-        next(
-          new PublicError('CONFLICT', err.message, [
-            { field: IDEMPOTENCY_HEADER, code: err.code, message: err.message },
-          ])
-        );
+      const conflict = toIdempotencyPublicError(err);
+      if (conflict) {
+        next(conflict);
         return;
       }
       if (

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -69,8 +69,6 @@ export interface ISalesRepository {
     productId: number,
     queryable?: Queryable
   ): Promise<Record<string, any> | null>;
-  updateProductStock(productId: number, newStock: number, queryable: Queryable): Promise<void>;
-  updateVariantStock(variantId: number, newStock: number, queryable: Queryable): Promise<void>;
   decrementProductStock(
     productId: number,
     quantity: number,
@@ -495,28 +493,6 @@ export class SalesRepository implements ISalesRepository {
       [variantId, productId]
     );
     return res.rows[0] || null;
-  }
-
-  async updateProductStock(
-    productId: number,
-    newStock: number,
-    queryable: Queryable
-  ): Promise<void> {
-    await queryable.query('UPDATE products SET stock = $1, updated_at = NOW() WHERE id = $2', [
-      newStock,
-      productId,
-    ]);
-  }
-
-  async updateVariantStock(
-    variantId: number,
-    newStock: number,
-    queryable: Queryable
-  ): Promise<void> {
-    await queryable.query(
-      'UPDATE product_variants SET stock = $1, updated_at = NOW() WHERE id = $2',
-      [newStock, variantId]
-    );
   }
 
   /**

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -65,6 +65,16 @@ export interface ISalesRepository {
   ): Promise<Record<string, any> | null>;
   updateProductStock(productId: number, newStock: number, queryable: Queryable): Promise<void>;
   updateVariantStock(variantId: number, newStock: number, queryable: Queryable): Promise<void>;
+  decrementProductStock(
+    productId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
+  decrementVariantStock(
+    variantId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
   createStockAdjustment(data: Record<string, any>, queryable: Queryable): Promise<void>;
   getSetting(key: string, queryable?: Queryable): Promise<string | undefined>;
   getCouponByCode(code: string, queryable?: Queryable): Promise<Record<string, any> | null>;
@@ -456,6 +466,49 @@ export class SalesRepository implements ISalesRepository {
       'UPDATE product_variants SET stock = $1, updated_at = NOW() WHERE id = $2',
       [newStock, variantId]
     );
+  }
+
+  /**
+   * Conditional relative decrement. Reading a quantity and writing back an absolute
+   * value computed in JavaScript loses updates: two concurrent checkouts both read
+   * stock 5, both write 3, and four units vanish. Folding the sufficiency check into the
+   * WHERE clause removes the stale-read window entirely — under READ COMMITTED
+   * PostgreSQL re-evaluates it after a concurrent writer's row lock is released.
+   *
+   * @returns the resulting stock, or null when there was not enough (rowCount 0).
+   *
+   * `$1::int` is cast explicitly: pg-mem, which backs most of this repo's suites,
+   * evaluates `column - $param` with the operands inverted unless the parameter is
+   * typed, silently turning a decrement into a negation. Addition is commutative, which
+   * is why the existing relative writes never exposed it.
+   */
+  async decrementProductStock(
+    productId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null> {
+    const res = await queryable.query<{ stock: number }>(
+      `UPDATE products SET stock = stock - $1::int, updated_at = NOW()
+        WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
+      [quantity, productId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /** Variant counterpart of {@link decrementProductStock}. */
+  async decrementVariantStock(
+    variantId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null> {
+    const res = await queryable.query<{ stock: number }>(
+      `UPDATE product_variants SET stock = stock - $1::int, updated_at = NOW()
+        WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
+      [quantity, variantId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
   }
 
   async createStockAdjustment(data: Record<string, any>, queryable: Queryable): Promise<void> {

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -37,6 +37,11 @@ export interface ISalesRepository {
     discount: number,
     queryable: Queryable
   ): Promise<void>;
+  redeemCustomerLoyalty(
+    customerId: number,
+    points: number,
+    queryable: Queryable
+  ): Promise<number | null>;
   updateCustomerLoyalty(
     customerId: number,
     deltaPoints: number,
@@ -379,6 +384,29 @@ export class SalesRepository implements ISalesRepository {
       'UPDATE customers SET loyalty_points = loyalty_points + $1, updated_at = NOW() WHERE id = $2',
       [deltaPoints, customerId]
     );
+  }
+
+  /**
+   * Guarded loyalty debit. The balance check in `buildBreakdown` is a stale read, so it
+   * can only produce the user-facing message; this write is what actually decides, and
+   * it cannot drive a balance negative.
+   *
+   * `$1::int` is cast for the same pg-mem reason as {@link decrementProductStock}.
+   *
+   * @returns the remaining balance, or null when there were not enough points.
+   */
+  async redeemCustomerLoyalty(
+    customerId: number,
+    points: number,
+    queryable: Queryable
+  ): Promise<number | null> {
+    const res = await queryable.query<{ loyalty_points: number }>(
+      `UPDATE customers SET loyalty_points = loyalty_points - $1::int, updated_at = NOW()
+        WHERE id = $2 AND loyalty_points >= $1::int
+        RETURNING loyalty_points`,
+      [points, customerId]
+    );
+    return res.rows[0] ? Number(res.rows[0].loyalty_points) : null;
   }
 
   async createLoyaltyTransaction(

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -4,6 +4,7 @@ import { SaleFilters, SaleCalculationSnapshot, CreateSaleCalculationInput } from
 
 export interface ISalesRepository {
   findById(id: number | string, queryable?: Queryable): Promise<Record<string, any> | null>;
+  findByIdForUpdate(id: number, queryable: Queryable): Promise<Record<string, any> | null>;
   findItemsBySaleId(saleId: number | string, queryable?: Queryable): Promise<Record<string, any>[]>;
   findPaymentsBySaleId(
     saleId: number | string,
@@ -75,6 +76,11 @@ export interface ISalesRepository {
     quantity: number,
     queryable: Queryable
   ): Promise<number | null>;
+  incrementProductStock(
+    productId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
   decrementVariantStock(
     variantId: number,
     quantity: number,
@@ -110,6 +116,23 @@ export class SalesRepository implements ISalesRepository {
     // so historical receipts/reads never depend on current settings/formulas.
     const calculation = await this.getSaleCalculationBySaleId(sale.id, queryable);
     return calculation ? { ...sale, calculation } : sale;
+  }
+
+  /**
+   * Locks one sale row for the rest of the caller's transaction.
+   *
+   * The refund cumulative check (`refunded_amount + amount <= total`) spans sibling
+   * refund rows, so no single conditional write can express it: three concurrent partial
+   * refunds would each read the same `refunded_amount`, each pass the check, and together
+   * exceed the sale total. Locking the parent row serializes them.
+   *
+   * Deliberately not {@link findById}'s query: `FOR UPDATE` cannot be applied to the
+   * nullable side of the outer joins that attach `cashier_name`/`customer_name`, and the
+   * caller needs the authoritative `sales` columns, not the display ones.
+   */
+  async findByIdForUpdate(id: number, queryable: Queryable): Promise<Record<string, any> | null> {
+    const res = await queryable.query('SELECT * FROM sales WHERE id = $1 FOR UPDATE', [id]);
+    return res.rows[0] || null;
   }
 
   async findItemsBySaleId(
@@ -518,6 +541,29 @@ export class SalesRepository implements ISalesRepository {
     const res = await queryable.query<{ stock: number }>(
       `UPDATE products SET stock = stock - $1::int, updated_at = NOW()
         WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
+      [quantity, productId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /**
+   * Relative restock, the inverse of {@link decrementProductStock}. A refund used to read
+   * `products.stock` and write back `currentStock + quantity`, which loses one of two
+   * concurrent restocks exactly as the checkout path did.
+   *
+   * No `WHERE stock >= ...` guard: adding stock has no insufficiency to guard against.
+   *
+   * @returns the resulting stock, or null when no such product exists.
+   */
+  async incrementProductStock(
+    productId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null> {
+    const res = await queryable.query<{ stock: number }>(
+      `UPDATE products SET stock = stock + $1::int, updated_at = NOW()
+        WHERE id = $2
         RETURNING stock`,
       [quantity, productId]
     );

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -31,6 +31,7 @@ import {
   ConfirmedPayment,
   SaleCalculationSnapshot,
   SalesValidationError,
+  InsufficientStockError,
   SPLIT_PAYMENT_MISMATCH_CODE,
   STRICT_SPLIT_PAYMENT_VALIDATION,
 } from './types';
@@ -48,9 +49,26 @@ interface ResolvedSaleLine {
   unit_price: number;
   cost_price: number;
   memo?: string | null;
-  previousStock: number;
-  newStock: number;
   isVariant: boolean;
+}
+
+/**
+ * Canonical order for the stock write phase: products before variants, then ascending by
+ * id. Two concurrent multi-line checkouts naming the same rows in opposite request order
+ * would otherwise lock them in opposite order and deadlock. Sorting is what removes the
+ * cycle, so this ordering must be applied by every path that decrements stock.
+ */
+function sortForStockWrites<T extends { product_id: number; variant_id?: number | null }>(
+  lines: T[]
+): T[] {
+  return [...lines].sort((a, b) => {
+    const aVariant = a.variant_id ?? 0;
+    const bVariant = b.variant_id ?? 0;
+    if (aVariant !== bVariant) {
+      return aVariant - bVariant;
+    }
+    return a.product_id - b.product_id;
+  });
 }
 
 interface ResolvedLines {
@@ -260,7 +278,6 @@ export class SalesService {
           throw new Error(`Insufficient stock for variant ID ${item.variant_id}`);
         }
         const unitPrice = Number(variant.price);
-        const previousStock = Number(variant.stock);
         resolvedItems.push({
           product_id: item.product_id,
           variant_id: item.variant_id,
@@ -268,8 +285,6 @@ export class SalesService {
           unit_price: unitPrice,
           cost_price: Number(variant.cost_price || 0),
           memo: item.memo || null,
-          previousStock,
-          newStock: previousStock - item.quantity,
           isVariant: true,
         });
         calcLines.push({ unitPriceMinor: toMinorUnits(unitPrice), quantity: item.quantity });
@@ -280,7 +295,6 @@ export class SalesService {
           throw new Error(`Insufficient stock for product ID ${item.product_id}`);
         }
         const unitPrice = Number(product.price);
-        const previousStock = Number(product.stock);
         resolvedItems.push({
           product_id: item.product_id,
           variant_id: null,
@@ -288,8 +302,6 @@ export class SalesService {
           unit_price: unitPrice,
           cost_price: Number(product.cost_price || 0),
           memo: item.memo || null,
-          previousStock,
-          newStock: previousStock - item.quantity,
           isVariant: false,
         });
         calcLines.push({ unitPriceMinor: toMinorUnits(unitPrice), quantity: item.quantity });
@@ -411,7 +423,6 @@ export class SalesService {
 
       const lineTotalMinor = lineTotalsMinor[i];
       const perUnitMinor = Math.round(lineTotalMinor / requestedQty);
-      const previousStock = Number(product.stock);
 
       resolvedItems.push({
         product_id: bi.product_id,
@@ -420,8 +431,6 @@ export class SalesService {
         unit_price: fromMinorUnits(perUnitMinor),
         cost_price: Number(product.cost_price || 0),
         memo: `[Bundle #${bundleId}] ${bundle.name}`,
-        previousStock,
-        newStock: previousStock - requestedQty,
         isVariant: false,
       });
       // Authoritative line contribution is the exact allocation, folded into
@@ -674,6 +683,8 @@ export class SalesService {
         );
       }
 
+      // Line rows keep the request's order, so the confirmed response's `items` array is
+      // exactly what it always was.
       for (const item of resolvedItems) {
         await this.repo.createSaleItem(
           {
@@ -687,18 +698,39 @@ export class SalesService {
           },
           client
         );
+      }
 
-        if (item.isVariant && item.variant_id) {
-          await this.repo.updateVariantStock(item.variant_id, item.newStock, client);
-        } else {
-          await this.repo.updateProductStock(item.product_id, item.newStock, client);
+      // Stock writes run in a canonical order instead of the request's. Two concurrent
+      // two-line checkouts naming the same products in opposite order would otherwise
+      // take row locks in opposite order and deadlock. Sorting removes the cycle.
+      for (const item of sortForStockWrites(resolvedItems)) {
+        const isVariantLine = Boolean(item.isVariant && item.variant_id);
+
+        const newStock = isVariantLine
+          ? await this.repo.decrementVariantStock(item.variant_id!, item.quantity, client)
+          : await this.repo.decrementProductStock(item.product_id, item.quantity, client);
+
+        if (newStock === null) {
+          // The guarded UPDATE matched nothing: stock was insufficient, or the row was
+          // deleted between resolve and write. Either way the transaction rolls back and
+          // no partial sale survives. The check in resolveLines is only a fail-fast
+          // courtesy; this is the authority.
+          throw new InsufficientStockError(
+            isVariantLine
+              ? `Insufficient stock for variant ID ${item.variant_id}`
+              : `Insufficient stock for product ID ${item.product_id}`,
+            item.product_id,
+            isVariantLine ? item.variant_id! : null
+          );
         }
 
         await this.repo.createStockAdjustment(
           {
             product_id: item.product_id,
-            previous_qty: item.previousStock,
-            new_qty: item.newStock,
+            // Derived from RETURNING, so the audit trail records what actually happened
+            // rather than what the earlier read predicted.
+            previous_qty: newStock + item.quantity,
+            new_qty: newStock,
             delta: -item.quantity,
             reason: 'Sale',
             user_id: cashierId,

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -4,6 +4,7 @@ import { ISalesRepository, salesRepository as defaultRepo } from './repository';
 import { bundlesRepository, IBundlesRepository } from '../../inventory/bundles/repository';
 import { couponsService, CouponsService } from '../../commerce/coupons/service';
 import { registerService, IRegisterService } from '../register/service';
+import { sortForStockWrites } from '../stockWriteOrder';
 import {
   parseLoyaltySettings,
   CanonicalLoyaltySettings,
@@ -50,25 +51,6 @@ interface ResolvedSaleLine {
   cost_price: number;
   memo?: string | null;
   isVariant: boolean;
-}
-
-/**
- * Canonical order for the stock write phase: products before variants, then ascending by
- * id. Two concurrent multi-line checkouts naming the same rows in opposite request order
- * would otherwise lock them in opposite order and deadlock. Sorting is what removes the
- * cycle, so this ordering must be applied by every path that decrements stock.
- */
-function sortForStockWrites<T extends { product_id: number; variant_id?: number | null }>(
-  lines: T[]
-): T[] {
-  return [...lines].sort((a, b) => {
-    const aVariant = a.variant_id ?? 0;
-    const bVariant = b.variant_id ?? 0;
-    if (aVariant !== bVariant) {
-      return aVariant - bVariant;
-    }
-    return a.product_id - b.product_id;
-  });
 }
 
 interface ResolvedLines {

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -851,7 +851,10 @@ export class SalesService {
     clientOrPool?: any
   ): Promise<{ refund: Record<string, any>; refundStatus: string; newRefundedTotal: number }> {
     return withTransaction(async (client) => {
-      const sale = await this.repo.findById(saleId, client);
+      // Lock the sale for the rest of this transaction BEFORE reading `refunded_amount`:
+      // the cumulative check below is only correct while no sibling refund can commit
+      // between the read and the write.
+      const sale = await this.repo.findByIdForUpdate(saleId, client);
       if (!sale) throw new Error('Sale not found');
       if (sale.refund_status === 'full') throw new Error('Sale already fully refunded');
 
@@ -895,12 +898,19 @@ export class SalesService {
       await this.repo.updateSaleRefundStatus(saleId, refundStatus, newRefundedTotal, client);
 
       if (input.restock) {
-        for (const item of input.items) {
-          const product = await this.repo.getProductById(item.product_id, client);
-          const currentStock = Number(product?.stock || 0);
-          await this.repo.updateProductStock(item.product_id, currentStock + item.quantity, client);
+        // Ascending by product id, the same canonical order the checkout write phase
+        // uses, so a refund and a checkout touching the same two products cannot lock
+        // them in opposite order and deadlock.
+        const restockOrder = [...input.items].sort((a, b) => a.product_id - b.product_id);
+        for (const item of restockOrder) {
+          await this.repo.incrementProductStock(item.product_id, item.quantity, client);
         }
       }
+
+      // Inside the transaction (R4): the previous after-the-fact, error-swallowing call
+      // from the controller could leave a drawer movement behind for a refund that
+      // rolled back. Mirrors `executeSale`'s in-transaction sale movement.
+      await this.register.recordRefundMovement(cashierId, refundAmount, client);
 
       return { refund, refundStatus, newRefundedTotal };
     }, clientOrPool);

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -450,10 +450,16 @@ export class SalesService {
    * (preview/legacy shape) and `executeSale` (persistence) so there is no
    * second, weaker calculation path.
    */
+  /**
+   * @param forConsumption true only on the path that is about to persist the sale. It
+   *   turns on the fail-fast stock pre-check and makes the coupon lookup take a row lock,
+   *   because this is the call that will record a `coupon_usage` row. Preview callers
+   *   pass false and take no locks.
+   */
   private async buildBreakdown(
     input: CreateSaleDTO,
     queryable: Queryable,
-    checkStock: boolean
+    forConsumption: boolean
   ): Promise<{
     breakdown: SaleCalculationBreakdown;
     resolvedItems: ResolvedSaleLine[];
@@ -462,7 +468,7 @@ export class SalesService {
     const { resolvedItems, calcLines } = await this.resolveLines(
       input.items,
       queryable,
-      checkStock
+      forConsumption
     );
     const subtotalMinor = calcLines.reduce((sum, l) => sum + l.unitPriceMinor * l.quantity, 0);
 
@@ -488,7 +494,8 @@ export class SalesService {
           customer_id: input.customer_id ?? null,
           item_product_ids: input.items.map((i) => i.product_id),
         },
-        queryable
+        queryable,
+        { forConsumption }
       );
       couponId = result.coupon_id;
       couponDiscountMinor = toMinorUnits(result.discount);
@@ -741,11 +748,16 @@ export class SalesService {
 
       if (input.customer_id && customer) {
         if (breakdown.pointsRedeemed > 0) {
-          await this.repo.updateCustomerLoyalty(
+          const remaining = await this.repo.redeemCustomerLoyalty(
             input.customer_id,
-            -breakdown.pointsRedeemed,
+            breakdown.pointsRedeemed,
             client
           );
+          if (remaining === null) {
+            // The balance moved between the breakdown's read and this write. Same
+            // wording the stale check produces, so the client sees no change.
+            throw new Error('Insufficient loyalty points');
+          }
           await this.repo.createLoyaltyTransaction(
             input.customer_id,
             sale.id,

--- a/server/src/modules/pos/sales/types.ts
+++ b/server/src/modules/pos/sales/types.ts
@@ -288,6 +288,27 @@ export class SalesValidationError extends Error {
   }
 }
 
+/** Stable, documented code for a checkout rejected because stock ran out. */
+export const INSUFFICIENT_STOCK_CODE = 'INSUFFICIENT_STOCK';
+
+/**
+ * Thrown when the guarded stock decrement matched no row — the line's stock was gone by
+ * the time the write ran. Typed rather than string-matched so the controller's message
+ * list stops growing, while the client-facing wording stays exactly as it was.
+ */
+export class InsufficientStockError extends Error {
+  constructor(
+    message: string,
+    public readonly productId: number,
+    public readonly variantId: number | null = null,
+    public readonly code: string = INSUFFICIENT_STOCK_CODE,
+    public readonly statusCode: number = 400
+  ) {
+    super(message);
+    this.name = 'InsufficientStockError';
+  }
+}
+
 /** A payment entry as persisted to `sale_payments` / returned in the confirmed sale response. Major EGP units, exactly as validated -- never coerced/rounded into balance. */
 export interface ConfirmedPayment {
   method: string;

--- a/server/src/modules/pos/stockWriteOrder.ts
+++ b/server/src/modules/pos/stockWriteOrder.ts
@@ -1,0 +1,28 @@
+/**
+ * The one canonical order in which any transaction may take product/variant row locks.
+ *
+ * Two transactions that touch the same rows in opposite orders deadlock. Sorting every
+ * stock write phase through this single function is what removes the cycle — and it only
+ * works if EVERY path uses the same rule, which is precisely why this lives in one place
+ * rather than being reimplemented per module.
+ *
+ * A path that mutates stock in more than one phase (an exchange restocks returned items
+ * and deducts new ones) must sort the COMBINED set, not each phase separately: sorting
+ * each half independently still lets two callers interleave the halves in opposite order.
+ */
+export interface StockWriteTarget {
+  product_id: number;
+  variant_id?: number | null;
+}
+
+/** Products before variants, then ascending by id. */
+export function sortForStockWrites<T extends StockWriteTarget>(lines: T[]): T[] {
+  return [...lines].sort((a, b) => {
+    const aVariant = a.variant_id ?? 0;
+    const bVariant = b.variant_id ?? 0;
+    if (aVariant !== bVariant) {
+      return aVariant - bVariant;
+    }
+    return a.product_id - b.product_id;
+  });
+}

--- a/server/tests/auditLog.test.ts
+++ b/server/tests/auditLog.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { newDb } from 'pg-mem';
 import type { Pool as PgPool } from 'pg';
 import path from 'path';
+import { createPgMemPool } from './support/pgMem';
 import { parseAuditLogListQuery } from '../src/modules/core/auditLog/types';
 import { AuditLogRepository } from '../src/modules/core/auditLog/repository';
 import { runMigrationsUp } from '../src/database/migrate';
@@ -41,9 +41,7 @@ describe('Audit Log repository', () => {
   let testPool: PgPool;
 
   beforeAll(async () => {
-    const memory = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memory.adapters.createPg();
-    testPool = new Pool() as unknown as PgPool;
+    testPool = createPgMemPool();
     await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
     await testPool.query(
       `INSERT INTO audit_log (user_id, user_name, action, entity_type, entity_id, details, created_at)

--- a/server/tests/auth.test.ts
+++ b/server/tests/auth.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { Request, Response } from 'express';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import { newDb } from 'pg-mem';
 import { Pool as PgPool } from 'pg';
 import path from 'path';
+import { createPgMemPool } from './support/pgMem';
 import { setPool, closePool } from '../src/database/pool';
 import { runMigrationsUp } from '../src/database/migrate';
 import { AuthController } from '../src/modules/core/auth/controller';
@@ -17,9 +17,7 @@ const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET!;
 let testPool: PgPool;
 
 beforeAll(async () => {
-  const memDb = newDb({ noAstCoverageCheck: true });
-  const { Pool } = memDb.adapters.createPg();
-  testPool = new Pool() as unknown as PgPool;
+  testPool = createPgMemPool();
   setPool(testPool);
 
   const migrationsDir = path.join(__dirname, '../src/database/migrations');

--- a/server/tests/commerce-contracts.test.ts
+++ b/server/tests/commerce-contracts.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { GiftCardsService } from '../src/modules/commerce/giftCards/service';
 import {
   parseCustomerListQuery,
   parseCustomerSalesQuery,
@@ -101,5 +107,133 @@ describe('commerce collection contracts', () => {
     });
     expect(() => parseVendorPayoutQuery({ limit: '20' })).toThrow();
     expect(() => parseWarrantyListQuery({ limit: '20' })).toThrow();
+  });
+});
+
+describe('gift card redemption invariants', () => {
+  let testPool: PgPool;
+  let userId: number;
+  let saleId: number;
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM gift_card_transactions');
+    await testPool.query('DELETE FROM gift_cards');
+    await testPool.query('DELETE FROM sales');
+    await testPool.query('DELETE FROM users');
+
+    const users = await testPool.query<{ id: number }>(
+      `INSERT INTO users (name, email, password_hash, role)
+       VALUES ('Cashier', 'gc@moon.com', 'x', 'Cashier') RETURNING id`
+    );
+    userId = users.rows[0].id;
+
+    const sales = await testPool.query<{ id: number }>(
+      'INSERT INTO sales (total, cashier_id) VALUES (100, $1) RETURNING id',
+      [userId]
+    );
+    saleId = sales.rows[0].id;
+  });
+
+  async function makeCard(options: {
+    balance: number;
+    status?: string;
+    expiresAt?: string | null;
+  }): Promise<string> {
+    const code = `GC-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+    await testPool.query(
+      `INSERT INTO gift_cards (code, barcode, initial_value, balance, status, expires_at, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        code,
+        code.replace('GC-', '890200'),
+        options.balance,
+        options.balance,
+        options.status ?? 'active',
+        options.expiresAt ?? null,
+        userId,
+      ]
+    );
+    return code;
+  }
+
+  async function balanceOf(code: string): Promise<number> {
+    const { rows } = await testPool.query<{ balance: number }>(
+      'SELECT balance FROM gift_cards WHERE code = $1',
+      [code]
+    );
+    return Number(rows[0].balance);
+  }
+
+  async function transactionCount(): Promise<number> {
+    const { rows } = await testPool.query<{ n: number }>(
+      'SELECT COUNT(*)::int AS n FROM gift_card_transactions'
+    );
+    return rows[0].n;
+  }
+
+  it('debits the redeemed amount and writes exactly one transaction row', async () => {
+    const code = await makeCard({ balance: 100 });
+
+    const result = await new GiftCardsService().redeem(code, 50, saleId, userId);
+
+    expect(result.new_balance).toBe(50);
+    expect(result.transaction).toMatchObject({ balance_before: 100, balance_after: 50 });
+    expect(await balanceOf(code)).toBe(50);
+    expect(await transactionCount()).toBe(1);
+  });
+
+  it('allows redeeming the exact remaining balance, leaving zero', async () => {
+    const code = await makeCard({ balance: 100 });
+
+    const result = await new GiftCardsService().redeem(code, 100, saleId, userId);
+
+    expect(result.new_balance).toBe(0);
+    expect(await balanceOf(code)).toBe(0);
+  });
+
+  it('refuses an over-redemption with the existing message and no balance change', async () => {
+    const code = await makeCard({ balance: 40 });
+
+    await expect(new GiftCardsService().redeem(code, 41, saleId, userId)).rejects.toThrow(
+      'Insufficient balance. Available: 40'
+    );
+    expect(await balanceOf(code)).toBe(40);
+    expect(await transactionCount()).toBe(0);
+  });
+
+  it('refuses an inactive card with the existing message and no balance change', async () => {
+    const code = await makeCard({ balance: 100, status: 'inactive' });
+
+    await expect(new GiftCardsService().redeem(code, 10, saleId, userId)).rejects.toThrow(
+      'Gift card is not active'
+    );
+    expect(await balanceOf(code)).toBe(100);
+    expect(await transactionCount()).toBe(0);
+  });
+
+  it('refuses an expired card with the existing message and no balance change', async () => {
+    const code = await makeCard({ balance: 100, expiresAt: '2020-01-01T00:00:00Z' });
+
+    await expect(new GiftCardsService().redeem(code, 10, saleId, userId)).rejects.toThrow(
+      'Gift card has expired'
+    );
+    expect(await balanceOf(code)).toBe(100);
+    expect(await transactionCount()).toBe(0);
+  });
+
+  it('reports an unknown code as not found', async () => {
+    await expect(new GiftCardsService().redeem('GC-NOPE', 10, saleId, userId)).rejects.toThrow(
+      'Gift card not found'
+    );
   });
 });

--- a/server/tests/concurrency/balances.concurrency.test.ts
+++ b/server/tests/concurrency/balances.concurrency.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Balance and stock invariants for gift-card redemption and exchanges, under genuine
+ * concurrency.
+ *
+ * These cannot live in a pg-mem suite: pg-mem has no MVCC (so two "concurrent" writers
+ * are really sequential) and silently ignores ROLLBACK (so a rollback assertion would
+ * pass for the wrong reason).
+ *
+ * The `CHECK (balance >= 0)` / `CHECK (stock >= 0)` constraints from migration 004 are a
+ * silent backstop, not the mechanism under test. Every case below asserts the outcome the
+ * APPLICATION guard produces — a clean typed error and an unchanged row — so a test that
+ * only passed because a constraint fired would show up as the wrong error, not as a pass.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { GiftCardsController } from '../../src/modules/commerce/giftCards/controller';
+import { ExchangesController } from '../../src/modules/pos/exchanges/controller';
+import { giftCardsService } from '../../src/modules/commerce/giftCards/service';
+import { adjustStock } from '../../../server/services/productService';
+import * as auditLogger from '../../../server/middleware/auditLogger';
+
+interface CapturedResponse {
+  status: number | null;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+interface Outcome {
+  response: CapturedResponse;
+  error: unknown;
+}
+
+describeWithPostgres('gift card and exchange balance invariants', () => {
+  let harness: RealPostgresHarness;
+  let userId: number;
+  let saleId: number;
+
+  beforeAll(async () => {
+    // The 5-way redemption race needs five genuinely simultaneous connections; one more
+    // is margin. Anything larger competes with the other real-PG files for
+    // max_connections and surfaces as opaque connection timeouts.
+    harness = await setupRealPostgres('balances-concurrency', { maxConnections: 6 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    vi.spyOn(auditLogger, 'logAuditFromReq').mockImplementation(() => undefined as never);
+
+    const users = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'c@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    userId = users.rows[0].id;
+
+    const sales = await harness.pool.query<{ id: number }>(
+      'INSERT INTO sales (total, cashier_id) VALUES (100, $1) RETURNING id',
+      [userId]
+    );
+    saleId = sales.rows[0].id;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function capture(): { res: Response; captured: CapturedResponse } {
+    const captured: CapturedResponse = { status: null, body: undefined, headers: {} };
+    const res = {
+      status(code: number) {
+        captured.status = code;
+        return this;
+      },
+      json(payload: unknown) {
+        captured.body = payload;
+        return this;
+      },
+      setHeader(name: string, value: string) {
+        captured.headers[name] = value;
+      },
+    } as unknown as Response;
+    return { res, captured };
+  }
+
+  async function makeCard(balance: number): Promise<string> {
+    const code = `GC-${balance}-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+    await harness.pool.query(
+      `INSERT INTO gift_cards (code, barcode, initial_value, balance, status, created_by)
+       VALUES ($1, $2, $3, $3, 'active', $4)`,
+      [code, code.slice(0, 20), balance, userId]
+    );
+    return code;
+  }
+
+  async function makeProduct(sku: string, stock: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      'INSERT INTO products (name, sku, price, stock) VALUES ($1, $2, 100, $3) RETURNING id',
+      [`Product ${sku}`, sku, stock]
+    );
+    return rows[0].id;
+  }
+
+  async function redeem(code: string, amount: number, key?: string): Promise<Outcome> {
+    const { res, captured } = capture();
+    let error: unknown = null;
+
+    await new GiftCardsController().redeemGiftCard(
+      {
+        body: { amount, sale_id: saleId },
+        params: { code },
+        user: { id: userId, name: 'Cashier' },
+        headers: key ? { 'idempotency-key': key } : {},
+      } as unknown as Request,
+      res,
+      ((err: unknown) => {
+        error = err;
+      }) as NextFunction
+    );
+
+    return { response: captured, error };
+  }
+
+  async function exchange(body: unknown, key?: string): Promise<Outcome> {
+    const { res, captured } = capture();
+    let error: unknown = null;
+
+    await new ExchangesController().createExchange(
+      {
+        body,
+        user: { id: userId, name: 'Cashier' },
+        headers: key ? { 'idempotency-key': key } : {},
+      } as unknown as Request,
+      res,
+      ((err: unknown) => {
+        error = err;
+      }) as NextFunction
+    );
+
+    return { response: captured, error };
+  }
+
+  async function balanceOf(code: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ balance: string }>(
+      'SELECT balance FROM gift_cards WHERE code = $1',
+      [code]
+    );
+    return Number(rows[0].balance);
+  }
+
+  async function stockOf(productId: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  async function countRows(table: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM ${table}`
+    );
+    return rows[0].n;
+  }
+
+  it('lets exactly one of five simultaneous full redemptions win (R1, R7)', async () => {
+    const code = await makeCard(100);
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: 5 }, () => giftCardsService.redeem(code, 100, saleId, userId))
+    );
+
+    const fulfilled = settled.filter((s) => s.status === 'fulfilled');
+    expect(fulfilled).toHaveLength(1);
+
+    // The losers must be stopped by the application guard, not by the CHECK backstop.
+    for (const outcome of settled.filter((s) => s.status === 'rejected')) {
+      expect((outcome as PromiseRejectedResult).reason.message).toBe(
+        'Insufficient balance. Available: 0'
+      );
+    }
+
+    expect(await balanceOf(code)).toBe(0);
+    expect(await countRows('gift_card_transactions')).toBe(1);
+  });
+
+  it('debits once when a redemption is retried with the same key (R2)', async () => {
+    const code = await makeCard(100);
+
+    const first = await redeem(code, 40, 'gc-retry');
+    const second = await redeem(code, 40, 'gc-retry');
+
+    expect(first.error).toBeNull();
+    expect(second.error).toBeNull();
+    expect(second.response.headers['Idempotent-Replay']).toBe('true');
+    expect(JSON.stringify(second.response.body)).toBe(JSON.stringify(first.response.body));
+
+    expect(await balanceOf(code)).toBe(60);
+    expect(await countRows('gift_card_transactions')).toBe(1);
+  });
+
+  it('collapses simultaneous duplicate redemptions of the same key into one debit (R2)', async () => {
+    const code = await makeCard(100);
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 5 }, () => redeem(code, 20, 'gc-storm'))
+    );
+
+    for (const outcome of outcomes) {
+      expect(outcome.error).toBeNull();
+      expect(outcome.response.status).toBe(200);
+    }
+
+    expect(await balanceOf(code)).toBe(80);
+    expect(await countRows('gift_card_transactions')).toBe(1);
+  });
+
+  it('leaves no key row when a redemption fails, so a corrected retry works (R4)', async () => {
+    const code = await makeCard(10);
+
+    const failed = await redeem(code, 50, 'gc-fail');
+    expect(failed.error).toMatchObject({
+      code: 'CONFLICT',
+      message: 'Insufficient balance. Available: 10',
+    });
+    expect(await countRows('idempotency_keys')).toBe(0);
+    expect(await balanceOf(code)).toBe(10);
+
+    const corrected = await redeem(code, 10, 'gc-fail');
+    expect(corrected.error).toBeNull();
+    expect(await balanceOf(code)).toBe(0);
+  });
+
+  function exchangeBody(returnProductId: number, newProductId: number, newQuantity: number) {
+    return {
+      original_sale_id: saleId,
+      returned_items: [
+        {
+          product_id: returnProductId,
+          quantity: 1,
+          price: 10,
+          reason: 'size',
+          condition: 'good',
+        },
+      ],
+      new_items: [{ product_id: newProductId, quantity: newQuantity, price: 10 }],
+    };
+  }
+
+  it('rolls back the returned-item restock when a new item exceeds stock (R4)', async () => {
+    const returned = await makeProduct('EXC-RET', 5);
+    const wanted = await makeProduct('EXC-NEW', 1);
+
+    const { error } = await exchange(exchangeBody(returned, wanted, 3));
+
+    expect(error).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: `Insufficient stock for product ID ${wanted}`,
+    });
+
+    // The restock ran before the failing deduction, so only a real ROLLBACK undoes it.
+    expect(await stockOf(returned)).toBe(5);
+    expect(await stockOf(wanted)).toBe(1);
+    expect(await countRows('exchanges')).toBe(0);
+    expect(await countRows('exchange_returned_items')).toBe(0);
+    expect(await countRows('exchange_new_items')).toBe(0);
+  });
+
+  it('never drives product stock negative under concurrent exchanges (R1)', async () => {
+    const returned = await makeProduct('EXC-CRET', 100);
+    const wanted = await makeProduct('EXC-CNEW', 5);
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 5 }, () => exchange(exchangeBody(returned, wanted, 2)))
+    );
+
+    const created = outcomes.filter((o) => o.error === null);
+    // Five requests want two units each out of a stock of five: exactly two can commit.
+    expect(created).toHaveLength(2);
+
+    for (const failure of outcomes.filter((o) => o.error !== null)) {
+      expect(failure.error).toMatchObject({
+        code: 'VALIDATION_ERROR',
+        message: `Insufficient stock for product ID ${wanted}`,
+      });
+    }
+
+    expect(await stockOf(wanted)).toBe(5 - created.length * 2);
+    expect(await stockOf(wanted)).toBeGreaterThanOrEqual(0);
+    expect(await countRows('exchanges')).toBe(created.length);
+    // Only committed exchanges restocked the returned product.
+    expect(await stockOf(returned)).toBe(100 + created.length);
+  });
+
+  it('creates one exchange when the same key is retried (R2)', async () => {
+    const returned = await makeProduct('EXC-KRET', 10);
+    const wanted = await makeProduct('EXC-KNEW', 10);
+
+    const first = await exchange(exchangeBody(returned, wanted, 1), 'exc-retry');
+    const second = await exchange(exchangeBody(returned, wanted, 1), 'exc-retry');
+
+    expect(first.error).toBeNull();
+    expect(second.error).toBeNull();
+    expect(second.response.headers['Idempotent-Replay']).toBe('true');
+    expect(JSON.stringify(second.response.body)).toBe(JSON.stringify(first.response.body));
+
+    expect(await countRows('exchanges')).toBe(1);
+    expect(await stockOf(wanted)).toBe(9);
+    expect(await stockOf(returned)).toBe(11);
+  });
+
+  it('never lets concurrent manual adjustments drive stock negative (R1)', async () => {
+    const productId = await makeProduct('ADJ-CONC', 10);
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: 5 }, () =>
+        adjustStock(productId, { delta: -4, reason: 'Shrinkage' }, userId)
+      )
+    );
+
+    const fulfilled = settled.filter((s) => s.status === 'fulfilled');
+    // Ten units, four per adjustment: two can succeed, the rest must be refused.
+    expect(fulfilled).toHaveLength(2);
+
+    for (const outcome of settled.filter((s) => s.status === 'rejected')) {
+      expect((outcome as PromiseRejectedResult).reason.message).toBe('Stock cannot go below zero');
+    }
+
+    expect(await stockOf(productId)).toBe(2);
+    expect(await countRows('stock_adjustments')).toBe(2);
+  });
+});

--- a/server/tests/concurrency/checkout.concurrency.test.ts
+++ b/server/tests/concurrency/checkout.concurrency.test.ts
@@ -20,7 +20,8 @@ describeWithPostgres('checkout stock under concurrency', () => {
   let cashierId: number;
 
   beforeAll(async () => {
-    harness = await setupRealPostgres('checkout-concurrency');
+    // The oversell race needs 10 genuinely simultaneous checkouts.
+    harness = await setupRealPostgres('checkout-concurrency', { maxConnections: 12 });
   });
 
   afterAll(async () => {

--- a/server/tests/concurrency/checkout.concurrency.test.ts
+++ b/server/tests/concurrency/checkout.concurrency.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Checkout stock invariants under real concurrency.
+ *
+ * These are the assertions the whole unit exists for, and none of them can be proven
+ * with a fake repository or an in-memory engine: each needs two genuinely concurrent
+ * connections racing for the same row.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { salesService } from '../../src/modules/pos/sales/service';
+import { salesRepository } from '../../src/modules/pos/sales/repository';
+import { InsufficientStockError } from '../../src/modules/pos/sales/types';
+
+describeWithPostgres('checkout stock under concurrency', () => {
+  let harness: RealPostgresHarness;
+  let cashierId: number;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('checkout-concurrency');
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    const { rows } = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'cashier@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    cashierId = rows[0].id;
+  });
+
+  async function makeProduct(sku: string, stock: number, price = 100): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      'INSERT INTO products (name, sku, price, stock) VALUES ($1, $2, $3, $4) RETURNING id',
+      [`Product ${sku}`, sku, price, stock]
+    );
+    return rows[0].id;
+  }
+
+  async function stockOf(productId: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  async function countRows(table: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM ${table}`
+    );
+    return rows[0].n;
+  }
+
+  function sell(productId: number, quantity: number) {
+    return salesService.executeSale(
+      {
+        items: [{ product_id: productId, quantity, unit_price: 100 }],
+        payment_method: 'Cash',
+      } as never,
+      cashierId
+    );
+  }
+
+  describe('single checkout', () => {
+    it('decrements stock and records the adjustment from what actually happened', async () => {
+      const productId = await makeProduct('SKU-A', 5);
+
+      await sell(productId, 2);
+
+      expect(await stockOf(productId)).toBe(3);
+
+      const { rows } = await harness.pool.query<{
+        previous_qty: number;
+        new_qty: number;
+        delta: number;
+      }>('SELECT previous_qty, new_qty, delta FROM stock_adjustments');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ previous_qty: 5, new_qty: 3, delta: -2 });
+    });
+
+    it('allows a sale of exactly the remaining stock, leaving zero', async () => {
+      const productId = await makeProduct('SKU-EXACT', 4);
+
+      await sell(productId, 4);
+
+      expect(await stockOf(productId)).toBe(0);
+    });
+
+    it('decrements every line of a multi-line sale exactly once', async () => {
+      const a = await makeProduct('SKU-M1', 5);
+      const b = await makeProduct('SKU-M2', 7);
+
+      await salesService.executeSale(
+        {
+          items: [
+            { product_id: a, quantity: 2, unit_price: 100 },
+            { product_id: b, quantity: 3, unit_price: 100 },
+          ],
+          payment_method: 'Cash',
+        } as never,
+        cashierId
+      );
+
+      expect(await stockOf(a)).toBe(3);
+      expect(await stockOf(b)).toBe(4);
+      expect(await countRows('stock_adjustments')).toBe(2);
+    });
+
+    it('rejects a quantity above stock and writes no sale, items, payments, or adjustments', async () => {
+      const productId = await makeProduct('SKU-SHORT', 1);
+
+      await expect(sell(productId, 2)).rejects.toThrow(/Insufficient stock/);
+
+      expect(await stockOf(productId)).toBe(1);
+      expect(await countRows('sales')).toBe(0);
+      expect(await countRows('sale_items')).toBe(0);
+      expect(await countRows('sale_payments')).toBe(0);
+      expect(await countRows('stock_adjustments')).toBe(0);
+    });
+
+    it('is authoritative when stock disappears after the fail-fast pre-check passed', async () => {
+      const productId = await makeProduct('SKU-VANISH', 1);
+
+      // The pre-check in resolveLines sees stock 1 and lets the sale through. A
+      // concurrent buyer then drains the row before the write phase runs. This is
+      // precisely the stale-read window that used to produce an oversell, so it is the
+      // guarded UPDATE -- not the earlier check -- that must reject the sale.
+      const spy = vi
+        .spyOn(salesRepository, 'createSaleItem')
+        .mockImplementationOnce(async (data, client) => {
+          await harness.pool.query('UPDATE products SET stock = 0 WHERE id = $1', [productId]);
+          spy.mockRestore();
+          return salesRepository.createSaleItem(data, client);
+        });
+
+      try {
+        await expect(sell(productId, 1)).rejects.toBeInstanceOf(InsufficientStockError);
+      } finally {
+        vi.restoreAllMocks();
+      }
+
+      expect(await stockOf(productId)).toBe(0);
+      expect(await countRows('sales')).toBe(0);
+      expect(await countRows('sale_items')).toBe(0);
+      expect(await countRows('stock_adjustments')).toBe(0);
+    });
+  });
+
+  describe('concurrent checkouts', () => {
+    it('lets exactly as many checkouts succeed as there is stock (R1)', async () => {
+      const STOCK = 5;
+      const ATTEMPTS = 10;
+      const productId = await makeProduct('SKU-RACE', STOCK);
+
+      const results = await Promise.allSettled(
+        Array.from({ length: ATTEMPTS }, () => sell(productId, 1))
+      );
+
+      const fulfilled = results.filter((r) => r.status === 'fulfilled');
+      const rejected = results.filter((r) => r.status === 'rejected');
+
+      expect(fulfilled).toHaveLength(STOCK);
+      expect(rejected).toHaveLength(ATTEMPTS - STOCK);
+      // A losing checkout is rejected either by the fail-fast pre-check or by the
+      // guarded UPDATE, depending on how the race lands. Both say the same thing to the
+      // caller; which layer caught it is not part of the contract.
+      for (const failure of rejected) {
+        expect(String((failure as PromiseRejectedResult).reason.message)).toMatch(
+          /Insufficient stock/
+        );
+      }
+
+      // The invariant that used to break: no oversell, no lost update.
+      expect(await stockOf(productId)).toBe(0);
+      expect(await countRows('sales')).toBe(STOCK);
+      expect(await countRows('sale_items')).toBe(STOCK);
+      expect(await countRows('stock_adjustments')).toBe(STOCK);
+    });
+
+    it('never drives stock negative even when demand far exceeds supply', async () => {
+      const productId = await makeProduct('SKU-STORM', 3);
+
+      await Promise.allSettled(Array.from({ length: 12 }, () => sell(productId, 1)));
+
+      const finalStock = await stockOf(productId);
+      expect(finalStock).toBe(0);
+      expect(finalStock).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does not deadlock when two multi-line checkouts name the same products in opposite order', async () => {
+      const a = await makeProduct('SKU-D1', 50);
+      const b = await makeProduct('SKU-D2', 50);
+
+      const forwards = () =>
+        salesService.executeSale(
+          {
+            items: [
+              { product_id: a, quantity: 1, unit_price: 100 },
+              { product_id: b, quantity: 1, unit_price: 100 },
+            ],
+            payment_method: 'Cash',
+          } as never,
+          cashierId
+        );
+
+      const backwards = () =>
+        salesService.executeSale(
+          {
+            items: [
+              { product_id: b, quantity: 1, unit_price: 100 },
+              { product_id: a, quantity: 1, unit_price: 100 },
+            ],
+            payment_method: 'Cash',
+          } as never,
+          cashierId
+        );
+
+      // Without a canonical write order these two would lock A->B and B->A and deadlock.
+      const results = await Promise.allSettled(
+        Array.from({ length: 6 }, (_, i) => (i % 2 === 0 ? forwards() : backwards()))
+      );
+
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          expect(String(result.reason?.message ?? result.reason)).not.toMatch(/deadlock/i);
+        }
+      }
+      expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+      expect(await stockOf(a)).toBe(44);
+      expect(await stockOf(b)).toBe(44);
+    });
+
+    it('keeps sale_items in the request order even though stock writes are sorted', async () => {
+      const lowerId = await makeProduct('SKU-LOW-ID', 10);
+      const higherId = await makeProduct('SKU-HIGH-ID', 10);
+      expect(higherId).toBeGreaterThan(lowerId);
+
+      const sale = await salesService.executeSale(
+        {
+          // Descending by id — the opposite of the canonical stock-write order.
+          items: [
+            { product_id: higherId, quantity: 1, unit_price: 100 },
+            { product_id: lowerId, quantity: 1, unit_price: 100 },
+          ],
+          payment_method: 'Cash',
+        } as never,
+        cashierId
+      );
+
+      const { rows } = await harness.pool.query<{ product_id: number }>(
+        'SELECT product_id FROM sale_items WHERE sale_id = $1 ORDER BY id',
+        [(sale as { id: number }).id]
+      );
+
+      // The response's `items` array is unchanged by the write-order fix (R8).
+      expect(rows.map((r) => r.product_id)).toEqual([higherId, lowerId]);
+    });
+  });
+});

--- a/server/tests/concurrency/exchanges.concurrency.test.ts
+++ b/server/tests/concurrency/exchanges.concurrency.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Exchange stock invariants under real concurrency.
+ *
+ * An exchange mutates stock twice — restocking what came back and deducting what went
+ * out. Sorting those two phases separately is not enough: an exchange returning product 5
+ * and taking product 2 would lock 5 then 2, while one returning 2 and taking 5 locks 2
+ * then 5. Opposite orders on the same pair is a deadlock, so the write phase has to sort
+ * the union of both sides, and it has to agree with the checkout path's ordering too.
+ */
+import { afterAll, beforeAll, beforeEach, expect, it } from 'vitest';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { exchangesService, ExchangeStockError } from '../../src/modules/pos/exchanges/service';
+import { salesService } from '../../src/modules/pos/sales/service';
+import { INSUFFICIENT_STOCK_CODE } from '../../src/modules/pos/sales/types';
+
+describeWithPostgres('exchange stock under concurrency', () => {
+  let harness: RealPostgresHarness;
+  let cashierId: number;
+  let saleId: number;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('exchanges-concurrency', { maxConnections: 10 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    const users = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'c@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    cashierId = users.rows[0].id;
+
+    const sales = await harness.pool.query<{ id: number }>(
+      'INSERT INTO sales (total, payment_method, cashier_id) VALUES (0, $1, $2) RETURNING id',
+      ['Cash', cashierId]
+    );
+    saleId = sales.rows[0].id;
+  });
+
+  async function makeProduct(sku: string, stock: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      'INSERT INTO products (name, sku, price, stock) VALUES ($1, $2, 100, $3) RETURNING id',
+      [`Product ${sku}`, sku, stock]
+    );
+    return rows[0].id;
+  }
+
+  async function stockOf(productId: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  function exchange(returnedId: number, newId: number, quantity = 1) {
+    return exchangesService.createExchange(
+      {
+        original_sale_id: saleId,
+        returned_items: [{ product_id: returnedId, quantity, price: 100, condition: 'good' }],
+        new_items: [{ product_id: newId, quantity, price: 100 }],
+        payment_method: 'cash',
+      } as never,
+      cashierId
+    );
+  }
+
+  it('restocks the returned line and deducts the new one', async () => {
+    const returned = await makeProduct('SKU-R', 5);
+    const taken = await makeProduct('SKU-T', 5);
+
+    await exchange(returned, taken);
+
+    expect(await stockOf(returned)).toBe(6);
+    expect(await stockOf(taken)).toBe(4);
+  });
+
+  it('does not restock a damaged return', async () => {
+    const returned = await makeProduct('SKU-DMG', 5);
+    const taken = await makeProduct('SKU-OK', 5);
+
+    await exchangesService.createExchange(
+      {
+        original_sale_id: saleId,
+        returned_items: [{ product_id: returned, quantity: 1, price: 100, condition: 'damaged' }],
+        new_items: [{ product_id: taken, quantity: 1, price: 100 }],
+        payment_method: 'cash',
+      } as never,
+      cashierId
+    );
+
+    expect(await stockOf(returned)).toBe(5);
+    expect(await stockOf(taken)).toBe(4);
+  });
+
+  it('rejects a new line exceeding stock and rolls the returned restock back', async () => {
+    const returned = await makeProduct('SKU-BACK', 5);
+    const taken = await makeProduct('SKU-GONE', 1);
+
+    await expect(exchange(returned, taken, 3)).rejects.toBeInstanceOf(ExchangeStockError);
+
+    // The whole exchange rolled back — the return never re-entered stock.
+    expect(await stockOf(returned)).toBe(5);
+    expect(await stockOf(taken)).toBe(1);
+
+    const exchanges = await harness.pool.query('SELECT id FROM exchanges');
+    expect(exchanges.rows).toHaveLength(0);
+  });
+
+  it('reports insufficient stock with the same code as the checkout path', async () => {
+    const returned = await makeProduct('SKU-C1', 5);
+    const taken = await makeProduct('SKU-C2', 0);
+
+    const error = (await exchange(returned, taken).catch((e: unknown) => e)) as ExchangeStockError;
+
+    expect(error).toBeInstanceOf(ExchangeStockError);
+    expect(error.code).toBe(INSUFFICIENT_STOCK_CODE);
+    expect(error.statusCode).toBe(400);
+  });
+
+  it('does not deadlock when two exchanges swap which product is returned vs taken', async () => {
+    const low = await makeProduct('SKU-LOW', 50);
+    const high = await makeProduct('SKU-HIGH', 50);
+    expect(high).toBeGreaterThan(low);
+
+    // A returns the higher id and takes the lower; B does the reverse. Sorting each
+    // phase on its own would lock (high, low) against (low, high) here.
+    const results = await Promise.allSettled(
+      Array.from({ length: 8 }, (_, i) => (i % 2 === 0 ? exchange(high, low) : exchange(low, high)))
+    );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        expect(String(result.reason?.message ?? result.reason)).not.toMatch(/deadlock/i);
+      }
+    }
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+
+    // Four of each direction: every product is returned 4 times and taken 4 times.
+    expect(await stockOf(low)).toBe(50);
+    expect(await stockOf(high)).toBe(50);
+  });
+
+  it('does not deadlock against concurrent checkouts touching the same two products', async () => {
+    const low = await makeProduct('SKU-X1', 100);
+    const high = await makeProduct('SKU-X2', 100);
+
+    const checkout = () =>
+      salesService.executeSale(
+        {
+          items: [
+            { product_id: high, quantity: 1, unit_price: 100 },
+            { product_id: low, quantity: 1, unit_price: 100 },
+          ],
+          payment_method: 'Cash',
+        } as never,
+        cashierId
+      );
+
+    // The exchange locks (returned=high, taken=low); the checkout sorts ascending. Both
+    // must resolve to the same canonical order or these deadlock against each other.
+    const results = await Promise.allSettled([
+      exchange(high, low),
+      checkout(),
+      exchange(high, low),
+      checkout(),
+      exchange(low, high),
+      checkout(),
+    ]);
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        expect(String(result.reason?.message ?? result.reason)).not.toMatch(/deadlock/i);
+      }
+    }
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+  });
+});

--- a/server/tests/concurrency/idempotency.concurrency.test.ts
+++ b/server/tests/concurrency/idempotency.concurrency.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Idempotency helper — the transactional and concurrent half.
+ *
+ * Every assertion here depends on a transaction genuinely committing or rolling back, or
+ * on two connections racing for the same unique index. pg-mem provides neither, so this
+ * suite runs only against real PostgreSQL.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { PoolClient } from 'pg';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { resetEnvCache } from '../../src/config/env';
+import {
+  IDEMPOTENCY_KEY_REUSED,
+  IdempotencyConflictError,
+  fingerprintPayload,
+  withIdempotency,
+} from '../../src/http/idempotency';
+import { withTransaction } from '../../src/database/transaction';
+
+const ENDPOINT = 'POST /api/v1/sales';
+
+describeWithPostgres('withIdempotency against real PostgreSQL', () => {
+  let harness: RealPostgresHarness;
+  let userId: number;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('idempotency');
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    const { rows } = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'c@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    userId = rows[0].id;
+    delete process.env.IDEMPOTENCY_REQUIRED;
+    resetEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.IDEMPOTENCY_REQUIRED;
+    resetEnvCache();
+  });
+
+  function countingRun(status = 201, body: unknown = { success: true, data: { id: 1 } }) {
+    let calls = 0;
+    const run = async (_client: PoolClient) => {
+      calls += 1;
+      return { status, body, result: { id: 1 }, resourceType: 'sale', resourceId: 1 };
+    };
+    return { run, calls: () => calls };
+  }
+
+  async function keyRows() {
+    const { rows } = await harness.pool.query('SELECT * FROM idempotency_keys');
+    return rows;
+  }
+
+  describe('claim and replay', () => {
+    it('runs the callback once and stores the outcome alongside its resource', async () => {
+      const { run, calls } = countingRun();
+
+      const outcome = await withIdempotency({
+        key: 'k1',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1 },
+        run,
+      });
+
+      expect(calls()).toBe(1);
+      expect(outcome.replayed).toBe(false);
+
+      const rows = await keyRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        key: 'k1',
+        endpoint: ENDPOINT,
+        user_id: userId,
+        response_status: 201,
+        resource_type: 'sale',
+        resource_id: 1,
+      });
+      expect(rows[0].request_fingerprint).toBe(fingerprintPayload({ a: 1 }));
+      expect(new Date(rows[0].expires_at).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('replays the stored outcome byte-identically without re-running the callback', async () => {
+      const body = { success: true, data: { id: 42, total: '99.50', items: [{ product_id: 3 }] } };
+      const first = countingRun(201, body);
+      await withIdempotency({
+        key: 'k2',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1 },
+        run: first.run,
+      });
+
+      const second = countingRun();
+      const replay = await withIdempotency({
+        key: 'k2',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1 },
+        run: second.run,
+      });
+
+      expect(second.calls()).toBe(0);
+      expect(replay.replayed).toBe(true);
+      expect(replay.status).toBe(201);
+      expect(replay.body).toEqual(body);
+      // Byte-identical, not merely deep-equal: the response the retrying caller receives
+      // must serialize exactly as the first one did.
+      expect(JSON.stringify(replay.body)).toBe(JSON.stringify(body));
+      expect(replay.result).toBeNull();
+      expect(await keyRows()).toHaveLength(1);
+    });
+
+    it('replays rather than conflicts when the payload differs only in key order', async () => {
+      const first = countingRun();
+      await withIdempotency({
+        key: 'k3',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1, b: { x: 1, y: 2 } },
+        run: first.run,
+      });
+
+      const second = countingRun();
+      const replay = await withIdempotency({
+        key: 'k3',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { b: { y: 2, x: 1 }, a: 1 },
+        run: second.run,
+      });
+
+      expect(second.calls()).toBe(0);
+      expect(replay.replayed).toBe(true);
+    });
+
+    it('treats a key past expires_at as fresh and runs the callback again', async () => {
+      const first = countingRun();
+      await withIdempotency({
+        key: 'k4',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1 },
+        run: first.run,
+      });
+
+      await harness.pool.query(
+        "UPDATE idempotency_keys SET expires_at = NOW() - INTERVAL '1 hour' WHERE key = 'k4'"
+      );
+
+      const second = countingRun();
+      const outcome = await withIdempotency({
+        key: 'k4',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1 },
+        run: second.run,
+      });
+
+      expect(second.calls()).toBe(1);
+      expect(outcome.replayed).toBe(false);
+      // The expired row was replaced, not duplicated.
+      expect(await keyRows()).toHaveLength(1);
+    });
+  });
+
+  describe('conflicts', () => {
+    const originalBody = { success: true, data: { secret: 'original body' } };
+
+    async function seed(key: string, payload: unknown, endpoint = ENDPOINT, user = () => userId) {
+      const { run } = countingRun(201, originalBody);
+      await withIdempotency({ key, endpoint, userId: user(), payload, run });
+    }
+
+    it('rejects the same key with a different payload without running the callback', async () => {
+      await seed('c1', { a: 1 });
+      const { run, calls } = countingRun();
+
+      await expect(
+        withIdempotency({ key: 'c1', endpoint: ENDPOINT, userId, payload: { a: 2 }, run })
+      ).rejects.toBeInstanceOf(IdempotencyConflictError);
+
+      expect(calls()).toBe(0);
+      expect(await keyRows()).toHaveLength(1);
+    });
+
+    it('carries IDEMPOTENCY_KEY_REUSED and never discloses the original response', async () => {
+      await seed('c2', { a: 1 });
+      const { run } = countingRun();
+
+      const error = (await withIdempotency({
+        key: 'c2',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 2 },
+        run,
+      }).catch((e: unknown) => e)) as IdempotencyConflictError;
+
+      expect(error).toBeInstanceOf(IdempotencyConflictError);
+      expect(error.code).toBe(IDEMPOTENCY_KEY_REUSED);
+      expect(error.statusCode).toBe(409);
+      expect(error.message).not.toContain('original body');
+      expect(JSON.stringify(error.message)).not.toContain('secret');
+    });
+
+    it('rejects the same key arriving on a different endpoint', async () => {
+      await seed('c3', { a: 1 });
+      const { run, calls } = countingRun();
+
+      await expect(
+        withIdempotency({
+          key: 'c3',
+          endpoint: 'POST /api/v1/exchanges',
+          userId,
+          payload: { a: 1 },
+          run,
+        })
+      ).rejects.toBeInstanceOf(IdempotencyConflictError);
+
+      expect(calls()).toBe(0);
+    });
+
+    it('rejects the same key arriving from a different user', async () => {
+      await seed('c4', { a: 1 });
+      const { rows } = await harness.pool.query<{ id: number }>(
+        "INSERT INTO users (name, email, password_hash, role) VALUES ('Other', 'o@moon.com', 'x', 'Cashier') RETURNING id"
+      );
+      const { run, calls } = countingRun();
+
+      await expect(
+        withIdempotency({
+          key: 'c4',
+          endpoint: ENDPOINT,
+          userId: rows[0].id,
+          payload: { a: 1 },
+          run,
+        })
+      ).rejects.toBeInstanceOf(IdempotencyConflictError);
+
+      expect(calls()).toBe(0);
+    });
+  });
+
+  describe('a failed mutation releases its key', () => {
+    it('rolls back the claim when the callback throws, so the key can be retried', async () => {
+      const boom = new Error('insufficient stock');
+
+      await expect(
+        withIdempotency({
+          key: 'f1',
+          endpoint: ENDPOINT,
+          userId,
+          payload: { a: 1 },
+          run: async () => {
+            throw boom;
+          },
+        })
+      ).rejects.toBe(boom);
+
+      // A key identifies a committed outcome, never a failed attempt.
+      expect(await keyRows()).toHaveLength(0);
+
+      const retry = countingRun();
+      const outcome = await withIdempotency({
+        key: 'f1',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1 },
+        run: retry.run,
+      });
+
+      expect(retry.calls()).toBe(1);
+      expect(outcome.replayed).toBe(false);
+      expect(await keyRows()).toHaveLength(1);
+    });
+
+    it('surfaces a unique violation raised by the callback instead of treating it as a replay', async () => {
+      await harness.pool.query(
+        "INSERT INTO products (name, sku, price, stock) VALUES ('Existing', 'SKU-TAKEN', 10, 1)"
+      );
+
+      // A 23505 from the business logic is a real failure. Only the claim INSERT's own
+      // unique violation means "a committed twin already holds this key".
+      await expect(
+        withIdempotency({
+          key: 'f3',
+          endpoint: ENDPOINT,
+          userId,
+          payload: { a: 1 },
+          run: async (client) => {
+            await client.query(
+              "INSERT INTO products (name, sku, price, stock) VALUES ('Clash', 'SKU-TAKEN', 10, 1)"
+            );
+            throw new Error('unreachable');
+          },
+        })
+      ).rejects.toMatchObject({ code: '23505' });
+
+      expect(await keyRows()).toHaveLength(0);
+    });
+
+    it('leaves no partial work behind when the callback writes and then throws', async () => {
+      await expect(
+        withIdempotency({
+          key: 'f2',
+          endpoint: ENDPOINT,
+          userId,
+          payload: { a: 1 },
+          run: async (client) => {
+            await client.query(
+              "INSERT INTO products (name, sku, price, stock) VALUES ('Doomed', 'SKU-DOOM', 10, 1)"
+            );
+            throw new Error('later failure');
+          },
+        })
+      ).rejects.toThrow('later failure');
+
+      const products = await harness.pool.query("SELECT id FROM products WHERE sku = 'SKU-DOOM'");
+      expect(products.rows).toHaveLength(0);
+      expect(await keyRows()).toHaveLength(0);
+    });
+  });
+
+  describe('concurrent duplicates', () => {
+    it('runs the callback exactly once for N simultaneous requests with one key', async () => {
+      const CONCURRENCY = 8;
+      let calls = 0;
+
+      const attempts = Array.from({ length: CONCURRENCY }, () =>
+        withIdempotency({
+          key: 'race',
+          endpoint: ENDPOINT,
+          userId,
+          payload: { a: 1 },
+          run: async (client) => {
+            calls += 1;
+            // Hold the transaction open so every duplicate is genuinely blocked on the
+            // unique index rather than arriving after the winner has already committed.
+            await client.query('SELECT pg_sleep(0.15)');
+            const { rows } = await client.query<{ id: number }>(
+              "INSERT INTO products (name, sku, price, stock) VALUES ('Raced', 'SKU-RACE', 10, 1) RETURNING id"
+            );
+            return {
+              status: 201,
+              body: { success: true, data: { id: rows[0].id } },
+              result: { id: rows[0].id },
+              resourceType: 'sale',
+              resourceId: rows[0].id,
+            };
+          },
+        })
+      );
+
+      const outcomes = await Promise.all(attempts);
+
+      expect(calls).toBe(1);
+      expect(outcomes).toHaveLength(CONCURRENCY);
+      expect(outcomes.filter((o) => !o.replayed)).toHaveLength(1);
+      expect(outcomes.filter((o) => o.replayed)).toHaveLength(CONCURRENCY - 1);
+
+      // Every caller sees the same status and the same body.
+      const bodies = new Set(outcomes.map((o) => JSON.stringify(o.body)));
+      expect(bodies.size).toBe(1);
+      expect(new Set(outcomes.map((o) => o.status))).toEqual(new Set([201]));
+
+      // Exactly one committed outcome, and exactly one side effect.
+      expect(await keyRows()).toHaveLength(1);
+      const products = await harness.pool.query('SELECT id FROM products');
+      expect(products.rows).toHaveLength(1);
+    });
+
+    it('lets a second caller win the key when the first transaction rolls back', async () => {
+      let firstStarted: () => void = () => {};
+      const firstIsRunning = new Promise<void>((resolve) => {
+        firstStarted = resolve;
+      });
+
+      const failing = withIdempotency({
+        key: 'handoff',
+        endpoint: ENDPOINT,
+        userId,
+        payload: { a: 1 },
+        run: async (client) => {
+          firstStarted();
+          await client.query('SELECT pg_sleep(0.2)');
+          throw new Error('first attempt failed');
+        },
+      }).catch((e: unknown) => e);
+
+      await firstIsRunning;
+
+      const second = countingRun();
+      const [firstResult, secondOutcome] = await Promise.all([
+        failing,
+        withIdempotency({
+          key: 'handoff',
+          endpoint: ENDPOINT,
+          userId,
+          payload: { a: 1 },
+          run: second.run,
+        }),
+      ]);
+
+      expect(firstResult).toBeInstanceOf(Error);
+      expect(second.calls()).toBe(1);
+      expect(secondOutcome.replayed).toBe(false);
+      expect(await keyRows()).toHaveLength(1);
+    });
+  });
+
+  describe('withTransaction retry', () => {
+    it('retries a deadlock (40P01) and ultimately commits once', async () => {
+      let attempts = 0;
+
+      const result = await withTransaction(
+        async (client) => {
+          attempts += 1;
+          if (attempts < 3) {
+            const error = new Error('deadlock detected') as Error & { code: string };
+            error.code = '40P01';
+            throw error;
+          }
+          await client.query(
+            "INSERT INTO products (name, sku, price, stock) VALUES ('Retried', 'SKU-RETRY', 10, 1)"
+          );
+          return 'committed';
+        },
+        undefined,
+        { retryOnSerializationFailure: true }
+      );
+
+      expect(result).toBe('committed');
+      expect(attempts).toBe(3);
+
+      const { rows } = await harness.pool.query("SELECT id FROM products WHERE sku = 'SKU-RETRY'");
+      expect(rows).toHaveLength(1);
+    });
+
+    it('gives up after the retry budget and propagates the original error', async () => {
+      let attempts = 0;
+
+      await expect(
+        withTransaction(
+          async () => {
+            attempts += 1;
+            const error = new Error('serialization failure') as Error & { code: string };
+            error.code = '40001';
+            throw error;
+          },
+          undefined,
+          { retryOnSerializationFailure: true, maxRetries: 2 }
+        )
+      ).rejects.toThrow('serialization failure');
+
+      expect(attempts).toBe(3);
+    });
+
+    it('does not retry a non-retryable error, and does not retry at all by default', async () => {
+      let optedIn = 0;
+      await expect(
+        withTransaction(
+          async () => {
+            optedIn += 1;
+            throw new Error('business rule violated');
+          },
+          undefined,
+          { retryOnSerializationFailure: true }
+        )
+      ).rejects.toThrow('business rule violated');
+      expect(optedIn).toBe(1);
+
+      let defaulted = 0;
+      await expect(
+        withTransaction(async () => {
+          defaulted += 1;
+          const error = new Error('deadlock detected') as Error & { code: string };
+          error.code = '40P01';
+          throw error;
+        })
+      ).rejects.toThrow('deadlock detected');
+      expect(defaulted).toBe(1);
+    });
+  });
+});

--- a/server/tests/concurrency/idempotency.concurrency.test.ts
+++ b/server/tests/concurrency/idempotency.concurrency.test.ts
@@ -28,7 +28,8 @@ describeWithPostgres('withIdempotency against real PostgreSQL', () => {
   let userId: number;
 
   beforeAll(async () => {
-    harness = await setupRealPostgres('idempotency');
+    // The duplicate-suppression race fires 8 simultaneous requests with one key.
+    harness = await setupRealPostgres('idempotency', { maxConnections: 12 });
   });
 
   afterAll(async () => {

--- a/server/tests/concurrency/promotions.concurrency.test.ts
+++ b/server/tests/concurrency/promotions.concurrency.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Coupon usage limits and loyalty balances under real concurrency.
+ *
+ * Both invariants used to be decided by a stale read: the usage count and the points
+ * balance were read, checked in JavaScript, and acted on later. N concurrent checkouts
+ * all saw the same pre-consumption value and all passed.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { salesService } from '../../src/modules/pos/sales/service';
+import { couponsService } from '../../src/modules/commerce/coupons/service';
+
+describeWithPostgres('coupon and loyalty consumption under concurrency', () => {
+  let harness: RealPostgresHarness;
+  let cashierId: number;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('promotions-concurrency', { maxConnections: 10 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    const { rows } = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'cashier@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    cashierId = rows[0].id;
+  });
+
+  async function makeProduct(sku: string, stock: number, price = 100): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      'INSERT INTO products (name, sku, price, stock) VALUES ($1, $2, $3, $4) RETURNING id',
+      [`Product ${sku}`, sku, price, stock]
+    );
+    return rows[0].id;
+  }
+
+  async function makeCoupon(
+    code: string,
+    options: { maxUses?: number | null; maxUsesPerCustomer?: number | null } = {}
+  ): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      `INSERT INTO coupons (code, type, value, max_uses, max_uses_per_customer)
+       VALUES ($1, 'fixed', 10, $2, $3) RETURNING id`,
+      [code, options.maxUses ?? null, options.maxUsesPerCustomer ?? null]
+    );
+    return rows[0].id;
+  }
+
+  async function makeCustomer(phone: string, points: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      'INSERT INTO customers (name, phone, loyalty_points) VALUES ($1, $2, $3) RETURNING id',
+      [`Customer ${phone}`, phone, points]
+    );
+    return rows[0].id;
+  }
+
+  /**
+   * Earning cannot be switched off by configuring a zero rate: resolveRate treats a
+   * non-positive value as invalid and falls back to the safe default. These tests
+   * therefore isolate redemption by making the redeemed points cover the whole amount
+   * due, which makes earnedPoints zero by the formula rather than by configuration.
+   */
+  async function enableLoyalty(egpPerPoint = '1', pointsPerEgp = '1'): Promise<void> {
+    await harness.pool.query(
+      `INSERT INTO settings (key, value) VALUES
+         ('loyalty_enabled', 'true'),
+         ('loyalty_egp_per_point', $1),
+         ('loyalty_points_per_egp', $2)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [egpPerPoint, pointsPerEgp]
+    );
+  }
+
+  async function countRows(table: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM ${table}`
+    );
+    return rows[0].n;
+  }
+
+  async function pointsOf(customerId: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ loyalty_points: number }>(
+      'SELECT loyalty_points FROM customers WHERE id = $1',
+      [customerId]
+    );
+    return Number(rows[0].loyalty_points);
+  }
+
+  async function stockOf(productId: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  describe('coupon usage limits', () => {
+    it('records one usage for a single sale with a max_uses coupon', async () => {
+      const productId = await makeProduct('SKU-C1', 10);
+      await makeCoupon('ONCE', { maxUses: 1 });
+
+      await salesService.executeSale(
+        {
+          items: [{ product_id: productId, quantity: 1, unit_price: 100 }],
+          payment_method: 'Cash',
+          coupon_code: 'ONCE',
+        } as never,
+        cashierId
+      );
+
+      expect(await countRows('coupon_usage')).toBe(1);
+    });
+
+    it('lets exactly one of five concurrent sales consume a max_uses = 1 coupon', async () => {
+      const productId = await makeProduct('SKU-C2', 50);
+      await makeCoupon('SOLO', { maxUses: 1 });
+
+      const results = await Promise.allSettled(
+        Array.from({ length: 5 }, () =>
+          salesService.executeSale(
+            {
+              items: [{ product_id: productId, quantity: 1, unit_price: 100 }],
+              payment_method: 'Cash',
+              coupon_code: 'SOLO',
+            } as never,
+            cashierId
+          )
+        )
+      );
+
+      expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1);
+      expect(results.filter((r) => r.status === 'rejected')).toHaveLength(4);
+      for (const failure of results.filter((r) => r.status === 'rejected')) {
+        expect(String((failure as PromiseRejectedResult).reason.message)).toMatch(
+          /usage limit reached/i
+        );
+      }
+
+      expect(await countRows('coupon_usage')).toBe(1);
+      expect(await countRows('sales')).toBe(1);
+    });
+
+    it('enforces max_uses_per_customer per customer, letting a different customer through', async () => {
+      const productId = await makeProduct('SKU-C3', 50);
+      await makeCoupon('PERCUST', { maxUsesPerCustomer: 1 });
+      const alice = await makeCustomer('+201000000010', 0);
+      const bob = await makeCustomer('+201000000011', 0);
+
+      const buy = (customerId: number) =>
+        salesService.executeSale(
+          {
+            items: [{ product_id: productId, quantity: 1, unit_price: 100 }],
+            payment_method: 'Cash',
+            coupon_code: 'PERCUST',
+            customer_id: customerId,
+          } as never,
+          cashierId
+        );
+
+      const results = await Promise.allSettled([buy(alice), buy(alice), buy(bob)]);
+
+      // Alice's limit binds; Bob's own allowance is untouched by it.
+      expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(2);
+      expect(await countRows('coupon_usage')).toBe(2);
+
+      const { rows } = await harness.pool.query<{ customer_id: number; n: number }>(
+        'SELECT customer_id, COUNT(*)::int AS n FROM coupon_usage GROUP BY customer_id'
+      );
+      expect(rows.every((r) => r.n === 1)).toBe(true);
+    });
+
+    it('rolls back the stock decrement when the coupon limit rejects the sale', async () => {
+      const productId = await makeProduct('SKU-C4', 10);
+      await makeCoupon('ONEONLY', { maxUses: 1 });
+
+      const sell = () =>
+        salesService.executeSale(
+          {
+            items: [{ product_id: productId, quantity: 1, unit_price: 100 }],
+            payment_method: 'Cash',
+            coupon_code: 'ONEONLY',
+          } as never,
+          cashierId
+        );
+
+      await sell();
+      await expect(sell()).rejects.toThrow(/usage limit reached/i);
+
+      // Only the first sale's unit left inventory (R4).
+      expect(await stockOf(productId)).toBe(9);
+      expect(await countRows('sales')).toBe(1);
+      expect(await countRows('stock_adjustments')).toBe(1);
+    });
+
+    it('never takes a row lock on the preview path', async () => {
+      const productId = await makeProduct('SKU-C5', 10);
+      await makeCoupon('PREVIEW', { maxUses: 1 });
+
+      // Hold the coupon row locked, as a live checkout would.
+      const holder = await harness.connect();
+      try {
+        await holder.query('BEGIN');
+        await holder.query("SELECT id FROM coupons WHERE code = 'PREVIEW' FOR UPDATE");
+
+        // A preview must not block behind it. If validate took a lock here this would
+        // hang until the timeout below fires.
+        const preview = couponsService.validate({
+          code: 'PREVIEW',
+          subtotal: 100,
+          customer_id: null,
+          item_product_ids: [productId],
+        });
+
+        const outcome = await Promise.race([
+          preview.then(() => 'completed'),
+          new Promise((resolve) => setTimeout(() => resolve('blocked'), 1_000)),
+        ]);
+
+        expect(outcome).toBe('completed');
+        await holder.query('COMMIT');
+      } finally {
+        holder.release();
+      }
+    });
+  });
+
+  describe('loyalty redemption', () => {
+    it('debits exactly the redeemed points and records one transaction', async () => {
+      await enableLoyalty();
+      const productId = await makeProduct('SKU-L1', 10, 100);
+      const customerId = await makeCustomer('+201000000020', 150);
+
+      await salesService.executeSale(
+        {
+          items: [{ product_id: productId, quantity: 1, unit_price: 100 }],
+          payment_method: 'Cash',
+          customer_id: customerId,
+          points_redeemed: 100,
+        } as never,
+        cashierId
+      );
+
+      expect(await pointsOf(customerId)).toBe(50);
+
+      const { rows } = await harness.pool.query<{ type: string; points: number }>(
+        "SELECT type, points FROM loyalty_transactions WHERE type = 'redeemed'"
+      );
+      expect(rows).toHaveLength(1);
+      expect(Number(rows[0].points)).toBe(-100);
+    });
+
+    it('lets only one of three concurrent redemptions drain a 150-point balance', async () => {
+      await enableLoyalty();
+      const productId = await makeProduct('SKU-L2', 50, 100);
+      const customerId = await makeCustomer('+201000000021', 150);
+
+      const redeem = () =>
+        salesService.executeSale(
+          {
+            items: [{ product_id: productId, quantity: 1, unit_price: 100 }],
+            payment_method: 'Cash',
+            customer_id: customerId,
+            points_redeemed: 100,
+          } as never,
+          cashierId
+        );
+
+      const results = await Promise.allSettled([redeem(), redeem(), redeem()]);
+
+      expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1);
+
+      const remaining = await pointsOf(customerId);
+      expect(remaining).toBe(50);
+      expect(remaining).toBeGreaterThanOrEqual(0);
+      expect(await countRows('loyalty_transactions')).toBe(1);
+    });
+
+    it('leaves the balance and transaction log untouched when redemption fails', async () => {
+      await enableLoyalty();
+      const productId = await makeProduct('SKU-L3', 1, 500);
+      const customerId = await makeCustomer('+201000000022', 150);
+
+      // Enough points, but not enough stock: the whole transaction must roll back.
+      await expect(
+        salesService.executeSale(
+          {
+            items: [{ product_id: productId, quantity: 5, unit_price: 500 }],
+            payment_method: 'Cash',
+            customer_id: customerId,
+            points_redeemed: 100,
+          } as never,
+          cashierId
+        )
+      ).rejects.toThrow();
+
+      expect(await pointsOf(customerId)).toBe(150);
+      expect(await countRows('loyalty_transactions')).toBe(0);
+    });
+  });
+});

--- a/server/tests/concurrency/refunds.concurrency.test.ts
+++ b/server/tests/concurrency/refunds.concurrency.test.ts
@@ -1,0 +1,263 @@
+/**
+ * `POST /api/v1/sales/:id/refund` under concurrency and retry, against real PostgreSQL.
+ *
+ * Every invariant here needs genuine MVCC: the sale-row lock that serializes the
+ * cumulative refund check, and the rollback that must take the register movement with it.
+ * pg-mem has neither (it silently ignores ROLLBACK), so these cannot live in a pg-mem
+ * suite — they would pass for the wrong reason.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { SalesController } from '../../src/modules/pos/sales/controller';
+import { RegisterRepository } from '../../src/modules/pos/register/repository';
+import { resetEnvCache } from '../../src/config/env';
+import * as auditLogger from '../../../server/middleware/auditLogger';
+
+interface CapturedResponse {
+  status: number | null;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency', () => {
+  let harness: RealPostgresHarness;
+  let cashierId: number;
+  let productId: number;
+
+  beforeAll(async () => {
+    // The default pool is enough: the widest test here holds three connections (one per
+    // simultaneous refund waiting on the sale-row lock).
+    harness = await setupRealPostgres('refunds-concurrency');
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+
+    const users = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'cashier@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    cashierId = users.rows[0].id;
+
+    const products = await harness.pool.query<{ id: number }>(
+      "INSERT INTO products (name, sku, price, stock) VALUES ('Silk Dress', 'SKU-R1', 500, 8) RETURNING id"
+    );
+    productId = products.rows[0].id;
+
+    vi.spyOn(auditLogger, 'logAuditFromReq').mockImplementation(() => undefined as never);
+
+    delete process.env.IDEMPOTENCY_REQUIRED;
+    resetEnvCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.IDEMPOTENCY_REQUIRED;
+    resetEnvCache();
+  });
+
+  /** A completed 2-unit sale totalling 1000, with stock already deducted to 8. */
+  async function makeSale(): Promise<number> {
+    const sale = await harness.pool.query<{ id: number }>(
+      `INSERT INTO sales (subtotal, total, payment_method, cashier_id)
+       VALUES (1000, 1000, 'Cash', $1) RETURNING id`,
+      [cashierId]
+    );
+    const saleId = sale.rows[0].id;
+    await harness.pool.query(
+      'INSERT INTO sale_items (sale_id, product_id, quantity, unit_price) VALUES ($1, $2, 2, 500)',
+      [saleId, productId]
+    );
+    return saleId;
+  }
+
+  async function openRegisterSession(): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      `INSERT INTO register_sessions (cashier_id, opening_float, expected_cash)
+       VALUES ($1, 1000, 1000) RETURNING id`,
+      [cashierId]
+    );
+    return rows[0].id;
+  }
+
+  async function countRows(table: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM ${table}`
+    );
+    return rows[0].n;
+  }
+
+  async function readSale(saleId: number) {
+    const { rows } = await harness.pool.query<{ refund_status: string; refunded_amount: string }>(
+      'SELECT refund_status, refunded_amount FROM sales WHERE id = $1',
+      [saleId]
+    );
+    return { status: rows[0].refund_status, refunded: Number(rows[0].refunded_amount) };
+  }
+
+  /** Drives the real controller and captures what it wrote to the response. */
+  async function postRefund(
+    saleId: number,
+    body: unknown,
+    key?: string
+  ): Promise<{ response: CapturedResponse; error: unknown }> {
+    const captured: CapturedResponse = { status: null, body: undefined, headers: {} };
+    let error: unknown = null;
+
+    const res = {
+      status(code: number) {
+        captured.status = code;
+        return this;
+      },
+      json(payload: unknown) {
+        captured.body = payload;
+        return this;
+      },
+      setHeader(name: string, value: string) {
+        captured.headers[name] = value;
+      },
+    } as unknown as Response;
+
+    const next = ((err: unknown) => {
+      error = err;
+    }) as NextFunction;
+
+    await new SalesController().refundSale(
+      {
+        params: { id: String(saleId) },
+        body,
+        user: { id: cashierId, name: 'Cashier' },
+        headers: key ? { 'idempotency-key': key } : {},
+      } as unknown as Request,
+      res,
+      next
+    );
+
+    return { response: captured, error };
+  }
+
+  function refundBody(quantity: number, unitPrice: number, restock = false) {
+    return {
+      items: [{ product_id: productId, quantity, unit_price: unitPrice }],
+      reason: 'Returned',
+      restock,
+    };
+  }
+
+  it('never lets concurrent partial refunds exceed the sale total (R1)', async () => {
+    const saleId = await makeSale();
+
+    // Three simultaneous 400 refunds against a 1000 sale: two fit, the third must not.
+    // Without the FOR UPDATE lock all three read refunded_amount = 0 and all three commit.
+    const outcomes = await Promise.all([
+      postRefund(saleId, refundBody(1, 400)),
+      postRefund(saleId, refundBody(1, 400)),
+      postRefund(saleId, refundBody(1, 400)),
+    ]);
+
+    const accepted = outcomes.filter((o) => o.error === null);
+    const rejected = outcomes.filter((o) => o.error !== null);
+
+    expect(accepted).toHaveLength(2);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].error).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'Refund amount exceeds sale total',
+    });
+
+    const sale = await readSale(saleId);
+    expect(sale.refunded).toBe(800);
+    expect(sale.refunded).toBeLessThanOrEqual(1000);
+    expect(sale.status).toBe('partial');
+    expect(await countRows('refunds')).toBe(2);
+  });
+
+  it('does not lose a restock when two refunds commit concurrently (R1)', async () => {
+    const saleId = await makeSale();
+
+    await Promise.all([
+      postRefund(saleId, refundBody(1, 400, true)),
+      postRefund(saleId, refundBody(1, 400, true)),
+    ]);
+
+    // 8 + 1 + 1. A read-then-write of an absolute value loses one of the two.
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    expect(Number(rows[0].stock)).toBe(10);
+  });
+
+  it('replays a retried refund without refunding, restocking, or paying out twice (R2)', async () => {
+    const saleId = await makeSale();
+    await openRegisterSession();
+
+    const first = await postRefund(saleId, refundBody(1, 400, true), 'refund-key');
+    const second = await postRefund(saleId, refundBody(1, 400, true), 'refund-key');
+
+    expect(first.error).toBeNull();
+    expect(second.error).toBeNull();
+    expect(second.response.status).toBe(201);
+    expect(second.response.headers['Idempotent-Replay']).toBe('true');
+    expect(JSON.stringify(second.response.body)).toBe(JSON.stringify(first.response.body));
+
+    expect(await countRows('refunds')).toBe(1);
+    expect(await countRows('register_movements')).toBe(1);
+    expect((await readSale(saleId)).refunded).toBe(400);
+
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    expect(Number(rows[0].stock)).toBe(9);
+  });
+
+  it('rejects one key reused against a different sale instead of replaying it', async () => {
+    const saleA = await makeSale();
+    const saleB = await makeSale();
+
+    await postRefund(saleA, refundBody(1, 400), 'shared-key');
+    const { error } = await postRefund(saleB, refundBody(1, 400), 'shared-key');
+
+    // The sale id lives in the fingerprinted payload, not the endpoint label, so the
+    // second refund conflicts rather than replaying saleA's response.
+    expect(error).toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
+    expect((await readSale(saleB)).refunded).toBe(0);
+    expect(await countRows('refunds')).toBe(1);
+  });
+
+  it('leaves no refund row and no register movement when the refund fails (R4)', async () => {
+    const saleId = await makeSale();
+    await openRegisterSession();
+
+    // Fail the LAST statement of the refund transaction: by then the refund row and the
+    // register movement are both already inserted, so only a real rollback can remove
+    // them. The old code recorded the movement after the transaction and swallowed its
+    // errors, which left exactly this orphan behind.
+    vi.spyOn(RegisterRepository.prototype, 'updateSessionExpectedCash').mockRejectedValue(
+      new Error('register write failed')
+    );
+
+    const { error } = await postRefund(saleId, refundBody(1, 400, true), 'doomed-key');
+
+    expect(error).toMatchObject({ message: 'register write failed' });
+    expect(await countRows('refunds')).toBe(0);
+    expect(await countRows('register_movements')).toBe(0);
+    expect(await countRows('idempotency_keys')).toBe(0);
+    expect((await readSale(saleId)).refunded).toBe(0);
+
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    expect(Number(rows[0].stock)).toBe(8);
+  });
+});

--- a/server/tests/concurrency/sales.idempotency.test.ts
+++ b/server/tests/concurrency/sales.idempotency.test.ts
@@ -1,0 +1,290 @@
+/**
+ * `POST /api/v1/sales` honouring `Idempotency-Key` end to end.
+ *
+ * Exercised through the controller rather than the service, because the parts that
+ * matter most here are the controller's: the header is read, the replay suppresses the
+ * notification and the audit entry, and the response body is byte-identical.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { SalesController } from '../../src/modules/pos/sales/controller';
+import { resetEnvCache } from '../../src/config/env';
+import { IDEMPOTENCY_KEY_REUSED } from '../../src/http/idempotency';
+import * as notifications from '../../../server/services/notifications';
+import * as auditLogger from '../../../server/middleware/auditLogger';
+
+interface CapturedResponse {
+  status: number | null;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+describeWithPostgres('POST /api/v1/sales idempotency', () => {
+  let harness: RealPostgresHarness;
+  let cashierId: number;
+  let notifySpy: ReturnType<typeof vi.spyOn>;
+  let auditSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(async () => {
+    // The 20-way replay storm needs genuinely simultaneous requests.
+    harness = await setupRealPostgres('sales-idempotency', { maxConnections: 12 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    const { rows } = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'cashier@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    cashierId = rows[0].id;
+
+    notifySpy = vi.spyOn(notifications, 'notifySale').mockImplementation(() => undefined as never);
+    auditSpy = vi
+      .spyOn(auditLogger, 'logAuditFromReq')
+      .mockImplementation(() => undefined as never);
+
+    delete process.env.IDEMPOTENCY_REQUIRED;
+    resetEnvCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.IDEMPOTENCY_REQUIRED;
+    resetEnvCache();
+  });
+
+  async function makeProduct(sku: string, stock: number, price = 100): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      'INSERT INTO products (name, sku, price, stock) VALUES ($1, $2, $3, $4) RETURNING id',
+      [`Product ${sku}`, sku, price, stock]
+    );
+    return rows[0].id;
+  }
+
+  async function countRows(table: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM ${table}`
+    );
+    return rows[0].n;
+  }
+
+  /** Drives the real controller and captures what it wrote to the response. */
+  async function postSale(
+    body: unknown,
+    key?: string
+  ): Promise<{ response: CapturedResponse; error: unknown }> {
+    const captured: CapturedResponse = { status: null, body: undefined, headers: {} };
+    let error: unknown = null;
+
+    const res = {
+      status(code: number) {
+        captured.status = code;
+        return this;
+      },
+      json(payload: unknown) {
+        captured.body = payload;
+        return this;
+      },
+      setHeader(name: string, value: string) {
+        captured.headers[name] = value;
+      },
+    } as unknown as Response;
+
+    const next = ((err: unknown) => {
+      error = err;
+    }) as NextFunction;
+
+    await new SalesController().createSale(
+      {
+        body,
+        user: { id: cashierId, name: 'Cashier' },
+        headers: key ? { 'idempotency-key': key } : {},
+      } as unknown as Request,
+      res,
+      next
+    );
+
+    return { response: captured, error };
+  }
+
+  function saleBody(productId: number, quantity = 1) {
+    return {
+      items: [{ product_id: productId, quantity, unit_price: 100 }],
+      payment_method: 'Cash',
+    };
+  }
+
+  it('persists one key row linked to the sale it produced', async () => {
+    const productId = await makeProduct('SKU-I1', 10);
+
+    const { response, error } = await postSale(saleBody(productId), 'key-1');
+
+    expect(error).toBeNull();
+    expect(response.status).toBe(201);
+
+    const { rows } = await harness.pool.query<{
+      key: string;
+      endpoint: string;
+      user_id: number;
+      resource_type: string;
+      resource_id: number;
+      response_status: number;
+    }>('SELECT * FROM idempotency_keys');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      key: 'key-1',
+      endpoint: 'POST /api/v1/sales',
+      user_id: cashierId,
+      resource_type: 'sale',
+      response_status: 201,
+    });
+
+    const sales = await harness.pool.query<{ id: number }>('SELECT id FROM sales');
+    expect(rows[0].resource_id).toBe(sales.rows[0].id);
+  });
+
+  it('replays the original response byte-identically and flags it', async () => {
+    const productId = await makeProduct('SKU-I2', 10);
+
+    const first = await postSale(saleBody(productId), 'key-2');
+    const second = await postSale(saleBody(productId), 'key-2');
+
+    expect(second.error).toBeNull();
+    expect(second.response.status).toBe(201);
+    expect(second.response.headers['Idempotent-Replay']).toBe('true');
+    expect(JSON.stringify(second.response.body)).toBe(JSON.stringify(first.response.body));
+
+    expect(await countRows('sales')).toBe(1);
+    expect(await countRows('sale_items')).toBe(1);
+  });
+
+  it('does not re-notify or re-audit on a replay', async () => {
+    const productId = await makeProduct('SKU-I3', 10);
+
+    await postSale(saleBody(productId), 'key-3');
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+    expect(auditSpy).toHaveBeenCalledTimes(1);
+
+    await postSale(saleBody(productId), 'key-3');
+
+    // A replayed request must not send a second SMS or write a second audit entry.
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+    expect(auditSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('behaves exactly as before when no key is sent, writing no key row', async () => {
+    const productId = await makeProduct('SKU-I4', 10);
+
+    const { response, error } = await postSale(saleBody(productId));
+
+    expect(error).toBeNull();
+    expect(response.status).toBe(201);
+    expect(response.headers['Idempotent-Replay']).toBeUndefined();
+    expect(await countRows('idempotency_keys')).toBe(0);
+    expect(await countRows('sales')).toBe(1);
+  });
+
+  it('treats two different keys with identical bodies as two distinct sales', async () => {
+    const productId = await makeProduct('SKU-I5', 10);
+
+    await postSale(saleBody(productId), 'key-5a');
+    await postSale(saleBody(productId), 'key-5b');
+
+    // Identical payloads are not duplicates; only a repeated key is.
+    expect(await countRows('sales')).toBe(2);
+    expect(await countRows('idempotency_keys')).toBe(2);
+  });
+
+  it('rejects the same key with a changed cart and creates no second sale', async () => {
+    const productId = await makeProduct('SKU-I6', 10);
+
+    await postSale(saleBody(productId, 1), 'key-6');
+    const { error } = await postSale(saleBody(productId, 2), 'key-6');
+
+    expect(error).toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
+    expect((error as { details: { code: string }[] }).details[0].code).toBe(IDEMPOTENCY_KEY_REUSED);
+    expect(await countRows('sales')).toBe(1);
+  });
+
+  it('leaves no key row when the request fails validation, so a corrected retry works', async () => {
+    const productId = await makeProduct('SKU-I7', 10);
+
+    const mismatched = {
+      ...saleBody(productId),
+      payments: [{ method: 'Cash', amount: 1 }],
+    };
+
+    const failed = await postSale(mismatched, 'key-7');
+    expect(failed.error).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(await countRows('idempotency_keys')).toBe(0);
+
+    // The key identifies a committed outcome, never a failed attempt.
+    const corrected = await postSale(saleBody(productId), 'key-7');
+    expect(corrected.error).toBeNull();
+    expect(corrected.response.status).toBe(201);
+    expect(await countRows('sales')).toBe(1);
+  });
+
+  it('leaves no key row and no sale when stock is insufficient', async () => {
+    const productId = await makeProduct('SKU-I8', 1);
+
+    const { error } = await postSale(saleBody(productId, 5), 'key-8');
+
+    expect(error).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(await countRows('idempotency_keys')).toBe(0);
+    expect(await countRows('sales')).toBe(0);
+  });
+
+  it('collapses 20 simultaneous identical requests into exactly one sale (R2, R4)', async () => {
+    const productId = await makeProduct('SKU-I9', 50);
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 20 }, () => postSale(saleBody(productId), 'storm'))
+    );
+
+    for (const outcome of outcomes) {
+      expect(outcome.error).toBeNull();
+      expect(outcome.response.status).toBe(201);
+    }
+
+    const bodies = new Set(outcomes.map((o) => JSON.stringify(o.response.body)));
+    expect(bodies.size).toBe(1);
+
+    expect(await countRows('sales')).toBe(1);
+    expect(await countRows('sale_items')).toBe(1);
+    expect(await countRows('stock_adjustments')).toBe(1);
+    expect(await countRows('idempotency_keys')).toBe(1);
+
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    expect(Number(rows[0].stock)).toBe(49);
+
+    // Exactly one notification, however many duplicates arrived.
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires the header once IDEMPOTENCY_REQUIRED closes the window', async () => {
+    process.env.IDEMPOTENCY_REQUIRED = 'true';
+    resetEnvCache();
+    const productId = await makeProduct('SKU-I10', 10);
+
+    const keyless = await postSale(saleBody(productId));
+    expect(keyless.error).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(await countRows('sales')).toBe(0);
+
+    const keyed = await postSale(saleBody(productId), 'key-10');
+    expect(keyed.error).toBeNull();
+    expect(keyed.response.status).toBe(201);
+  });
+});

--- a/server/tests/database/migrate.test.ts
+++ b/server/tests/database/migrate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { newDb } from 'pg-mem';
 import { Pool as PgPool } from 'pg';
 import path from 'path';
+import { createPgMemPool } from '../support/pgMem';
 import {
   runMigrationsUp,
   runMigrationsDown,
@@ -14,9 +14,7 @@ describe('PostgreSQL Migration Runner', () => {
   const migrationsDir = path.join(__dirname, '../../src/database/migrations');
 
   beforeEach(() => {
-    const memDb = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memDb.adapters.createPg();
-    memPool = new Pool() as unknown as PgPool;
+    memPool = createPgMemPool();
   });
 
   afterEach(async () => {
@@ -49,6 +47,7 @@ describe('PostgreSQL Migration Runner', () => {
       '001_initial_schema.sql',
       '002_checkout_financial_contract.sql',
       '003_sale_calculation_snapshot.sql',
+      '004_concurrency_and_idempotency.sql',
     ]);
   });
 
@@ -60,8 +59,9 @@ describe('PostgreSQL Migration Runner', () => {
 
   it('should rollback migrations with down runner', async () => {
     await runMigrationsUp(memPool, migrationsDir);
-    const rolledBack = await runMigrationsDown(3, memPool, migrationsDir);
+    const rolledBack = await runMigrationsDown(4, memPool, migrationsDir);
     expect(rolledBack).toEqual([
+      '004_concurrency_and_idempotency.sql',
       '003_sale_calculation_snapshot.sql',
       '002_checkout_financial_contract.sql',
       '001_initial_schema.sql',
@@ -77,9 +77,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
   const migrationsDir = path.join(__dirname, '../../src/database/migrations');
 
   beforeEach(() => {
-    const memDb = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memDb.adapters.createPg();
-    memPool = new Pool() as unknown as PgPool;
+    memPool = createPgMemPool();
   });
 
   afterEach(async () => {
@@ -99,6 +97,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
       '001_initial_schema.sql',
       '002_checkout_financial_contract.sql',
       '003_sale_calculation_snapshot.sql',
+      '004_concurrency_and_idempotency.sql',
     ]);
 
     const applied = await getAppliedMigrations(memPool);
@@ -106,6 +105,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
       '001_initial_schema.sql',
       '002_checkout_financial_contract.sql',
       '003_sale_calculation_snapshot.sql',
+      '004_concurrency_and_idempotency.sql',
     ]);
   });
 
@@ -123,9 +123,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
     // alias settings, then run the remaining migrations (002).
     await memPool.end();
 
-    const memDb = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memDb.adapters.createPg();
-    const upgradePool = new Pool() as unknown as PgPool;
+    const upgradePool = createPgMemPool();
 
     const fs = await import('fs');
     const sql001 = fs.readFileSync(path.join(migrationsDir, '001_initial_schema.sql'), 'utf8');
@@ -141,6 +139,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
     expect(applied).toEqual([
       '002_checkout_financial_contract.sql',
       '003_sale_calculation_snapshot.sql',
+      '004_concurrency_and_idempotency.sql',
     ]);
 
     const settings = await settingsMap(upgradePool);
@@ -156,9 +155,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
   it('precedence: canonical and alias both exist -> canonical value wins deterministically', async () => {
     await memPool.end();
 
-    const memDb = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memDb.adapters.createPg();
-    const upgradePool = new Pool() as unknown as PgPool;
+    const upgradePool = createPgMemPool();
 
     const fs = await import('fs');
     const sql001 = fs.readFileSync(path.join(migrationsDir, '001_initial_schema.sql'), 'utf8');
@@ -187,9 +184,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
   it('down migration preserves a pre-existing canonical value (no destructive rollback)', async () => {
     await memPool.end();
 
-    const memDb = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memDb.adapters.createPg();
-    const upgradePool = new Pool() as unknown as PgPool;
+    const upgradePool = createPgMemPool();
 
     const fs = await import('fs');
     const sql001 = fs.readFileSync(path.join(migrationsDir, '001_initial_schema.sql'), 'utf8');
@@ -201,10 +196,11 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
     );
 
     await runMigrationsUp(upgradePool, migrationsDir);
-    // Roll back both 003 (unrelated to loyalty settings) and 002 (the
-    // migration under test) to exercise 002's down migration specifically.
-    const rolledBack = await runMigrationsDown(2, upgradePool, migrationsDir);
+    // Roll back 004 and 003 (both unrelated to loyalty settings) down to and
+    // including 002, to exercise 002's down migration specifically.
+    const rolledBack = await runMigrationsDown(3, upgradePool, migrationsDir);
     expect(rolledBack).toEqual([
+      '004_concurrency_and_idempotency.sql',
       '003_sale_calculation_snapshot.sql',
       '002_checkout_financial_contract.sql',
     ]);

--- a/server/tests/database/migration004.test.ts
+++ b/server/tests/database/migration004.test.ts
@@ -35,7 +35,7 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
   let harness: RealPostgresHarness;
 
   beforeAll(async () => {
-    harness = await setupRealPostgres('migration-004');
+    harness = await setupRealPostgres('migration-004', { maxConnections: 3 });
   });
 
   afterAll(async () => {
@@ -181,7 +181,10 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
   it('applies over pre-existing negative rows because the constraints are NOT VALID', async () => {
     // A database that predates this migration: 001-003 applied, stock already negative
     // because nothing guarded exchanges. Applying 004 must not fail on that legacy row.
-    const legacy = await setupRealPostgres('migration-004-legacy', { installAsAppPool: false });
+    const legacy = await setupRealPostgres('migration-004-legacy', {
+      installAsAppPool: false,
+      maxConnections: 2,
+    });
 
     try {
       await runMigrationsDown(1, legacy.pool, MIGRATIONS_DIR);
@@ -209,7 +212,10 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
   });
 
   it('rolls back cleanly and re-applies (down then up leaves _migrations consistent)', async () => {
-    const cycle = await setupRealPostgres('migration-004-cycle', { installAsAppPool: false });
+    const cycle = await setupRealPostgres('migration-004-cycle', {
+      installAsAppPool: false,
+      maxConnections: 2,
+    });
 
     try {
       const rolledBack = await runMigrationsDown(1, cycle.pool, MIGRATIONS_DIR);
@@ -253,6 +259,7 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
 
     const pool = new Pool({
       connectionString: TEST_DATABASE_URL,
+      max: 2,
       options: `-c search_path=${schema}`,
     });
 

--- a/server/tests/database/migration004.test.ts
+++ b/server/tests/database/migration004.test.ts
@@ -73,7 +73,7 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
       'user_id',
     ]);
 
-    expect(byName.response_body.data_type).toBe('jsonb');
+    expect(byName.response_body.data_type).toBe('json');
     expect(byName.expires_at.is_nullable).toBe('NO');
     expect(byName.request_fingerprint.is_nullable).toBe('NO');
     expect(byName.endpoint.is_nullable).toBe('NO');
@@ -99,7 +99,7 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
     await expect(harness.pool.query(insert, ['dup-key'])).rejects.toMatchObject({ code: '23505' });
   });
 
-  it('round-trips a stored response body through JSONB unchanged', async () => {
+  it('round-trips a stored response body through JSON with its key order intact', async () => {
     const body = { success: true, data: { id: 7, total: '199.99', items: [{ product_id: 3 }] } };
 
     await harness.pool.query(
@@ -116,6 +116,9 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
 
     expect(rows[0].response_body).toEqual(body);
     expect(rows[0].response_status).toBe(201);
+    // Byte-identity, not just deep equality: a replay must serialize exactly as the
+    // original response did. jsonb would reorder these keys; json does not.
+    expect(JSON.stringify(rows[0].response_body)).toBe(JSON.stringify(body));
   });
 
   it('adds all four non-negative constraints as NOT VALID', async () => {

--- a/server/tests/database/migration004.test.ts
+++ b/server/tests/database/migration004.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Migration 004 — idempotency keys and non-negative invariants.
+ *
+ * These assertions are about real PostgreSQL behavior (SQLSTATE codes, NOT VALID
+ * semantics, JSONB round-tripping), so they run against the real-PostgreSQL harness
+ * rather than pg-mem. The pg-mem suites still apply this migration; see
+ * `tests/support/pgMem.ts` for the one clause they cannot parse.
+ */
+import { afterAll, afterEach, beforeAll, expect, it } from 'vitest';
+import path from 'path';
+import { Pool } from 'pg';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  TEST_DATABASE_URL,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import {
+  runMigrationsUp,
+  runMigrationsDown,
+  getAppliedMigrations,
+} from '../../src/database/migrate';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/database/migrations');
+const MIGRATION = '004_concurrency_and_idempotency.sql';
+
+const NON_NEGATIVE_CONSTRAINTS = [
+  ['products', 'products_stock_non_negative'],
+  ['product_variants', 'product_variants_stock_non_negative'],
+  ['gift_cards', 'gift_cards_balance_non_negative'],
+  ['customers', 'customers_loyalty_points_non_negative'],
+] as const;
+
+describeWithPostgres('migration 004 — idempotency keys and non-negative invariants', () => {
+  let harness: RealPostgresHarness;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('migration-004');
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  afterEach(async () => {
+    await harness.truncate();
+  });
+
+  it('creates idempotency_keys with the expected columns and a primary key on key', async () => {
+    const { rows: columns } = await harness.pool.query<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+    }>(
+      `SELECT column_name, data_type, is_nullable
+         FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'idempotency_keys'`,
+      [harness.schema]
+    );
+
+    const byName = Object.fromEntries(columns.map((c) => [c.column_name, c]));
+
+    expect(Object.keys(byName).sort()).toEqual([
+      'created_at',
+      'endpoint',
+      'expires_at',
+      'key',
+      'request_fingerprint',
+      'resource_id',
+      'resource_type',
+      'response_body',
+      'response_status',
+      'user_id',
+    ]);
+
+    expect(byName.response_body.data_type).toBe('jsonb');
+    expect(byName.expires_at.is_nullable).toBe('NO');
+    expect(byName.request_fingerprint.is_nullable).toBe('NO');
+    expect(byName.endpoint.is_nullable).toBe('NO');
+    // Only the outcome columns are nullable: a claim is written before the outcome exists.
+    expect(byName.response_status.is_nullable).toBe('YES');
+
+    const { rows: pk } = await harness.pool.query<{ column_name: string }>(
+      `SELECT a.attname AS column_name
+         FROM pg_constraint c
+         JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+        WHERE c.conrelid = ($1 || '.idempotency_keys')::regclass AND c.contype = 'p'`,
+      [harness.schema]
+    );
+    expect(pk.map((r) => r.column_name)).toEqual(['key']);
+  });
+
+  it('rejects a duplicate key with SQLSTATE 23505 — the claim-collision signal', async () => {
+    const insert = `INSERT INTO idempotency_keys (key, endpoint, request_fingerprint, expires_at)
+                    VALUES ($1, 'POST /api/v1/sales', 'fp', NOW() + INTERVAL '24 hours')`;
+
+    await harness.pool.query(insert, ['dup-key']);
+
+    await expect(harness.pool.query(insert, ['dup-key'])).rejects.toMatchObject({ code: '23505' });
+  });
+
+  it('round-trips a stored response body through JSONB unchanged', async () => {
+    const body = { success: true, data: { id: 7, total: '199.99', items: [{ product_id: 3 }] } };
+
+    await harness.pool.query(
+      `INSERT INTO idempotency_keys
+         (key, endpoint, request_fingerprint, response_status, response_body, resource_type, resource_id, expires_at)
+       VALUES ('k', 'POST /api/v1/sales', 'fp', 201, $1, 'sale', 7, NOW() + INTERVAL '24 hours')`,
+      [JSON.stringify(body)]
+    );
+
+    const { rows } = await harness.pool.query<{ response_body: unknown; response_status: number }>(
+      'SELECT response_body, response_status FROM idempotency_keys WHERE key = $1',
+      ['k']
+    );
+
+    expect(rows[0].response_body).toEqual(body);
+    expect(rows[0].response_status).toBe(201);
+  });
+
+  it('adds all four non-negative constraints as NOT VALID', async () => {
+    const { rows } = await harness.pool.query<{ conname: string; convalidated: boolean }>(
+      `SELECT conname, convalidated
+         FROM pg_constraint
+        WHERE connamespace = $1::regnamespace AND contype = 'c'`,
+      [harness.schema]
+    );
+    const byName = Object.fromEntries(rows.map((r) => [r.conname, r]));
+
+    for (const [, constraint] of NON_NEGATIVE_CONSTRAINTS) {
+      expect(byName[constraint], `${constraint} should exist`).toBeDefined();
+      // NOT VALID is what lets this migration apply over already-negative legacy rows.
+      expect(byName[constraint].convalidated, `${constraint} should be NOT VALID`).toBe(false);
+    }
+  });
+
+  it('enforces the floors on new and updated rows', async () => {
+    await harness.pool.query(
+      "INSERT INTO products (name, sku, price, stock) VALUES ('Silk scarf', 'SKU-NEG', 100, 5)"
+    );
+
+    await expect(
+      harness.pool.query("UPDATE products SET stock = -1 WHERE sku = 'SKU-NEG'")
+    ).rejects.toMatchObject({ code: '23514', constraint: 'products_stock_non_negative' });
+
+    await expect(
+      harness.pool.query(
+        "INSERT INTO products (name, sku, price, stock) VALUES ('Bad', 'SKU-BAD', 10, -3)"
+      )
+    ).rejects.toMatchObject({ code: '23514' });
+
+    // The failed writes changed nothing.
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      "SELECT stock FROM products WHERE sku = 'SKU-NEG'"
+    );
+    expect(rows[0].stock).toBe(5);
+  });
+
+  it('permits NULL loyalty_points, which the column still allows', async () => {
+    // A CHECK passes on NULL. The constraint must not turn a nullable column into a
+    // required one, or it would break every customer created without a points balance.
+    await harness.pool.query(
+      "INSERT INTO customers (name, phone, loyalty_points) VALUES ('No points', '+201000000001', NULL)"
+    );
+
+    const { rows } = await harness.pool.query<{ loyalty_points: number | null }>(
+      "SELECT loyalty_points FROM customers WHERE phone = '+201000000001'"
+    );
+    expect(rows[0].loyalty_points).toBeNull();
+
+    await expect(
+      harness.pool.query(
+        "INSERT INTO customers (name, phone, loyalty_points) VALUES ('Negative', '+201000000002', -1)"
+      )
+    ).rejects.toMatchObject({ code: '23514' });
+  });
+
+  it('applies over pre-existing negative rows because the constraints are NOT VALID', async () => {
+    // A database that predates this migration: 001-003 applied, stock already negative
+    // because nothing guarded exchanges. Applying 004 must not fail on that legacy row.
+    const legacy = await setupRealPostgres('migration-004-legacy', { installAsAppPool: false });
+
+    try {
+      await runMigrationsDown(1, legacy.pool, MIGRATIONS_DIR);
+      expect(await getAppliedMigrations(legacy.pool)).not.toContain(MIGRATION);
+
+      await legacy.pool.query(
+        "INSERT INTO products (name, sku, price, stock) VALUES ('Oversold', 'SKU-LEGACY', 10, -4)"
+      );
+
+      const applied = await runMigrationsUp(legacy.pool, MIGRATIONS_DIR);
+      expect(applied).toEqual([MIGRATION]);
+
+      // The legacy row survives untouched; only new writes are policed.
+      const { rows } = await legacy.pool.query<{ stock: number }>(
+        "SELECT stock FROM products WHERE sku = 'SKU-LEGACY'"
+      );
+      expect(rows[0].stock).toBe(-4);
+
+      await expect(
+        legacy.pool.query("UPDATE products SET stock = -5 WHERE sku = 'SKU-LEGACY'")
+      ).rejects.toMatchObject({ code: '23514' });
+    } finally {
+      await legacy.teardown();
+    }
+  });
+
+  it('rolls back cleanly and re-applies (down then up leaves _migrations consistent)', async () => {
+    const cycle = await setupRealPostgres('migration-004-cycle', { installAsAppPool: false });
+
+    try {
+      const rolledBack = await runMigrationsDown(1, cycle.pool, MIGRATIONS_DIR);
+      expect(rolledBack).toEqual([MIGRATION]);
+
+      const gone = await cycle.pool.query<{ n: number }>(
+        `SELECT COUNT(*)::int AS n FROM information_schema.tables
+          WHERE table_schema = $1 AND table_name = 'idempotency_keys'`,
+        [cycle.schema]
+      );
+      expect(gone.rows[0].n).toBe(0);
+
+      const constraints = await cycle.pool.query<{ n: number }>(
+        `SELECT COUNT(*)::int AS n FROM pg_constraint
+          WHERE connamespace = $1::regnamespace AND conname = ANY($2)`,
+        [cycle.schema, NON_NEGATIVE_CONSTRAINTS.map(([, c]) => c)]
+      );
+      expect(constraints.rows[0].n).toBe(0);
+
+      // A negative row is writable again once the floors are dropped.
+      await cycle.pool.query(
+        "INSERT INTO products (name, sku, price, stock) VALUES ('Rolled back', 'SKU-CYCLE', 10, -1)"
+      );
+
+      expect(await runMigrationsUp(cycle.pool, MIGRATIONS_DIR)).toEqual([MIGRATION]);
+      expect(await getAppliedMigrations(cycle.pool)).toEqual([
+        '001_initial_schema.sql',
+        '002_checkout_financial_contract.sql',
+        '003_sale_calculation_snapshot.sql',
+        MIGRATION,
+      ]);
+    } finally {
+      await cycle.teardown();
+    }
+  });
+
+  it('applies on top of 001-003 in order on a database built from scratch', async () => {
+    const schema = `test_m004_chain_${Date.now().toString(36)}`;
+    const admin = new Pool({ connectionString: TEST_DATABASE_URL });
+    await admin.query(`CREATE SCHEMA "${schema}"`);
+
+    const pool = new Pool({
+      connectionString: TEST_DATABASE_URL,
+      options: `-c search_path=${schema}`,
+    });
+
+    try {
+      expect(await runMigrationsUp(pool, MIGRATIONS_DIR)).toEqual([
+        '001_initial_schema.sql',
+        '002_checkout_financial_contract.sql',
+        '003_sale_calculation_snapshot.sql',
+        MIGRATION,
+      ]);
+    } finally {
+      await pool.end();
+      await admin.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await admin.end();
+    }
+  });
+});

--- a/server/tests/database/seed.test.ts
+++ b/server/tests/database/seed.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { newDb } from 'pg-mem';
 import { Pool as PgPool } from 'pg';
 import path from 'path';
+import { createPgMemPool } from '../support/pgMem';
 import { runMigrationsUp } from '../../src/database/migrate';
 import { seedDatabase } from '../../src/database/seed';
 
@@ -10,9 +10,7 @@ describe('PostgreSQL Seed System', () => {
   const migrationsDir = path.join(__dirname, '../../src/database/migrations');
 
   beforeEach(async () => {
-    const memDb = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memDb.adapters.createPg();
-    memPool = new Pool() as unknown as PgPool;
+    memPool = createPgMemPool();
     await runMigrationsUp(memPool, migrationsDir);
   });
 

--- a/server/tests/exchanges.test.ts
+++ b/server/tests/exchanges.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Request, Response } from 'express';
 import { parseExchangeListQuery } from '../src/modules/pos/exchanges/types';
 import { ExchangesController } from '../src/modules/pos/exchanges/controller';
-import type { IExchangesService } from '../src/modules/pos/exchanges/service';
+import {
+  ExchangesService,
+  ExchangeStockError,
+  type IExchangesService,
+} from '../src/modules/pos/exchanges/service';
+import type { IExchangesRepository } from '../src/modules/pos/exchanges/repository';
+import type { Queryable } from '../src/database/transaction';
 
 describe('Exchanges list contract', () => {
   it('strictly parses canonical pagination, search, and sorting', () => {
@@ -50,5 +56,119 @@ describe('Exchanges list contract', () => {
         },
       },
     });
+  });
+});
+
+describe('Exchange stock invariants', () => {
+  const client = {} as Queryable;
+
+  function fakeRepo(
+    overrides: Partial<IExchangesRepository> = {}
+  ): IExchangesRepository & { deducted: Array<{ productId: number; variantId: number | null }> } {
+    const deducted: Array<{ productId: number; variantId: number | null }> = [];
+
+    const repo = {
+      findSaleById: vi.fn().mockResolvedValue({ id: 1, customer_id: null }),
+      createExchange: vi.fn().mockResolvedValue({ id: 10, exchange_number: 'EXC-1' }),
+      createReturnedItem: vi.fn().mockResolvedValue(undefined),
+      createNewItem: vi.fn().mockResolvedValue(undefined),
+      restockVariant: vi.fn().mockResolvedValue(undefined),
+      restockProduct: vi.fn().mockResolvedValue(undefined),
+      deductVariantStock: vi.fn(async (variantId: number) => {
+        deducted.push({ productId: 0, variantId });
+        return 1;
+      }),
+      deductProductStock: vi.fn(async (productId: number) => {
+        deducted.push({ productId, variantId: null });
+        return 1;
+      }),
+      listExchanges: vi.fn(),
+      findById: vi.fn(),
+      findReturnedItems: vi.fn(),
+      findNewItems: vi.fn(),
+      ...overrides,
+    } as unknown as IExchangesRepository;
+
+    return Object.assign(repo, { deducted });
+  }
+
+  function newItem(productId: number) {
+    return { product_id: productId, quantity: 1, price: 10 };
+  }
+
+  const returnedItem = {
+    product_id: 1,
+    quantity: 1,
+    price: 10,
+    reason: 'size',
+    condition: 'damaged' as const,
+  };
+
+  it('deducts new-item stock in canonical ascending order, not request order', async () => {
+    const repo = fakeRepo();
+
+    await new ExchangesService(repo).createExchange(
+      {
+        original_sale_id: 1,
+        returned_items: [returnedItem],
+        new_items: [newItem(9), newItem(3), newItem(6)],
+      },
+      1,
+      client
+    );
+
+    // Two concurrent exchanges naming the same rows in opposite order would otherwise
+    // lock them in opposite order and deadlock.
+    expect(repo.deducted.map((d) => d.productId)).toEqual([3, 6, 9]);
+  });
+
+  it('raises a typed stock error when the guarded deduction matches nothing', async () => {
+    const repo = fakeRepo({ deductProductStock: vi.fn().mockResolvedValue(null) });
+
+    await expect(
+      new ExchangesService(repo).createExchange(
+        { original_sale_id: 1, returned_items: [returnedItem], new_items: [newItem(4)] },
+        1,
+        client
+      )
+    ).rejects.toMatchObject({
+      name: 'ExchangeStockError',
+      message: 'Insufficient stock for product ID 4',
+      productId: 4,
+    });
+  });
+
+  it('maps a stock error to a 400 rather than an unhandled 500', async () => {
+    const service = {
+      createExchange: vi
+        .fn()
+        .mockRejectedValue(new ExchangeStockError('Insufficient stock for product ID 4', 4, null)),
+    } as unknown as IExchangesService;
+    const next = vi.fn();
+
+    await new ExchangesController(service).createExchange(
+      {
+        body: {
+          original_sale_id: 1,
+          returned_items: [{ ...returnedItem }],
+          new_items: [newItem(4)],
+        },
+        user: { id: 1 },
+        headers: {},
+      } as unknown as Request,
+      {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn(),
+        setHeader: vi.fn(),
+      } as unknown as Response,
+      next
+    );
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'VALIDATION_ERROR',
+        message: 'Insufficient stock for product ID 4',
+      })
+    );
   });
 });

--- a/server/tests/http/idempotency.test.ts
+++ b/server/tests/http/idempotency.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Idempotency helper — the parts provable without real transactions.
+ *
+ * Canonicalization, fingerprinting, key validation, and the no-key compatibility path
+ * live here on pg-mem. Everything that depends on a transaction actually committing or
+ * rolling back is in `tests/concurrency/idempotency.concurrency.test.ts`: pg-mem's pg
+ * adapter does not honour ROLLBACK, so a claim-release assertion would pass there for
+ * the wrong reason.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool, PoolClient } from 'pg';
+import { createPgMemPool } from '../support/pgMem';
+import { setPool, closePool } from '../../src/database/pool';
+import { runMigrationsUp } from '../../src/database/migrate';
+import { resetEnvCache } from '../../src/config/env';
+import { PublicError } from '../../src/http/errors';
+import {
+  IDEMPOTENCY_HEADER,
+  IDEMPOTENCY_KEY_REUSED,
+  IDEMPOTENCY_REPLAY_HEADER,
+  IDEMPOTENCY_KEY_TTL_HOURS,
+  IdempotencyConflictError,
+  assertValidIdempotencyKey,
+  canonicalJson,
+  fingerprintPayload,
+  withIdempotency,
+} from '../../src/http/idempotency';
+
+const ENDPOINT = 'POST /api/v1/sales';
+
+let testPool: PgPool;
+
+beforeAll(async () => {
+  testPool = createPgMemPool();
+  setPool(testPool);
+  await runMigrationsUp(testPool, path.join(__dirname, '../../src/database/migrations'));
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
+beforeEach(async () => {
+  await testPool.query('DELETE FROM idempotency_keys');
+  delete process.env.IDEMPOTENCY_REQUIRED;
+  resetEnvCache();
+});
+
+afterEach(() => {
+  delete process.env.IDEMPOTENCY_REQUIRED;
+  resetEnvCache();
+});
+
+function countingRun(status = 201, body: unknown = { success: true, data: { id: 1 } }) {
+  const calls: PoolClient[] = [];
+  const run = async (client: PoolClient) => {
+    calls.push(client);
+    return { status, body, result: { id: 1 }, resourceType: 'sale', resourceId: 1 };
+  };
+  return { run, calls };
+}
+
+async function keyRows(): Promise<Record<string, unknown>[]> {
+  const { rows } = await testPool.query('SELECT * FROM idempotency_keys');
+  return rows;
+}
+
+describe('canonicalJson', () => {
+  it('sorts object keys recursively so field order cannot change the fingerprint', () => {
+    expect(canonicalJson({ a: 1, b: 2 })).toBe(canonicalJson({ b: 2, a: 1 }));
+    expect(canonicalJson({ o: { x: 1, y: 2 }, n: 3 })).toBe(
+      canonicalJson({ n: 3, o: { y: 2, x: 1 } })
+    );
+  });
+
+  it('sorts keys inside array elements too', () => {
+    expect(canonicalJson([{ a: 1, b: 2 }])).toBe(canonicalJson([{ b: 2, a: 1 }]));
+  });
+
+  it('preserves array order, which is semantically meaningful', () => {
+    expect(canonicalJson([1, 2])).not.toBe(canonicalJson([2, 1]));
+  });
+
+  it('distinguishes absent keys from null and from empty string', () => {
+    expect(canonicalJson({ a: 1 })).not.toBe(canonicalJson({ a: 1, b: null }));
+    expect(canonicalJson({ a: null })).not.toBe(canonicalJson({ a: '' }));
+  });
+
+  it('rejects non-finite numbers rather than serializing them as null', () => {
+    expect(() => canonicalJson({ n: NaN })).toThrow(PublicError);
+    expect(() => canonicalJson({ n: Infinity })).toThrow(PublicError);
+    expect(() => canonicalJson({ nested: [{ n: -Infinity }] })).toThrow(PublicError);
+  });
+});
+
+describe('fingerprintPayload', () => {
+  it('is stable across key order and differs on any value change', () => {
+    const a = fingerprintPayload({ items: [{ product_id: 1, quantity: 2 }], total: 10 });
+    const b = fingerprintPayload({ total: 10, items: [{ quantity: 2, product_id: 1 }] });
+    const c = fingerprintPayload({ items: [{ product_id: 1, quantity: 3 }], total: 10 });
+
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('distinguishes a numeric value from its string form', () => {
+    expect(fingerprintPayload({ total: 10 })).not.toBe(fingerprintPayload({ total: '10' }));
+  });
+});
+
+describe('assertValidIdempotencyKey', () => {
+  it.each([
+    ['empty', ''],
+    ['whitespace only', '   '],
+    ['over 255 characters', 'k'.repeat(256)],
+    ['containing a control character', 'abcdef'],
+    ['containing a newline', 'abc\ndef'],
+    ['containing a non-ASCII character', 'abcédef'],
+  ])('rejects a key that is %s', (_label, key) => {
+    expect(() => assertValidIdempotencyKey(key)).toThrow(PublicError);
+  });
+
+  it.each([
+    ['a UUID', '0f6a2b1c-1d3e-4f50-9a7b-2c8d9e0f1a2b'],
+    ['255 characters', 'k'.repeat(255)],
+  ])('accepts %s', (_label, key) => {
+    expect(() => assertValidIdempotencyKey(key)).not.toThrow();
+  });
+});
+
+describe('withIdempotency — no key supplied', () => {
+  it('runs the callback and writes no row while the header is optional', async () => {
+    const { run, calls } = countingRun();
+
+    const outcome = await withIdempotency({ endpoint: ENDPOINT, payload: { a: 1 }, run });
+
+    expect(calls).toHaveLength(1);
+    expect(outcome.replayed).toBe(false);
+    expect(outcome.status).toBe(201);
+    expect(outcome.result).toEqual({ id: 1 });
+    expect(await keyRows()).toHaveLength(0);
+  });
+
+  it('rejects the request when IDEMPOTENCY_REQUIRED is on, naming the header', async () => {
+    process.env.IDEMPOTENCY_REQUIRED = 'true';
+    resetEnvCache();
+    const { run, calls } = countingRun();
+
+    const error = await withIdempotency({ endpoint: ENDPOINT, payload: { a: 1 }, run }).catch(
+      (e: unknown) => e as PublicError
+    );
+
+    expect(error).toBeInstanceOf(PublicError);
+    expect(error.code).toBe('VALIDATION_ERROR');
+    expect(error.message.toLowerCase()).toContain(IDEMPOTENCY_HEADER);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('withIdempotency — malformed key', () => {
+  it('rejects before running the callback or writing a row', async () => {
+    const { run, calls } = countingRun();
+
+    await expect(
+      withIdempotency({ key: '', endpoint: ENDPOINT, payload: { a: 1 }, run })
+    ).rejects.toBeInstanceOf(PublicError);
+
+    expect(calls).toHaveLength(0);
+    expect(await keyRows()).toHaveLength(0);
+  });
+});
+
+describe('IdempotencyConflictError', () => {
+  it('carries the stable code and a 409, and discloses nothing about the original request', () => {
+    const error = new IdempotencyConflictError();
+
+    expect(error.code).toBe(IDEMPOTENCY_KEY_REUSED);
+    expect(error.statusCode).toBe(409);
+    expect(error.name).toBe('IdempotencyConflictError');
+  });
+});
+
+describe('exported constants', () => {
+  it('names the request and replay headers and the TTL', () => {
+    expect(IDEMPOTENCY_HEADER).toBe('idempotency-key');
+    expect(IDEMPOTENCY_REPLAY_HEADER).toBe('Idempotent-Replay');
+    expect(IDEMPOTENCY_KEY_TTL_HOURS).toBe(24);
+  });
+});

--- a/server/tests/inventory-bounded.test.ts
+++ b/server/tests/inventory-bounded.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextFunction, Request, Response } from 'express';
+import path from 'path';
+import { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { adjustStock } from '../services/productService';
 import { CategoriesController } from '../src/modules/inventory/categories/controller';
 import { categoriesService } from '../src/modules/inventory/categories/service';
 import { DistributorsController } from '../src/modules/inventory/distributors/controller';
@@ -102,5 +108,78 @@ describe('paginated inventory query contracts', () => {
     });
     expect(() => parseStockCountListQuery({ limit: '20' })).toThrow();
     expect(() => parseStockAdjustmentListQuery({ limit: '50' })).toThrow();
+  });
+});
+
+describe('manual stock adjustment invariants', () => {
+  let testPool: PgPool;
+  let userId: number;
+  let productId: number;
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM stock_adjustments');
+    await testPool.query('DELETE FROM products');
+    await testPool.query('DELETE FROM users');
+
+    const users = await testPool.query<{ id: number }>(
+      `INSERT INTO users (name, email, password_hash, role)
+       VALUES ('Admin', 'adj@moon.com', 'x', 'Admin') RETURNING id`
+    );
+    userId = users.rows[0].id;
+
+    const products = await testPool.query<{ id: number }>(
+      `INSERT INTO products (name, sku, price, stock, min_stock)
+       VALUES ('Scarf', 'SKU-ADJ', 100, 10, 0) RETURNING id`
+    );
+    productId = products.rows[0].id;
+  });
+
+  async function stockOf(): Promise<number> {
+    const { rows } = await testPool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  async function adjustmentRows(): Promise<Array<{ previous_qty: number; new_qty: number }>> {
+    const { rows } = await testPool.query<{ previous_qty: number; new_qty: number }>(
+      'SELECT previous_qty, new_qty FROM stock_adjustments'
+    );
+    return rows;
+  }
+
+  it('applies a positive delta and records both quantities', async () => {
+    const result = await adjustStock(productId, { delta: 5, reason: 'Restock' }, userId);
+
+    expect(result).toEqual({ previous_qty: 10, new_qty: 15, delta: 5 });
+    expect(await stockOf()).toBe(15);
+    expect(await adjustmentRows()).toEqual([{ previous_qty: 10, new_qty: 15 }]);
+  });
+
+  it('allows a delta that lands exactly on zero', async () => {
+    const result = await adjustStock(productId, { delta: -10, reason: 'Shrinkage' }, userId);
+
+    expect(result.new_qty).toBe(0);
+    expect(await stockOf()).toBe(0);
+  });
+
+  it('refuses a delta below zero with the existing message and writes nothing', async () => {
+    await expect(
+      adjustStock(productId, { delta: -11, reason: 'Shrinkage' }, userId)
+    ).rejects.toThrow('Stock cannot go below zero');
+
+    expect(await stockOf()).toBe(10);
+    expect(await adjustmentRows()).toEqual([]);
   });
 });

--- a/server/tests/register.test.ts
+++ b/server/tests/register.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import type { Request, Response } from 'express';
-import { newDb } from 'pg-mem';
 import { Pool as PgPool } from 'pg';
 import path from 'path';
+import { createPgMemPool } from './support/pgMem';
 import { parseSessionHistoryQuery } from '../src/modules/pos/register/types';
 import { RegisterController } from '../src/modules/pos/register/controller';
 import { RegisterService, IRegisterService } from '../src/modules/pos/register/service';
@@ -74,9 +74,7 @@ describe('RegisterService.recordSaleMovement - transaction threading', () => {
   const service = new RegisterService(repo);
 
   beforeAll(async () => {
-    const memDb = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memDb.adapters.createPg();
-    testPool = new Pool() as unknown as PgPool;
+    testPool = createPgMemPool();
     setPool(testPool);
 
     const migrationsDir = path.join(__dirname, '../src/database/migrations');

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -67,6 +67,7 @@ describe('Sales - Mutation Contract', () => {
           payment_method: 'Card',
         },
         user: { id: 1, name: 'Cashier' },
+        headers: {},
       } as unknown as Request,
       { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response,
       next as NextFunction
@@ -86,6 +87,7 @@ describe('Sales - Mutation Contract', () => {
         params: { id: '42' },
         body: { items: [{ product_id: 1, quantity: 1, unit_price: 10 }], reason: 'Returned' },
         user: { id: 1, name: 'Cashier' },
+        headers: {},
       } as unknown as Request,
       { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response,
       next as NextFunction
@@ -307,6 +309,136 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
       [1]
     );
     expect(prod.rows[0].stock).toBe(9); // 8 + 1 restocked
+  });
+
+  describe('refund cumulative accounting', () => {
+    /** A two-unit cash sale of Silk Dress: total 1000, stock 10 -> 8. */
+    async function sellTwoDresses(): Promise<Record<string, any>> {
+      const input = {
+        items: [{ product_id: 1, quantity: 2, unit_price: 500 }],
+        discount: 0,
+        discount_type: 'fixed',
+        payment_method: 'Cash',
+      };
+      const totals = await calculateSaleTotals(input, testPool);
+      return executeSaleTransaction(input, totals, 1, testPool);
+    }
+
+    async function readSale(saleId: number) {
+      const res = await testPool.query<{ refund_status: string; refunded_amount: string }>(
+        'SELECT refund_status, refunded_amount FROM sales WHERE id = $1',
+        [saleId]
+      );
+      return res.rows[0];
+    }
+
+    async function readStock(productId: number): Promise<number> {
+      const res = await testPool.query<{ stock: number }>(
+        'SELECT stock FROM products WHERE id = $1',
+        [productId]
+      );
+      return Number(res.rows[0].stock);
+    }
+
+    it('persists partial status and the cumulative refunded amount', async () => {
+      const sale = await sellTwoDresses();
+
+      await executeRefundTransaction(
+        sale.id,
+        { items: [{ product_id: 1, quantity: 1, unit_price: 500 }], reason: 'Wrong size' },
+        1,
+        testPool
+      );
+
+      expect(await readSale(sale.id)).toMatchObject({ refund_status: 'partial' });
+      expect(Number((await readSale(sale.id)).refunded_amount)).toBe(500);
+    });
+
+    it('restocks exactly the refunded quantity', async () => {
+      const sale = await sellTwoDresses();
+      expect(await readStock(1)).toBe(8);
+
+      await executeRefundTransaction(
+        sale.id,
+        {
+          items: [{ product_id: 1, quantity: 2, unit_price: 500 }],
+          reason: 'Returned',
+          restock: true,
+        },
+        1,
+        testPool
+      );
+
+      expect(await readStock(1)).toBe(10);
+    });
+
+    it('marks the sale full once the cumulative refunds reach the total exactly', async () => {
+      const sale = await sellTwoDresses();
+
+      const first = await executeRefundTransaction(
+        sale.id,
+        { items: [{ product_id: 1, quantity: 1, unit_price: 500 }], reason: 'Wrong size' },
+        1,
+        testPool
+      );
+      expect(first.refundStatus).toBe('partial');
+
+      const second = await executeRefundTransaction(
+        sale.id,
+        { items: [{ product_id: 1, quantity: 1, unit_price: 500 }], reason: 'Wrong size too' },
+        1,
+        testPool
+      );
+
+      expect(second.refundStatus).toBe('full');
+      expect(second.newRefundedTotal).toBe(1000);
+      expect(await readSale(sale.id)).toMatchObject({ refund_status: 'full' });
+    });
+
+    it('rejects a refund exceeding what is left to refund, and writes nothing', async () => {
+      const sale = await sellTwoDresses();
+
+      await executeRefundTransaction(
+        sale.id,
+        { items: [{ product_id: 1, quantity: 1, unit_price: 500 }], reason: 'Wrong size' },
+        1,
+        testPool
+      );
+
+      // 500 already refunded, so a second 1000 would take the cumulative past the total.
+      await expect(
+        executeRefundTransaction(
+          sale.id,
+          { items: [{ product_id: 1, quantity: 2, unit_price: 500 }], reason: 'Too much' },
+          1,
+          testPool
+        )
+      ).rejects.toThrow('Refund amount exceeds sale total');
+
+      expect(Number((await readSale(sale.id)).refunded_amount)).toBe(500);
+      const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
+      expect(refunds.rows).toHaveLength(1);
+    });
+
+    it('refuses a further refund once the sale is fully refunded', async () => {
+      const sale = await sellTwoDresses();
+
+      await executeRefundTransaction(
+        sale.id,
+        { items: [{ product_id: 1, quantity: 2, unit_price: 500 }], reason: 'Returned' },
+        1,
+        testPool
+      );
+
+      await expect(
+        executeRefundTransaction(
+          sale.id,
+          { items: [{ product_id: 1, quantity: 1, unit_price: 500 }], reason: 'Again' },
+          1,
+          testPool
+        )
+      ).rejects.toThrow('Sale already fully refunded');
+    });
   });
 
   it('should auto-fetch catalog price if unit_price is not provided', async () => {
@@ -1339,6 +1471,7 @@ describe('Unit 4 - Controller: stable validation error mapping', () => {
           payments: [{ method: 'Cash', amount: 50 }],
         },
         user: { id: 1, name: 'Cashier' },
+        headers: {},
       } as unknown as Request,
       { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response,
       next as NextFunction

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import type { NextFunction, Request, Response } from 'express';
-import { newDb } from 'pg-mem';
 import { Pool as PgPool } from 'pg';
 import path from 'path';
 import fs from 'fs';
+import { createPgMemPool } from './support/pgMem';
 import { setPool, closePool } from '../src/database/pool';
 import { runMigrationsUp } from '../src/database/migrate';
 import {
@@ -133,9 +133,7 @@ describe('Sales - List Contract', () => {
 let testPool: PgPool;
 
 beforeAll(async () => {
-  const memDb = newDb({ noAstCoverageCheck: true });
-  const { Pool } = memDb.adapters.createPg();
-  testPool = new Pool() as unknown as PgPool;
+  testPool = createPgMemPool();
   setPool(testPool);
 
   const migrationsDir = path.join(__dirname, '../src/database/migrations');

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -1498,8 +1498,9 @@ describe('Unit 4 - OpenAPI documentation: additive confirmed response is scoped 
   });
 
   it('documents the additive calculation/items/payments fields on the confirmed create response', () => {
+    // 201, matching what the controller actually returns; the spec previously said 200.
     const dataSchema =
-      salesPost.responses['200'].content['application/json'].schema.properties.data;
+      salesPost.responses['201'].content['application/json'].schema.properties.data;
     expect(dataSchema.properties.calculation.$ref).toBe(
       '#/components/schemas/SaleCalculationSnapshot'
     );

--- a/server/tests/support/pgMem.ts
+++ b/server/tests/support/pgMem.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared pg-mem pool factory.
+ *
+ * pg-mem is the fast in-memory engine behind most suites here. It covers nearly all the
+ * SQL this schema uses — `ON CONFLICT DO NOTHING`, guarded `UPDATE ... RETURNING`,
+ * `FOR UPDATE`, `JSONB`, `CHECK` enforcement — but its parser rejects `NOT VALID`.
+ *
+ * Migration 004 needs `NOT VALID` against real PostgreSQL so it cannot fail on legacy
+ * rows that are already negative. Rather than weaken the production SQL to suit the test
+ * engine, this shim strips the clause on the way into pg-mem. The result is a *stricter*
+ * constraint there, which is harmless: a pg-mem database is always freshly created, so
+ * there are no legacy rows for a validating constraint to reject.
+ *
+ * Suites that need genuine concurrency use `./realPostgres` instead — pg-mem has no MVCC.
+ */
+import { newDb, type IMemoryDb } from 'pg-mem';
+import type { Pool as PgPool, PoolClient, QueryResult, QueryResultRow } from 'pg';
+
+/** Matches a trailing `NOT VALID` on an ALTER TABLE ... ADD CONSTRAINT statement. */
+const TRAILING_NOT_VALID = /\s+NOT\s+VALID(?=\s*;|\s*$)/gi;
+
+export function toPgMemCompatibleSql(sql: string): string {
+  return sql.replace(TRAILING_NOT_VALID, '');
+}
+
+type QueryArgs = [string | { text: string }, unknown[]?];
+
+function rewriteQueryArgs(args: QueryArgs): QueryArgs {
+  const [first, params] = args;
+
+  if (typeof first === 'string') {
+    return [toPgMemCompatibleSql(first), params];
+  }
+  if (first && typeof first === 'object' && typeof first.text === 'string') {
+    return [{ ...first, text: toPgMemCompatibleSql(first.text) }, params];
+  }
+  return args;
+}
+
+function patchQueryable<T extends { query: (...args: never[]) => unknown }>(target: T): T {
+  const original = target.query.bind(target) as (
+    ...args: QueryArgs
+  ) => Promise<QueryResult<QueryResultRow>>;
+
+  Object.defineProperty(target, 'query', {
+    configurable: true,
+    writable: true,
+    value: (...args: QueryArgs) => original(...rewriteQueryArgs(args)),
+  });
+
+  return target;
+}
+
+/**
+ * Wraps an existing pg-mem database in a pool that speaks the dialect the migrations are
+ * written in. Migrations run through `pool.connect()`, so pooled clients are patched too.
+ */
+export function pgMemPoolFrom(memDb: IMemoryDb): PgPool {
+  const { Pool } = memDb.adapters.createPg();
+  const pool = patchQueryable(new Pool() as unknown as PgPool);
+
+  const originalConnect = pool.connect.bind(pool) as () => Promise<PoolClient>;
+  pool.connect = (async () => patchQueryable(await originalConnect())) as PgPool['connect'];
+
+  return pool;
+}
+
+/** Convenience for the common case: a fresh in-memory database and its pool. */
+export function createPgMemPool(): PgPool {
+  return pgMemPoolFrom(newDb({ noAstCoverageCheck: true }));
+}

--- a/server/tests/support/realPostgres.test.ts
+++ b/server/tests/support/realPostgres.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, beforeEach, expect, it } from 'vitest';
+import { describeWithPostgres, setupRealPostgres, type RealPostgresHarness } from './realPostgres';
+
+describeWithPostgres('real-PostgreSQL harness', () => {
+  let harness: RealPostgresHarness;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('harness-self-test');
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+  });
+
+  it('applies every migration into an isolated schema and round-trips a query', async () => {
+    const ping = await harness.pool.query<{ one: number }>('SELECT 1 AS one');
+    expect(ping.rows[0].one).toBe(1);
+
+    const { rows } = await harness.pool.query<{ tablename: string }>(
+      'SELECT tablename FROM pg_tables WHERE schemaname = $1',
+      [harness.schema]
+    );
+    const tables = rows.map((r) => r.tablename);
+
+    expect(tables).toEqual(expect.arrayContaining(['users', 'products', 'sales', 'sale_items']));
+    expect(tables).toContain('_migrations');
+  });
+
+  it('records every migration file exactly once', async () => {
+    const { rows } = await harness.pool.query<{ name: string; count: string }>(
+      'SELECT name, COUNT(*) AS count FROM _migrations GROUP BY name'
+    );
+
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+    for (const row of rows) {
+      expect(row.count).toBe('1');
+    }
+  });
+
+  it('supports two genuinely concurrent transactions (proves this is not pg-mem)', async () => {
+    const a = await harness.connect();
+    const b = await harness.connect();
+
+    try {
+      await a.query('BEGIN');
+      await b.query('BEGIN');
+
+      await a.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('A', 'a@moon.com', 'x')"
+      );
+
+      // B's snapshot cannot see A's uncommitted row.
+      const beforeCommit = await b.query('SELECT COUNT(*)::int AS n FROM users');
+      expect(beforeCommit.rows[0].n).toBe(0);
+
+      await a.query('COMMIT');
+
+      // READ COMMITTED takes a fresh snapshot per statement, so B sees it now.
+      const afterCommit = await b.query('SELECT COUNT(*)::int AS n FROM users');
+      expect(afterCommit.rows[0].n).toBe(1);
+
+      await b.query('COMMIT');
+    } finally {
+      a.release();
+      b.release();
+    }
+  });
+
+  it('blocks a second writer on a locked row until the first transaction ends', async () => {
+    await harness.pool.query(
+      "INSERT INTO products (name, sku, price, stock) VALUES ('Lock target', 'LOCK-1', 10, 5)"
+    );
+
+    const a = await harness.connect();
+    const b = await harness.connect();
+
+    try {
+      await a.query('BEGIN');
+      await a.query("SELECT id FROM products WHERE sku = 'LOCK-1' FOR UPDATE");
+
+      let bAcquired = false;
+      await b.query('BEGIN');
+      const bLock = b.query("SELECT id FROM products WHERE sku = 'LOCK-1' FOR UPDATE").then(() => {
+        bAcquired = true;
+      });
+
+      // Give B a real chance to acquire the lock; it must not.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(bAcquired).toBe(false);
+
+      await a.query('COMMIT');
+      await bLock;
+      expect(bAcquired).toBe(true);
+
+      await b.query('COMMIT');
+    } finally {
+      a.release();
+      b.release();
+    }
+  });
+
+  it('isolates one harness from another so parallel test files cannot cross-contaminate', async () => {
+    const other = await setupRealPostgres('harness-isolation', { installAsAppPool: false });
+
+    try {
+      await harness.pool.query(
+        "INSERT INTO users (name, email, password_hash) VALUES ('Only here', 'here@moon.com', 'x')"
+      );
+
+      const mine = await harness.pool.query('SELECT COUNT(*)::int AS n FROM users');
+      const theirs = await other.pool.query('SELECT COUNT(*)::int AS n FROM users');
+
+      expect(mine.rows[0].n).toBe(1);
+      expect(theirs.rows[0].n).toBe(0);
+      expect(other.schema).not.toBe(harness.schema);
+    } finally {
+      await other.teardown();
+    }
+  });
+
+  it('truncate empties tables and resets identity sequences', async () => {
+    await harness.pool.query(
+      "INSERT INTO users (name, email, password_hash) VALUES ('First', 'first@moon.com', 'x')"
+    );
+    await harness.truncate();
+    const reinserted = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash) VALUES ('Second', 'second@moon.com', 'x') RETURNING id"
+    );
+
+    expect(reinserted.rows[0].id).toBe(1);
+
+    const migrations = await harness.pool.query('SELECT COUNT(*)::int AS n FROM _migrations');
+    expect(migrations.rows[0].n).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/server/tests/support/realPostgres.test.ts
+++ b/server/tests/support/realPostgres.test.ts
@@ -5,7 +5,7 @@ describeWithPostgres('real-PostgreSQL harness', () => {
   let harness: RealPostgresHarness;
 
   beforeAll(async () => {
-    harness = await setupRealPostgres('harness-self-test');
+    harness = await setupRealPostgres('harness-self-test', { maxConnections: 4 });
   });
 
   afterAll(async () => {
@@ -104,7 +104,10 @@ describeWithPostgres('real-PostgreSQL harness', () => {
   });
 
   it('isolates one harness from another so parallel test files cannot cross-contaminate', async () => {
-    const other = await setupRealPostgres('harness-isolation', { installAsAppPool: false });
+    const other = await setupRealPostgres('harness-isolation', {
+      installAsAppPool: false,
+      maxConnections: 2,
+    });
 
     try {
       await harness.pool.query(

--- a/server/tests/support/realPostgres.ts
+++ b/server/tests/support/realPostgres.ts
@@ -1,0 +1,153 @@
+/**
+ * Real-PostgreSQL test harness.
+ *
+ * The concurrency and idempotency invariants this repo depends on (guarded relative
+ * writes, `SELECT ... FOR UPDATE`, unique-claim races) cannot be proven against pg-mem:
+ * they need two genuinely concurrent connections and real MVCC. This harness gives a
+ * test file an isolated PostgreSQL schema, migrated through the real migration runner.
+ *
+ * Activated by `TEST_DATABASE_URL`. When it is absent, `describeWithPostgres` skips the
+ * suite *loudly* — a concurrency suite that quietly no-ops is worse than no suite.
+ */
+import { Client, Pool, PoolClient } from 'pg';
+import path from 'path';
+import { randomBytes } from 'crypto';
+import { describe } from 'vitest';
+import { runMigrationsUp } from '../../src/database/migrate';
+import { setPool } from '../../src/database/pool';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/database/migrations');
+
+export const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
+export const hasRealPostgres = Boolean(TEST_DATABASE_URL);
+
+const SKIP_REASON =
+  'SKIPPED (no real PostgreSQL): set TEST_DATABASE_URL to run this suite. ' +
+  'These tests prove concurrency/idempotency invariants and cannot run on pg-mem.';
+
+let announced = false;
+
+/**
+ * `describe` that runs only when a real PostgreSQL URL is configured, and otherwise
+ * reports the suite as skipped with an explicit reason instead of passing silently.
+ */
+export function describeWithPostgres(name: string, fn: () => void): void {
+  if (!hasRealPostgres) {
+    if (!announced) {
+      announced = true;
+      console.warn(`\n[real-postgres] ${SKIP_REASON}\n`);
+    }
+    describe.skip(`${name} — ${SKIP_REASON}`, fn);
+    return;
+  }
+  describe(name, fn);
+}
+
+export interface RealPostgresHarness {
+  /** Pool bound to this file's isolated schema. Also installed as the app pool. */
+  pool: Pool;
+  /** The isolated schema name, for diagnostics. */
+  schema: string;
+  /** Checks out a dedicated client. Callers must release it. */
+  connect(): Promise<PoolClient>;
+  /** Empties every table in the schema and resets identity sequences. */
+  truncate(): Promise<void>;
+  /** Ends the pool and drops the schema. */
+  teardown(): Promise<void>;
+}
+
+function schemaNameFor(label: string): string {
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 24);
+  // PostgreSQL identifiers cap at 63 bytes; this stays well under.
+  return `test_${slug}_${randomBytes(6).toString('hex')}`;
+}
+
+async function withAdminClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: TEST_DATABASE_URL });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+export interface RealPostgresOptions {
+  /**
+   * Install the harness pool as the process-wide application pool via `setPool`.
+   * Defaults to true, which is what a suite exercising services wants. Pass false for a
+   * secondary harness so it does not displace the primary one.
+   */
+  installAsAppPool?: boolean;
+}
+
+/**
+ * Creates an isolated schema, migrates it, and installs it as the application pool.
+ *
+ * `label` only shapes the schema name for readability in `pg_stat_activity`; isolation
+ * comes from the random suffix, so two files sharing a label still cannot collide.
+ */
+export async function setupRealPostgres(
+  label: string,
+  options: RealPostgresOptions = {}
+): Promise<RealPostgresHarness> {
+  if (!TEST_DATABASE_URL) {
+    throw new Error('setupRealPostgres called without TEST_DATABASE_URL; use describeWithPostgres');
+  }
+
+  const schema = schemaNameFor(label);
+
+  await withAdminClient(async (client) => {
+    await client.query(`CREATE SCHEMA "${schema}"`);
+  });
+
+  const pool = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    max: 12,
+    idleTimeoutMillis: 5_000,
+    connectionTimeoutMillis: 10_000,
+    // Every connection from this pool resolves unqualified names inside the schema,
+    // so the unmodified migrations build a private copy of the real schema.
+    options: `-c search_path=${schema}`,
+  });
+
+  await runMigrationsUp(pool, MIGRATIONS_DIR);
+
+  if (options.installAsAppPool !== false) {
+    setPool(pool);
+  }
+
+  const harness: RealPostgresHarness = {
+    pool,
+    schema,
+    connect: () => pool.connect(),
+
+    async truncate() {
+      const { rows } = await pool.query<{ tablename: string }>(
+        'SELECT tablename FROM pg_tables WHERE schemaname = $1',
+        [schema]
+      );
+      const targets = rows
+        .map((r) => r.tablename)
+        .filter((t) => t !== '_migrations')
+        .map((t) => `"${schema}"."${t}"`);
+
+      if (targets.length > 0) {
+        await pool.query(`TRUNCATE ${targets.join(', ')} RESTART IDENTITY CASCADE`);
+      }
+    },
+
+    async teardown() {
+      await pool.end();
+      await withAdminClient(async (client) => {
+        await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      });
+    },
+  };
+
+  return harness;
+}

--- a/server/tests/support/realPostgres.ts
+++ b/server/tests/support/realPostgres.ts
@@ -83,7 +83,17 @@ export interface RealPostgresOptions {
    * secondary harness so it does not displace the primary one.
    */
   installAsAppPool?: boolean;
+  /**
+   * Pool size. Kept deliberately small by default: vitest runs test files in parallel
+   * across every core, and each file (sometimes each test) builds its own harness, so a
+   * generous per-harness pool exhausts PostgreSQL's max_connections and surfaces as
+   * connection timeouts rather than as an obvious resource error. Suites that need real
+   * parallelism — a 10-way oversell race, say — raise this deliberately.
+   */
+  maxConnections?: number;
 }
+
+const DEFAULT_MAX_CONNECTIONS = 5;
 
 /**
  * Creates an isolated schema, migrates it, and installs it as the application pool.
@@ -107,7 +117,7 @@ export async function setupRealPostgres(
 
   const pool = new Pool({
     connectionString: TEST_DATABASE_URL,
-    max: 12,
+    max: options.maxConnections ?? DEFAULT_MAX_CONNECTIONS,
     idleTimeoutMillis: 5_000,
     connectionTimeoutMillis: 10_000,
     // Every connection from this pool resolves unqualified names inside the schema,

--- a/server/tests/users.test.ts
+++ b/server/tests/users.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Request, Response } from 'express';
-import { newDb } from 'pg-mem';
 import type { Pool as PgPool } from 'pg';
 import path from 'path';
+import { createPgMemPool } from './support/pgMem';
 import { parseUserListQuery } from '../src/modules/core/users/types';
 import { UsersRepository } from '../src/modules/core/users/repository';
 import { runMigrationsUp } from '../src/database/migrate';
@@ -42,9 +42,7 @@ describe('Users repository pagination', () => {
   let testPool: PgPool;
 
   beforeAll(async () => {
-    const memory = newDb({ noAstCoverageCheck: true });
-    const { Pool } = memory.adapters.createPg();
-    testPool = new Pool() as unknown as PgPool;
+    testPool = createPgMemPool();
     await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
     await testPool.query(
       `INSERT INTO users (name, email, password_hash, role, created_at)

--- a/server/tests/verification/endpointHealth.test.ts
+++ b/server/tests/verification/endpointHealth.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import path from 'path';
-import { Pool as PgPool } from 'pg';
 import { newDb } from 'pg-mem';
+import { toPgMemCompatibleSql } from '../support/pgMem';
+import { Pool as PgPool } from 'pg';
 import { setPool, closePool } from '../../src/database/pool';
 import { runMigrationsUp } from '../../src/database/migrate';
 import { seedDatabase } from '../../src/database/seed';
@@ -182,7 +183,7 @@ beforeAll(async () => {
   const rawPool = new Pool() as unknown as PgPool;
 
   function sanitizeSql(text: string): string {
-    let s = text;
+    let s = toPgMemCompatibleSql(text);
     if (s.toUpperCase().includes('SET TRANSACTION ISOLATION LEVEL')) {
       return '';
     }

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,10 +1,25 @@
 import { defineConfig } from 'vitest/config';
 
+/**
+ * The real-PostgreSQL suites do real work in their hooks: `beforeAll` runs every
+ * migration into a fresh schema, and `beforeEach` truncates ~40 tables. Under vitest's
+ * default fan-out (one worker per core) that contends hard enough on a single server to
+ * blow the 10s default hook timeout, which surfaces as a hook failure in whichever suite
+ * loses the race rather than as anything resembling its real cause.
+ *
+ * Both bounds apply only when those suites actually run, so the ordinary pg-mem run keeps
+ * full parallelism and the default timeouts.
+ */
+const usesRealPostgres = Boolean(process.env.TEST_DATABASE_URL);
+
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     include: ['**/*.test.ts'],
     setupFiles: ['./tests/setup.ts'],
+    ...(usesRealPostgres
+      ? { maxWorkers: 4, minWorkers: 1, hookTimeout: 60_000, testTimeout: 60_000 }
+      : {}),
   },
 });


### PR DESCRIPTION
Closes #42.

Every financial mutation on this server read a quantity or balance, computed a new absolute value in JavaScript, and wrote it back. Inside a transaction that is atomic against torn writes but **not** against lost updates: two concurrent checkouts both read `stock = 5`, both write `stock = 3`, and four units vanish. Nothing took a row lock, and nothing recognised a retried request — so a network failure after commit produced a second sale, a second stock deduction, a second coupon use, and a second loyalty award.

This adds two server-side invariants and proves them against real PostgreSQL.

## What changed

**Quantities and balances move through conditional relative writes.**
`UPDATE products SET stock = stock - $1 WHERE id = $2 AND stock >= $1 RETURNING stock` removes the stale-read window instead of narrowing it — under `READ COMMITTED`, PostgreSQL re-evaluates that `WHERE` after a concurrent writer's lock is released. `rowCount = 0` means insufficient, raised as a typed error. Audit rows derive from `RETURNING`, so they record what happened rather than what was predicted. Where the invariant spans rows and no single write can express it — coupon `max_uses` counts `coupon_usage`, a cumulative refund compares against sibling refunds — the parent row is locked instead. Preview paths deliberately take no locks.

**A caller-supplied `Idempotency-Key` makes a retry return the original outcome.** The claim is the first statement inside the business transaction, so it shares that transaction's fate: a commit makes the outcome replayable, a failure releases the key. No `in_progress` state, no lease, no reaper. A key identifies a *committed outcome*, never an attempt — so a corrected retry after a 400 runs normally.

Covered: sale creation, refunds, gift-card redemption, exchanges. Coupons and loyalty are serialized inside checkout.

## Compatibility

`IDEMPOTENCY_REQUIRED` defaults to `false`. A request without the header behaves exactly as it did before — that is what keeps an unpatched till working. Replay is signalled additively via an `Idempotent-Replay` response header, so **no envelope or existing response field changes**. Rollout is server first, then client; neither half breaks the other at any point between.

The flip criterion is an observable, not a date: set `IDEMPOTENCY_REQUIRED=true` once `SELECT COUNT(*) FROM idempotency_keys WHERE created_at > NOW() - INTERVAL '1 day'` matches the day's sale count.

## Migration 004

Additive: a new `idempotency_keys` table plus four `NOT VALID` non-negative constraints as defence-in-depth behind the application guards.

`NOT VALID` skips the validation scan so the migration cannot fail on rows that are already negative — nothing was guarding exchanges. It does **not** make this lock-free: `ADD CONSTRAINT` still takes ACCESS EXCLUSIVE to write the catalog entry, and a waiting ALTER queues every later reader behind it. Each one therefore runs under a short `lock_timeout` and fails fast rather than stalling the shop. Prefer a quiet window anyway. The migration ships the query to find pre-existing violators; `VALIDATE CONSTRAINT` is the operational follow-up.

`response_body` is `json`, not `jsonb`, deliberately — `jsonb` normalises key order, which would stop a replay being byte-identical to the original response.

## Testing

None of the core claims can be proven with a fake repository or an in-memory engine; each needs two genuinely concurrent connections. This adds a `TEST_DATABASE_URL`-gated harness that migrates an isolated schema per test file through the real migration runner, and **this repo's first CI**, with a `postgres:16` service container and a guard that fails the build if those suites were skipped.

`330 passing` against real PostgreSQL (`253 + 77 skipped` without it), `299` on the client.

The concurrency tests discriminate — verified by reverting the fix and watching them fail:

- restoring read-then-write fails the 10-way oversell test and the deterministic stale-read test
- restoring the per-phase exchange sort produces a real PostgreSQL `deadlock detected`
- swapping `findByIdForUpdate` back to `findById` lets 3 concurrent refunds exceed the sale total

Three engine defects shaped the implementation and are worth knowing about:

- **pg-mem silently ignores `ROLLBACK`.** Every transactional assertion had to move to real PostgreSQL — on pg-mem a claim-release test passes for the wrong reason. This also means the pre-existing suite's transaction coverage was weaker than it looked.
- **pg-mem inverts `column - $param`** unless the parameter is cast: `5 - 2` returned `-3`. Addition is commutative, which is exactly why the existing relative writes never exposed it.
- **pg-mem cannot parse `NOT VALID`**, so the test harness strips that one clause rather than the production SQL being weakened.

## Review

Ten reviewer personas ran against the finished branch. They found two P1 defects that are fixed here:

- **The exchange write phase sorted its two stock passes separately**, which reintroduced the deadlock the sorting existed to remove — an exchange returning product 5 and taking product 2 locked 5→2 while its mirror locked 2→5, and it deadlocked against checkout too. The comment claimed the opposite. Now one sorted pass over the union, through a comparator shared with checkout so the two cannot drift.
- **The client key lived in a `useRef`**, so it did not survive a reload — while the cart it protects is persisted. A till refreshing mid-checkout minted a new key and rang the sale up twice. It now lives in the persisted cart slice.

Also from review: the bounded `40001`/`40P01` retry was built and tested but **no call site ever enabled it**, so the documented deadlock mitigation was inert; the claim INSERT had no `lock_timeout`, so a duplicate storm on one key could starve the pool for every till; and three documentation claims overstated what the code does (the migration's lock safety, a global lock order the checkout path does not follow, and a `200` status for endpoints returning `201`). All corrected.

## Post-Deploy Monitoring & Validation

**Watch**

- `SELECT COUNT(*) FROM idempotency_keys WHERE created_at > NOW() - INTERVAL '1 hour'` — should track sale volume once clients ship. Zero after the client deploy means keys are not arriving.
- Log searches: `IDEMPOTENCY_KEY_REUSED` (a misbehaving till reusing a key across carts), `IDEMPOTENCY_UNRESOLVED` (claim contention — should be near zero), `Retrying transaction after a serialization failure` (deadlock pressure), `Insufficient stock`.
- `SELECT COUNT(*) FROM products WHERE stock < 0` and the same for `product_variants`, `gift_cards.balance`, `customers.loyalty_points` — **must stay flat**. The `CHECK` constraints are a silent backstop; if one ever fires, an application guard was bypassed.
- Connection count against `max_connections`, for the first busy period.

**Healthy signals:** replay rate low and non-zero once clients ship; no negative-stock rows; deadlock retries rare; `idempotency_keys` growing roughly with sale volume.

**Rollback triggers:** any negative stock/balance row; sustained `IDEMPOTENCY_UNRESOLVED`; deadlock retries exhausting; connection saturation. The migration's `.down.sql` is a clean reversal, and `IDEMPOTENCY_REQUIRED` is a config flip, not a deploy.

**Window/owner:** first full trading day, backend owner. `idempotency_keys` has a 24h TTL with only opportunistic cleanup — if volume warrants it, a scheduled `DELETE FROM idempotency_keys WHERE expires_at < NOW()` is the intended next step.

## Known gaps, deliberately not fixed here

- **The offline queue stores a *reduced* payload under the failed request's key.** If that request actually committed, the replay correctly gets a 409 instead of duplicating the sale — but the entry then stays queued, because `useOffline` only quarantines on `SPLIT_PAYMENT_MISMATCH`. That is #30's replay/quarantine logic and out of scope.
- **Manual stock adjustments got the guarded write but no idempotency wrapper** — the endpoint lives in `products/controller.ts`, outside this issue's enumerated scope. A retried adjustment can still double-apply.
- Deleting a user nulls `idempotency_keys.user_id`, so their own replay inside the 24h TTL would be answered with a conflict. Narrow; documented in the migration.
- `client/` has ~34 pre-existing type errors unrelated to this work, so CI runs lint + tests there but not `tsc`. Server CI runs all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEs3PijM1d6sKWBAqQuAiL
