### PR TITLE
fix(offline): stop the sale queue busy-looping and make failures visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,13 @@ on teardown, so files cannot contaminate each other. The target database only ne
 privileges. CI (`.github/workflows/ci.yml`) always sets `TEST_DATABASE_URL` and fails the
 build if these suites were skipped.
 
+## Offline queue
+
+Sales rung up offline are queued in `localStorage` and replayed by
+`client/src/shared/hooks/useOffline.ts`. A failed replay backs off, and a rejection the server will
+repeat parks for a cashier rather than retrying forever — see the **Offline queue replay contract**
+in `docs/CONVENTIONS.md` before changing the hook or its store.
+
 ## Idempotency compatibility window
 
 Retry-prone mutations (`POST /api/v1/sales` and the other wrapped endpoints) accept an

--- a/client/src/app/Layout.tsx
+++ b/client/src/app/Layout.tsx
@@ -72,12 +72,19 @@ export default function Layout(): React.JSX.Element {
 
         {/* Offline banner */}
         {!isOnline && (
-          <div className="bg-warning/10 border-b border-warning/30 text-warning px-4 py-2 text-sm flex items-center gap-2">
+          <div
+            role="status"
+            className="bg-warning/10 border-b border-warning/30 text-warning px-4 py-2 text-sm flex items-center gap-2"
+          >
             <WifiOff className="h-4 w-4" />
             {t('offline.offlineBanner')}
             {queueLength > 0 && ` ${t('offline.queuedForSync', { count: queueLength })}`}
             {quarantinedCount > 0 &&
               ` ${t('offline.quarantinedForReview', { count: quarantinedCount })}`}
+            {/* Parked sales are otherwise only named in the online branch below,
+                so dropping the link would hide them behind "queued for sync" --
+                which promises they will go on their own, and they will not. */}
+            {failedCount > 0 && ` ${t('offline.failedToSync', { count: failedCount })}`}
           </div>
         )}
 
@@ -87,7 +94,10 @@ export default function Layout(): React.JSX.Element {
             back in the queue, which is what Retry does. Counted separately
             because the answers differ. */}
         {isOnline && (quarantinedCount > 0 || failedCount > 0) && (
-          <div className="bg-warning/10 border-b border-warning/30 text-warning px-4 py-2 text-sm flex items-center gap-2 flex-wrap">
+          <div
+            role="status"
+            className="bg-warning/10 border-b border-warning/30 text-warning px-4 py-2 text-sm flex items-center gap-2 flex-wrap"
+          >
             <WifiOff className="h-4 w-4" />
             {quarantinedCount > 0 && (
               <span>{t('offline.quarantinedForReview', { count: quarantinedCount })}</span>

--- a/client/src/app/Layout.tsx
+++ b/client/src/app/Layout.tsx
@@ -11,7 +11,7 @@ import { useSettingsStore } from '../shared/store/settingsStore';
 import { WifiOff, Languages, Moon, Sun, Menu } from 'lucide-react';
 
 export default function Layout(): React.JSX.Element {
-  const { isOnline, queueLength, quarantinedCount } = useOffline();
+  const { isOnline, queueLength, quarantinedCount, failedCount, retryFailed } = useOffline();
   const { t, locale } = useTranslation();
   const { user } = useAuthStore();
   const { toggleLocale, toggleTheme, theme } = useSettingsStore();
@@ -81,13 +81,28 @@ export default function Layout(): React.JSX.Element {
           </div>
         )}
 
-        {/* Quarantined queued sale(s) needing manual review -- shown even once
-            back online, since these never auto-resolve on their own (see
-            `isQuarantined` in offlineStore.ts). */}
-        {isOnline && quarantinedCount > 0 && (
-          <div className="bg-warning/10 border-b border-warning/30 text-warning px-4 py-2 text-sm flex items-center gap-2">
+        {/* Queued sale(s) needing a human -- shown even once back online, since
+            neither state auto-resolves. Quarantined (legacy or no longer
+            balanced) needs a re-ring; parked (`syncFailed`) just needs putting
+            back in the queue, which is what Retry does. Counted separately
+            because the answers differ. */}
+        {isOnline && (quarantinedCount > 0 || failedCount > 0) && (
+          <div className="bg-warning/10 border-b border-warning/30 text-warning px-4 py-2 text-sm flex items-center gap-2 flex-wrap">
             <WifiOff className="h-4 w-4" />
-            {t('offline.quarantinedForReview', { count: quarantinedCount })}
+            {quarantinedCount > 0 && (
+              <span>{t('offline.quarantinedForReview', { count: quarantinedCount })}</span>
+            )}
+            {failedCount > 0 && <span>{t('offline.failedToSync', { count: failedCount })}</span>}
+            {failedCount > 0 && (
+              <Button
+                size="sm"
+                variant="light"
+                onClick={retryFailed}
+                className="h-7 min-w-0 px-3 text-warning underline"
+              >
+                {t('offline.retry')}
+              </Button>
+            )}
           </div>
         )}
 

--- a/client/src/app/__tests__/Layout.test.tsx
+++ b/client/src/app/__tests__/Layout.test.tsx
@@ -1,11 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  createMemoryHistory,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useAuthStore } from '@/features/auth';
 import { useSettingsStore } from '@/shared/store/settingsStore';
 import { useOfflineStore, SALE_QUEUE_CONTRACT_VERSION } from '@/shared/store/offlineStore';
 import { TransportProvider } from '@/shared/lib/transport/index';
 import { createMemoryTransport } from '@/shared/lib/transport/memory';
-import { renderWithRouter } from '@/shared/tests/routerTestUtils';
 import en from '@/shared/i18n/en.json';
 import ar from '@/shared/i18n/ar.json';
 import Layout from '../Layout';
@@ -21,17 +28,47 @@ const healthySale = (id: string) => ({
   contractVersion: SALE_QUEUE_CONTRACT_VERSION,
 });
 
+/**
+ * Layout renders an `<Outlet/>`, so handing it to `renderWithRouter` as the
+ * `ui` mounts it as both the root and the index component -- Layout nested
+ * inside itself, two schedulers, two banners, and every assertion needing
+ * `getAllBy*`. That is not the shipped environment, so this builds the router
+ * the real app has: Layout at the root, a page inside it.
+ */
 function renderLayout() {
   const transport = createMemoryTransport({ sales: [] });
-  return {
-    transport,
-    ...renderWithRouter(
+  const rootRoute = createRootRoute({
+    component: () => (
       <TransportProvider transport={transport}>
         <Layout />
-      </TransportProvider>,
-      { initialRoute: '/', authState: { isAuthenticated: true, user: ADMIN } }
+      </TransportProvider>
+    ),
+  });
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>page</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  });
+
+  return {
+    transport,
+    ...render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     ),
   };
+}
+
+/** The shipped English copy, so a wording change is not a test failure. */
+function copy(key: string, count: number): string {
+  return (en as Record<string, string>)[key].replace('{count}', String(count));
 }
 
 describe('Layout - queued sale review banner', () => {
@@ -61,7 +98,10 @@ describe('Layout - queued sale review banner', () => {
 
     renderLayout();
 
-    expect(await screen.findAllByText(/2 queued sale\(s\) failed to sync/i)).not.toHaveLength(0);
+    // One banner, not two: Layout must not be mounted inside itself here, or
+    // every count below would be asserted against a duplicate render.
+    const banner = await screen.findByRole('status');
+    expect(banner).toHaveTextContent(copy('offline.failedToSync', 2));
   });
 
   it('puts every parked sale back in play when Retry is pressed', async () => {
@@ -74,18 +114,26 @@ describe('Layout - queued sale review banner', () => {
     });
 
     const { transport } = renderLayout();
-
-    // Parked means parked: nothing was replayed on its own.
-    await waitFor(() =>
-      expect(screen.queryAllByRole('button', { name: /retry/i })).not.toHaveLength(0)
-    );
     const salePosts = () =>
       transport.calls().filter((call) => call.method === 'POST' && call.path === 'sales');
+
+    // Parked means parked: nothing was replayed on its own.
+    const retry = await screen.findByRole('button', { name: en['offline.retry'] });
     expect(salePosts()).toEqual([]);
 
-    fireEvent.click((await screen.findAllByRole('button', { name: /retry/i }))[0]);
+    fireEvent.click(retry);
 
-    // Back in play: the scheduler picks them up and both replay.
+    // Retry clears the parked state itself...
+    await waitFor(() =>
+      expect(useOfflineStore.getState().queue.every((item) => item.syncFailed === undefined)).toBe(
+        true
+      )
+    );
+    expect(useOfflineStore.getState().queue.every((item) => item.attempts === undefined)).toBe(
+      true
+    );
+
+    // ...and the scheduler takes it from there.
     await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(0));
     expect(salePosts()).toHaveLength(2);
   });
@@ -101,8 +149,10 @@ describe('Layout - queued sale review banner', () => {
 
     renderLayout();
 
-    expect(await screen.findAllByText(/1 of these need manual review/i)).not.toHaveLength(0);
-    expect(screen.getAllByText(/1 queued sale\(s\) failed to sync/i)).not.toHaveLength(0);
+    // A parked sale is not a quarantined one: the cashier's next step differs.
+    const banner = await screen.findByRole('status');
+    expect(banner).toHaveTextContent(copy('offline.quarantinedForReview', 1));
+    expect(banner).toHaveTextContent(copy('offline.failedToSync', 1));
   });
 
   it('renders no review banner for a healthy queue', async () => {
@@ -110,12 +160,27 @@ describe('Layout - queued sale review banner', () => {
 
     renderLayout();
 
-    await waitFor(() => expect(screen.queryAllByText(/failed to sync/i)).toHaveLength(0));
-    expect(screen.queryAllByText(/need manual review/i)).toHaveLength(0);
-    expect(screen.queryAllByRole('button', { name: /^retry$/i })).toHaveLength(0);
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: en['offline.retry'] })).not.toBeInTheDocument();
   });
 
-  it('composes the offline banner exactly as it did before', async () => {
+  it('still names parked sales while the till is offline', async () => {
+    // The review banner is gated on being online, so without this the one sale
+    // that will never sync on its own hides behind "queued for sync" -- which
+    // promises the opposite.
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    useOfflineStore.setState({
+      queue: [healthySale('a'), { ...healthySale('b'), syncFailed: true, attempts: 17 }],
+      isSyncing: false,
+    });
+
+    renderLayout();
+
+    const banner = await screen.findByRole('status');
+    expect(banner).toHaveTextContent(copy('offline.failedToSync', 1));
+  });
+
+  it('composes the offline banner as it did before', async () => {
     Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
     useOfflineStore.setState({
       queue: [healthySale('a'), { id: 'legacy', createdAt: '', type: 'sale', payload: {} }],
@@ -124,9 +189,10 @@ describe('Layout - queued sale review banner', () => {
 
     renderLayout();
 
-    expect(await screen.findAllByText(/You are offline\./)).not.toHaveLength(0);
-    expect(screen.getAllByText(/2 item\(s\) queued for sync/i)).not.toHaveLength(0);
-    expect(screen.getAllByText(/1 of these need manual review/i)).not.toHaveLength(0);
+    const banner = await screen.findByRole('status');
+    expect(banner).toHaveTextContent(en['offline.offlineBanner']);
+    expect(banner).toHaveTextContent(copy('offline.queuedForSync', 2));
+    expect(banner).toHaveTextContent(copy('offline.quarantinedForReview', 1));
   });
 
   it('gives the Retry control an accessible name and keyboard reach', async () => {
@@ -137,7 +203,7 @@ describe('Layout - queued sale review banner', () => {
 
     renderLayout();
 
-    const [retry] = await screen.findAllByRole('button', { name: /retry/i });
+    const retry = await screen.findByRole('button', { name: en['offline.retry'] });
     retry.focus();
     expect(retry).toHaveFocus();
   });

--- a/client/src/app/__tests__/Layout.test.tsx
+++ b/client/src/app/__tests__/Layout.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { useAuthStore } from '@/features/auth';
+import { useSettingsStore } from '@/shared/store/settingsStore';
+import { useOfflineStore, SALE_QUEUE_CONTRACT_VERSION } from '@/shared/store/offlineStore';
+import { TransportProvider } from '@/shared/lib/transport/index';
+import { createMemoryTransport } from '@/shared/lib/transport/memory';
+import { renderWithRouter } from '@/shared/tests/routerTestUtils';
+import en from '@/shared/i18n/en.json';
+import ar from '@/shared/i18n/ar.json';
+import Layout from '../Layout';
+
+const ADMIN = { id: 1, name: 'Admin User', email: 'admin@moon.com', role: 'Admin' as const };
+
+/** A sale that would replay cleanly if anything ever asked it to. */
+const healthySale = (id: string) => ({
+  id,
+  createdAt: '',
+  type: 'sale',
+  payload: {},
+  contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+});
+
+function renderLayout() {
+  const transport = createMemoryTransport({ sales: [] });
+  return {
+    transport,
+    ...renderWithRouter(
+      <TransportProvider transport={transport}>
+        <Layout />
+      </TransportProvider>,
+      { initialRoute: '/', authState: { isAuthenticated: true, user: ADMIN } }
+    ),
+  };
+}
+
+describe('Layout - queued sale review banner', () => {
+  let online: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    online = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    useSettingsStore.setState({ locale: 'en' });
+    useAuthStore.setState({ user: ADMIN, isAuthenticated: true });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+  });
+
+  afterEach(() => {
+    if (online) Object.defineProperty(Navigator.prototype, 'onLine', online);
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+  });
+
+  it('names how many sales failed to sync', async () => {
+    useOfflineStore.setState({
+      queue: [
+        { ...healthySale('a'), syncFailed: true, attempts: 10 },
+        { ...healthySale('b'), syncFailed: true, attempts: 10 },
+      ],
+      isSyncing: false,
+    });
+
+    renderLayout();
+
+    expect(await screen.findAllByText(/2 queued sale\(s\) failed to sync/i)).not.toHaveLength(0);
+  });
+
+  it('puts every parked sale back in play when Retry is pressed', async () => {
+    useOfflineStore.setState({
+      queue: [
+        { ...healthySale('a'), syncFailed: true, attempts: 10, nextAttemptAt: undefined },
+        { ...healthySale('b'), syncFailed: true, attempts: 10 },
+      ],
+      isSyncing: false,
+    });
+
+    const { transport } = renderLayout();
+
+    // Parked means parked: nothing was replayed on its own.
+    await waitFor(() =>
+      expect(screen.queryAllByRole('button', { name: /retry/i })).not.toHaveLength(0)
+    );
+    const salePosts = () =>
+      transport.calls().filter((call) => call.method === 'POST' && call.path === 'sales');
+    expect(salePosts()).toEqual([]);
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /retry/i }))[0]);
+
+    // Back in play: the scheduler picks them up and both replay.
+    await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(0));
+    expect(salePosts()).toHaveLength(2);
+  });
+
+  it('counts quarantined and parked sales independently', async () => {
+    useOfflineStore.setState({
+      queue: [
+        { id: 'legacy', createdAt: '', type: 'sale', payload: {} }, // quarantined
+        { ...healthySale('a'), syncFailed: true, attempts: 10 }, // parked
+      ],
+      isSyncing: false,
+    });
+
+    renderLayout();
+
+    expect(await screen.findAllByText(/1 of these need manual review/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/1 queued sale\(s\) failed to sync/i)).not.toHaveLength(0);
+  });
+
+  it('renders no review banner for a healthy queue', async () => {
+    useOfflineStore.setState({ queue: [healthySale('a')], isSyncing: false });
+
+    renderLayout();
+
+    await waitFor(() => expect(screen.queryAllByText(/failed to sync/i)).toHaveLength(0));
+    expect(screen.queryAllByText(/need manual review/i)).toHaveLength(0);
+    expect(screen.queryAllByRole('button', { name: /^retry$/i })).toHaveLength(0);
+  });
+
+  it('composes the offline banner exactly as it did before', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    useOfflineStore.setState({
+      queue: [healthySale('a'), { id: 'legacy', createdAt: '', type: 'sale', payload: {} }],
+      isSyncing: false,
+    });
+
+    renderLayout();
+
+    expect(await screen.findAllByText(/You are offline\./)).not.toHaveLength(0);
+    expect(screen.getAllByText(/2 item\(s\) queued for sync/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/1 of these need manual review/i)).not.toHaveLength(0);
+  });
+
+  it('gives the Retry control an accessible name and keyboard reach', async () => {
+    useOfflineStore.setState({
+      queue: [{ ...healthySale('a'), syncFailed: true, attempts: 10 }],
+      isSyncing: false,
+    });
+
+    renderLayout();
+
+    const [retry] = await screen.findAllByRole('button', { name: /retry/i });
+    retry.focus();
+    expect(retry).toHaveFocus();
+  });
+});
+
+describe('i18n key parity', () => {
+  it('keeps en.json and ar.json at identical key sets', () => {
+    expect(Object.keys(en).sort()).toEqual(Object.keys(ar).sort());
+  });
+
+  it('carries the new offline review keys in both locales', () => {
+    for (const bundle of [en, ar]) {
+      expect(bundle).toHaveProperty('offline.failedToSync');
+      expect(bundle).toHaveProperty('offline.retry');
+    }
+  });
+});

--- a/client/src/shared/hooks/useOffline.test.tsx
+++ b/client/src/shared/hooks/useOffline.test.tsx
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { ReactNode } from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { ApiError, TransportProvider } from '../lib/transport/index';
 import type { Transport, TransportRequest, TransportResult } from '../lib/transport/index';
 import { createMemoryTransport, type MemoryTransport } from '../lib/transport/memory';
-import { useOfflineStore, SALE_QUEUE_CONTRACT_VERSION } from '../store/offlineStore';
+import {
+  useOfflineStore,
+  SALE_QUEUE_CONTRACT_VERSION,
+  MAX_RETRYABLE_ATTEMPTS,
+  RETRY_CEILING_MS,
+} from '../store/offlineStore';
 import { useOffline } from './useOffline';
 
 /**
@@ -44,20 +49,30 @@ function wrapperFor(transport: Transport) {
 }
 
 /**
- * Fails the first replay outright and then hangs. The hook retries a failed
- * replay for as long as the queue is non-empty, so hanging the second attempt
- * stops the test observing a spin rather than the state after one failure.
+ * Rejects every replay with the same error, and records each attempt.
+ *
+ * It does NOT have to hang after the first failure the way its predecessor
+ * did. That helper hung because the hook retried a failed replay as fast as
+ * its event loop allowed, so a test could only observe post-failure state by
+ * making the second attempt never resolve. Attempts are now spaced by an
+ * explicit backoff, which is exactly what these tests count.
  */
-function failingTransport() {
+function rejectingTransport(error: () => ApiError) {
   const attempts: TransportRequest[] = [];
   const transport: Transport = {
     request<T>(req: TransportRequest): Promise<TransportResult<T>> {
       attempts.push(req);
-      if (attempts.length === 1) return Promise.reject(new ApiError('', 500));
-      return new Promise<TransportResult<T>>(() => {});
+      return Promise.reject(error());
     },
   };
   return { transport, attempts };
+}
+
+/** Lets pending backoff timers and the promises they resolve into settle. */
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
 }
 
 describe('offline sale replay', () => {
@@ -70,6 +85,7 @@ describe('offline sale replay', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (online) Object.defineProperty(Navigator.prototype, 'onLine', online);
     useOfflineStore.setState({ queue: [], isSyncing: false });
   });
@@ -126,23 +142,6 @@ describe('offline sale replay', () => {
     expect(transport.calls()[0]).not.toHaveProperty('idempotencyKey');
   });
 
-  it('leaves a sale queued when the replay fails', async () => {
-    const { transport, attempts } = failingTransport();
-    queueOneSale();
-
-    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
-
-    await waitFor(() => expect(attempts.length).toBeGreaterThanOrEqual(1));
-    expect(attempts[0]).toEqual({ method: 'POST', path: 'sales', body: QUEUED_SALE });
-
-    // No attempt ever succeeds here, so the queue holding the sale is true at
-    // every instant rather than at one the assertion happened to catch.
-    expect(useOfflineStore.getState().queue).toHaveLength(1);
-    expect(useOfflineStore.getState().queue[0].payload).toBe(QUEUED_SALE);
-
-    unmount();
-  });
-
   it('does not replay anything while the till is offline', async () => {
     const transport: MemoryTransport = createMemoryTransport({ sales: [] });
     Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
@@ -152,7 +151,9 @@ describe('offline sale replay', () => {
       wrapper: wrapperFor(transport),
     });
 
-    await result.current.syncQueue();
+    await act(async () => {
+      await result.current.syncQueue();
+    });
 
     expect(transport.calls()).toEqual([]);
     expect(useOfflineStore.getState().queue).toHaveLength(1);
@@ -173,7 +174,9 @@ describe('offline sale replay', () => {
 
     const { result, unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
-    await result.current.syncQueue();
+    await act(async () => {
+      await result.current.syncQueue();
+    });
 
     expect(transport.calls()).toEqual([]);
     // Still there, visible for manual review -- not silently dropped either.
@@ -237,16 +240,378 @@ describe('offline sale replay', () => {
       isSyncing: false,
     });
 
-    const { result, unmount } = renderHook(() => useOffline(), {
+    const { unmount } = renderHook(() => useOffline(), {
       wrapper: wrapperFor(mismatchTransport),
     });
 
-    await result.current.syncQueue();
-
     // Not dropped, not resubmitted-as-successful -- stays for the cashier to
     // review and rebalance/re-ring.
+    await waitFor(() => expect(useOfflineStore.getState().queue[0].mismatched).toBe(true));
+    await waitFor(() => expect(useOfflineStore.getState().isSyncing).toBe(false));
     expect(useOfflineStore.getState().queue).toHaveLength(1);
-    expect(useOfflineStore.getState().isSyncing).toBe(false);
+    // Quarantined, not parked: the cashier sees one problem, not two.
+    expect(useOfflineStore.getState().queue[0].syncFailed).toBeUndefined();
+
+    unmount();
+  });
+});
+
+describe('offline sale replay - backoff and parking', () => {
+  let online: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    online = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (online) Object.defineProperty(Navigator.prototype, 'onLine', online);
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+  });
+
+  it('makes exactly one attempt before any backoff has elapsed', async () => {
+    // The issue's core claim. Before this fix the hook re-fired as fast as the
+    // event loop allowed for as long as the queue was non-empty, so this count
+    // was unbounded and a test could only observe state by hanging the second
+    // attempt.
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    queueOneSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(attempts).toHaveLength(1);
+
+    // Nothing spins in the gap before the first backoff expires.
+    await advance(500);
+    expect(attempts).toHaveLength(1);
+
+    unmount();
+  });
+
+  it('spaces each further attempt by a strictly longer backoff', async () => {
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    queueOneSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(attempts).toHaveLength(1);
+
+    // Past the first backoff step (1s base, +/-20% jitter).
+    await advance(1_500);
+    expect(attempts).toHaveLength(2);
+
+    // The second step is ~2s, so the window that produced attempt 2 is not
+    // enough on its own to produce attempt 3.
+    await advance(1_500);
+    expect(attempts).toHaveLength(2);
+
+    await advance(1_500);
+    expect(attempts).toHaveLength(3);
+
+    unmount();
+  });
+
+  it('dequeues and clears retry state when an attempt finally succeeds', async () => {
+    let failures = 0;
+    const transport: Transport = {
+      request<T>(): Promise<TransportResult<T>> {
+        if (failures++ < 2) return Promise.reject(new ApiError('', 503));
+        return Promise.resolve({ data: undefined as T });
+      },
+    };
+    queueOneSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(useOfflineStore.getState().queue[0].attempts).toBe(1);
+
+    await advance(10_000);
+
+    expect(useOfflineStore.getState().queue).toHaveLength(0);
+    expect(failures).toBe(3);
+
+    unmount();
+  });
+
+  it('parks a deterministic rejection on the first attempt and never retries it', async () => {
+    const { transport, attempts } = rejectingTransport(
+      () => new ApiError('bad request', 400, 'VALIDATION_ERROR')
+    );
+    queueOneSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+
+    const item = useOfflineStore.getState().queue[0];
+    expect(item.syncFailed).toBe(true);
+    expect(item.attempts).toBe(1);
+
+    // However far the clock runs, a rejection the server will repeat verbatim
+    // never consumes another attempt.
+    await advance(RETRY_CEILING_MS * 20);
+    expect(attempts).toHaveLength(1);
+
+    unmount();
+  });
+
+  it('parks an entry once the retryable budget runs out, and stops attempting', async () => {
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    queueOneSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    // Comfortably past the full ladder: ten steps capped at five minutes each.
+    // Stepped rather than one long jump, because each attempt's next timer is
+    // armed by a React effect that has to run between them.
+    for (let step = 0; step < MAX_RETRYABLE_ATTEMPTS + 2; step++) {
+      await advance(RETRY_CEILING_MS * 2);
+    }
+
+    expect(attempts).toHaveLength(MAX_RETRYABLE_ATTEMPTS);
+    expect(useOfflineStore.getState().queue[0].syncFailed).toBe(true);
+
+    await advance(RETRY_CEILING_MS * 20);
+    expect(attempts).toHaveLength(MAX_RETRYABLE_ATTEMPTS);
+    // Parked, never dropped -- the sale is still recoverable.
+    expect(useOfflineStore.getState().queue).toHaveLength(1);
+
+    unmount();
+  });
+
+  it('does no work and arms no timer for a queue of only quarantined entries', async () => {
+    // This is the case that busy-looped with zero network traffic: every entry
+    // was skipped, yet a non-empty queue kept re-firing the effect.
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    useOfflineStore.setState({
+      queue: [
+        { id: 1, createdAt: '', type: 'sale', payload: QUEUED_SALE }, // legacy
+        {
+          id: 2,
+          createdAt: '',
+          type: 'sale',
+          payload: QUEUED_SALE,
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          mismatched: true,
+        },
+      ],
+      isSyncing: false,
+    });
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+
+    expect(attempts).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+
+    unmount();
+  });
+
+  it('arms no timer for a queue of only parked entries', async () => {
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 1,
+          createdAt: '',
+          type: 'sale',
+          payload: QUEUED_SALE,
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          attempts: MAX_RETRYABLE_ATTEMPTS,
+          syncFailed: true,
+        },
+      ],
+      isSyncing: false,
+    });
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+
+    expect(attempts).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+
+    unmount();
+  });
+
+  it('issues no request for an entry still inside its backoff window', async () => {
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 1,
+          createdAt: '',
+          type: 'sale',
+          payload: QUEUED_SALE,
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          attempts: 1,
+          nextAttemptAt: new Date(Date.now() + 60_000).toISOString(),
+        },
+      ],
+      isSyncing: false,
+    });
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(59_000);
+    expect(attempts).toEqual([]);
+
+    await advance(2_000);
+    expect(attempts).toHaveLength(1);
+
+    unmount();
+  });
+
+  it('does not let a poison entry in backoff hold up a healthy one behind it', async () => {
+    const transport: Transport = {
+      request<T>(req: TransportRequest): Promise<TransportResult<T>> {
+        const body = req.body as { poison?: boolean };
+        if (body.poison) return Promise.reject(new ApiError('', 500));
+        return Promise.resolve({ data: undefined as T });
+      },
+    };
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 1,
+          createdAt: '',
+          type: 'sale',
+          payload: { poison: true },
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+        },
+        {
+          id: 2,
+          createdAt: '',
+          type: 'sale',
+          payload: { poison: false },
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+        },
+      ],
+      isSyncing: false,
+    });
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+
+    // The healthy sale went through on the same sweep the poison one failed on.
+    expect(useOfflineStore.getState().queue.map((item) => item.id)).toEqual([1]);
+    expect(useOfflineStore.getState().queue[0].attempts).toBe(1);
+
+    unmount();
+  });
+
+  it('retries immediately when the till reconnects, without forgiving attempts', async () => {
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 1,
+          createdAt: '',
+          type: 'sale',
+          payload: QUEUED_SALE,
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          attempts: 3,
+          nextAttemptAt: new Date(Date.now() + RETRY_CEILING_MS).toISOString(),
+        },
+      ],
+      isSyncing: false,
+    });
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(attempts).toEqual([]);
+
+    // A backoff computed against a dead link says nothing about a live one.
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+    });
+    await advance(0);
+
+    expect(attempts).toHaveLength(1);
+    // Attempt 4, not attempt 1: reconnecting is not a free pass for a sale the
+    // server keeps rejecting.
+    expect(useOfflineStore.getState().queue[0].attempts).toBe(4);
+
+    unmount();
+  });
+
+  it('replays under the same key on every retry, never a fresh one', async () => {
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 1,
+          createdAt: '',
+          type: 'sale',
+          payload: QUEUED_SALE,
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          idempotencyKey: 'checkout-attempt-key',
+        },
+      ],
+      isSyncing: false,
+    });
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    await advance(10_000);
+
+    expect(attempts.length).toBeGreaterThan(1);
+    // A fresh key per retry would let the server commit the sale once per
+    // attempt -- the exact double-charge the key exists to prevent.
+    expect(new Set(attempts.map((req) => req.idempotencyKey))).toEqual(
+      new Set(['checkout-attempt-key'])
+    );
+
+    unmount();
+  });
+
+  it('clears its pending backoff timer on unmount', async () => {
+    const { transport } = rejectingTransport(() => new ApiError('', 500));
+    queueOneSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('puts a parked sale back in play when the cashier retries it', async () => {
+    let reject = true;
+    const transport: Transport = {
+      request<T>(): Promise<TransportResult<T>> {
+        if (reject) return Promise.reject(new ApiError('bad request', 400));
+        return Promise.resolve({ data: undefined as T });
+      },
+    };
+    queueOneSale();
+
+    const { result, unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(result.current.failedCount).toBe(1);
+    expect(result.current.quarantinedCount).toBe(0);
+
+    reject = false;
+    await act(async () => {
+      result.current.retryFailed();
+    });
+    await advance(0);
+
+    expect(useOfflineStore.getState().queue).toHaveLength(0);
 
     unmount();
   });

--- a/client/src/shared/hooks/useOffline.test.tsx
+++ b/client/src/shared/hooks/useOffline.test.tsx
@@ -4,13 +4,9 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { ApiError, TransportProvider } from '../lib/transport/index';
 import type { Transport, TransportRequest, TransportResult } from '../lib/transport/index';
 import { createMemoryTransport, type MemoryTransport } from '../lib/transport/memory';
-import {
-  useOfflineStore,
-  SALE_QUEUE_CONTRACT_VERSION,
-  MAX_RETRYABLE_ATTEMPTS,
-  RETRY_CEILING_MS,
-} from '../store/offlineStore';
-import { useOffline } from './useOffline';
+import { useOfflineStore, SALE_QUEUE_CONTRACT_VERSION, isParked } from '../store/offlineStore';
+import { MAX_RETRYABLE_ATTEMPTS, RETRY_CEILING_MS } from '../lib/offlineRetry';
+import { useOffline, resetOfflineSchedulerForTests } from './useOffline';
 
 /**
  * The body CartPanel queues when the till loses its connection mid-checkout —
@@ -36,6 +32,27 @@ function queueOneSale() {
         // Composed under the current checkout contract (Unit 6) -- see the
         // "quarantined legacy sale" tests below for the unversioned case.
         contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+      },
+    ],
+    isSyncing: false,
+  });
+}
+
+/**
+ * The same sale, carrying the key it was stamped with at ring-up. Retrying is
+ * only safe under a key, so the backoff tests need one: a keyless entry is
+ * deliberately parked on its first failure rather than replayed unguarded.
+ */
+function queueOneKeyedSale() {
+  useOfflineStore.setState({
+    queue: [
+      {
+        id: 1,
+        createdAt: '2026-02-01T10:00:00.000Z',
+        type: 'sale',
+        payload: QUEUED_SALE,
+        contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+        idempotencyKey: 'checkout-attempt-key',
       },
     ],
     isSyncing: false,
@@ -85,12 +102,14 @@ describe('offline sale replay', () => {
     online = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
     useOfflineStore.setState({ queue: [], isSyncing: false });
+    resetOfflineSchedulerForTests();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     if (online) Object.defineProperty(Navigator.prototype, 'onLine', online);
     useOfflineStore.setState({ queue: [], isSyncing: false });
+    resetOfflineSchedulerForTests();
   });
 
   it('replays a queued sale with the exact body it was queued with', async () => {
@@ -266,6 +285,7 @@ describe('offline sale replay - backoff and parking', () => {
     online = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
     useOfflineStore.setState({ queue: [], isSyncing: false });
+    resetOfflineSchedulerForTests();
     vi.useFakeTimers();
   });
 
@@ -273,6 +293,7 @@ describe('offline sale replay - backoff and parking', () => {
     vi.useRealTimers();
     if (online) Object.defineProperty(Navigator.prototype, 'onLine', online);
     useOfflineStore.setState({ queue: [], isSyncing: false });
+    resetOfflineSchedulerForTests();
   });
 
   it('makes exactly one attempt before any backoff has elapsed', async () => {
@@ -281,7 +302,7 @@ describe('offline sale replay - backoff and parking', () => {
     // was unbounded and a test could only observe state by hanging the second
     // attempt.
     const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
-    queueOneSale();
+    queueOneKeyedSale();
 
     const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
@@ -297,7 +318,7 @@ describe('offline sale replay - backoff and parking', () => {
 
   it('spaces each further attempt by a strictly longer backoff', async () => {
     const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
-    queueOneSale();
+    queueOneKeyedSale();
 
     const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
@@ -334,14 +355,18 @@ describe('offline sale replay - backoff and parking', () => {
         return Promise.resolve({ data: undefined as T });
       },
     };
-    queueOneSale();
+    queueOneKeyedSale();
 
     const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
     await advance(0);
     expect(useOfflineStore.getState().queue[0].attempts).toBe(1);
 
-    await advance(10_000);
+    // Stepped: each attempt's next wake-up is armed by a React effect that has
+    // to run between them, so one long jump would outrun the scheduler.
+    for (let step = 0; step < 4; step++) {
+      await advance(2_500);
+    }
 
     expect(useOfflineStore.getState().queue).toHaveLength(0);
     expect(failures).toBe(3);
@@ -353,7 +378,7 @@ describe('offline sale replay - backoff and parking', () => {
     const { transport, attempts } = rejectingTransport(
       () => new ApiError('bad request', 400, 'VALIDATION_ERROR')
     );
-    queueOneSale();
+    queueOneKeyedSale();
 
     const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
@@ -373,7 +398,7 @@ describe('offline sale replay - backoff and parking', () => {
 
   it('parks an entry once the retryable budget runs out, and stops attempting', async () => {
     const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
-    queueOneSale();
+    queueOneKeyedSale();
 
     const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
@@ -495,6 +520,7 @@ describe('offline sale replay - backoff and parking', () => {
           type: 'sale',
           payload: { poison: true },
           contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          idempotencyKey: 'poison-key',
         },
         {
           id: 2,
@@ -502,6 +528,7 @@ describe('offline sale replay - backoff and parking', () => {
           type: 'sale',
           payload: { poison: false },
           contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          idempotencyKey: 'healthy-key',
         },
       ],
       isSyncing: false,
@@ -528,6 +555,7 @@ describe('offline sale replay - backoff and parking', () => {
           type: 'sale',
           payload: QUEUED_SALE,
           contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          idempotencyKey: 'checkout-attempt-key',
           attempts: 3,
           nextAttemptAt: new Date(Date.now() + RETRY_CEILING_MS).toISOString(),
         },
@@ -544,7 +572,12 @@ describe('offline sale replay - backoff and parking', () => {
     await act(async () => {
       window.dispatchEvent(new Event('online'));
     });
+    // Pulled in to about a second, not to zero -- every till in the shop gets
+    // this same event, and firing them all on the same instant is the stampede
+    // the jitter exists to prevent.
     await advance(0);
+    expect(attempts).toEqual([]);
+    await advance(1_500);
 
     expect(attempts).toHaveLength(1);
     // Attempt 4, not attempt 1: reconnecting is not a free pass for a sale the
@@ -587,7 +620,7 @@ describe('offline sale replay - backoff and parking', () => {
 
   it('clears its pending backoff timer on unmount', async () => {
     const { transport } = rejectingTransport(() => new ApiError('', 500));
-    queueOneSale();
+    queueOneKeyedSale();
 
     const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
@@ -607,7 +640,7 @@ describe('offline sale replay - backoff and parking', () => {
         return Promise.resolve({ data: undefined as T });
       },
     };
-    queueOneSale();
+    queueOneKeyedSale();
 
     const { result, unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
@@ -622,6 +655,217 @@ describe('offline sale replay - backoff and parking', () => {
     await advance(0);
 
     expect(useOfflineStore.getState().queue).toHaveLength(0);
+
+    unmount();
+  });
+});
+
+describe('offline sale replay - scheduler robustness', () => {
+  let online: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    online = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    resetOfflineSchedulerForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (online) Object.defineProperty(Navigator.prototype, 'onLine', online);
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    resetOfflineSchedulerForTests();
+  });
+
+  it('picks up a sale rung up while a sweep was already running', async () => {
+    // The sweep captured its work list before this entry existed, and the
+    // scheduler's scalar is already zero so no dependency changes -- the
+    // sweep's own tail check is the only thing that can catch it.
+    let release: (() => void) | undefined;
+    const posted: unknown[] = [];
+    const transport: Transport = {
+      request<T>(req: TransportRequest): Promise<TransportResult<T>> {
+        posted.push(req.body);
+        if (posted.length === 1) {
+          return new Promise<TransportResult<T>>((resolve) => {
+            release = () => resolve({ data: undefined as T });
+          });
+        }
+        return Promise.resolve({ data: undefined as T });
+      },
+    };
+    queueOneKeyedSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(posted).toHaveLength(1);
+
+    // Second sale rung up mid-sweep.
+    await act(async () => {
+      useOfflineStore.getState().addToQueue({
+        type: 'sale',
+        payload: { late: true },
+        contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+        idempotencyKey: 'late-key',
+      });
+    });
+    expect(posted).toHaveLength(1);
+
+    await act(async () => {
+      release?.();
+    });
+    await advance(0);
+
+    expect(posted).toHaveLength(2);
+    expect(useOfflineStore.getState().queue).toHaveLength(0);
+
+    unmount();
+  });
+
+  it('recovers from a replay that never settles instead of wedging the queue forever', async () => {
+    // No axios timeout backs this transport in production either, so without
+    // an explicit deadline the in-flight guard would stay raised for the life
+    // of the tab and every later sweep -- including the cashier's Retry --
+    // would silently no-op.
+    const attempts: TransportRequest[] = [];
+    const transport: Transport = {
+      request<T>(req: TransportRequest): Promise<TransportResult<T>> {
+        attempts.push(req);
+        return new Promise<TransportResult<T>>(() => {});
+      },
+    };
+    queueOneKeyedSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(attempts).toHaveLength(1);
+    // Still hanging: nothing has been recorded against the entry yet.
+    expect(useOfflineStore.getState().queue[0].attempts).toBeUndefined();
+
+    // Past the replay deadline.
+    await advance(31_000);
+
+    expect(useOfflineStore.getState().queue[0].attempts).toBe(1);
+    expect(useOfflineStore.getState().queue[0].syncFailed).toBeUndefined();
+
+    // And the queue keeps moving afterwards.
+    for (let step = 0; step < 3; step++) {
+      await advance(35_000);
+    }
+    expect(attempts.length).toBeGreaterThan(1);
+
+    unmount();
+  });
+
+  it('parks a keyless entry on its first failure rather than replaying it unguarded', async () => {
+    // Without a key the server cannot collapse a duplicate: if the original
+    // POST committed and only the response was lost, every retry rings the
+    // sale up again. A human decides instead.
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    queueOneSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+
+    expect(attempts).toHaveLength(1);
+    expect(isParked(useOfflineStore.getState().queue[0])).toBe(true);
+
+    for (let step = 0; step < 3; step++) {
+      await advance(RETRY_CEILING_MS);
+    }
+    expect(attempts).toHaveLength(1);
+
+    unmount();
+  });
+
+  it('does not burn the attempt budget when the link flaps', async () => {
+    // Attempts are spent per event, not per elapsed minute. Ten reconnects in
+    // a few seconds must not park a sale the budget was sized to carry through
+    // a multi-minute outage.
+    const { transport, attempts } = rejectingTransport(() => new ApiError('', 500));
+    queueOneKeyedSale();
+
+    const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(attempts).toHaveLength(1);
+
+    for (let flap = 0; flap < 10; flap++) {
+      await act(async () => {
+        window.dispatchEvent(new Event('offline'));
+        window.dispatchEvent(new Event('online'));
+      });
+      await advance(100);
+    }
+
+    // The throttle means the flapping produced at most the one reconnect
+    // retry, not ten -- nowhere near the budget.
+    expect(attempts.length).toBeLessThanOrEqual(3);
+    expect(useOfflineStore.getState().queue[0].syncFailed).toBeUndefined();
+
+    unmount();
+  });
+
+  it('replays what was queued offline once the till comes back', async () => {
+    // The end-to-end path: offline, nothing attempted; online, drained.
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    const transport: MemoryTransport = createMemoryTransport({ sales: [] });
+    queueOneKeyedSale();
+
+    const { result, unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
+
+    await advance(0);
+    expect(result.current.isOnline).toBe(false);
+    expect(transport.calls()).toEqual([]);
+    expect(result.current.queueLength).toBe(1);
+
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+    });
+    await advance(1_500);
+
+    expect(result.current.isOnline).toBe(true);
+    expect(transport.calls()).toHaveLength(1);
+    // The counts the banner renders track the store at every step.
+    expect(result.current.queueLength).toBe(0);
+    expect(result.current.failedCount).toBe(0);
+    expect(result.current.quarantinedCount).toBe(0);
+
+    unmount();
+  });
+
+  it('does not re-render its consumer on every store write', async () => {
+    // The plan's named root cause: the old hook destructured the whole store,
+    // so each sweep's setSyncing re-rendered it -- and Layout beneath it,
+    // which wraps every authenticated page. Counting attempts alone would not
+    // catch a regression here, because the scheduler now gates those.
+    const { transport } = rejectingTransport(() => new ApiError('', 500));
+    queueOneKeyedSale();
+
+    let renders = 0;
+    const { unmount } = renderHook(
+      () => {
+        renders++;
+        return useOffline();
+      },
+      { wrapper: wrapperFor(transport) }
+    );
+
+    await advance(0);
+    const afterFirstSweep = renders;
+
+    // setSyncing is written twice per sweep and nothing here subscribes to it.
+    await act(async () => {
+      useOfflineStore.getState().setSyncing(true);
+      useOfflineStore.getState().setSyncing(false);
+    });
+
+    expect(renders).toBe(afterFirstSweep);
 
     unmount();
   });

--- a/client/src/shared/hooks/useOffline.test.tsx
+++ b/client/src/shared/hooks/useOffline.test.tsx
@@ -73,6 +73,9 @@ async function advance(ms: number) {
   await act(async () => {
     await vi.advanceTimersByTimeAsync(ms);
   });
+  // The next timer is armed by a React effect, which only runs once the sweep's
+  // state updates have been committed -- so give that a turn before asserting.
+  await act(async () => {});
 }
 
 describe('offline sale replay', () => {
@@ -298,20 +301,27 @@ describe('offline sale replay - backoff and parking', () => {
 
     const { unmount } = renderHook(() => useOffline(), { wrapper: wrapperFor(transport) });
 
+    // Elapsed times chosen so jitter cannot make any of these ambiguous.
+    // Steps are 1s, 2s and 4s at +/-20%, so attempt 2 lands in [800, 1200],
+    // attempt 3 in [2400, 3600] and attempt 4 in [5600, 8400] -- non-overlapping
+    // windows, which is what "each gap is longer than the last" means here.
     await advance(0);
     expect(attempts).toHaveLength(1);
 
-    // Past the first backoff step (1s base, +/-20% jitter).
     await advance(1_500);
     expect(attempts).toHaveLength(2);
 
-    // The second step is ~2s, so the window that produced attempt 2 is not
-    // enough on its own to produce attempt 3.
-    await advance(1_500);
+    // t=2000: still short of the earliest attempt 3.
+    await advance(500);
     expect(attempts).toHaveLength(2);
 
-    await advance(1_500);
+    // t=4000: past the latest attempt 3, short of the earliest attempt 4.
+    await advance(2_000);
     expect(attempts).toHaveLength(3);
+
+    // t=9000: past the latest attempt 4, short of the earliest attempt 5.
+    await advance(5_000);
+    expect(attempts).toHaveLength(4);
 
     unmount();
   });

--- a/client/src/shared/hooks/useOffline.ts
+++ b/client/src/shared/hooks/useOffline.ts
@@ -1,14 +1,16 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import toast from 'react-hot-toast';
 import { useTransport } from '../lib/transport/index';
+import { ApiError } from '../lib/transport/types';
 import {
   useOfflineStore,
   isQuarantined,
+  isParked,
   isEligible,
   earliestAttemptAt,
 } from '../store/offlineStore';
 import { t } from '../i18n/index';
-import { classifyFailure, FAILURE_REASON } from '../lib/offlineRetry';
+import { classifyFailure, FAILURE_REASON, RETRY_CEILING_MS } from '../lib/offlineRetry';
 
 /**
  * Guards a sweep against re-entry. Module-scoped, not a ref, because the queue
@@ -21,6 +23,62 @@ import { classifyFailure, FAILURE_REASON } from '../lib/offlineRetry';
  * to deadlock the queue when a killed tab persisted it as true.
  */
 let sweepInFlight = false;
+
+/**
+ * Test-only. Both module-scoped values outlive any component, and vitest
+ * isolates the module registry per file rather than per test -- so a stranded
+ * guard would silently no-op every later sweep, and a stale reconnect stamp
+ * would silently swallow the next `online` event.
+ */
+export function resetOfflineSchedulerForTests(): void {
+  sweepInFlight = false;
+  lastReconnectRetryAt = 0;
+}
+
+/**
+ * A replay that never settles used to hold `sweepInFlight` forever, and the
+ * axios instance sets no timeout -- so a black-holed connection (a captive
+ * portal on shop wifi, a half-open socket after an access-point handover)
+ * silently killed the queue for the life of the tab. The old busy loop was
+ * accidentally its own recovery path; removing the loop removed that, so the
+ * deadline has to be explicit.
+ *
+ * The underlying request is not cancelled, only abandoned. That is safe: it
+ * carries the same `Idempotency-Key`, so if it does land the retry collapses
+ * onto the original outcome instead of charging twice.
+ */
+const REPLAY_TIMEOUT_MS = 30_000;
+
+/**
+ * The shortest gap between two reconnect-driven retries. Without it a flapping
+ * link burns the whole attempt budget in seconds: every `online` event pulls
+ * every entry forward, each sweep fails, and ten flaps park a sale that a
+ * budget sized for a 40-minute outage was meant to carry through.
+ */
+const RECONNECT_RETRY_THROTTLE_MS = 60_000;
+
+let lastReconnectRetryAt = 0;
+
+function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      // A null status is the shape http.ts produces for "never reached the
+      // server", which is exactly what this is, and classifies as retryable.
+      () => reject(new ApiError('', null)),
+      ms
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
 
 interface UseOfflineReturn {
   isOnline: boolean;
@@ -36,15 +94,16 @@ interface UseOfflineReturn {
 
 export function useOffline(): UseOfflineReturn {
   const [isOnline, setIsOnline] = useState(navigator.onLine);
+  // Bumped when a scheduled wake-up lands, so the scheduler effect re-measures
+  // the wait instead of trusting a delay it may have clamped.
+  const [schedulerTick, setSchedulerTick] = useState(0);
   // Narrow, scalar subscriptions on purpose. Destructuring the whole store
   // re-rendered this hook -- and Layout beneath it, which wraps every
   // authenticated page -- on every unrelated `set()`, including the two
   // `setSyncing` calls each sweep makes.
   const queueLength = useOfflineStore((state) => state.queue.length);
   const quarantinedCount = useOfflineStore((state) => state.queue.filter(isQuarantined).length);
-  const failedCount = useOfflineStore(
-    (state) => state.queue.filter((item) => item.syncFailed === true).length
-  );
+  const failedCount = useOfflineStore((state) => state.queue.filter(isParked).length);
   // The single scalar that drives auto-sync: when the queue next wants a
   // sweep, or null when it never will on its own.
   const nextAttemptAt = useOfflineStore((state) => earliestAttemptAt(state.queue));
@@ -58,9 +117,14 @@ export function useOffline(): UseOfflineReturn {
     const handleOnline = () => {
       setIsOnline(true);
       // A backoff computed against a dead link says nothing about a live one,
-      // so reconnecting retries at once. Attempts are untouched, so a poison
-      // entry still parks on schedule.
-      useOfflineStore.getState().clearBackoff();
+      // so reconnecting pulls the queue forward -- but throttled, because
+      // attempts are spent per event, not per elapsed minute, and a flapping
+      // link would otherwise park perfectly healthy sales.
+      const now = Date.now();
+      if (now - lastReconnectRetryAt >= RECONNECT_RETRY_THROTTLE_MS) {
+        lastReconnectRetryAt = now;
+        useOfflineStore.getState().retrySoon();
+      }
       toast.success(t('offline.backOnline'));
     };
     const handleOffline = () => {
@@ -70,6 +134,10 @@ export function useOffline(): UseOfflineReturn {
 
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
+    // `navigator.onLine` was sampled during render, before these listeners
+    // existed. A transition in that window would otherwise be lost for the
+    // life of the session, leaving the scheduler permanently short-circuited.
+    setIsOnline(navigator.onLine);
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
@@ -95,11 +163,15 @@ export function useOffline(): UseOfflineReturn {
     if (due.length === 0) return;
 
     sweepInFlight = true;
-    setSyncing(true);
     let synced = 0;
     let mismatched = 0;
 
     try {
+      // Inside the try: zustand's persist wrapper rethrows a storage failure
+      // (a full or disabled localStorage) straight out of `set`, and raising
+      // the guard without a matching release would strand the queue for good.
+      setSyncing(true);
+
       for (const item of due) {
         try {
           // The queued payload goes up untouched — it is the body the till
@@ -107,15 +179,18 @@ export function useOffline(): UseOfflineReturn {
           // different sale than the one the cashier rang up. The server
           // still independently prices every line and validates any split
           // against its own authoritative total.
-          await transport.request({
-            method: 'POST',
-            path: 'sales',
-            body: item.payload,
-            // Omitted entirely for an entry queued before keys existed, so it
-            // replays exactly as it did before rather than under a key the
-            // server never saw.
-            ...(item.idempotencyKey ? { idempotencyKey: item.idempotencyKey } : {}),
-          });
+          await withDeadline(
+            transport.request({
+              method: 'POST',
+              path: 'sales',
+              body: item.payload,
+              // Omitted entirely for an entry queued before keys existed, so it
+              // replays exactly as it did before rather than under a key the
+              // server never saw.
+              ...(item.idempotencyKey ? { idempotencyKey: item.idempotencyKey } : {}),
+            }),
+            REPLAY_TIMEOUT_MS
+          );
           removeFromQueue(item.id);
           synced++;
         } catch (err) {
@@ -127,6 +202,13 @@ export function useOffline(): UseOfflineReturn {
             // a sync failure -- the cashier sees one problem, not two.
             markMismatched(item.id);
             mismatched++;
+          } else if (outcome.retryable && !item.idempotencyKey) {
+            // The retry budget is only safe because a replay carries a key the
+            // server can collapse onto one sale. This entry predates keys, so
+            // every retry is an unguarded financial write: if the original POST
+            // committed and only the response was lost, retrying rings the sale
+            // up again. Park it on the first failure and let a human decide.
+            recordFailure(item.id, { retryable: false, reason: FAILURE_REASON.unguardedReplay });
           } else {
             recordFailure(item.id, outcome);
           }
@@ -154,22 +236,35 @@ export function useOffline(): UseOfflineReturn {
     }
   }, [isOnline, transport]);
 
-  syncQueueRef.current = syncQueue;
+  // Assigned in an effect, not during render: a render can be started and
+  // discarded, and a discarded render must not publish a callback closing over
+  // connectivity state the committed tree disagrees with.
+  useEffect(() => {
+    syncQueueRef.current = syncQueue;
+  }, [syncQueue]);
 
   // Auto-sync, driven by when the queue is next due rather than by callback
   // identity. Nothing due ever => no timer at all.
   useEffect(() => {
     if (!isOnline || nextAttemptAt === null) return;
 
-    const delay = nextAttemptAt - Date.now();
-    if (delay <= 0) {
+    // Clamped because `nextAttemptAt` is an absolute wall-clock instant: a
+    // clock correction can put it arbitrarily far out, and past the int32
+    // timer limit setTimeout fires immediately instead of waiting.
+    const delay = Math.min(Math.max(nextAttemptAt - Date.now(), 0), RETRY_CEILING_MS);
+    if (delay === 0) {
       void syncQueue();
       return;
     }
 
-    const timer = setTimeout(() => void syncQueue(), delay);
+    // The timer advances a tick rather than sweeping directly. A clamped delay
+    // can expire before the entry is actually due, and a blind sweep would
+    // then do nothing, write nothing, leave every dependency unchanged and
+    // wedge the queue -- whereas a tick re-runs this effect, which re-measures
+    // against the current clock and arms the next slice.
+    const timer = setTimeout(() => setSchedulerTick((tick) => tick + 1), delay);
     return () => clearTimeout(timer);
-  }, [isOnline, nextAttemptAt, syncQueue]);
+  }, [isOnline, nextAttemptAt, syncQueue, schedulerTick]);
 
   const retryFailed = useCallback(() => {
     useOfflineStore.getState().clearRetryState();

--- a/client/src/shared/hooks/useOffline.ts
+++ b/client/src/shared/hooks/useOffline.ts
@@ -10,6 +10,18 @@ import {
 import { t } from '../i18n/index';
 import { classifyFailure, FAILURE_REASON } from '../lib/offlineRetry';
 
+/**
+ * Guards a sweep against re-entry. Module-scoped, not a ref, because the queue
+ * it protects is a single global store: two mounted consumers would otherwise
+ * each hold their own guard and post the same sale twice. (The shared
+ * `Idempotency-Key` means the server would still commit it once -- this keeps
+ * the till from making the request at all.)
+ *
+ * Deliberately not the store's `isSyncing`, which is a UI indicator and used
+ * to deadlock the queue when a killed tab persisted it as true.
+ */
+let sweepInFlight = false;
+
 interface UseOfflineReturn {
   isOnline: boolean;
   syncQueue: () => Promise<void>;
@@ -41,10 +53,6 @@ export function useOffline(): UseOfflineReturn {
   // callback long after render, but the transport it closes over is stable for
   // the life of the component, so nothing has to reach for it at call time.
   const transport = useTransport();
-  // Guards re-entry within this session. Deliberately not the store's
-  // `isSyncing`, which is a UI indicator and used to deadlock the queue when a
-  // killed tab persisted it as true.
-  const inFlight = useRef(false);
 
   useEffect(() => {
     const handleOnline = () => {
@@ -73,7 +81,7 @@ export function useOffline(): UseOfflineReturn {
   const syncQueueRef = useRef<() => Promise<void>>(async () => {});
 
   const syncQueue = useCallback(async () => {
-    if (!isOnline || inFlight.current) return;
+    if (!isOnline || sweepInFlight) return;
 
     // Read at call time rather than closing over the queue: a callback whose
     // identity changes on every store write is what drove the old effect to
@@ -86,7 +94,7 @@ export function useOffline(): UseOfflineReturn {
     // queue holding only quarantined, parked or backing-off entries lands here.
     if (due.length === 0) return;
 
-    inFlight.current = true;
+    sweepInFlight = true;
     setSyncing(true);
     let synced = 0;
     let mismatched = 0;
@@ -125,7 +133,7 @@ export function useOffline(): UseOfflineReturn {
         }
       }
     } finally {
-      inFlight.current = false;
+      sweepInFlight = false;
       setSyncing(false);
     }
 

--- a/client/src/shared/hooks/useOffline.ts
+++ b/client/src/shared/hooks/useOffline.ts
@@ -1,31 +1,58 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import toast from 'react-hot-toast';
 import { useTransport } from '../lib/transport/index';
-import { ApiError } from '../lib/transport/types';
-import { useOfflineStore, isQuarantined } from '../store/offlineStore';
+import {
+  useOfflineStore,
+  isQuarantined,
+  isEligible,
+  earliestAttemptAt,
+} from '../store/offlineStore';
 import { t } from '../i18n/index';
-import { SPLIT_PAYMENT_MISMATCH_CODE } from '../lib/checkout';
+import { classifyFailure, FAILURE_REASON } from '../lib/offlineRetry';
 
 interface UseOfflineReturn {
   isOnline: boolean;
   syncQueue: () => Promise<void>;
   queueLength: number;
-  /** Legacy unversioned queued sales awaiting manual cashier review -- never auto-replayed. */
+  /** Legacy unversioned or split-mismatched queued sales -- never auto-replayed. */
   quarantinedCount: number;
+  /** Sales parked after a failed replay, awaiting an explicit cashier Retry. */
+  failedCount: number;
+  /** Puts every parked sale back in play; the scheduler picks it up from there. */
+  retryFailed: () => void;
 }
 
 export function useOffline(): UseOfflineReturn {
   const [isOnline, setIsOnline] = useState(navigator.onLine);
-  const { queue, removeFromQueue, markMismatched, setSyncing, isSyncing } = useOfflineStore();
+  // Narrow, scalar subscriptions on purpose. Destructuring the whole store
+  // re-rendered this hook -- and Layout beneath it, which wraps every
+  // authenticated page -- on every unrelated `set()`, including the two
+  // `setSyncing` calls each sweep makes.
+  const queueLength = useOfflineStore((state) => state.queue.length);
+  const quarantinedCount = useOfflineStore((state) => state.queue.filter(isQuarantined).length);
+  const failedCount = useOfflineStore(
+    (state) => state.queue.filter((item) => item.syncFailed === true).length
+  );
+  // The single scalar that drives auto-sync: when the queue next wants a
+  // sweep, or null when it never will on its own.
+  const nextAttemptAt = useOfflineStore((state) => earliestAttemptAt(state.queue));
   // Taken here, at the top of the hook, so the replay below runs on the same
   // transport CartPanel posted the sale on. The replay itself happens in a
   // callback long after render, but the transport it closes over is stable for
   // the life of the component, so nothing has to reach for it at call time.
   const transport = useTransport();
+  // Guards re-entry within this session. Deliberately not the store's
+  // `isSyncing`, which is a UI indicator and used to deadlock the queue when a
+  // killed tab persisted it as true.
+  const inFlight = useRef(false);
 
   useEffect(() => {
     const handleOnline = () => {
       setIsOnline(true);
+      // A backoff computed against a dead link says nothing about a live one,
+      // so reconnecting retries at once. Attempts are untouched, so a poison
+      // entry still parks on schedule.
+      useOfflineStore.getState().clearBackoff();
       toast.success(t('offline.backOnline'));
     };
     const handleOffline = () => {
@@ -41,29 +68,37 @@ export function useOffline(): UseOfflineReturn {
     };
   }, []);
 
-  const syncQueue = useCallback(async () => {
-    if (!isOnline || isSyncing || queue.length === 0) return;
+  // syncQueue re-invokes itself at the end of a sweep; a ref keeps that from
+  // making the callback depend on its own identity.
+  const syncQueueRef = useRef<() => Promise<void>>(async () => {});
 
+  const syncQueue = useCallback(async () => {
+    if (!isOnline || inFlight.current) return;
+
+    // Read at call time rather than closing over the queue: a callback whose
+    // identity changes on every store write is what drove the old effect to
+    // re-fire without pause after a failed replay.
+    const { queue, removeFromQueue, markMismatched, recordFailure, setSyncing } =
+      useOfflineStore.getState();
+    const now = Date.now();
+    const due = queue.filter((item) => isEligible(item, now));
+    // Nothing to do -- and nothing written, so no re-render and no churn. A
+    // queue holding only quarantined, parked or backing-off entries lands here.
+    if (due.length === 0) return;
+
+    inFlight.current = true;
     setSyncing(true);
     let synced = 0;
     let mismatched = 0;
 
-    for (const item of queue) {
-      // Quarantined legacy sales are never auto-submitted -- they stay in the
-      // queue for manual review, and skipping them here does not block any
-      // other (non-sale, or current-contract) entry in a mixed queue.
-      if (isQuarantined(item)) continue;
-
-      try {
-        if (item.type === 'sale') {
+    try {
+      for (const item of due) {
+        try {
           // The queued payload goes up untouched — it is the body the till
           // already composed, and a replay that reshaped it would post a
           // different sale than the one the cashier rang up. The server
           // still independently prices every line and validates any split
-          // against its own authoritative total (Units 2/4), so this is the
-          // "revalidates against the current authoritative total before
-          // submission" the plan calls for -- the check happens server-side,
-          // not by recomputing the total here first.
+          // against its own authoritative total.
           await transport.request({
             method: 'POST',
             path: 'sales',
@@ -75,45 +110,69 @@ export function useOffline(): UseOfflineReturn {
           });
           removeFromQueue(item.id);
           synced++;
+        } catch (err) {
+          const outcome = classifyFailure(err);
+          if (outcome.reason === FAILURE_REASON.splitMismatch) {
+            // Something changed since this sale was queued (catalog price, tax,
+            // coupon/loyalty settings) and its split no longer balances. It
+            // keeps its own quarantine state rather than also being counted as
+            // a sync failure -- the cashier sees one problem, not two.
+            markMismatched(item.id);
+            mismatched++;
+          } else {
+            recordFailure(item.id, outcome);
+          }
         }
-      } catch (err) {
-        const isSplitMismatch =
-          err instanceof ApiError &&
-          err.details?.some((d) => d.code === SPLIT_PAYMENT_MISMATCH_CODE);
-        if (isSplitMismatch) {
-          // Something changed since this sale was queued (catalog price, tax,
-          // coupon/loyalty settings) and its split no longer balances. Flag it
-          // as quarantined so it stays queued for a cashier to review and
-          // rebalance/re-ring, instead of being silently re-posted (and
-          // re-failing) on every subsequent sync.
-          markMismatched(item.id);
-          mismatched++;
-        }
-        // Any other failure (still offline, server error): keep in queue and
-        // retry on the next sync.
       }
+    } finally {
+      inFlight.current = false;
+      setSyncing(false);
     }
 
-    setSyncing(false);
     if (synced > 0) {
       toast.success(t('offline.synced', { count: synced }));
     }
     if (mismatched > 0) {
       toast.error(t('offline.splitMismatch', { count: mismatched }));
     }
-  }, [isOnline, isSyncing, queue, removeFromQueue, markMismatched, setSyncing, transport]);
 
-  // Auto-sync when coming back online
-  useEffect(() => {
-    if (isOnline && queue.length > 0) {
-      syncQueue();
+    // A sale rung up while this sweep was running was not in `due` and cannot
+    // move the scheduler's scalar (it is already zero), so it would otherwise
+    // sit until something else woke the queue. This terminates: every sweep
+    // leaves each entry it touched removed, parked, or scheduled into the
+    // future, so only genuinely new work re-enters here.
+    if (useOfflineStore.getState().queue.some((item) => isEligible(item))) {
+      void syncQueueRef.current();
     }
-  }, [isOnline, queue.length, syncQueue]);
+  }, [isOnline, transport]);
+
+  syncQueueRef.current = syncQueue;
+
+  // Auto-sync, driven by when the queue is next due rather than by callback
+  // identity. Nothing due ever => no timer at all.
+  useEffect(() => {
+    if (!isOnline || nextAttemptAt === null) return;
+
+    const delay = nextAttemptAt - Date.now();
+    if (delay <= 0) {
+      void syncQueue();
+      return;
+    }
+
+    const timer = setTimeout(() => void syncQueue(), delay);
+    return () => clearTimeout(timer);
+  }, [isOnline, nextAttemptAt, syncQueue]);
+
+  const retryFailed = useCallback(() => {
+    useOfflineStore.getState().clearRetryState();
+  }, []);
 
   return {
     isOnline,
     syncQueue,
-    queueLength: queue.length,
-    quarantinedCount: queue.filter(isQuarantined).length,
+    queueLength,
+    quarantinedCount,
+    failedCount,
+    retryFailed,
   };
 }

--- a/client/src/shared/i18n/ar.json
+++ b/client/src/shared/i18n/ar.json
@@ -603,6 +603,8 @@
   "offline.synced": "تمت مزامنة {count} عملية بيع",
   "offline.splitMismatch": "{count} عملية بيع في الانتظار لم تعد متوازنة -- يرجى المراجعة قبل إعادة المحاولة",
   "offline.quarantinedForReview": "{count} منها يحتاج إلى مراجعة يدوية قبل المزامنة.",
+  "offline.failedToSync": "فشلت مزامنة {count} عملية بيع -- لن تتم إعادة المحاولة تلقائياً.",
+  "offline.retry": "إعادة المحاولة",
 
   "pwa.installApp": "تثبيت تطبيق MOON",
   "pwa.installDesc": "ثبّت التطبيق للوصول السريع والعمل بدون إنترنت",

--- a/client/src/shared/i18n/en.json
+++ b/client/src/shared/i18n/en.json
@@ -604,6 +604,8 @@
   "offline.synced": "{count} offline sale(s) synced",
   "offline.splitMismatch": "{count} queued sale(s) no longer balance -- please review before retrying",
   "offline.quarantinedForReview": "{count} of these need manual review before they can sync.",
+  "offline.failedToSync": "{count} queued sale(s) failed to sync -- they will not retry on their own.",
+  "offline.retry": "Retry",
 
   "pwa.installApp": "Install MOON App",
   "pwa.installDesc": "Install for quick access and offline support",

--- a/client/src/shared/lib/offlineRetry.test.ts
+++ b/client/src/shared/lib/offlineRetry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ApiError } from './transport/types';
 import { classifyFailure, FAILURE_REASON } from './offlineRetry';
-import { RETRY_CEILING_MS } from '@/shared/store/offlineStore';
+import { RETRY_CEILING_MS } from './offlineRetry';
 
 describe('classifyFailure - retryable', () => {
   it('treats a network failure as retryable', () => {

--- a/client/src/shared/lib/offlineRetry.test.ts
+++ b/client/src/shared/lib/offlineRetry.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { ApiError } from './transport/types';
+import { classifyFailure, FAILURE_REASON } from './offlineRetry';
+import { RETRY_CEILING_MS } from '@/shared/store/offlineStore';
+
+describe('classifyFailure - retryable', () => {
+  it('treats a network failure as retryable', () => {
+    // The exact shape http.ts produces when axios never reached the server:
+    // no status, and the message deliberately blanked.
+    expect(classifyFailure(new ApiError('', null))).toEqual({
+      retryable: true,
+      reason: FAILURE_REASON.network,
+    });
+  });
+
+  it.each([500, 502, 503, 504])('treats a %i as retryable', (status) => {
+    expect(classifyFailure(new ApiError('', status))).toEqual({
+      retryable: true,
+      reason: FAILURE_REASON.serverError,
+    });
+  });
+
+  it('treats a 408 timeout as retryable', () => {
+    expect(classifyFailure(new ApiError('', 408))).toMatchObject({ retryable: true });
+  });
+
+  it('treats a 429 as retryable, but not before the backoff ceiling', () => {
+    // Retrying a rate limiter on the 1s base step is how a till earns a
+    // longer ban, so this failure alone carries its own floor.
+    expect(classifyFailure(new ApiError('', 429))).toEqual({
+      retryable: true,
+      reason: FAILURE_REASON.rateLimited,
+      minDelayMs: RETRY_CEILING_MS,
+    });
+  });
+
+  it('treats a 401 as retryable, since the transport may refresh the token', () => {
+    expect(classifyFailure(new ApiError('', 401))).toMatchObject({ retryable: true });
+  });
+
+  it('treats an unresolved idempotency claim as retryable', () => {
+    // The server's own message says "Please retry" -- nothing conflicts, a
+    // concurrent twin just held the claim past the lock timeout.
+    const error = new ApiError('still being processed', 409, 'CONFLICT', [
+      { field: 'Idempotency-Key', code: 'IDEMPOTENCY_UNRESOLVED', message: 'Please retry.' },
+    ]);
+    expect(classifyFailure(error)).toEqual({
+      retryable: true,
+      reason: FAILURE_REASON.idempotencyUnresolved,
+    });
+  });
+});
+
+describe('classifyFailure - terminal', () => {
+  it('parks a reused idempotency key', () => {
+    // Same key, different payload. A replay is guaranteed to fail identically;
+    // getting this backwards against IDEMPOTENCY_UNRESOLVED spins forever.
+    const error = new ApiError('already used', 409, 'CONFLICT', [
+      { field: 'Idempotency-Key', code: 'IDEMPOTENCY_KEY_REUSED', message: 'already used' },
+    ]);
+    expect(classifyFailure(error)).toEqual({
+      retryable: false,
+      reason: FAILURE_REASON.idempotencyKeyReused,
+    });
+  });
+
+  it('parks a split-payment mismatch and names it as such', () => {
+    const error = new ApiError('Split payment mismatch', 400, 'VALIDATION_ERROR', [
+      { field: 'payments', code: 'SPLIT_PAYMENT_MISMATCH', message: 'stale split' },
+    ]);
+    expect(classifyFailure(error)).toEqual({
+      retryable: false,
+      reason: FAILURE_REASON.splitMismatch,
+    });
+  });
+
+  it.each([400, 403, 404, 422])('parks a plain %i', (status) => {
+    expect(classifyFailure(new ApiError('', status))).toEqual({
+      retryable: false,
+      reason: FAILURE_REASON.rejected,
+    });
+  });
+
+  it('parks a 409 carrying no details, since the conflict is unknown', () => {
+    expect(classifyFailure(new ApiError('', 409, 'CONFLICT'))).toEqual({
+      retryable: false,
+      reason: FAILURE_REASON.rejected,
+    });
+  });
+
+  it.each([
+    ['a plain Error', new Error('boom')],
+    ['a thrown string', 'boom'],
+    ['undefined', undefined],
+  ])('parks %s, so a bug in the replay surfaces instead of retrying forever', (_label, thrown) => {
+    expect(classifyFailure(thrown)).toEqual({
+      retryable: false,
+      reason: FAILURE_REASON.unexpected,
+    });
+  });
+});

--- a/client/src/shared/lib/offlineRetry.ts
+++ b/client/src/shared/lib/offlineRetry.ts
@@ -1,0 +1,87 @@
+/**
+ * How a failed offline-sale replay should be treated.
+ *
+ * This is the single place that decides retryable vs terminal. A server error
+ * code that should start being retried is added here and nowhere else.
+ *
+ * The distinction matters in both directions: retrying a rejection the server
+ * will never accept is the busy loop this module exists to end, just slower --
+ * and parking a transient failure forces a cashier to re-ring a sale that
+ * would have gone through on its own.
+ */
+
+import { ApiError } from './transport/types';
+import { SPLIT_PAYMENT_MISMATCH_CODE } from './checkout';
+import { RETRY_CEILING_MS, type FailureOutcome } from '@/shared/store/offlineStore';
+
+/**
+ * Both are 409s and they are easy to conflate. `IDEMPOTENCY_UNRESOLVED` means
+ * a concurrent twin held the claim past the server's lock timeout -- nothing
+ * conflicts and the server's own message says to retry. `IDEMPOTENCY_KEY_REUSED`
+ * means the key now identifies a different payload, which no amount of waiting
+ * fixes. Mirrors `server/src/http/idempotency.ts`, which puts the code in
+ * `details[0].code` under a generic `CONFLICT`.
+ */
+const IDEMPOTENCY_UNRESOLVED = 'IDEMPOTENCY_UNRESOLVED';
+const IDEMPOTENCY_KEY_REUSED = 'IDEMPOTENCY_KEY_REUSED';
+
+/** Short, stable reasons -- persisted on the entry and shown to support. */
+export const FAILURE_REASON = {
+  network: 'network',
+  serverError: 'server-error',
+  timeout: 'timeout',
+  rateLimited: 'rate-limited',
+  unauthorized: 'unauthorized',
+  idempotencyUnresolved: 'idempotency-unresolved',
+  idempotencyKeyReused: 'idempotency-key-reused',
+  splitMismatch: 'split-mismatch',
+  rejected: 'rejected',
+  unexpected: 'unexpected',
+} as const;
+
+export function classifyFailure(error: unknown): FailureOutcome {
+  // Not an ApiError means the throw came from the replay code itself, not the
+  // server. Park it so the defect reaches a human instead of retrying forever.
+  if (!(error instanceof ApiError)) {
+    return { retryable: false, reason: FAILURE_REASON.unexpected };
+  }
+
+  const codes = error.details?.map((detail) => detail.code) ?? [];
+  if (codes.includes(SPLIT_PAYMENT_MISMATCH_CODE)) {
+    return { retryable: false, reason: FAILURE_REASON.splitMismatch };
+  }
+  if (codes.includes(IDEMPOTENCY_KEY_REUSED)) {
+    return { retryable: false, reason: FAILURE_REASON.idempotencyKeyReused };
+  }
+  if (codes.includes(IDEMPOTENCY_UNRESOLVED)) {
+    return { retryable: true, reason: FAILURE_REASON.idempotencyUnresolved };
+  }
+
+  // http.ts leaves the status null when the request never reached the server.
+  if (error.status === null) {
+    return { retryable: true, reason: FAILURE_REASON.network };
+  }
+  if (error.status >= 500) {
+    return { retryable: true, reason: FAILURE_REASON.serverError };
+  }
+  if (error.status === 408) {
+    return { retryable: true, reason: FAILURE_REASON.timeout };
+  }
+  if (error.status === 429) {
+    // Retrying a rate limiter on the 1s base step earns a longer ban, so this
+    // one failure carries its own floor rather than climbing to it.
+    return {
+      retryable: true,
+      reason: FAILURE_REASON.rateLimited,
+      minDelayMs: RETRY_CEILING_MS,
+    };
+  }
+  if (error.status === 401) {
+    // The transport's refresh interceptor may recover this; a hard failure
+    // redirects to login, which moots the question.
+    return { retryable: true, reason: FAILURE_REASON.unauthorized };
+  }
+
+  // Any other 4xx is deterministic: a replay produces the identical rejection.
+  return { retryable: false, reason: FAILURE_REASON.rejected };
+}

--- a/client/src/shared/lib/offlineRetry.ts
+++ b/client/src/shared/lib/offlineRetry.ts
@@ -1,5 +1,6 @@
 /**
- * How a failed offline-sale replay should be treated.
+ * The retry policy for replaying offline sales: how a failure is classified,
+ * and how long to wait before trying again.
  *
  * This is the single place that decides retryable vs terminal. A server error
  * code that should start being retried is added here and nowhere else.
@@ -12,7 +13,6 @@
 
 import { ApiError } from './transport/types';
 import { SPLIT_PAYMENT_MISMATCH_CODE } from './checkout';
-import { RETRY_CEILING_MS, type FailureOutcome } from '@/shared/store/offlineStore';
 
 /**
  * Both are 409s and they are easy to conflate. `IDEMPOTENCY_UNRESOLVED` means
@@ -24,6 +24,50 @@ import { RETRY_CEILING_MS, type FailureOutcome } from '@/shared/store/offlineSto
  */
 const IDEMPOTENCY_UNRESOLVED = 'IDEMPOTENCY_UNRESOLVED';
 const IDEMPOTENCY_KEY_REUSED = 'IDEMPOTENCY_KEY_REUSED';
+
+/** First backoff step. Doubles per consecutive retryable failure. */
+export const RETRY_BASE_MS = 1_000;
+/** Backoff never grows past this, so a recovered server is retried promptly. */
+export const RETRY_CEILING_MS = 5 * 60 * 1_000;
+/**
+ * Attempts a retryable failure may consume before the entry parks.
+ *
+ * The ladder is 1s, 2s, 4s ... 256s, then the 5-minute ceiling, so this many
+ * attempts is roughly 43 minutes of trying (511s of doubling plus 7 ceiling
+ * steps). That is deliberately longer than any routine server restart:
+ * parking a legitimate sale forces the cashier to re-ring it, which is the
+ * more expensive mistake. It is affordable only because every replay carries
+ * the same `Idempotency-Key`, so retrying cannot double-charge -- shrink this
+ * if that ever stops being true.
+ */
+export const MAX_RETRYABLE_ATTEMPTS = 17;
+/**
+ * Every till in the shop comes back on the same `online` event and would
+ * otherwise retry in lockstep against a server that just restarted.
+ */
+export const RETRY_JITTER = 0.2;
+
+/** Applies +/-RETRY_JITTER to a delay, rounded to whole milliseconds. */
+export function jitter(delayMs: number): number {
+  return Math.round(delayMs * (1 - RETRY_JITTER + Math.random() * 2 * RETRY_JITTER));
+}
+
+/**
+ * Delay before attempt `attempts + 1`, given `attempts` consecutive failures
+ * so far. Exported so tests assert the policy rather than a hard-coded ladder.
+ */
+export function nextAttemptDelay(attempts: number, minDelayMs = 0): number {
+  const exponential = RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1);
+  return jitter(Math.min(Math.max(exponential, minDelayMs), RETRY_CEILING_MS));
+}
+
+/** How a failed replay should be recorded. */
+export interface FailureOutcome {
+  retryable: boolean;
+  reason: string;
+  /** Floor for the next backoff step, for a failure that says how long to wait. */
+  minDelayMs?: number;
+}
 
 /** Short, stable reasons -- persisted on the entry and shown to support. */
 export const FAILURE_REASON = {
@@ -37,6 +81,8 @@ export const FAILURE_REASON = {
   splitMismatch: 'split-mismatch',
   rejected: 'rejected',
   unexpected: 'unexpected',
+  /** A retryable failure on an entry with no idempotency key -- see useOffline. */
+  unguardedReplay: 'unguarded-replay',
 } as const;
 
 export function classifyFailure(error: unknown): FailureOutcome {
@@ -77,8 +123,11 @@ export function classifyFailure(error: unknown): FailureOutcome {
     };
   }
   if (error.status === 401) {
-    // The transport's refresh interceptor may recover this; a hard failure
-    // redirects to login, which moots the question.
+    // Retryable because the transport's refresh interceptor may recover it.
+    // Note what happens when it cannot: the interceptor's auth-failure path
+    // logs out, and the logout handler in app/session.ts calls clearQueue() --
+    // so the queue is discarded before this classification is ever applied.
+    // That is a real defect, tracked separately; it is not "moot".
     return { retryable: true, reason: FAILURE_REASON.unauthorized };
   }
 

--- a/client/src/shared/store/offlineStore.test.ts
+++ b/client/src/shared/store/offlineStore.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OFFLINE_QUEUE_STORAGE_KEY } from '@/shared/lib/storageKeys';
-import { useOfflineStore, isQuarantined, SALE_QUEUE_CONTRACT_VERSION } from './offlineStore';
+import {
+  useOfflineStore,
+  isQuarantined,
+  needsReview,
+  isDue,
+  isEligible,
+  earliestAttemptAt,
+  nextAttemptDelay,
+  SALE_QUEUE_CONTRACT_VERSION,
+  MAX_RETRYABLE_ATTEMPTS,
+  RETRY_BASE_MS,
+  RETRY_CEILING_MS,
+  RETRY_JITTER,
+  type OfflineQueueItemId,
+} from './offlineStore';
 
 beforeEach(() => {
   useOfflineStore.setState({ queue: [], isSyncing: false });
+  localStorage.removeItem(OFFLINE_QUEUE_STORAGE_KEY);
 });
 
 describe('offlineStore - addToQueue', () => {
@@ -160,5 +175,295 @@ describe('offlineStore - queue entry identity', () => {
     await useOfflineStore.persist.rehydrate();
 
     expect(useOfflineStore.getState().queue[0].id).toBe(id);
+  });
+});
+
+describe('offlineStore - nextAttemptDelay', () => {
+  it('grows exponentially and then holds at the ceiling, within the jitter band', () => {
+    for (let attempts = 1; attempts <= MAX_RETRYABLE_ATTEMPTS; attempts++) {
+      const expected = Math.min(RETRY_BASE_MS * 2 ** (attempts - 1), RETRY_CEILING_MS);
+      for (let sample = 0; sample < 50; sample++) {
+        const delay = nextAttemptDelay(attempts);
+        expect(delay).toBeGreaterThanOrEqual(Math.floor(expected * (1 - RETRY_JITTER)));
+        expect(delay).toBeLessThanOrEqual(Math.ceil(expected * (1 + RETRY_JITTER)));
+      }
+    }
+  });
+
+  it('never exceeds the ceiling band however many attempts have been made', () => {
+    for (const attempts of [MAX_RETRYABLE_ATTEMPTS, 40, 1000]) {
+      expect(nextAttemptDelay(attempts)).toBeLessThanOrEqual(
+        Math.ceil(RETRY_CEILING_MS * (1 + RETRY_JITTER))
+      );
+    }
+  });
+});
+
+describe('offlineStore - recordFailure', () => {
+  function queueOne(): OfflineQueueItemId {
+    useOfflineStore.getState().addToQueue({
+      type: 'sale',
+      payload: { n: 1 },
+      contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+      idempotencyKey: 'key-1',
+    });
+    return useOfflineStore.getState().queue[0].id;
+  }
+
+  it('counts a retryable failure and schedules the next attempt in the future', () => {
+    const id = queueOne();
+    useOfflineStore.getState().recordFailure(id, { retryable: true, reason: 'server-error' });
+
+    const item = useOfflineStore.getState().queue[0];
+    expect(item.attempts).toBe(1);
+    expect(item.syncFailed).toBeUndefined();
+    expect(item.lastFailure).toBe('server-error');
+    expect(Date.parse(item.nextAttemptAt as string)).toBeGreaterThan(Date.now());
+  });
+
+  it('pushes each consecutive retryable failure further out, up to the ceiling', () => {
+    const id = queueOne();
+    const delays: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const before = Date.now();
+      useOfflineStore.getState().recordFailure(id, { retryable: true, reason: 'server-error' });
+      const at = Date.parse(useOfflineStore.getState().queue[0].nextAttemptAt as string);
+      delays.push(at - before);
+    }
+
+    // Jitter makes strict monotonicity a flaky assertion; the doubling band is
+    // the actual policy, so assert that instead.
+    delays.forEach((delay, i) => {
+      const expected = Math.min(RETRY_BASE_MS * 2 ** i, RETRY_CEILING_MS);
+      expect(delay).toBeGreaterThanOrEqual(Math.floor(expected * (1 - RETRY_JITTER)));
+      expect(delay).toBeLessThanOrEqual(Math.ceil(expected * (1 + RETRY_JITTER)));
+    });
+  });
+
+  it('parks a terminal failure immediately without consuming the retry budget', () => {
+    const id = queueOne();
+    useOfflineStore.getState().recordFailure(id, { retryable: false, reason: 'key-reused' });
+
+    const item = useOfflineStore.getState().queue[0];
+    expect(item.syncFailed).toBe(true);
+    expect(item.attempts).toBe(1);
+    expect(item.nextAttemptAt).toBeUndefined();
+    expect(item.lastFailure).toBe('key-reused');
+  });
+
+  it('parks the entry once the retryable budget is exhausted, rather than scheduling again', () => {
+    const id = queueOne();
+    for (let i = 0; i < MAX_RETRYABLE_ATTEMPTS - 1; i++) {
+      useOfflineStore.getState().recordFailure(id, { retryable: true, reason: 'server-error' });
+      expect(useOfflineStore.getState().queue[0].syncFailed).toBeUndefined();
+    }
+
+    useOfflineStore.getState().recordFailure(id, { retryable: true, reason: 'server-error' });
+
+    const item = useOfflineStore.getState().queue[0];
+    expect(item.attempts).toBe(MAX_RETRYABLE_ATTEMPTS);
+    expect(item.syncFailed).toBe(true);
+    expect(item.nextAttemptAt).toBeUndefined();
+  });
+
+  it('touches only the entry named', () => {
+    const { addToQueue } = useOfflineStore.getState();
+    addToQueue({ type: 'sale', payload: { n: 1 } });
+    addToQueue({ type: 'sale', payload: { n: 2 } });
+    const [first, second] = useOfflineStore.getState().queue;
+
+    useOfflineStore.getState().recordFailure(first.id, { retryable: true, reason: 'x' });
+
+    expect(useOfflineStore.getState().queue[1]).toEqual(second);
+  });
+});
+
+describe('offlineStore - clearRetryState and clearBackoff', () => {
+  it('clears retry state but preserves payload, key and contract version', () => {
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 'a',
+          createdAt: '',
+          type: 'sale',
+          payload: { n: 1 },
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          idempotencyKey: 'key-1',
+          attempts: 4,
+          nextAttemptAt: '2999-01-01T00:00:00.000Z',
+          syncFailed: true,
+          lastFailure: 'server-error',
+        },
+      ],
+      isSyncing: false,
+    });
+
+    useOfflineStore.getState().clearRetryState('a');
+
+    expect(useOfflineStore.getState().queue[0]).toEqual({
+      id: 'a',
+      createdAt: '',
+      type: 'sale',
+      payload: { n: 1 },
+      contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+      // Preserved on purpose: if the original attempt did commit, the manual
+      // retry replays onto the same key rather than charging a second time.
+      idempotencyKey: 'key-1',
+    });
+  });
+
+  it('revives every parked entry when called with no id, and leaves healthy ones alone', () => {
+    useOfflineStore.setState({
+      queue: [
+        { id: 'a', createdAt: '', type: 'sale', payload: {}, attempts: 10, syncFailed: true },
+        { id: 'b', createdAt: '', type: 'sale', payload: {}, attempts: 10, syncFailed: true },
+        { id: 'c', createdAt: '', type: 'sale', payload: {}, attempts: 2, nextAttemptAt: 'x' },
+      ],
+      isSyncing: false,
+    });
+
+    useOfflineStore.getState().clearRetryState();
+
+    const [a, b, c] = useOfflineStore.getState().queue;
+    expect(a.syncFailed).toBeUndefined();
+    expect(a.attempts).toBeUndefined();
+    expect(b.syncFailed).toBeUndefined();
+    expect(c.attempts).toBe(2);
+  });
+
+  it('drops pending backoff on reconnect without forgiving attempts', () => {
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 'a',
+          createdAt: '',
+          type: 'sale',
+          payload: {},
+          attempts: 3,
+          nextAttemptAt: '2999-01-01T00:00:00.000Z',
+        },
+      ],
+      isSyncing: false,
+    });
+
+    useOfflineStore.getState().clearBackoff();
+
+    expect(useOfflineStore.getState().queue[0].nextAttemptAt).toBeUndefined();
+    expect(useOfflineStore.getState().queue[0].attempts).toBe(3);
+  });
+});
+
+describe('offlineStore - review and eligibility predicates', () => {
+  const healthy = {
+    type: 'sale',
+    payload: {},
+    contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+  };
+
+  it('treats legacy, mismatched and parked entries as needing review', () => {
+    expect(needsReview({ type: 'sale', payload: {} })).toBe(true);
+    expect(needsReview({ ...healthy, mismatched: true })).toBe(true);
+    expect(needsReview({ ...healthy, syncFailed: true })).toBe(true);
+    expect(needsReview(healthy)).toBe(false);
+  });
+
+  it('does not widen isQuarantined to cover a parked entry', () => {
+    expect(isQuarantined({ ...healthy, syncFailed: true })).toBe(false);
+  });
+
+  it('treats an entry with no retry state as due now and eligible', () => {
+    expect(isDue(healthy)).toBe(true);
+    expect(isEligible(healthy)).toBe(true);
+  });
+
+  it('holds an entry back until its nextAttemptAt', () => {
+    const item = { ...healthy, attempts: 1, nextAttemptAt: '2999-01-01T00:00:00.000Z' };
+    expect(isDue(item)).toBe(false);
+    expect(isEligible(item)).toBe(false);
+    expect(isDue(item, Date.parse('2999-01-01T00:00:00.000Z'))).toBe(true);
+  });
+
+  it('reports no next sweep at all when every entry needs review', () => {
+    expect(
+      earliestAttemptAt([
+        { id: 'a', createdAt: '', type: 'sale', payload: {} },
+        { id: 'b', createdAt: '', ...healthy, syncFailed: true },
+      ])
+    ).toBeNull();
+    expect(earliestAttemptAt([])).toBeNull();
+  });
+
+  it('reports the earliest eligible entry as the next sweep', () => {
+    const at = earliestAttemptAt([
+      { id: 'a', createdAt: '', ...healthy, nextAttemptAt: '2999-01-02T00:00:00.000Z' },
+      { id: 'b', createdAt: '', ...healthy, nextAttemptAt: '2999-01-01T00:00:00.000Z' },
+      { id: 'c', createdAt: '', ...healthy, syncFailed: true },
+    ]);
+    expect(at).toBe(Date.parse('2999-01-01T00:00:00.000Z'));
+  });
+
+  it('reports a sweep due now when any entry carries no backoff', () => {
+    const at = earliestAttemptAt([
+      { id: 'a', createdAt: '', ...healthy, nextAttemptAt: '2999-01-01T00:00:00.000Z' },
+      { id: 'b', createdAt: '', ...healthy },
+    ]);
+    expect(at).toBe(0);
+  });
+
+  it('counts parked entries separately from quarantined ones', () => {
+    useOfflineStore.setState({
+      queue: [
+        { id: 'a', createdAt: '', type: 'sale', payload: {} }, // legacy, quarantined
+        { id: 'b', createdAt: '', ...healthy, syncFailed: true }, // parked
+        { id: 'c', createdAt: '', ...healthy }, // healthy
+      ],
+      isSyncing: false,
+    });
+
+    expect(useOfflineStore.getState().getQuarantinedCount()).toBe(1);
+    expect(useOfflineStore.getState().getFailedCount()).toBe(1);
+  });
+});
+
+describe('offlineStore - isSyncing is not persisted', () => {
+  it('writes no isSyncing key to storage', () => {
+    useOfflineStore.setState({ isSyncing: true });
+    useOfflineStore.getState().addToQueue({ type: 'sale', payload: {} });
+
+    const persisted = JSON.parse(localStorage.getItem(OFFLINE_QUEUE_STORAGE_KEY) as string);
+    expect(persisted.state).not.toHaveProperty('isSyncing');
+  });
+
+  it('rehydrates a blob written by a tab killed mid-sync as not syncing', async () => {
+    // What a pre-partialize build left behind: syncQueue early-returns on
+    // isSyncing, so without the reset this queue never syncs again.
+    localStorage.setItem(
+      OFFLINE_QUEUE_STORAGE_KEY,
+      JSON.stringify({
+        state: { queue: [{ id: 'a', createdAt: '', type: 'sale', payload: {} }], isSyncing: true },
+        version: 0,
+      })
+    );
+
+    await useOfflineStore.persist.rehydrate();
+
+    expect(useOfflineStore.getState().isSyncing).toBe(false);
+    expect(useOfflineStore.getState().queue).toHaveLength(1);
+  });
+});
+
+describe('offlineStore - retry state persistence', () => {
+  it('survives a persist round-trip', async () => {
+    useOfflineStore.getState().addToQueue({ type: 'sale', payload: {} });
+    const id = useOfflineStore.getState().queue[0].id;
+    useOfflineStore.getState().recordFailure(id, { retryable: true, reason: 'server-error' });
+    const before = useOfflineStore.getState().queue[0];
+    const raw = localStorage.getItem(OFFLINE_QUEUE_STORAGE_KEY) as string;
+
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    localStorage.setItem(OFFLINE_QUEUE_STORAGE_KEY, raw);
+    await useOfflineStore.persist.rehydrate();
+
+    expect(useOfflineStore.getState().queue[0]).toEqual(before);
   });
 });

--- a/client/src/shared/store/offlineStore.test.ts
+++ b/client/src/shared/store/offlineStore.test.ts
@@ -94,3 +94,71 @@ describe('offlineStore - getQuarantinedCount', () => {
     expect(useOfflineStore.getState().getQueueLength()).toBe(3);
   });
 });
+
+describe('offlineStore - queue entry identity', () => {
+  it('gives two entries queued in the same millisecond distinct ids', () => {
+    const { addToQueue } = useOfflineStore.getState();
+    addToQueue({ type: 'sale', payload: { n: 1 } });
+    addToQueue({ type: 'sale', payload: { n: 2 } });
+
+    const [first, second] = useOfflineStore.getState().queue;
+    expect(first.id).not.toBe(second.id);
+  });
+
+  it('removes exactly the entry asked for when two were queued back to back', () => {
+    const { addToQueue } = useOfflineStore.getState();
+    addToQueue({ type: 'sale', payload: { n: 1 } });
+    addToQueue({ type: 'sale', payload: { n: 2 } });
+
+    const [first, second] = useOfflineStore.getState().queue;
+    useOfflineStore.getState().removeFromQueue(first.id);
+
+    // Under `Date.now()` ids these two collided and this deleted both -- an
+    // unrecoverable, silent loss of a rung-up sale.
+    const remaining = useOfflineStore.getState().queue;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(second.id);
+    expect(remaining[0].payload).toEqual({ n: 2 });
+  });
+
+  it('flags exactly one entry when two were queued back to back', () => {
+    const { addToQueue } = useOfflineStore.getState();
+    addToQueue({ type: 'sale', payload: { n: 1 } });
+    addToQueue({ type: 'sale', payload: { n: 2 } });
+
+    const [first] = useOfflineStore.getState().queue;
+    useOfflineStore.getState().markMismatched(first.id);
+
+    expect(useOfflineStore.getState().queue.map((item) => item.mismatched)).toEqual([
+      true,
+      undefined,
+    ]);
+  });
+
+  it('still removes an entry rehydrated with a legacy numeric id', () => {
+    // The shape a till that updated mid-shift finds in its localStorage.
+    useOfflineStore.setState({
+      queue: [
+        { id: 1738000000000, createdAt: '', type: 'sale', payload: {} },
+        { id: 'str-id', createdAt: '', type: 'sale', payload: {} },
+      ],
+      isSyncing: false,
+    });
+
+    useOfflineStore.getState().removeFromQueue(1738000000000);
+
+    expect(useOfflineStore.getState().queue.map((item) => item.id)).toEqual(['str-id']);
+  });
+
+  it('preserves generated ids across a persist round-trip', async () => {
+    useOfflineStore.getState().addToQueue({ type: 'sale', payload: {} });
+    const id = useOfflineStore.getState().queue[0].id;
+    const raw = localStorage.getItem(OFFLINE_QUEUE_STORAGE_KEY) as string;
+
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    localStorage.setItem(OFFLINE_QUEUE_STORAGE_KEY, raw);
+    await useOfflineStore.persist.rehydrate();
+
+    expect(useOfflineStore.getState().queue[0].id).toBe(id);
+  });
+});

--- a/client/src/shared/store/offlineStore.test.ts
+++ b/client/src/shared/store/offlineStore.test.ts
@@ -1,20 +1,24 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { OFFLINE_QUEUE_STORAGE_KEY } from '@/shared/lib/storageKeys';
 import {
   useOfflineStore,
   isQuarantined,
   needsReview,
+  isParked,
   isDue,
   isEligible,
   earliestAttemptAt,
-  nextAttemptDelay,
+  migrateQueueIds,
   SALE_QUEUE_CONTRACT_VERSION,
+  type OfflineQueueItemId,
+} from './offlineStore';
+import {
+  nextAttemptDelay,
   MAX_RETRYABLE_ATTEMPTS,
   RETRY_BASE_MS,
   RETRY_CEILING_MS,
   RETRY_JITTER,
-  type OfflineQueueItemId,
-} from './offlineStore';
+} from '@/shared/lib/offlineRetry';
 
 beforeEach(() => {
   useOfflineStore.setState({ queue: [], isSyncing: false });
@@ -111,6 +115,19 @@ describe('offlineStore - getQuarantinedCount', () => {
 });
 
 describe('offlineStore - queue entry identity', () => {
+  // Freeze the clock. Without this these tests only exercise the collision
+  // when two addToQueue calls happen to land in the same millisecond -- so
+  // reintroducing `id: Date.now()` would pass whenever the clock ticked
+  // between them, which on a loaded CI box is most of the time.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-31T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('gives two entries queued in the same millisecond distinct ids', () => {
     const { addToQueue } = useOfflineStore.getState();
     addToQueue({ type: 'sale', payload: { n: 1 } });
@@ -232,11 +249,14 @@ describe('offlineStore - recordFailure', () => {
     }
 
     // Jitter makes strict monotonicity a flaky assertion; the doubling band is
-    // the actual policy, so assert that instead.
+    // the actual policy, so assert that instead. The few ms of slack absorb the
+    // real-clock drift between `before` and the store's own Date.now() -- the
+    // band is otherwise exact at the top, and a single millisecond would fail.
+    const SLACK_MS = 50;
     delays.forEach((delay, i) => {
       const expected = Math.min(RETRY_BASE_MS * 2 ** i, RETRY_CEILING_MS);
-      expect(delay).toBeGreaterThanOrEqual(Math.floor(expected * (1 - RETRY_JITTER)));
-      expect(delay).toBeLessThanOrEqual(Math.ceil(expected * (1 + RETRY_JITTER)));
+      expect(delay).toBeGreaterThanOrEqual(Math.floor(expected * (1 - RETRY_JITTER)) - SLACK_MS);
+      expect(delay).toBeLessThanOrEqual(Math.ceil(expected * (1 + RETRY_JITTER)) + SLACK_MS);
     });
   });
 
@@ -315,7 +335,18 @@ describe('offlineStore - clearRetryState and clearBackoff', () => {
   it('revives every parked entry when called with no id, and leaves healthy ones alone', () => {
     useOfflineStore.setState({
       queue: [
-        { id: 'a', createdAt: '', type: 'sale', payload: {}, attempts: 10, syncFailed: true },
+        // Carries a backoff as well as the parked flag: a Retry that cleared
+        // syncFailed but left nextAttemptAt would un-park the sale into a wait
+        // the cashier cannot see and did not ask for.
+        {
+          id: 'a',
+          createdAt: '',
+          type: 'sale',
+          payload: {},
+          attempts: 10,
+          syncFailed: true,
+          nextAttemptAt: '2999-01-01T00:00:00.000Z',
+        },
         { id: 'b', createdAt: '', type: 'sale', payload: {}, attempts: 10, syncFailed: true },
         { id: 'c', createdAt: '', type: 'sale', payload: {}, attempts: 2, nextAttemptAt: 'x' },
       ],
@@ -327,6 +358,8 @@ describe('offlineStore - clearRetryState and clearBackoff', () => {
     const [a, b, c] = useOfflineStore.getState().queue;
     expect(a.syncFailed).toBeUndefined();
     expect(a.attempts).toBeUndefined();
+    expect(a.nextAttemptAt).toBeUndefined();
+    expect(isParked(a)).toBe(false);
     expect(b.syncFailed).toBeUndefined();
     expect(c.attempts).toBe(2);
   });
@@ -346,10 +379,14 @@ describe('offlineStore - clearRetryState and clearBackoff', () => {
       isSyncing: false,
     });
 
-    useOfflineStore.getState().clearBackoff();
+    const before = Date.now();
+    useOfflineStore.getState().retrySoon();
 
-    expect(useOfflineStore.getState().queue[0].nextAttemptAt).toBeUndefined();
-    expect(useOfflineStore.getState().queue[0].attempts).toBe(3);
+    const item = useOfflineStore.getState().queue[0];
+    // Pulled in to the next second or so, not to zero -- see the retrySoon
+    // block below for why the difference matters across a shop full of tills.
+    expect(Date.parse(item.nextAttemptAt as string) - before).toBeLessThan(2_000);
+    expect(item.attempts).toBe(3);
   });
 });
 
@@ -421,7 +458,7 @@ describe('offlineStore - review and eligibility predicates', () => {
     });
 
     expect(useOfflineStore.getState().getQuarantinedCount()).toBe(1);
-    expect(useOfflineStore.getState().getFailedCount()).toBe(1);
+    expect(useOfflineStore.getState().queue.filter(isParked)).toHaveLength(1);
   });
 });
 
@@ -465,5 +502,160 @@ describe('offlineStore - retry state persistence', () => {
     await useOfflineStore.persist.rehydrate();
 
     expect(useOfflineStore.getState().queue[0]).toEqual(before);
+  });
+});
+
+describe('offlineStore - legacy id migration', () => {
+  it('restamps every numeric id so pre-upgrade entries stop colliding', () => {
+    // Two sales rung up in the same millisecond before the upgrade: the whole
+    // defect, preserved verbatim in a real cashier's localStorage.
+    const collided = migrateQueueIds([
+      { id: 1738000000000, createdAt: '', type: 'sale', payload: { n: 1 } },
+      { id: 1738000000000, createdAt: '', type: 'sale', payload: { n: 2 } },
+    ]);
+
+    expect(collided[0].id).not.toBe(collided[1].id);
+    expect(typeof collided[0].id).toBe('string');
+    // Payloads are untouched -- this restamps identity, nothing else.
+    expect(collided.map((item) => item.payload)).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  it('leaves an already-migrated string id alone', () => {
+    const migrated = migrateQueueIds([
+      { id: 'already-opaque', createdAt: '', type: 'sale', payload: {} },
+    ]);
+
+    expect(migrated[0].id).toBe('already-opaque');
+  });
+
+  it('runs on rehydrate, so a collided queue is repaired before anything reads it', async () => {
+    localStorage.setItem(
+      OFFLINE_QUEUE_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          queue: [
+            { id: 1738000000000, createdAt: '', type: 'sale', payload: { n: 1 } },
+            { id: 1738000000000, createdAt: '', type: 'sale', payload: { n: 2 } },
+          ],
+        },
+        version: 0,
+      })
+    );
+
+    await useOfflineStore.persist.rehydrate();
+
+    const [first, second] = useOfflineStore.getState().queue;
+    expect(first.id).not.toBe(second.id);
+
+    // The behaviour that mattered: removing one no longer deletes the other.
+    useOfflineStore.getState().removeFromQueue(first.id);
+    expect(useOfflineStore.getState().queue).toHaveLength(1);
+    expect(useOfflineStore.getState().queue[0].payload).toEqual({ n: 2 });
+  });
+});
+
+describe('offlineStore - rate-limit backoff floor', () => {
+  it('honours a failure that carries its own minimum delay', () => {
+    // The classifier returns minDelayMs for a 429. If recordFailure ignored
+    // it, a till would retry a rate limiter on the 1s base step and earn a
+    // longer ban -- and nothing downstream would notice.
+    useOfflineStore.getState().addToQueue({ type: 'sale', payload: {} });
+    const id = useOfflineStore.getState().queue[0].id;
+    const before = Date.now();
+
+    useOfflineStore
+      .getState()
+      .recordFailure(id, { retryable: true, reason: 'rate-limited', minDelayMs: RETRY_CEILING_MS });
+
+    const delay = Date.parse(useOfflineStore.getState().queue[0].nextAttemptAt as string) - before;
+    // Jittered, but never back down at the base step.
+    expect(delay).toBeGreaterThanOrEqual(Math.floor(RETRY_CEILING_MS * (1 - RETRY_JITTER)) - 5);
+  });
+
+  it('applies the floor through nextAttemptDelay itself', () => {
+    for (let sample = 0; sample < 50; sample++) {
+      expect(nextAttemptDelay(1, RETRY_CEILING_MS)).toBeGreaterThanOrEqual(
+        Math.floor(RETRY_CEILING_MS * (1 - RETRY_JITTER))
+      );
+    }
+  });
+});
+
+describe('offlineStore - retrySoon', () => {
+  it('pulls a pending backoff in without dropping it to zero', () => {
+    // Dropping to zero would put every till in the shop on the same instant --
+    // the lockstep stampede the jitter exists to break.
+    useOfflineStore.setState({
+      queue: [
+        {
+          id: 'a',
+          createdAt: '',
+          type: 'sale',
+          payload: {},
+          attempts: 5,
+          nextAttemptAt: new Date(Date.now() + RETRY_CEILING_MS).toISOString(),
+        },
+      ],
+      isSyncing: false,
+    });
+
+    const before = Date.now();
+    useOfflineStore.getState().retrySoon();
+
+    const item = useOfflineStore.getState().queue[0];
+    const delay = Date.parse(item.nextAttemptAt as string) - before;
+    expect(delay).toBeGreaterThan(0);
+    expect(delay).toBeLessThanOrEqual(Math.ceil(RETRY_BASE_MS * (1 + RETRY_JITTER)) + 5);
+    // Reconnecting is not a free pass for a sale the server keeps rejecting.
+    expect(item.attempts).toBe(5);
+  });
+
+  it('leaves an already-due entry exactly as it is', () => {
+    useOfflineStore.setState({
+      queue: [{ id: 'a', createdAt: '', type: 'sale', payload: {}, attempts: 2 }],
+      isSyncing: false,
+    });
+    const before = useOfflineStore.getState().queue[0];
+
+    useOfflineStore.getState().retrySoon();
+
+    expect(useOfflineStore.getState().queue[0]).toEqual(before);
+  });
+});
+
+describe('offlineStore - corrupt nextAttemptAt', () => {
+  it('treats an unparseable timestamp as due now rather than stranding the entry', () => {
+    // A NaN compares false against everything, so a corrupt localStorage value
+    // would otherwise make the entry never due, never parked and never
+    // quarantined -- invisible in every banner and replayed by nothing.
+    const corrupt = { type: 'sale', payload: {}, nextAttemptAt: 'not-a-date' };
+
+    expect(isDue(corrupt)).toBe(true);
+    expect(earliestAttemptAt([{ id: 'a', createdAt: '', ...corrupt, contractVersion: 'v1' }])).toBe(
+      0
+    );
+  });
+
+  it('does not let one corrupt entry poison the whole scheduler scalar', () => {
+    const at = earliestAttemptAt([
+      {
+        id: 'a',
+        createdAt: '',
+        type: 'sale',
+        payload: {},
+        contractVersion: 'v1',
+        nextAttemptAt: 'garbage',
+      },
+      {
+        id: 'b',
+        createdAt: '',
+        type: 'sale',
+        payload: {},
+        contractVersion: 'v1',
+        nextAttemptAt: '2999-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    expect(at).toBe(0);
   });
 });

--- a/client/src/shared/store/offlineStore.ts
+++ b/client/src/shared/store/offlineStore.ts
@@ -101,9 +101,9 @@ export const RETRY_JITTER = 0.2;
  * Delay before attempt `attempts + 1`, given `attempts` consecutive failures
  * so far. Exported so tests assert the policy rather than a hard-coded ladder.
  */
-export function nextAttemptDelay(attempts: number): number {
+export function nextAttemptDelay(attempts: number, minDelayMs = 0): number {
   const exponential = RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1);
-  const capped = Math.min(exponential, RETRY_CEILING_MS);
+  const capped = Math.min(Math.max(exponential, minDelayMs), RETRY_CEILING_MS);
   return Math.round(capped * (1 - RETRY_JITTER + Math.random() * 2 * RETRY_JITTER));
 }
 
@@ -111,6 +111,8 @@ export function nextAttemptDelay(attempts: number): number {
 export interface FailureOutcome {
   retryable: boolean;
   reason: string;
+  /** Floor for the next backoff step, for a failure that says how long to wait. */
+  minDelayMs?: number;
 }
 
 export interface OfflineQueueItem extends OfflineAction {
@@ -154,9 +156,19 @@ export function isDue(item: OfflineAction, now: number = Date.now()): boolean {
   return !item.nextAttemptAt || Date.parse(item.nextAttemptAt) <= now;
 }
 
+/**
+ * `sale` is the only type anything enqueues, and the only type useOffline
+ * knows how to replay. Anything else is inert -- it must not be counted as
+ * work waiting to happen, or the scheduler would arm a timer for a sweep that
+ * can never do anything.
+ */
+export function isReplayable(item: OfflineAction): boolean {
+  return item.type === 'sale';
+}
+
 /** Whether an entry may be auto-replayed right now. */
 export function isEligible(item: OfflineAction, now: number = Date.now()): boolean {
-  return !needsReview(item) && isDue(item, now);
+  return isReplayable(item) && !needsReview(item) && isDue(item, now);
 }
 
 /**
@@ -168,7 +180,7 @@ export function isEligible(item: OfflineAction, now: number = Date.now()): boole
 export function earliestAttemptAt(queue: OfflineQueueItem[]): number | null {
   let earliest: number | null = null;
   for (const item of queue) {
-    if (needsReview(item)) continue;
+    if (!isReplayable(item) || needsReview(item)) continue;
     const at = item.nextAttemptAt ? Date.parse(item.nextAttemptAt) : 0;
     if (earliest === null || at < earliest) earliest = at;
   }
@@ -234,7 +246,7 @@ export const useOfflineStore = create<OfflineState>()(
           queue: state.queue.map((item) => (item.id === id ? { ...item, mismatched: true } : item)),
         })),
 
-      recordFailure: (id, { retryable, reason }) =>
+      recordFailure: (id, { retryable, reason, minDelayMs }) =>
         set((state) => ({
           queue: state.queue.map((item) => {
             if (item.id !== id) return item;
@@ -247,7 +259,9 @@ export const useOfflineStore = create<OfflineState>()(
               ...item,
               attempts,
               lastFailure: reason,
-              nextAttemptAt: new Date(Date.now() + nextAttemptDelay(attempts)).toISOString(),
+              nextAttemptAt: new Date(
+                Date.now() + nextAttemptDelay(attempts, minDelayMs)
+              ).toISOString(),
             };
           }),
         })),

--- a/client/src/shared/store/offlineStore.ts
+++ b/client/src/shared/store/offlineStore.ts
@@ -55,6 +55,62 @@ export interface OfflineAction {
    * (and re-fail) on every subsequent sync; a cashier must review/re-ring it.
    */
   mismatched?: boolean;
+  /**
+   * How many replay attempts this entry has consumed. Absent means zero: an
+   * entry persisted before retry state existed is at attempt zero and due
+   * immediately, so it replays exactly as it did before.
+   */
+  attempts?: number;
+  /**
+   * Earliest instant (ISO, matching `createdAt`) at which this entry may be
+   * replayed again, set from `nextAttemptDelay` after a retryable failure.
+   * Absent means due now -- which is also the pre-retry-state shape.
+   */
+  nextAttemptAt?: string;
+  /**
+   * Set when the entry is parked: either the failure was deterministic (the
+   * server will reject the replay identically however long we wait) or the
+   * retryable budget ran out. A parked entry is never auto-replayed and never
+   * dropped; only an explicit cashier Retry (`clearRetryState`) revives it.
+   * Absent means the entry is still in normal play.
+   */
+  syncFailed?: boolean;
+  /** Short reason for the last failure, for the banner and for support. */
+  lastFailure?: string;
+}
+
+/** First backoff step. Doubles per consecutive retryable failure. */
+export const RETRY_BASE_MS = 1_000;
+/** Backoff never grows past this, so a recovered server is retried promptly. */
+export const RETRY_CEILING_MS = 5 * 60 * 1_000;
+/**
+ * Attempts a retryable failure may consume before the entry parks. Sized for
+ * roughly 40 minutes of trying -- affordable only because every replay carries
+ * the same `Idempotency-Key`, so retrying cannot double-charge. Parking a
+ * legitimate sale during a ten-minute server restart would force the cashier
+ * to re-ring it, which is the more expensive mistake.
+ */
+export const MAX_RETRYABLE_ATTEMPTS = 10;
+/**
+ * Every till in the shop comes back on the same `online` event and would
+ * otherwise retry in lockstep against a server that just restarted.
+ */
+export const RETRY_JITTER = 0.2;
+
+/**
+ * Delay before attempt `attempts + 1`, given `attempts` consecutive failures
+ * so far. Exported so tests assert the policy rather than a hard-coded ladder.
+ */
+export function nextAttemptDelay(attempts: number): number {
+  const exponential = RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1);
+  const capped = Math.min(exponential, RETRY_CEILING_MS);
+  return Math.round(capped * (1 - RETRY_JITTER + Math.random() * 2 * RETRY_JITTER));
+}
+
+/** How a failed replay should be recorded -- see `client/src/shared/lib/offlineRetry.ts`. */
+export interface FailureOutcome {
+  retryable: boolean;
+  reason: string;
 }
 
 export interface OfflineQueueItem extends OfflineAction {
@@ -83,6 +139,42 @@ export function isQuarantined(item: OfflineAction): boolean {
   return item.type === 'sale' && (!item.contractVersion || item.mismatched === true);
 }
 
+/**
+ * An entry a cashier has to deal with by hand: quarantined (legacy or
+ * split-mismatched) or parked after a failed replay. Deliberately separate
+ * from `isQuarantined`, which keeps its two existing meanings so the comments
+ * and tests around it stay true -- a parked entry is not quarantined.
+ */
+export function needsReview(item: OfflineAction): boolean {
+  return isQuarantined(item) || item.syncFailed === true;
+}
+
+/** Whether an entry's backoff has elapsed. No `nextAttemptAt` means due now. */
+export function isDue(item: OfflineAction, now: number = Date.now()): boolean {
+  return !item.nextAttemptAt || Date.parse(item.nextAttemptAt) <= now;
+}
+
+/** Whether an entry may be auto-replayed right now. */
+export function isEligible(item: OfflineAction, now: number = Date.now()): boolean {
+  return !needsReview(item) && isDue(item, now);
+}
+
+/**
+ * When the queue next wants a sync sweep, as an epoch instant, or null when
+ * nothing will ever become due on its own (empty, or every entry needs review).
+ * Null is what lets the scheduler arm no timer at all rather than spinning on
+ * a queue it can do no work on.
+ */
+export function earliestAttemptAt(queue: OfflineQueueItem[]): number | null {
+  let earliest: number | null = null;
+  for (const item of queue) {
+    if (needsReview(item)) continue;
+    const at = item.nextAttemptAt ? Date.parse(item.nextAttemptAt) : 0;
+    if (earliest === null || at < earliest) earliest = at;
+  }
+  return earliest;
+}
+
 interface OfflineState {
   queue: OfflineQueueItem[];
   isSyncing: boolean;
@@ -90,11 +182,32 @@ interface OfflineState {
   removeFromQueue: (id: OfflineQueueItemId) => void;
   /** Flags a queued entry as quarantined after a SPLIT_PAYMENT_MISMATCH rejection. */
   markMismatched: (id: OfflineQueueItemId) => void;
+  /**
+   * Records one failed replay: counts the attempt, and either schedules the
+   * next one or parks the entry (terminal failure, or budget exhausted).
+   */
+  recordFailure: (id: OfflineQueueItemId, outcome: FailureOutcome) => void;
+  /**
+   * The cashier's Retry. Clears attempts/backoff/parked state -- and nothing
+   * else. `idempotencyKey` is deliberately preserved: if the original attempt
+   * did commit server-side, the manual retry replays onto the same key and
+   * returns the original outcome instead of charging twice. With no id, revives
+   * every parked entry.
+   */
+  clearRetryState: (id?: OfflineQueueItemId) => void;
+  /**
+   * Drops pending backoff on reconnect without forgiving any attempts, so a
+   * network change retries at once while a poison entry still parks on
+   * schedule.
+   */
+  clearBackoff: () => void;
   clearQueue: () => void;
   setSyncing: (isSyncing: boolean) => void;
   getQueueLength: () => number;
   /** Legacy unversioned 'sale' entries awaiting manual cashier review -- see `isQuarantined`. */
   getQuarantinedCount: () => number;
+  /** Entries parked after a failed replay, awaiting an explicit cashier Retry. */
+  getFailedCount: () => number;
 }
 
 export const useOfflineStore = create<OfflineState>()(
@@ -121,6 +234,49 @@ export const useOfflineStore = create<OfflineState>()(
           queue: state.queue.map((item) => (item.id === id ? { ...item, mismatched: true } : item)),
         })),
 
+      recordFailure: (id, { retryable, reason }) =>
+        set((state) => ({
+          queue: state.queue.map((item) => {
+            if (item.id !== id) return item;
+            const attempts = (item.attempts ?? 0) + 1;
+            if (!retryable || attempts >= MAX_RETRYABLE_ATTEMPTS) {
+              const { nextAttemptAt: _dropped, ...rest } = item;
+              return { ...rest, attempts, syncFailed: true, lastFailure: reason };
+            }
+            return {
+              ...item,
+              attempts,
+              lastFailure: reason,
+              nextAttemptAt: new Date(Date.now() + nextAttemptDelay(attempts)).toISOString(),
+            };
+          }),
+        })),
+
+      clearRetryState: (id) =>
+        set((state) => ({
+          queue: state.queue.map((item) => {
+            const target = id === undefined ? item.syncFailed === true : item.id === id;
+            if (!target) return item;
+            const {
+              attempts: _attempts,
+              nextAttemptAt: _nextAttemptAt,
+              syncFailed: _syncFailed,
+              lastFailure: _lastFailure,
+              ...rest
+            } = item;
+            return rest;
+          }),
+        })),
+
+      clearBackoff: () =>
+        set((state) => ({
+          queue: state.queue.map((item) => {
+            if (!item.nextAttemptAt) return item;
+            const { nextAttemptAt: _dropped, ...rest } = item;
+            return rest;
+          }),
+        })),
+
       clearQueue: () => set({ queue: [] }),
 
       setSyncing: (isSyncing) => set({ isSyncing }),
@@ -128,9 +284,20 @@ export const useOfflineStore = create<OfflineState>()(
       getQueueLength: () => get().queue.length,
 
       getQuarantinedCount: () => get().queue.filter(isQuarantined).length,
+
+      getFailedCount: () => get().queue.filter((item) => item.syncFailed === true).length,
     }),
     {
       name: OFFLINE_QUEUE_STORAGE_KEY,
+      // `isSyncing` describes a sweep happening in THIS tab, so persisting it
+      // is meaningless at best. At worst a tab killed mid-sync writes `true`
+      // and every later load early-returns out of syncQueue forever, stranding
+      // the queue. Partialize keeps new writes clean; the rehydrate reset is
+      // what rescues a blob already carrying `true`.
+      partialize: (state) => ({ queue: state.queue }),
+      onRehydrateStorage: () => (state) => {
+        if (state) state.isSyncing = false;
+      },
     }
   )
 );

--- a/client/src/shared/store/offlineStore.ts
+++ b/client/src/shared/store/offlineStore.ts
@@ -2,12 +2,25 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { OFFLINE_QUEUE_STORAGE_KEY } from '@/shared/lib/storageKeys';
 import { createIdempotencyKey } from '@/shared/lib/transport/idempotency';
+import {
+  jitter,
+  nextAttemptDelay,
+  MAX_RETRYABLE_ATTEMPTS,
+  RETRY_BASE_MS,
+  type FailureOutcome,
+} from '@/shared/lib/offlineRetry';
 
 /**
  * A queue entry's identity. Entries minted since collision-free ids shipped
- * carry an opaque string; entries already in a cashier's `localStorage` from
- * before carry the `Date.now()` number they were given. Both keep matching
- * under the `===`/`!==` lookups below, so no rehydrate migration is needed.
+ * carry an opaque string; entries persisted before that carry the `Date.now()`
+ * number they were given.
+ *
+ * Widening the type is not on its own enough. A numeric id still *matches*
+ * under the `===`/`!==` lookups below, but two pre-upgrade entries rung up in
+ * the same millisecond still share one -- which is the whole defect, surviving
+ * in exactly the population that already has queued money. `migrateQueueIds`
+ * on rehydrate is what actually closes it; the union type is here so entries
+ * are addressable in the window before that runs.
  */
 export type OfflineQueueItemId = string | number;
 
@@ -79,42 +92,6 @@ export interface OfflineAction {
   lastFailure?: string;
 }
 
-/** First backoff step. Doubles per consecutive retryable failure. */
-export const RETRY_BASE_MS = 1_000;
-/** Backoff never grows past this, so a recovered server is retried promptly. */
-export const RETRY_CEILING_MS = 5 * 60 * 1_000;
-/**
- * Attempts a retryable failure may consume before the entry parks. Sized for
- * roughly 40 minutes of trying -- affordable only because every replay carries
- * the same `Idempotency-Key`, so retrying cannot double-charge. Parking a
- * legitimate sale during a ten-minute server restart would force the cashier
- * to re-ring it, which is the more expensive mistake.
- */
-export const MAX_RETRYABLE_ATTEMPTS = 10;
-/**
- * Every till in the shop comes back on the same `online` event and would
- * otherwise retry in lockstep against a server that just restarted.
- */
-export const RETRY_JITTER = 0.2;
-
-/**
- * Delay before attempt `attempts + 1`, given `attempts` consecutive failures
- * so far. Exported so tests assert the policy rather than a hard-coded ladder.
- */
-export function nextAttemptDelay(attempts: number, minDelayMs = 0): number {
-  const exponential = RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1);
-  const capped = Math.min(Math.max(exponential, minDelayMs), RETRY_CEILING_MS);
-  return Math.round(capped * (1 - RETRY_JITTER + Math.random() * 2 * RETRY_JITTER));
-}
-
-/** How a failed replay should be recorded -- see `client/src/shared/lib/offlineRetry.ts`. */
-export interface FailureOutcome {
-  retryable: boolean;
-  reason: string;
-  /** Floor for the next backoff step, for a failure that says how long to wait. */
-  minDelayMs?: number;
-}
-
 export interface OfflineQueueItem extends OfflineAction {
   id: OfflineQueueItemId;
   createdAt: string;
@@ -148,12 +125,29 @@ export function isQuarantined(item: OfflineAction): boolean {
  * and tests around it stay true -- a parked entry is not quarantined.
  */
 export function needsReview(item: OfflineAction): boolean {
-  return isQuarantined(item) || item.syncFailed === true;
+  return isQuarantined(item) || isParked(item);
+}
+
+/** Parked after a failed replay -- see `syncFailed`. Never auto-replayed. */
+export function isParked(item: OfflineAction): boolean {
+  return item.syncFailed === true;
+}
+
+/**
+ * The instant an entry may next be replayed, as epoch ms. No `nextAttemptAt`
+ * means due now -- and so does an unparseable one: a corrupt `localStorage`
+ * value must make the entry retry, not vanish from every code path that could
+ * ever surface it (`NaN` compares false against everything).
+ */
+function attemptAt(item: OfflineAction): number {
+  if (!item.nextAttemptAt) return 0;
+  const parsed = Date.parse(item.nextAttemptAt);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 /** Whether an entry's backoff has elapsed. No `nextAttemptAt` means due now. */
 export function isDue(item: OfflineAction, now: number = Date.now()): boolean {
-  return !item.nextAttemptAt || Date.parse(item.nextAttemptAt) <= now;
+  return attemptAt(item) <= now;
 }
 
 /**
@@ -162,7 +156,7 @@ export function isDue(item: OfflineAction, now: number = Date.now()): boolean {
  * work waiting to happen, or the scheduler would arm a timer for a sweep that
  * can never do anything.
  */
-export function isReplayable(item: OfflineAction): boolean {
+function isReplayable(item: OfflineAction): boolean {
   return item.type === 'sale';
 }
 
@@ -181,7 +175,7 @@ export function earliestAttemptAt(queue: OfflineQueueItem[]): number | null {
   let earliest: number | null = null;
   for (const item of queue) {
     if (!isReplayable(item) || needsReview(item)) continue;
-    const at = item.nextAttemptAt ? Date.parse(item.nextAttemptAt) : 0;
+    const at = attemptAt(item);
     if (earliest === null || at < earliest) earliest = at;
   }
   return earliest;
@@ -208,18 +202,37 @@ interface OfflineState {
    */
   clearRetryState: (id?: OfflineQueueItemId) => void;
   /**
-   * Drops pending backoff on reconnect without forgiving any attempts, so a
-   * network change retries at once while a poison entry still parks on
-   * schedule.
+   * Pulls every pending backoff in to a short jittered delay on reconnect,
+   * without forgiving any attempts -- so a network change retries promptly
+   * while a poison entry still parks on schedule.
+   *
+   * Deliberately not "due immediately": every till in the shop gets the same
+   * `online` event, and setting them all to zero restores exactly the lockstep
+   * stampede the jitter exists to break.
    */
-  clearBackoff: () => void;
+  retrySoon: () => void;
   clearQueue: () => void;
   setSyncing: (isSyncing: boolean) => void;
   getQueueLength: () => number;
   /** Legacy unversioned 'sale' entries awaiting manual cashier review -- see `isQuarantined`. */
   getQuarantinedCount: () => number;
-  /** Entries parked after a failed replay, awaiting an explicit cashier Retry. */
-  getFailedCount: () => number;
+}
+
+/**
+ * Replaces every legacy `Date.now()` id with a collision-free one, in place,
+ * on rehydrate.
+ *
+ * Widening the id type made old entries addressable but left them colliding:
+ * two sales rung up in the same millisecond before the upgrade still share an
+ * id, so removing one drops both and `recordFailure` on one charges attempts
+ * to the other. Ids are internal to this store -- nothing persists or
+ * transmits them -- so restamping is safe, and it is the only thing that makes
+ * R5 true for the tills that already have queued money.
+ */
+export function migrateQueueIds(queue: OfflineQueueItem[]): OfflineQueueItem[] {
+  return queue.map((item) =>
+    typeof item.id === 'number' ? { ...item, id: createQueueItemId() } : item
+  );
 }
 
 export const useOfflineStore = create<OfflineState>()(
@@ -282,14 +295,19 @@ export const useOfflineStore = create<OfflineState>()(
           }),
         })),
 
-      clearBackoff: () =>
-        set((state) => ({
-          queue: state.queue.map((item) => {
-            if (!item.nextAttemptAt) return item;
-            const { nextAttemptAt: _dropped, ...rest } = item;
-            return rest;
-          }),
-        })),
+      retrySoon: () =>
+        set((state) => {
+          const now = Date.now();
+          return {
+            queue: state.queue.map((item) => {
+              if (attemptAt(item) <= now) return item;
+              return {
+                ...item,
+                nextAttemptAt: new Date(now + jitter(RETRY_BASE_MS)).toISOString(),
+              };
+            }),
+          };
+        }),
 
       clearQueue: () => set({ queue: [] }),
 
@@ -298,8 +316,6 @@ export const useOfflineStore = create<OfflineState>()(
       getQueueLength: () => get().queue.length,
 
       getQuarantinedCount: () => get().queue.filter(isQuarantined).length,
-
-      getFailedCount: () => get().queue.filter((item) => item.syncFailed === true).length,
     }),
     {
       name: OFFLINE_QUEUE_STORAGE_KEY,
@@ -310,7 +326,9 @@ export const useOfflineStore = create<OfflineState>()(
       // what rescues a blob already carrying `true`.
       partialize: (state) => ({ queue: state.queue }),
       onRehydrateStorage: () => (state) => {
-        if (state) state.isSyncing = false;
+        if (!state) return;
+        state.isSyncing = false;
+        state.queue = migrateQueueIds(state.queue);
       },
     }
   )

--- a/client/src/shared/store/offlineStore.ts
+++ b/client/src/shared/store/offlineStore.ts
@@ -1,6 +1,28 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { OFFLINE_QUEUE_STORAGE_KEY } from '@/shared/lib/storageKeys';
+import { createIdempotencyKey } from '@/shared/lib/transport/idempotency';
+
+/**
+ * A queue entry's identity. Entries minted since collision-free ids shipped
+ * carry an opaque string; entries already in a cashier's `localStorage` from
+ * before carry the `Date.now()` number they were given. Both keep matching
+ * under the `===`/`!==` lookups below, so no rehydrate migration is needed.
+ */
+export type OfflineQueueItemId = string | number;
+
+/**
+ * Deliberately the same generator as the `Idempotency-Key`, and deliberately
+ * a different name: a queue id identifies a row in this device's queue, a key
+ * identifies a mutation to the server. Reusing the generator inherits its
+ * documented non-secure-context fallback, which a till served over plain HTTP
+ * on a shop LAN actually needs -- and `Date.now()` alone collides whenever two
+ * sales are rung up in the same millisecond, at which point syncing one
+ * silently deletes the other.
+ */
+export function createQueueItemId(): OfflineQueueItemId {
+  return createIdempotencyKey();
+}
 
 /**
  * Sale-payload contract version stamped onto every NEW `type: 'sale'` queue
@@ -36,7 +58,7 @@ export interface OfflineAction {
 }
 
 export interface OfflineQueueItem extends OfflineAction {
-  id: number;
+  id: OfflineQueueItemId;
   createdAt: string;
 }
 
@@ -65,9 +87,9 @@ interface OfflineState {
   queue: OfflineQueueItem[];
   isSyncing: boolean;
   addToQueue: (action: OfflineAction) => void;
-  removeFromQueue: (id: number) => void;
+  removeFromQueue: (id: OfflineQueueItemId) => void;
   /** Flags a queued entry as quarantined after a SPLIT_PAYMENT_MISMATCH rejection. */
-  markMismatched: (id: number) => void;
+  markMismatched: (id: OfflineQueueItemId) => void;
   clearQueue: () => void;
   setSyncing: (isSyncing: boolean) => void;
   getQueueLength: () => number;
@@ -85,7 +107,7 @@ export const useOfflineStore = create<OfflineState>()(
         set((state) => ({
           queue: [
             ...state.queue,
-            { ...action, id: Date.now(), createdAt: new Date().toISOString() },
+            { ...action, id: createQueueItemId(), createdAt: new Date().toISOString() },
           ],
         })),
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -86,23 +86,35 @@ govern how they are replayed; `client/src/shared/hooks/useOffline.ts` and
 
 1. **Every queued entry has a unique, opaque id.** Ids come from `createQueueItemId()`, not from
    `Date.now()` — two sales rung up in the same millisecond used to share an id, and syncing one
-   silently deleted the other. `id` is typed `string | number` so entries persisted under the old
-   scheme keep matching.
+   silently deleted the other. Widening `id` to `string | number` only made old entries
+   *addressable*; `migrateQueueIds` on rehydrate is what makes them *unique*, and it is what closes
+   the defect for the tills that already have queued money.
 2. **A failed replay is classified before it is counted.** `client/src/shared/lib/offlineRetry.ts`
-   is the single place that decides retryable vs terminal. A new server error code that should be
-   retried is added there and nowhere else.
+   is the single place that decides retryable vs terminal, and owns the backoff policy. A new
+   server error code that should be retried is added there and nowhere else.
 3. **A retryable failure backs off; a deterministic one parks immediately.** Backoff doubles from
    `RETRY_BASE_MS` to `RETRY_CEILING_MS` with ±`RETRY_JITTER` (tills in one shop reconnect on the
-   same event and must not retry in lockstep), for at most `MAX_RETRYABLE_ATTEMPTS`. Auto-sync is
-   driven by a timer keyed on the earliest due entry — when nothing is eligible, no timer is armed
-   at all.
+   same event and must not retry in lockstep), for at most `MAX_RETRYABLE_ATTEMPTS` — currently
+   about 43 minutes of trying. If you change either constant, recompute that figure: the budget is
+   sized to outlast a routine server restart, and the ladder reaching the ceiling is what makes it
+   do so. Auto-sync is driven by a timer keyed on the earliest due entry — when nothing is
+   eligible, no timer is armed at all.
 4. **A parked entry is never dropped.** It keeps its payload *and its idempotency key*, and only
    an explicit cashier Retry (`clearRetryState`) revives it.
 
 The retry budget is deliberately generous **because** every replay carries the same
 `Idempotency-Key` (see `docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md`, Unit 9),
 so retrying cannot double-charge. The two decisions are coupled: anyone removing the key would have
-to shrink the budget.
+to shrink the budget. That coupling is enforced per entry, not just by convention — an entry with
+no `idempotencyKey` (queued in the window between the `contractVersion` and idempotency-key
+deploys) is parked on its **first** failure rather than replayed, because each unguarded retry of a
+sale that may already have committed is another charge.
+
+Two things the scheduler must keep doing, both learned the hard way: a replay carries an explicit
+deadline (the axios instance sets no timeout, and one black-holed request otherwise holds the
+in-flight guard for the life of the tab, silently freezing the queue), and reconnect-driven retries
+are throttled (attempts are spent per `online` event, so a flapping link would otherwise burn a
+40-minute budget in seconds and park healthy sales).
 
 **Persisted-field rule.** A new field on a queue entry is optional and documents what its *absence*
 means for an entry persisted before it existed. `contractVersion`, `idempotencyKey` and the retry

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -78,6 +78,38 @@ there," raise it as its own change instead.
 
 ---
 
+## Offline queue replay contract
+
+The persisted `moon-offline-queue` holds sales a till rang up but could not post. Four invariants
+govern how they are replayed; `client/src/shared/hooks/useOffline.ts` and
+`client/src/shared/store/offlineStore.ts` implement them, and a change to either should keep them.
+
+1. **Every queued entry has a unique, opaque id.** Ids come from `createQueueItemId()`, not from
+   `Date.now()` — two sales rung up in the same millisecond used to share an id, and syncing one
+   silently deleted the other. `id` is typed `string | number` so entries persisted under the old
+   scheme keep matching.
+2. **A failed replay is classified before it is counted.** `client/src/shared/lib/offlineRetry.ts`
+   is the single place that decides retryable vs terminal. A new server error code that should be
+   retried is added there and nowhere else.
+3. **A retryable failure backs off; a deterministic one parks immediately.** Backoff doubles from
+   `RETRY_BASE_MS` to `RETRY_CEILING_MS` with ±`RETRY_JITTER` (tills in one shop reconnect on the
+   same event and must not retry in lockstep), for at most `MAX_RETRYABLE_ATTEMPTS`. Auto-sync is
+   driven by a timer keyed on the earliest due entry — when nothing is eligible, no timer is armed
+   at all.
+4. **A parked entry is never dropped.** It keeps its payload *and its idempotency key*, and only
+   an explicit cashier Retry (`clearRetryState`) revives it.
+
+The retry budget is deliberately generous **because** every replay carries the same
+`Idempotency-Key` (see `docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md`, Unit 9),
+so retrying cannot double-charge. The two decisions are coupled: anyone removing the key would have
+to shrink the budget.
+
+**Persisted-field rule.** A new field on a queue entry is optional and documents what its *absence*
+means for an entry persisted before it existed. `contractVersion`, `idempotencyKey` and the retry
+fields all follow this shape; it is what lets a cashier update mid-shift without stranding a queue.
+
+---
+
 ## When to split or merge a slice
 
 Split a slice when **both** of these are true:

--- a/docs/plans/2026-08-31-001-fix-offline-queue-backoff-and-identity-plan.md
+++ b/docs/plans/2026-08-31-001-fix-offline-queue-backoff-and-identity-plan.md
@@ -1,0 +1,698 @@
+---
+title: 'fix: Stop the offline sale queue busy-looping and make failures visible'
+type: fix
+status: active
+date: 2026-08-31
+origin: https://github.com/zhamdy/moon-store/issues/30
+---
+
+# fix: Stop the offline sale queue busy-looping and make failures visible
+
+## Overview
+
+`client/src/shared/hooks/useOffline.ts` retries a failed sale replay with no delay, for as long as
+the queue is non-empty and the till is online. There is no attempt counter, no backoff, and no way
+for a permanently-rejecting sale to stop spinning or to become visible to the cashier as something
+that needs attention.
+
+This plan adds a per-entry retry state (attempt count, next-attempt time, terminal failure flag)
+to the persisted queue, replaces the identity-driven auto-sync effect with a scheduled one, and
+surfaces parked entries in the existing "needs manual review" banner with an explicit Retry action.
+
+It also fixes a second, unreported defect discovered in the same file while planning: queue entries
+are identified by `id: Date.now()`, so two sales queued in the same millisecond share an id and
+`removeFromQueue` deletes both — a silently lost sale, with the same P0 blast radius as the issue
+itself.
+
+The `Idempotency-Key` contract, the queued payload, the split-mismatch quarantine, and every
+behavior of a queue that syncs successfully on the first attempt are unchanged.
+
+## Problem Frame
+
+### The busy loop (issue #30, problem 1)
+
+`useOffline` destructures the whole store (`const { queue, removeFromQueue, ... } = useOfflineStore()`),
+so every `set()` re-renders the hook. `syncQueue` is a `useCallback` whose deps include `isSyncing`
+and `queue`. The auto-sync effect depends on `syncQueue`:
+
+```
+setSyncing(true)  -> store set -> re-render -> new syncQueue identity -> effect re-fires (guarded by isSyncing)
+   ...replay fails, item stays queued...
+setSyncing(false) -> store set -> re-render -> new syncQueue identity -> effect re-fires -> syncQueue runs again
+```
+
+Nothing spaces those iterations. `queue.length` is also a dep but is unchanged on failure, so it is
+`syncQueue`'s identity that drives the spin. The existing test suite documents this rather than
+asserting it — `failingTransport()` in `client/src/shared/hooks/useOffline.test.tsx` has to *hang*
+the second attempt, with the comment "the hook retries a failed replay for as long as the queue is
+non-empty", precisely so the test can observe post-failure state instead of a spin.
+
+Two consequences beyond the one the issue names:
+
+- A **quarantined-only queue spins with zero network requests.** Every entry hits
+  `if (isQuarantined(item)) continue`, so the loop does no work at all, yet `queue.length > 0`
+  keeps the effect re-firing and `setSyncing` keeps churning store state. A till that has parked
+  one legacy sale burns CPU and re-renders `Layout` indefinitely.
+- A **server outage becomes a request storm.** Every online till with a queued sale hammers a
+  recovering server as fast as its event loop allows, with no jitter.
+
+### The double-charge window (issue #30, problem 2) — already closed
+
+The issue states "the queue has no idempotency key, so the server cannot recognise the retry as the
+same sale." **That is no longer true.** It was closed by
+`docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md` (Unit 9, shipped in `1c8d7fb`,
+PR #60), which post-dates the issue. Verified in the current tree:
+
+- `OfflineAction.idempotencyKey` is persisted on the queue entry
+  (`client/src/shared/store/offlineStore.ts`).
+- `useOffline.ts` replays it verbatim, and omits the field entirely for pre-key entries.
+- `client/src/shared/lib/transport/http.ts` sends it as the `Idempotency-Key` header.
+- Server-side, `server/src/http/idempotency.ts` wraps `POST /api/v1/sales` and three sibling
+  mutations; `server/tests/concurrency/sales.idempotency.test.ts` proves 20 simultaneous identical
+  posts commit one sale.
+
+This plan therefore does **not** re-implement idempotency. It treats the key as an existing
+guarantee and relies on it: because a replay is safe, the retry budget below can be generous, and
+an attempt cap is a *visibility* mechanism rather than a correctness one.
+
+### Queue-entry identity (found while planning, in scope per user decision)
+
+```
+addToQueue: (action) => set((state) => ({
+  queue: [...state.queue, { ...action, id: Date.now(), createdAt: ... }],
+}))
+```
+
+`removeFromQueue(id)` and `markMismatched(id)` both filter/map on that id. Two sales queued within
+the same millisecond — an offline cashier ringing up quickly, or any programmatic double-enqueue —
+collide, and syncing the first silently deletes the second. That is unrecoverable data loss in the
+same file, on the same P0 surface. The retry state this plan adds is *also* keyed by id, so the
+collision would corrupt attempt counters too.
+
+### Persisted `isSyncing` (latent, adjacent)
+
+`isSyncing` sits in the persisted slice with no `partialize`. A tab killed mid-sync writes
+`isSyncing: true` to `localStorage`; on the next load `syncQueue` early-returns forever and the
+queue never syncs again. This plan fixes it because the scheduler it introduces would otherwise
+inherit the same trap.
+
+## Requirements Trace
+
+- **R1.** A failed replay never retries immediately. Consecutive failures back off exponentially
+  with a ceiling and jitter.
+- **R2.** An entry that keeps failing stops being auto-replayed after a bounded number of attempts
+  and becomes visible to the cashier as "failed to sync".
+- **R3.** A rejection the server will never accept (a deterministic 4xx) parks immediately rather
+  than consuming the retry budget.
+- **R4.** A parked entry is never dropped and is recoverable by an explicit cashier action that
+  resets its retry state.
+- **R5.** Queue entries have collision-free identity, so syncing one entry can never remove another.
+- **R6.** A queue whose every entry is ineligible (quarantined, parked, or not yet due) performs no
+  work and schedules no immediate wake-up.
+- **R7.** No behavior change for a queue that syncs on the first attempt. Entries already persisted
+  in cashiers' browsers — which carry none of the new fields and a numeric id — keep replaying
+  exactly as they do today.
+- **R8.** The `Idempotency-Key` replay contract established by #42 is unchanged: the same key on
+  every replay of the same queued sale, no key for pre-key entries.
+
+## Scope Boundaries
+
+- **Not** re-implementing or changing idempotency-key generation or stamping — shipped in #42,
+  Unit 9. This plan consumes that guarantee.
+- **Not** changing the queued sale payload, its `contractVersion` stamping, or the existing
+  `SPLIT_PAYMENT_MISMATCH` quarantine semantics. The split-mismatch branch becomes one case of the
+  new terminal classification; its outcome is identical.
+- **No server changes.** `Idempotent-Replay` is not readable cross-origin today (no
+  `exposedHeaders` in `server/index.ts`), but nothing in this plan needs to read it. Recorded as a
+  follow-up below.
+- **Not** changing `client/src/app/session.ts`, which calls `clearQueue()` on logout and therefore
+  discards unsynced sales. Real, out of scope, recorded as a follow-up.
+- **Not** background or service-worker sync, and not general PWA/offline policy — that is #53.
+- **Not** retrying non-`sale` queue entry types. `type: 'sale'` is the only type ever enqueued
+  today; the retry state is generic but only the sale branch exercises it.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `client/src/shared/hooks/useOffline.ts` — the hook under change: online/offline listeners,
+  `syncQueue`, and the auto-sync effect.
+- `client/src/shared/store/offlineStore.ts` — persisted queue (`moon-offline-queue` via
+  `client/src/shared/lib/storageKeys.ts`), `OfflineAction` / `OfflineQueueItem`, `isQuarantined`,
+  `markMismatched`. **The pattern to follow throughout**: `contractVersion` and `idempotencyKey` are
+  both optional additive fields with an explicitly documented meaning for entries that predate them.
+  Every field this plan adds follows that shape.
+- `client/src/shared/lib/transport/types.ts` — `ApiError { status, code, details }`. Note that
+  `client/src/shared/lib/transport/http.ts` deliberately discards axios's "Network Error" text, so a
+  **network failure surfaces as `ApiError` with `status: null`** — that is the primary retryable
+  signal.
+- `client/src/shared/lib/transport/idempotency.ts` — `createIdempotencyKey()`, with a documented
+  `crypto.randomUUID` → `crypto.getRandomValues` → `Math.random` fallback chain for a till served
+  over plain HTTP on a shop LAN. Reuse for queue-entry ids rather than minting a second scheme.
+- `client/src/shared/lib/checkout.ts` — `SPLIT_PAYMENT_MISMATCH_CODE`, the existing precedent for
+  a named error code shared between `CartPanel.tsx` and `useOffline.ts`.
+- `client/src/app/Layout.tsx:73-92` — the two existing banner branches (offline, and
+  always-visible quarantined-needs-review). The new "failed to sync" state extends the second.
+- `client/src/features/pos/components/CartPanel.tsx:468-500` — the only `addToQueue` call site.
+- `client/src/shared/i18n/en.json` / `ar.json` — flat `offline.*` keyspace, `{param}` interpolation.
+  Verified at key parity (1395 keys each) as of this plan; keep it that way.
+
+### Institutional Learnings
+
+`docs/solutions/` is empty. The nearest institutional record is
+`docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md`, which is the direct upstream:
+
+> "**Not** fixing the client offline queue's replay/quarantine logic — that is #30. This plan
+> touches the client only to stamp and persist a stable idempotency key."
+
+and, in its Unchanged Invariants: "the offline queue's quarantine semantics". This plan is the
+other half of that split, and inherits its constraint that persisted entries from before a change
+must keep working.
+
+Server error codes that constrain the classifier (from `server/src/http/idempotency.ts`), both
+409s and easy to conflate:
+
+| `details[0].code` | Meaning | Correct client action |
+|---|---|---|
+| `IDEMPOTENCY_KEY_REUSED` | Same key, different payload/endpoint/user | **Park.** A human must resolve it; retrying is guaranteed to fail identically. |
+| `IDEMPOTENCY_UNRESOLVED` | A concurrent duplicate held the claim past a 3s `lock_timeout` | **Retry.** The message literally says "Please retry." |
+
+A failed server mutation *releases* its idempotency key (the claim shares the business
+transaction's fate), so a corrected retry under the same key runs normally. Retrying is therefore
+safe at every point in this design.
+
+### External References
+
+None gathered. This is a standard retry/backoff shape, and the repo already carries every pattern
+the work needs (optional additive persisted fields, transport-seam test fakes, the quarantine
+concept). External research would have added nothing the local code does not already answer.
+
+## Key Technical Decisions
+
+- **Per-entry retry state, not queue-level.** A poison sale must not stall a healthy one behind it.
+  The queue is already iterated per item with per-item outcomes (`removeFromQueue`,
+  `markMismatched`); attempt counters belong at the same granularity.
+  *(user decision: "Backoff + attempt cap → needs-review")*
+
+- **Failures are classified before they are counted.** A deterministic 4xx parks on the first
+  failure; only genuinely retryable failures consume the backoff budget. Burning ten spaced-out
+  attempts on a validation error the server will never accept is the same busy loop, just slower.
+
+  | Outcome | Classification | Rationale |
+  |---|---|---|
+  | `status: null` (network failure) | Retryable | The till or the link is down; nothing is wrong with the sale. |
+  | `>= 500` | Retryable | Server-side, transient by assumption. |
+  | `408`, `429` | Retryable | Explicitly "try again"; `429` uses the backoff ceiling as its floor. |
+  | `401` | Retryable | The transport's refresh interceptor may recover it; a hard failure redirects to login and moots the question. |
+  | `409` + `IDEMPOTENCY_UNRESOLVED` | Retryable | The server says to retry. |
+  | `409` + `IDEMPOTENCY_KEY_REUSED` | **Terminal** | The payload no longer matches the key. Needs a human. |
+  | `400` + `SPLIT_PAYMENT_MISMATCH` | **Terminal** (existing `markMismatched` path, unchanged) | Already the established behavior. |
+  | Any other `4xx` | **Terminal** | Deterministic; a replay produces the identical rejection. |
+
+- **A generous retryable budget, a hard terminal one.** `MAX_RETRYABLE_ATTEMPTS = 10` with a base
+  of 1s, a 5-minute ceiling and ±20% jitter — roughly 40 minutes of trying before parking. Because
+  idempotency makes replay safe, the cost of retrying too long is bounded, whereas parking a
+  legitimate sale during a ten-minute server restart forces manual re-ringing. Terminal failures
+  park at attempt one.
+
+- **Jitter is not optional.** Every till in the shop comes back online on the same `online` event
+  and would otherwise retry in lockstep against a server that just restarted.
+
+- **The scheduler replaces the identity-driven effect.** `syncQueue` reads the queue via
+  `useOfflineStore.getState()` at call time rather than closing over it, so it no longer depends on
+  `queue` or `isSyncing` and its identity stops churning. A separate effect subscribes to a *scalar*
+  — the earliest due `nextAttemptAt` among eligible entries — and arms a single `setTimeout`. When
+  nothing is eligible, no timer is armed at all (R6). This is the actual root-cause fix; backoff
+  values alone would only slow the loop down.
+
+- **An in-flight guard that is not the persisted flag.** A `useRef` guards re-entry within the
+  session; `isSyncing` stays as the store-visible indicator but is removed from the persisted slice
+  (`partialize`), with an `onRehydrateStorage` reset so blobs already carrying `isSyncing: true`
+  from a killed tab do not permanently deadlock the queue.
+
+- **Queue ids become opaque strings via `createIdempotencyKey()`.** Reusing the existing generator
+  keeps one uniqueness scheme in the client and inherits its non-secure-context fallback, which the
+  till deployment actually needs. `id` widens to `string | number` so numeric ids already in
+  `localStorage` keep matching. *(user decision: "Fix it in this plan")*
+
+- **Parking is reversible and never destructive.** A parked entry keeps its payload and its
+  idempotency key; Retry clears `syncFailed`, `attempts` and `nextAttemptAt` and nothing else. The
+  key is deliberately preserved — if the original attempt did commit server-side, the manual retry
+  replays onto the same key and returns the original outcome instead of double-charging.
+
+- **`isQuarantined` is not widened.** It keeps its current two meanings (legacy-unversioned,
+  split-mismatched) so existing tests and comments stay true. A new `needsReview(item)` predicate
+  covers "quarantined or parked", and the hook exposes both counts so the banner can say which is
+  which.
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Does #30's double-charge half still need work?* No — closed by #42 Unit 9 (`1c8d7fb`). Verified
+  in the current tree at all four layers (store field, hook replay, transport header, server
+  wrapper + real-PG test). The issue text predates that commit.
+- *Should an attempt cap exist at all, given replays are now idempotent?* Yes, but as a visibility
+  mechanism. Hence the generous retryable budget and the immediate terminal park.
+- *Reuse `isQuarantined` for the parked state, or add a new one?* New flag, new predicate. See above.
+- *Is the `Date.now()` id collision in scope?* Yes — user decision.
+- *Does the client need to read `Idempotent-Replay`?* No. Nothing in this design branches on
+  whether a replay was a replay; a 2xx means "committed, dequeue" either way. Which is fortunate,
+  because it is not currently exposed cross-origin.
+
+### Deferred to Implementation
+
+- **Exact `waitFor` / fake-timer interaction.** `client/vitest.config.ts` configures no global fake
+  timers and `client/src/shared/tests/setup.ts` adds none. Testing backoff needs `vi.useFakeTimers()`
+  per-test with `advanceTimersByTime` wrapped in `act`; whether `@testing-library/react`'s `waitFor`
+  needs an explicit `advanceTimers` option under this vitest version is worth one experiment rather
+  than a guess in a plan.
+- **Whether the scheduler effect wants `nextAttemptAt` as an epoch scalar or a derived
+  `dueInMs`.** Both avoid the identity churn; which reads better falls out of writing it.
+- **Whether `recordFailure` and `markMismatched` collapse into one store action.** They may be the
+  same operation with different terminal reasons once both exist.
+- **Whether `Layout.tsx` wants one combined review banner or two.** Depends on how the two message
+  strings read side by side once translated.
+
+## High-Level Technical Design
+
+Directional only — shapes and control flow, not signatures.
+
+### Entry lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Eligible: addToQueue
+    Eligible --> Syncing: due and online
+    Syncing --> [*]: 2xx, removeFromQueue
+    Syncing --> Backoff: retryable failure, attempts < MAX
+    Syncing --> Parked: terminal failure
+    Syncing --> Parked: retryable failure, attempts == MAX
+    Backoff --> Eligible: nextAttemptAt reached
+    Backoff --> Eligible: online event clears the wait
+    Parked --> Eligible: cashier taps Retry
+    Quarantined --> Eligible: cashier re-rings (existing, unchanged)
+```
+
+`Quarantined` (legacy-unversioned / split-mismatched) is the pre-existing state and is entered by
+the paths that already exist. `Parked` is new. Both render in the review banner; neither is ever
+auto-replayed.
+
+### Scheduling, in outline
+
+```
+syncQueue():                         # no queue/isSyncing in its closure
+  if offline or in-flight: return
+  items = getState().queue
+  due   = items where not quarantined, not parked, nextAttemptAt <= now
+  if due is empty: return            # R6 - no work, no state churn
+  for item in due:
+     try post -> removeFromQueue
+     catch -> classify(err) -> recordFailure(id, classification)
+
+scheduler effect (deps: isOnline, earliestDueAt):
+  if offline or nothing eligible: arm nothing
+  if something is due now: syncQueue()
+  else: setTimeout(syncQueue, earliestDueAt - now)   # cleared on unmount/dep change
+
+backoff(attempts) = min(1s * 2^(attempts-1), 5min) * jitter(0.8 .. 1.2)
+```
+
+The `online` event handler additionally clears pending `nextAttemptAt` values (without resetting
+`attempts`), so reconnecting retries at once but a poison item still parks on schedule.
+
+## Implementation Units
+
+- [ ] **Unit 1: Collision-free queue-entry identity**
+
+**Goal:** Make a queue entry's id unique, so syncing one entry can never delete another — and so
+the per-entry retry state Units 2-3 add is addressable at all.
+
+**Requirements:** R5, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `client/src/shared/store/offlineStore.ts` (`OfflineQueueItem.id` widens to
+  `string | number`; `addToQueue` mints via `createIdempotencyKey()`)
+- Modify: `client/src/shared/hooks/useOffline.ts` (id type only, if it names the type)
+- Test: `client/src/shared/store/offlineStore.test.ts` (extend)
+
+**Approach:**
+- Widen the type rather than migrate persisted data. Entries already in `localStorage` carry
+  numeric ids; `filter`/`map` on `!==` / `===` keeps matching them, so no rehydrate migration is
+  needed and R7 holds for free.
+- Reuse `createIdempotencyKey()` from `client/src/shared/lib/transport/idempotency.ts` rather than
+  calling `crypto.randomUUID()` directly — a till on plain HTTP has no secure context, and that
+  function already documents and handles the fallback chain.
+- Consider a thin named re-export (`createQueueItemId`) so the store does not read as if the queue
+  id and the `Idempotency-Key` are the same concept. They are generated the same way and mean
+  different things.
+- Sanity-check that nothing outside the store treats `id` as a number (arithmetic, sort, `toFixed`).
+  Grep says the only consumers are the store's own `filter`/`map` and test fixtures, but confirm.
+
+**Patterns to follow:**
+- `client/src/shared/lib/transport/idempotency.ts` — the existing generator and its documented
+  secure-context fallback.
+
+**Test scenarios:**
+- Happy path: two `addToQueue` calls in immediate succession produce two entries with different ids.
+- Happy path: `removeFromQueue` on one of two same-millisecond entries leaves exactly the other.
+- Edge case: an entry rehydrated with a legacy numeric id is still removable by that numeric id.
+- Edge case: `markMismatched` on one of two entries flags exactly one.
+- Edge case: ids survive a persist round-trip (`useOfflineStore.persist.rehydrate()`), mirroring the
+  existing `idempotencyKey` round-trip test in the same file.
+
+**Verification:**
+- No pair of entries enqueued in the same tick shares an id, and removing one never affects another.
+- Entries persisted before this change still remove and flag correctly.
+
+---
+
+- [ ] **Unit 2: Retry state on the persisted queue entry**
+
+**Goal:** Give each entry an attempt count, a next-attempt time, and a terminal-failure flag, plus
+the store actions that move it between those states — with entries persisted before this change
+behaving exactly as they do today.
+
+**Requirements:** R1, R2, R4, R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `client/src/shared/store/offlineStore.ts`
+- Test: `client/src/shared/store/offlineStore.test.ts` (extend)
+
+**Approach:**
+- Add to `OfflineAction`, all optional and all documented in the house style already used for
+  `contractVersion` and `idempotencyKey` (what the field means, and what its absence means for an
+  entry persisted before it existed): `attempts?`, `nextAttemptAt?` (ISO string, matching
+  `createdAt`), `syncFailed?`, and a short `lastFailure?` reason for the UI and for support.
+- New actions: `recordFailure(id, { retryable, reason })` — increments `attempts`, and either sets
+  `nextAttemptAt` from the backoff formula or sets `syncFailed: true` when terminal or when the
+  budget is exhausted; `clearRetryState(id?)` — the cashier's Retry, clearing `syncFailed`,
+  `attempts` and `nextAttemptAt` (and **not** `idempotencyKey`, so a manual retry of a sale that
+  did commit replays onto the original key); `clearBackoff()` — drops pending `nextAttemptAt` on
+  reconnect without touching `attempts`.
+- Export the backoff policy as named constants (`RETRY_BASE_MS`, `RETRY_CEILING_MS`,
+  `MAX_RETRYABLE_ATTEMPTS`, jitter fraction) and a pure `nextAttemptDelay(attempts)` so the tests
+  assert the policy, not a hard-coded ladder.
+- Add `needsReview(item)` alongside `isQuarantined`, and a `getFailedCount()` selector. Leave
+  `isQuarantined` semantically untouched.
+- Remove `isSyncing` from the persisted slice via `partialize`, and force it to `false` in
+  `onRehydrateStorage` so a blob persisted as `true` by a killed tab cannot deadlock the queue.
+- An entry with no `attempts` field is at attempt zero and due immediately — that is what makes R7
+  hold.
+
+**Patterns to follow:**
+- `client/src/shared/store/offlineStore.ts` — the `contractVersion` / `idempotencyKey` doc-comment
+  shape, and `isQuarantined` as a standalone exported predicate rather than a method.
+
+**Test scenarios:**
+- Happy path: `recordFailure(id, { retryable: true })` on a fresh entry sets `attempts: 1` and a
+  `nextAttemptAt` in the future.
+- Happy path: successive retryable failures produce strictly increasing delays until the ceiling,
+  after which they stay at the ceiling (assert the band, since jitter is applied).
+- Happy path: `recordFailure(id, { retryable: false })` sets `syncFailed: true` immediately, with
+  `attempts: 1` — the budget is not consumed.
+- Edge case: the `MAX_RETRYABLE_ATTEMPTS`-th retryable failure sets `syncFailed: true` rather than
+  scheduling another attempt.
+- Edge case: `nextAttemptDelay` never returns a value outside `[base*0.8, ceiling*1.2]` across the
+  attempt range.
+- Edge case: an entry with no `attempts`/`nextAttemptAt` (persisted before this unit) is reported
+  as due now and not failed.
+- Edge case: `clearRetryState` clears `attempts`, `nextAttemptAt` and `syncFailed` but preserves
+  `payload`, `idempotencyKey` and `contractVersion`.
+- Edge case: `clearBackoff` drops `nextAttemptAt` and leaves `attempts` intact.
+- Edge case: `needsReview` is true for a legacy entry, a mismatched entry, and a `syncFailed`
+  entry, and false for a healthy one; `isQuarantined` still answers false for a `syncFailed` entry.
+- Edge case: rehydrating a persisted blob containing `isSyncing: true` yields `isSyncing: false`,
+  and a fresh persist writes no `isSyncing` key at all.
+- Integration: retry fields survive a persist round-trip via `useOfflineStore.persist.rehydrate()`.
+
+**Verification:**
+- The retry state machine is fully exercisable through store actions with no React involved.
+- Entries persisted before this unit are indistinguishable from fresh ones at attempt zero.
+
+---
+
+- [ ] **Unit 3: Classify failures and replace the busy loop with a scheduler**
+
+**Goal:** Stop the unbounded retry. Classify each replay failure, apply the retry state from Unit 2,
+and drive auto-sync from a timer keyed on the earliest due entry rather than from callback identity.
+
+**Requirements:** R1, R2, R3, R6, R7, R8
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `client/src/shared/hooks/useOffline.ts`
+- Create: `client/src/shared/lib/offlineRetry.ts` (the failure classifier, as a pure function of
+  `unknown` → `{ retryable, reason }`)
+- Test: `client/src/shared/lib/offlineRetry.test.ts`
+- Test: `client/src/shared/hooks/useOffline.test.tsx` (extend, and rewrite `failingTransport`)
+
+**Approach:**
+- The classifier is a pure function over `ApiError` and lives in `shared/lib/` so it can be tested
+  exhaustively without rendering anything. It implements the table in Key Technical Decisions —
+  most importantly, it must distinguish the two 409 codes: `IDEMPOTENCY_UNRESOLVED` is retryable
+  and `IDEMPOTENCY_KEY_REUSED` is terminal, and getting that backwards either parks a recoverable
+  sale or spins on an unrecoverable one.
+- A non-`ApiError` throw (a bug in the hook itself) classifies as terminal, so a defect surfaces to
+  a human instead of retrying forever.
+- `syncQueue` stops closing over `queue` and `isSyncing`: it reads `useOfflineStore.getState()` at
+  call time and guards re-entry with a `useRef`. Its `useCallback` deps shrink to `[isOnline,
+  transport]` (plus stable store actions), which is what stops the identity churn.
+- Prefer narrow `useOfflineStore(selector)` subscriptions over destructuring the whole store, so an
+  unrelated `set()` no longer re-renders the hook and `Layout` beneath it.
+- The auto-sync effect depends on `isOnline` and the earliest due timestamp among eligible entries.
+  Nothing eligible → no timer armed (R6). Something due later → one `setTimeout`, cleared on
+  cleanup. Something due now → call `syncQueue`.
+- Keep the split-mismatch branch as the first terminal case so its existing behavior and its
+  `offline.splitMismatch` toast are byte-identical; route it through `recordFailure` only if that
+  does not change what the cashier sees.
+- Preserve the `...(item.idempotencyKey ? { idempotencyKey: ... } : {})` conditional spread exactly
+  — R8 depends on a pre-key entry sending no header at all, and the existing test asserts the
+  request object has no such property.
+- The `online` handler calls `clearBackoff()` before the effect re-evaluates, so reconnecting
+  retries promptly rather than waiting out a backoff that a network change just invalidated.
+- Extend the hook's return with `failedCount` for Unit 4, and a `retryFailed` action.
+
+**Execution note:** Write the classifier's test table first — it is a pure function with an
+enumerable input space, and the two-409-codes distinction is the single easiest thing in this plan
+to get backwards.
+
+**Patterns to follow:**
+- `client/src/shared/lib/checkout.ts` — a shared, testable pure module holding a named error-code
+  contract used by both `CartPanel.tsx` and `useOffline.ts`.
+- The existing hand-written `Transport` object in `useOffline.test.tsx`'s split-mismatch test — the
+  established way to fake repeated/typed failures, since `createMemoryTransport().failNext` only
+  fails the next matching request.
+
+**Test scenarios:**
+
+*Classifier (`offlineRetry.test.ts`):*
+- Happy path: `ApiError` with `status: null` (the shape `http.ts` produces for a network failure) →
+  retryable.
+- Happy path: `500`, `502`, `503` → retryable; `408`, `429`, `401` → retryable.
+- Error path: `409` with `details[0].code === 'IDEMPOTENCY_UNRESOLVED'` → retryable.
+- Error path: `409` with `details[0].code === 'IDEMPOTENCY_KEY_REUSED'` → terminal.
+- Error path: `400` with a `SPLIT_PAYMENT_MISMATCH` detail → terminal, carrying the mismatch reason.
+- Error path: `400`, `403`, `404`, `422` with no special code → terminal.
+- Edge case: a plain `Error` or a thrown string → terminal.
+- Edge case: `409` with no `details` → terminal (unknown conflict, needs a human).
+
+*Hook (`useOffline.test.tsx`):*
+- Happy path: a successful replay still dequeues, still posts exactly one request with the exact
+  queued body, and still sends the stored idempotency key (the existing tests, unchanged).
+- **Regression, the issue's core claim:** with a transport that always rejects with a 500, exactly
+  one attempt occurs before the timers are advanced — replacing today's `failingTransport`, whose
+  comment documents the spin. Rewrite that helper and its docstring; leaving it would leave the
+  suite asserting the old behavior.
+- Happy path: advancing timers past the first backoff produces a second attempt, and past the second
+  produces a third, with the third strictly later than the second.
+- Happy path: an attempt that succeeds after two failures dequeues the entry and clears its retry
+  state.
+- Error path: a terminal 400 produces exactly one attempt, marks the entry `syncFailed`, and no
+  further attempt occurs however far the timers advance.
+- Error path: `MAX_RETRYABLE_ATTEMPTS` consecutive 500s park the entry; the attempt count stops
+  growing after that.
+- Edge case (R6): a queue containing only quarantined entries issues zero requests, and no timer is
+  pending after the effect settles — the case that busy-loops with zero network traffic today.
+- Edge case (R6): a queue whose only entry is in backoff issues no request until its
+  `nextAttemptAt`, and a queue whose only entry is parked issues none at all.
+- Edge case: a poison entry in backoff does not delay a healthy entry queued behind it — the
+  healthy one posts on the next due sweep.
+- Edge case: an `online` event while an entry is in backoff triggers an attempt immediately and
+  does not reset `attempts`.
+- Edge case (R8): a pre-key entry replays with no `idempotencyKey` property on the request; a keyed
+  entry replays under the same key on every attempt, not a fresh one per retry.
+- Edge case: the split-mismatch rejection still marks the entry mismatched and still surfaces the
+  existing toast, with sync not blocked for other entries.
+- Edge case: unmounting mid-backoff clears the pending timer (no post-unmount state update).
+- Integration: the offline → online → replay → dequeue path end-to-end through the hook, with the
+  banner counts the hook returns matching the store at each step.
+
+**Verification:**
+- A permanently-rejecting sale produces a bounded, strictly increasing sequence of attempts and then
+  stops, instead of an unbounded burst.
+- A quarantined-only or parked-only queue arms no timer and issues no request.
+- Every existing test in `useOffline.test.tsx` still passes, except `failingTransport`, which is
+  rewritten because it encodes the bug being fixed.
+
+---
+
+- [ ] **Unit 4: Surface parked entries and give the cashier a way back**
+
+**Goal:** Make "this sale failed to sync" visible where the cashier already looks for queue trouble,
+with an explicit action that puts the entry back in play.
+
+**Requirements:** R2, R4
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `client/src/app/Layout.tsx` (review banner branch + Retry control)
+- Modify: `client/src/shared/i18n/en.json`
+- Modify: `client/src/shared/i18n/ar.json`
+- Create: `client/src/app/__tests__/Layout.test.tsx` (the app layer keeps its tests in
+  `client/src/app/__tests__/`, alongside `Sidebar.test.tsx` and `UIProvider.test.tsx`, rather than
+  colocated — follow that layer's existing placement, not the general R5 colocation rule)
+
+**Approach:**
+- The hook already returns `quarantinedCount`; add `failedCount` and `retryFailed`. The existing
+  always-visible `isOnline && quarantinedCount > 0` branch is the model — parked entries have the
+  same "never resolves on its own" property and belong in the same place.
+- New keys in the established flat `offline.*` keyspace with `{count}` interpolation:
+  `offline.failedToSync` and `offline.retry`. Add both to `en.json` and `ar.json` at the same
+  position; the files are currently at exact key parity (1395 each) and must stay there.
+- The Retry control calls `clearRetryState()` for all parked entries, which makes them eligible and
+  lets Unit 3's scheduler pick them up on the next tick. It does not itself post anything.
+- Match the existing banner's markup and warning tokens rather than introducing a new treatment;
+  RTL-safe logical properties per `docs/CONVENTIONS.md`.
+- Keep the offline-banner branch's message composition unchanged — only the online review branch
+  gains the new state.
+
+**Patterns to follow:**
+- `client/src/app/Layout.tsx:87-92` — the existing always-visible quarantined-review banner.
+- `client/src/shared/i18n/en.json:600-606` — the `offline.*` block and its `{count}` phrasing.
+
+**Test scenarios:**
+- Happy path: with one parked entry and the till online, the banner renders the failed-to-sync
+  message with the correct count.
+- Happy path: tapping Retry clears `syncFailed`/`attempts`/`nextAttemptAt` on every parked entry in
+  the store.
+- Edge case: parked and quarantined entries coexisting render both messages with independent,
+  correct counts — a parked entry is not counted as quarantined, and vice versa.
+- Edge case: with a healthy queue, neither review banner renders.
+- Edge case: while offline, the offline banner still composes exactly as it does today.
+- Edge case: the Retry control has an accessible name and is reachable by keyboard.
+- Edge case: both new keys exist in `en.json` and `ar.json`, and the two files remain at key parity
+  (a parity assertion is worth adding if the suite has none).
+
+**Verification:**
+- A cashier can see that a sale failed to sync and can put it back in the queue without dev tools.
+- `en.json` and `ar.json` still have identical key sets.
+
+---
+
+- [ ] **Unit 5: Record the replay contract**
+
+**Goal:** Write down the retry/park semantics so the next change to this file does not reintroduce
+the loop.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `docs/CONVENTIONS.md` (a short "offline queue replay contract" entry near the existing
+  global string-coupling section, which already discusses `moon-offline-queue`)
+- Modify: `CLAUDE.md` (one line in the offline/PWA area pointing at the contract)
+
+**Approach:**
+- State the four invariants plainly: every queued entry has a unique id; a failed replay is
+  classified before it is counted; a retryable failure backs off and a deterministic one parks; a
+  parked entry is never dropped and only a cashier action revives it.
+- Note that the retry budget is deliberately generous *because* replays carry an idempotency key,
+  and link the #42 plan — the two decisions are coupled, and someone removing the key later would
+  need to shrink the budget.
+- Add the persisted-field rule that this file has now applied three times (`contractVersion`,
+  `idempotencyKey`, and this plan's retry fields): a new field on a persisted queue entry is
+  optional and documents what its absence means.
+
+**Test scenarios:**
+- Test expectation: none — documentation only. The behavior it describes is covered by Units 1-4.
+
+**Verification:**
+- The contract is discoverable from `docs/CONVENTIONS.md` without reading `useOffline.ts`.
+
+## System-Wide Impact
+
+- **Interaction graph:** `useOffline` has exactly one consumer, `client/src/app/Layout.tsx`, which
+  wraps every authenticated page — so a re-render loop in the hook re-renders the whole shell.
+  Narrowing the store subscription (Unit 3) removes that pressure as a side effect of the fix. The
+  only enqueue site is `CartPanel.tsx`; it is untouched.
+- **Error propagation:** a replay failure currently vanishes into a bare `catch`. After this plan it
+  becomes a classified, persisted, cashier-visible outcome. The classifier is the single place that
+  decides retryable vs terminal — a new server error code that should be retried needs adding there
+  and nowhere else.
+- **State lifecycle risks:** the queue is persisted in `localStorage` on real tills with real
+  unsynced sales. Every new field is optional, and the id widening is type-only, so a cashier
+  updating mid-shift keeps their queue. The one persisted-state *change* is removing `isSyncing`,
+  which is a strict improvement (it currently deadlocks a queue after a mid-sync tab kill) — but it
+  needs the explicit rehydrate reset, not just `partialize`, since existing blobs already contain
+  `true`.
+- **API surface parity:** none. No server change, no request shape change, no new endpoint. The
+  request `useOffline` sends after this plan is byte-identical to the one it sends today.
+- **Integration coverage:** the timing behavior cannot be proven by store unit tests alone — the
+  loop lives in the interaction between `useCallback` identity, store subscriptions and effect deps.
+  The Unit 3 hook tests with fake timers are where the issue's actual claim is verified.
+- **Unchanged invariants:** the queued sale payload and its `contractVersion`; the `Idempotency-Key`
+  contract from #42 (same key on every replay, no key for pre-key entries); `isQuarantined`'s two
+  existing meanings and the `SPLIT_PAYMENT_MISMATCH` quarantine outcome; the offline banner's
+  composition; `clearQueue()` on logout; every server endpoint and response.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| A too-eager attempt cap parks legitimate sales during a routine server restart, forcing manual re-ringing — turning a UX fix into a workflow regression | Budget sized for ~40 minutes of retrying (10 attempts, 5-min ceiling), which is only affordable because replays are idempotent. Terminal 4xx park immediately, so the budget is spent only on genuinely transient failures. |
+| The classifier gets the two 409 codes backwards, parking recoverable sales or spinning on unrecoverable ones | Both codes are enumerated in Key Technical Decisions and have dedicated tests; the classifier is a pure function tested independently of the hook, written test-first. |
+| Fake-timer tests are flaky or the hook's timer leaks across tests | An explicit unmount-clears-the-timer test; per-test `vi.useFakeTimers()` with restore in `afterEach`, matching the file's existing `navigator.onLine` save/restore discipline. |
+| The persisted-state change strands a cashier's queued sales | Every new field optional; id widened rather than migrated; the `isSyncing` removal paired with an explicit rehydrate reset. Covered by round-trip tests in Units 1 and 2. |
+| Fleet-wide retry stampede against a recovering server | ±20% jitter on every computed delay, and a 5-minute ceiling. |
+| Scope creep into #53 (PWA/offline policy) or back into #42 (idempotency) | Both named as explicit non-goals; the request shape is an unchanged invariant. |
+| `docs/plans/2026-08-30-002-…` is `status: completed` but its Unit 9 client code is what this plan builds on — a later revert there silently breaks R8 | Unit 5 documents the coupling: the generous retry budget is justified *by* the idempotency key. |
+
+## Documentation / Operational Notes
+
+- No deploy coupling and no env flag. This is client-only and independently deployable; a till on
+  the old bundle keeps working against the same server.
+- No change to the `IDEMPOTENCY_REQUIRED` flip criterion in `CLAUDE.md`. Worth noting for whoever
+  flips it: after this plan a parked sale stops posting, so the "keys per day matches sales per day"
+  observable can legitimately undercount by the number of parked entries.
+- Support-facing behavior change: a cashier may now see "N sale(s) failed to sync". The runbook
+  answer is the Retry control; the sale is not lost and its idempotency key guarantees a retry
+  cannot double-charge.
+
+**Follow-ups this plan deliberately does not do:**
+- `client/src/app/session.ts:36` calls `clearQueue()` on logout, discarding unsynced sales. Parking
+  makes this more likely to bite, since a parked sale can now sit in the queue across a shift change.
+  Worth its own issue.
+- `server/index.ts` sets no `exposedHeaders`, so `Idempotent-Replay` is unreadable cross-origin.
+  Nothing here needs it; a future "this was already recorded" receipt hint would.
+- `server/index.ts` also sets no `allowedHeaders`; `Idempotency-Key` passes preflight only because
+  the `cors` package echoes the requested headers by default. Undeclared, not broken.
+
+## Sources & References
+
+- Origin issue: [#30 — Offline sale queue busy-loops on failure and can double-charge](https://github.com/zhamdy/moon-store/issues/30)
+- Upstream plan (server idempotency + client key stamping): `docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md`
+- Checkout total parity (source of `contractVersion` and the quarantine concept): `docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md`
+- Related code: `client/src/shared/hooks/useOffline.ts`, `client/src/shared/store/offlineStore.ts`,
+  `client/src/shared/lib/transport/`, `client/src/app/Layout.tsx`,
+  `client/src/features/pos/components/CartPanel.tsx`, `server/src/http/idempotency.ts`
+- Related PRs: #60 (idempotency), #59 (checkout totals), #13 (transport seam)
+- Adjacent open issues: #53 (PWA/offline policy), #52 (mutation errors and double-submit), #57 (checkout reliability epic)
+- Conventions: `docs/CONVENTIONS.md` (R5 placement, transport test seam, string-coupling contract)

--- a/docs/plans/2026-08-31-001-fix-offline-queue-backoff-and-identity-plan.md
+++ b/docs/plans/2026-08-31-001-fix-offline-queue-backoff-and-identity-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'fix: Stop the offline sale queue busy-looping and make failures visible'
 type: fix
-status: active
+status: completed
 date: 2026-08-31
 origin: https://github.com/zhamdy/moon-store/issues/30
 ---
@@ -323,7 +323,7 @@ The `online` event handler additionally clears pending `nextAttemptAt` values (w
 
 ## Implementation Units
 
-- [ ] **Unit 1: Collision-free queue-entry identity**
+- [x] **Unit 1: Collision-free queue-entry identity**
 
 **Goal:** Make a queue entry's id unique, so syncing one entry can never delete another — and so
 the per-entry retry state Units 2-3 add is addressable at all.
@@ -369,7 +369,7 @@ the per-entry retry state Units 2-3 add is addressable at all.
 
 ---
 
-- [ ] **Unit 2: Retry state on the persisted queue entry**
+- [x] **Unit 2: Retry state on the persisted queue entry**
 
 **Goal:** Give each entry an attempt count, a next-attempt time, and a terminal-failure flag, plus
 the store actions that move it between those states — with entries persisted before this change
@@ -436,7 +436,7 @@ behaving exactly as they do today.
 
 ---
 
-- [ ] **Unit 3: Classify failures and replace the busy loop with a scheduler**
+- [x] **Unit 3: Classify failures and replace the busy loop with a scheduler**
 
 **Goal:** Stop the unbounded retry. Classify each replay failure, apply the retry state from Unit 2,
 and drive auto-sync from a timer keyed on the earliest due entry rather than from callback identity.
@@ -542,7 +542,7 @@ to get backwards.
 
 ---
 
-- [ ] **Unit 4: Surface parked entries and give the cashier a way back**
+- [x] **Unit 4: Surface parked entries and give the cashier a way back**
 
 **Goal:** Make "this sale failed to sync" visible where the cashier already looks for queue trouble,
 with an explicit action that puts the entry back in play.
@@ -596,7 +596,7 @@ with an explicit action that puts the entry back in play.
 
 ---
 
-- [ ] **Unit 5: Record the replay contract**
+- [x] **Unit 5: Record the replay contract**
 
 **Goal:** Write down the retry/park semantics so the next change to this file does not reintroduce
 the loop.


### PR DESCRIPTION
Closes #30.

## What was wrong

`useOffline` retried a failed sale replay with **no delay at all**, for as long as the queue was non-empty and the till was online. `syncQueue` closed over `queue` and `isSyncing`, so every `setSyncing` re-rendered the hook, minted a new callback identity, and re-fired the auto-sync effect. Two consequences beyond the one the issue names:

- A **quarantined-only queue spun with zero network requests** — every entry hit `continue`, yet a non-empty queue kept re-firing the effect and churning store state, re-rendering `Layout` (which wraps every authenticated page) indefinitely.
- A **server outage became a request storm**, with no jitter.

While planning, a second unreported defect turned up in the same file: queue entries were identified by `id: Date.now()`, so two sales rung up in the same millisecond shared an id and `removeFromQueue` deleted **both** — silent, unrecoverable loss of a rung-up sale.

The issue's second claim — "no idempotency key, so the server cannot recognise the retry" — is already closed by #60. This PR consumes that guarantee rather than reimplementing it.

## What changed

- **Collision-free entry ids**, minted from the existing idempotency-key generator (which carries the non-secure-context fallback a plain-HTTP till needs). `migrateQueueIds` restamps legacy numeric ids on rehydrate — widening the type alone left pre-upgrade entries *addressable* but still *colliding*, i.e. the defect surviving in exactly the tills that already have queued money.
- **Per-entry retry state** (`attempts`, `nextAttemptAt`, `syncFailed`, `lastFailure`), all optional and documenting what their absence means, so an entry persisted before this replays exactly as it did before.
- **A pure failure classifier** (`shared/lib/offlineRetry.ts`) — the single place deciding retryable vs terminal. It distinguishes the two 409 codes: `IDEMPOTENCY_UNRESOLVED` is retryable, `IDEMPOTENCY_KEY_REUSED` is terminal. Getting that backwards either spins forever or parks a recoverable sale.
- **A scheduler, not a spin.** `syncQueue` reads the store at call time and guards re-entry, so its identity stops churning. A separate effect watches one scalar — when the queue is next due — and arms a single timer, or **none at all** when nothing is eligible.
- **A cashier-visible parked state** with a Retry action, in the banner where queue trouble already surfaces.
- `isSyncing` dropped from the persisted slice: a tab killed mid-sync wrote `true`, and every later load then early-returned out of `syncQueue` forever.

The request shape is byte-identical: same body, same key on every replay, no key for pre-key entries. No server changes.

## Review found six more, all fixed here

A multi-persona review of the first five commits surfaced defects worth calling out, because several were introduced *by* the fix:

| Defect | Why it mattered |
|---|---|
| Budget was **~8.5 min, not the ~40** the comment and plan both claimed — the ladder parked at attempt 10 having never reached the 5-min ceiling | A routine 10-minute server restart parked *every* queued sale fleet-wide: the exact workflow regression the sizing existed to prevent. Now 17 attempts (~43 min). |
| One request that **never settles** held the module-scoped guard forever (axios sets no timeout) | The queue froze silently for the life of the tab — even the cashier's Retry no-opped. The old busy loop was accidentally its own recovery path; removing it removed that. Replays now carry a deadline. |
| `clearBackoff()` on **every** `online` event | Attempts were spent per reconnect, not per elapsed minute — a flapping link burned the budget in seconds and parked healthy sales. It also dropped every till to due-now, restoring the lockstep stampede jitter exists to break. Now a throttled, jittered pull-in. |
| A **keyless** entry was retried unguarded up to the full budget | Each retry of a sale that may already have committed is another charge. It parks on its first failure instead. |
| A clamped timer could fire early and **wedge** the scheduler; an unparseable `nextAttemptAt` poisoned the scalar for the whole queue | Both strand sales invisibly. Fixed. |
| `Layout.test.tsx` mounted **Layout inside itself** | Every count assertion was vacuous. The test now builds the router the real app has. |

Also: retry policy moved into `offlineRetry.ts` so the module documented as owning it no longer imports it back from the store; `navigator.onLine` is re-read after listeners attach; the ref is no longer mutated during render; banners gained `role="status"`.

## Testing

`cd client && npm test` — **380 passing, 42 files.** Typecheck and ESLint clean on every changed file (the repo has pre-existing `tsc` errors elsewhere, none in these files).

New coverage targets the things that would let the bug back in: a bounded, strictly-growing attempt sequence with non-overlapping jitter windows; a quarantined-only or parked-only queue issuing zero requests and arming **zero timers**; same-millisecond id collisions under a frozen clock (otherwise the test only catches the bug when the clock happens not to tick); the never-settling replay; link flapping; a sale rung up mid-sweep; and a render-count assertion, since the plan's named root cause — subscription churn — is invisible to tests that only count network calls.

`failingTransport` was rewritten: it had to *hang* the second attempt precisely because the hook spun, so keeping it would have left the suite asserting the old behaviour.

**Not verified in a browser.** Chrome in this environment cannot reach the local dev servers (connection refused on every loopback form while `curl` succeeds), so the banner is covered by tests but has not been seen rendered.

## Follow-ups this PR deliberately does not do

Two are worth prioritising — the first is a live revenue bug, not a latent one:

1. **`CartPanel.tsx:469-481` enqueues a different payload than it posted.** The offline fallback recomposes the sale and drops `tip`, `payments` (the whole split), `coupon_code`, `points_redeemed`, `notes`, and per-item `memo`, while reusing the original idempotency key. So an offline sale with a tip or a split replays as *a different sale than the customer was charged for* — and if the original POST did commit, the differing fingerprint returns `IDEMPOTENCY_KEY_REUSED`, which now parks it with a Retry button that can never succeed. Out of this plan's scope (payload composition is an explicit non-goal) but it should be next.
2. **`app/session.ts:36` calls `clearQueue()` on logout.** A 401 during replay whose refresh fails logs out and **wipes every queued and parked sale**, with no toast and no trace. Pre-existing, but parking makes queues longer-lived and this PR classifies 401 as retryable, so it routes failures toward that path more often.
3. Server-side, `IDEMPOTENCY_KEY_TTL_HOURS = 24` is shorter than a queue's realistic lifetime — a sale queued Friday evening and replayed Monday can commit twice.
4. Two tabs on one till last-writer-wins on `localStorage`; no cross-tab merge.
5. `docs/ARCHITECTURE.md` is cited by `CLAUDE.md` and `docs/CONVENTIONS.md` but does not exist.

## Post-Deploy Monitoring & Validation

Client-only and independently deployable — a till on the old bundle keeps working against the same server. No env flag, no migration, no deploy coupling.

**Watch for 48h after rollout:**

- **Sale POST rate to `/api/v1/sales`.** The headline signal. The spin meant a till with a failing sale could emit continuous requests; the expected shape afterwards is a bounded, decaying series per queued sale. A *sustained* rise from any single client IP means the scheduler is re-arming when it shouldn't.
- **`SELECT COUNT(*) FROM idempotency_keys WHERE created_at > NOW() - INTERVAL '1 day'` against the day's sale count.** Note for whoever flips `IDEMPOTENCY_REQUIRED`: this observable can now legitimately **undercount** by the number of parked entries, since a parked sale stops posting. That is new, and expected.
- **409s carrying `IDEMPOTENCY_KEY_REUSED`.** A rise means follow-up (1) is biting — offline sales with tips/splits whose replay no longer matches. Each one is a sale a cashier cannot clear from the banner.
- **429 rate.** Should fall, not rise; the reconnect path is now jittered and throttled.

**Healthy:** sale POST volume flat or lower; no sustained per-client request streams; parked-sale reports rare and individually explainable.

**Rollback trigger:** any report of a sale disappearing from a till's queue, or of the "failed to sync" banner appearing on more than an isolated sale or two. Rollback is a client redeploy of the previous bundle — persisted queue entries stay readable by it, because every field this PR adds is optional. The one exception is that migrated string ids stay strings; the old bundle handles them fine (it only compares ids).

**Window/owner:** first two trading days after rollout, @zhamdy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
