### PR TITLE
test(e2e): Playwright harness for critical POS workflows (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ nul
 
 # vitest JSON report, written by CI to check the real-PostgreSQL suites actually ran
 vitest-report.json
+
+# Playwright E2E artifacts
+e2e/playwright-report/
+e2e/blob-report/
+e2e/test-results/
+e2e/playwright/.auth/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,35 @@ on teardown, so files cannot contaminate each other. The target database only ne
 privileges. CI (`.github/workflows/ci.yml`) always sets `TEST_DATABASE_URL` and fails the
 build if these suites were skipped.
 
+### End-to-end suite (`e2e/`)
+
+Playwright driving the real client production build against the real server and a real
+PostgreSQL database — the wire between the two halves the unit suites already cover.
+Chromium only. Full detail in `e2e/README.md`.
+
+```bash
+npm ci --prefix e2e && npx --prefix e2e playwright install --with-deps chromium
+npm run build --prefix client                 # deliberately its own step, not webServer
+cd e2e && E2E_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/moon_store_e2e npm test
+```
+
+> **This suite deletes every row in 77 tables and restarts their sequences.** Point it at a
+> disposable database only. `E2E_DATABASE_URL` has **no default** and the run aborts without
+> it; a second guard aborts if the running API is not on that same database, which is what
+> makes `reuseExistingServer` safe when a dev server is already on port 3001.
+
+Two new production-facing knobs, both defaulting to today's values so an unset server
+behaves exactly as before:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `RATE_LIMIT_MAX` | `200` | Global ceiling per 15 min. |
+| `AUTH_RATE_LIMIT_MAX` | `10` | Ceiling on `/auth/login` and `/auth/refresh`. |
+
+They are deliberately separate: one variable raising both would let a config written to
+unblock a test run silently relax the credential brute-force ceiling. A value that is not a
+positive integer falls back to the default, and any override is warned about at boot.
+
 ## Offline queue
 
 Sales rung up offline are queued in `localStorage` and replayed by

--- a/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
+++ b/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'test: End-to-end coverage for critical POS workflows'
 type: test
-status: active
+status: phase-1-complete
 date: 2026-08-31
 deepened: 2026-08-31
 issue: 50
@@ -586,7 +586,7 @@ Units 1 and 2 are independent and can land in parallel.
 
 ### Phase 1 — Harness
 
-- [ ] **Unit 1: Scaffold the `e2e/` project and Playwright config**
+- [x] **Unit 1: Scaffold the `e2e/` project and Playwright config**
 
 **Goal:** A runnable, empty Playwright project that boots both servers and produces artifacts.
 
@@ -659,7 +659,7 @@ the installed package and drop or substitute anything that does not resolve.
 
 ---
 
-- [ ] **Unit 2: Make the server's rate limits test-operable**
+- [x] **Unit 2: Make the server's rate limits test-operable**
 
 **Goal:** Stop **both** rate limiters from throttling the suite, without weakening production defaults.
 
@@ -733,7 +733,7 @@ env-driven, defaulting to the pre-existing behavior, documented in `CLAUDE.md`.
 
 ---
 
-- [ ] **Unit 3: Database lifecycle, global setup, and the settings baseline**
+- [x] **Unit 3: Database lifecycle, global setup, and the settings baseline**
 
 **Goal:** A deterministic, known-state E2E database and a pinned settings baseline before any spec runs.
 
@@ -804,7 +804,7 @@ production refusal (`FORCE_SEED`) is the same instinct.
 
 ---
 
-- [ ] **Unit 4: Worker-scoped fixtures — auth, per-worker cashier, namespaced data**
+- [x] **Unit 4: Worker-scoped fixtures — auth, per-worker cashier, namespaced data**
 
 **Goal:** Every worker gets an isolated cashier, an open shift and register, and a namespace it owns.
 
@@ -880,7 +880,7 @@ retype them).
 
 ---
 
-- [ ] **Unit 5: Locator affordances — accessible names, i18n-driven selectors, minimal test ids**
+- [x] **Unit 5: Locator affordances — accessible names, i18n-driven selectors, minimal test ids**
 
 **Goal:** POS, cart, checkout and login are addressable by role and label in both locales.
 

--- a/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
+++ b/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
@@ -1,0 +1,1640 @@
+---
+title: 'test: End-to-end coverage for critical POS workflows'
+type: test
+status: active
+date: 2026-08-31
+deepened: 2026-08-31
+issue: 50
+origin: none (planned directly from issue #50; no requirements document exists)
+---
+
+# test: End-to-end coverage for critical POS workflows
+
+## Overview
+
+Stand up a Playwright end-to-end suite that drives the real client build against a real Express
+server and a real PostgreSQL database, and use it to cover the cashier workflows that carry money:
+login, register readiness, search, cart, checkout across every payment and adjustment mode, and the
+failure paths (stock conflict, rejected sale, expired session, duplicate submit, offline replay).
+
+The repo has strong *unit* coverage — 42 client test files (~351 cases) and 35 server files (~290
+cases), including real-PostgreSQL concurrency suites. What it has is coverage of **halves**. The
+client's money math is proven against `contracts/checkout-totals.v1.json` through an in-process
+memory transport; the server's idempotency and stock invariants are proven against real PostgreSQL
+through direct service calls. **Nothing exercises the wire between them.** A regression in the
+transport layer, the React Query cache, the offline scheduler's browser integration, or the
+serialization boundary can land with every suite green.
+
+This plan closes that gap. It is greenfield: there is no browser runner, no `e2e/` directory, and no
+CI artifact upload anywhere in the repo today.
+
+## Problem Frame
+
+From issue #50:
+
+> Unit and component tests do not verify the complete cashier workflow across routing, state,
+> transport, and server behavior. Financial regressions can survive while isolated helpers remain
+> green.
+
+Two recently-closed issues make this urgent rather than merely nice:
+
+- **#42** (`fix(pos)`, commit `1c8d7fb`) made sale creation concurrency-safe and idempotent. Its
+  invariants — one sale per `Idempotency-Key`, guarded relative stock writes, `409
+  IDEMPOTENCY_KEY_REUSED` on payload divergence — are proven at the service layer only. Whether the
+  *browser* sends the header on a double-click, and whether the till's UI reflects a replayed
+  outcome correctly, is untested.
+- **#30** (`fix(offline)`, commit `49f29e8`) rebuilt the offline replay scheduler with backoff,
+  parking, and per-entry idempotency keys. Its 26 tests run in jsdom with a fake transport. Whether
+  a genuinely offline browser queues, and a genuinely reconnected browser replays exactly once, is
+  untested.
+
+Both are double-charge-adjacent. Unit tests cannot prove either end to end.
+
+## Requirements Trace
+
+Directly from the issue's scope and acceptance criteria:
+
+- **R1.** Cover login, register readiness, product search, cart changes, and sale completion.
+- **R2.** Cover cash, card, split payment, discount, tip, coupon, tax modes, loyalty, and receipt output.
+- **R3.** Cover stock conflicts, expired sessions, rejected payments, duplicate submission, and retry.
+- **R4.** Cover offline queueing and reconnection, in coordination with #30 and backend #42.
+- **R5.** Use stable fixtures, and test IDs *only* where accessible queries are insufficient.
+- **R6.** Critical POS paths run against a real application and API test environment.
+- **R7.** Assertions verify both visible cashier state **and** persisted server state.
+- **R8.** Duplicate interaction cannot create duplicate sales.
+- **R9.** Failure cases preserve or recover cart state predictably.
+- **R10.** Tests produce useful diagnostics and artifacts on CI failure.
+- **R11.** A documented smoke subset runs quickly on pull requests.
+
+## Scope Boundaries
+
+- **Not** a rewrite or expansion of the existing vitest suites. Client unit tests keep the memory
+  transport; server suites keep pg-mem and `describeWithPostgres`. This plan adds a third layer, it
+  does not relocate the first two.
+- **Not** cross-browser. Chromium only until the suite is green and stable; Firefox/WebKit is
+  follow-up work with its own flake budget.
+- **Not** visual regression, performance, or load testing.
+- **Not** coverage tooling. The repo has no `@vitest/coverage-*` today and this plan does not add it.
+- **Not** non-POS slices. Inventory, purchasing, fulfillment, analytics, and admin are touched only
+  where a POS path requires them (e.g. an admin token seeding a product).
+- **Not** a payment-gateway integration. There is none — `PaymentMethod` is `'Cash' | 'Card' |
+  'Other'`, a label on the sale record with no processor behind it. See the scope clarification
+  under Key Technical Decisions.
+- **Not** the PWA service worker's own caching behavior. See D3.
+- **Held carts are a deliberate addition beyond issue #50's stated requirements.** R1 names "cart
+  changes" and R9 names failure-case cart preservation; hold/resume is neither, strictly read. It is
+  included because it is a persisted, money-adjacent surface with a client-only lifecycle and no
+  server record — the exact shape a jsdom test proves in isolation and a real browser breaks across a
+  reload. Recorded here as an addition rather than mapped to a requirement it does not serve; drop it
+  first if Unit 7 needs trimming.
+- **Not** camera barcode *decoding*. `client/src/shared/hooks/useScanner.ts` drives Quagga2 in
+  `LiveStream` mode against a real camera, and there is no keyboard-wedge path to substitute. Decoding
+  a barcode from a synthetic video stream in headless Chromium is a disproportionate amount of
+  machinery for the one step it would prove. The **consequence** of a scan — the
+  `GET /api/v1/products/barcode/:barcode` lookup and the resulting cart line — is covered in Unit 6;
+  only the optical decode is excluded. See the note in Unit 6.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Client — the POS surface**
+
+| Path | Note |
+|---|---|
+| `client/src/features/pos/pages/POS.tsx` | 527 lines. Main page; renders `CartPanel`, `BarcodeScanner`, `StartupPrompt`. |
+| `client/src/features/pos/components/CartPanel.tsx` | 1487 lines. **Cart, checkout sheet, payment UI and receipt all live here.** There is no separate Checkout or Payment component. Holds `paymentMethod`, `splitPayment`, `payments[]`, `couponInput`, `redeemPoints`/`pointsToRedeem`, `receiptData`. |
+| `client/src/features/pos/components/StartupPrompt.tsx` | Gates the till on an open shift + open register. Dismissal persists to `sessionStorage` under `moon-startup-dismissed`. |
+| `client/src/features/auth/pages/Login.tsx` | HeroUI `Input`s via react-hook-form. No `data-testid`. |
+| `client/src/shared/lib/checkout.ts` | Client projection of the money contract; consumes `contracts/checkout-totals.v1.json`. |
+| `client/src/shared/lib/transport/client.ts` | `baseURL: import.meta.env.VITE_API_URL \|\| 'http://localhost:3001'`. **No Vite proxy** — the client always talks to an absolute origin. |
+| `client/src/shared/lib/transport/http.ts:39` | The single place `Idempotency-Key` is attached. |
+| `client/src/shared/hooks/useOffline.ts` | Replay scheduler. `REPLAY_TIMEOUT_MS = 30_000`, `RECONNECT_RETRY_THROTTLE_MS = 60_000`. Exports `resetOfflineSchedulerForTests()`. |
+| `client/src/shared/store/offlineStore.ts` | Persisted queue; exports `isQuarantined`, `isParked`, `isEligible`, `earliestAttemptAt`. |
+| `client/src/shared/lib/offlineRetry.ts` | `classifyFailure`, `FAILURE_REASON`, `RETRY_CEILING_MS`. |
+| `client/src/shared/lib/storageKeys.ts` | `moon-auth`, `moon-cart-recovery`, `moon-held-carts`, `moon-offline-queue`, `moon-settings`. |
+| `client/src/shared/store/settingsStore.ts` | **Default locale is `'ar'`, direction `rtl`.** `client/index.html` is `<html lang="ar" dir="rtl">`. |
+
+**Server**
+
+| Path | Note |
+|---|---|
+| `server/index.ts:70-77` | **Global rate limiter: 200 requests / 15 min, hardcoded**, applied ahead of every route including `/api/health`. |
+| `server/src/modules/core/auth/routes.ts:9-18` | **A second, tighter limiter — `authLimiter`, `max: 10` / 15 min — on `POST /login` and `POST /refresh`.** No `keyGenerator`, so it keys on `req.ip`; every Playwright worker is `127.0.0.1`, sharing one in-process bucket. **This, not the 200 ceiling, is the binding constraint** (Unit 2). |
+| `server/src/modules/core/auth/service.ts:30-35` | Refresh tokens are `jwt.sign({ id }, …, { expiresIn: '7d' })` — payload is user id plus second-resolution `iat`/`exp`, no jti — stored in `refresh_tokens.token … UNIQUE`. Two logins as the same user in the same second collide. See the Unit 4 note and the pre-existing-defect callout under Risks. |
+| `server/index.ts:37-44` | CORS allowlist is `CLIENT_URL` plus `localhost:5173/5174/5175`, under `credentials: true`. **The preview port 4173 is not on it** (D2). |
+| `server/src/http/idempotency.ts` | `withIdempotency`, `IDEMPOTENCY_HEADER`, `IDEMPOTENCY_KEY_REUSED`, `IDEMPOTENCY_REPLAY_HEADER`. |
+| `server/src/modules/pos/sales/routes.ts` | `GET /`, `GET /:id`, `POST /` (Admin/Cashier), `POST /:id/refund`. Mounted at `/api/v1/sales`. |
+| `server/src/modules/pos/register/routes.ts` | `register/current`, `register/open`, cash movements. |
+| `server/src/modules/pos/shifts/routes.ts` | `shifts/current`, `shifts/clock-in`, `shifts/clock-out`. |
+| `server/src/modules/core/settings/routes.ts` | `GET /` (any authed), `PUT /` (**Admin only**). Key/value rows (`SettingsMap`, `upsertMany` in `repository.ts`), not a single row — globally shared, the parallelism hazard behind D5. The server re-reads on every call and holds no cache; the **client** caches them for 5 minutes (see D5). |
+| `server/src/database/seed.ts` | `seedDatabase(pool?)` issues `DELETE FROM` over a fixed list of **77 tables** (not `TRUNCATE`) inside a transaction, restarts every public sequence at 1, then reseeds. **Doubles as the reset mechanism — but the list does *not* include `idempotency_keys`** (see Unit 3). |
+| `server/tests/support/realPostgres.ts` | `describeWithPostgres`, `setupRealPostgres` — schema-per-file, `truncate()`, `teardown()`. The pattern this plan's DB lifecycle mirrors in spirit but cannot reuse directly (see D4). |
+| `server/tests/verification/authHelpers.ts` | `getAdminToken()`, `getCashierToken()`, `getDeliveryToken()` — JWT signing helpers worth mirroring. |
+| `server/scripts/assertRealPostgresSuitesRan.mjs` | Precedent for **guarding against silently-skipped suites**. Unit 13 applies the same idea to the smoke tag. |
+
+**Shared**
+
+- `contracts/checkout-totals.v1.json` — the runtime-agnostic money contract already consumed by both
+  `client/src/shared/lib/checkout.ts` and `server/src/modules/pos/sales/service.ts`. **The E2E suite
+  must not re-derive these numbers.** See D7.
+
+**Conventions that bind this work**
+
+- `docs/CONVENTIONS.md` → *Offline queue replay contract* (four invariants; parked entries keep their
+  idempotency key; an entry with no key parks on first failure).
+- `docs/CONVENTIONS.md` → *Concurrency and idempotency* (guarded relative writes, the lock-order
+  table, `withIdempotency` claiming inside the business transaction).
+- `CLAUDE.md` → *Idempotency compatibility window* (`IDEMPOTENCY_REQUIRED` defaults `false`).
+
+### Institutional Learnings
+
+`docs/solutions/` does not exist in this repo. The nearest equivalents are the three plan documents
+whose invariants this suite exists to protect, and they are the right reading before writing specs:
+
+- `docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md` — the canonical calculation contract.
+- `docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md` — Unit 9 is where the queued
+  sale's idempotency key was introduced.
+- `docs/plans/2026-08-31-001-fix-offline-queue-backoff-and-identity-plan.md` — backoff ladder, parking,
+  queue-id migration.
+
+### External References
+
+Playwright research (2026-08-31), Chromium-only starting stack:
+
+- Pin **`@playwright/test` 1.62.1**. 1.62.0 shipped TS config-resolution regressions that break
+  monorepo config discovery. Bundles Chromium 151.
+- [`webServer` array](https://playwright.dev/docs/test-webserver) — each entry polled independently;
+  prefer `url` over `port` (proves the app *answers*, not merely that a socket is bound); `env`
+  inherits `process.env` and adds `PLAYWRIGHT_TEST=1`; `reuseExistingServer: !process.env.CI`.
+- [Parallelism](https://playwright.dev/docs/test-parallel) — the docs' own guidance for a shared
+  backend is *"Use worker index for isolating test data across workers, such as creating separate
+  database users per worker."* Per-test transaction rollback is explicitly unworkable for E2E: the
+  transaction lives on a connection owned by the **server's** pool, and the browser's requests are
+  served by arbitrary pooled connections that cannot see uncommitted rows.
+- [Service workers](https://playwright.dev/docs/service-workers) — *"`browserContext.route()` will
+  not intercept requests intercepted by a Service Worker."* Decisive for D3.
+- [Auth](https://playwright.dev/docs/auth) — setup-project + `storageState`; worker-scoped variant
+  for per-worker accounts. `storageState` captures cookies **and** localStorage.
+- [Retries](https://playwright.dev/docs/test-retries) — `retryStrategy: 'isolated'` (1.62) runs
+  retries at the end in a single worker; the right lever for a DB-sharing suite.
+- [Sharding](https://playwright.dev/docs/test-sharding) — `blob` reporter per shard +
+  `merge-reports`; the merge job needs `if: ${{ !cancelled() }}` or the report is lost precisely
+  when it is needed.
+- [Locators](https://playwright.dev/docs/locators) — documented priority role → label → text → test
+  id. Test ids justified *"when you can't locate by role or text."*
+
+## Key Technical Decisions
+
+### D1 — Playwright, in a new top-level `e2e/` npm project
+
+R6 requires "a real application and API test environment," which rules out extending the jsdom
+vitest suites. Playwright over Cypress for the `webServer` array, worker-scoped fixtures, trace
+viewer, and blob-report sharding — all of which this plan uses directly.
+
+`e2e/` becomes a third independent npm project alongside `client/` and `server/`, with its own
+`package.json` and lockfile. This matches the repo's existing shape (there is no npm workspace) and
+keeps Playwright and its browser binaries out of the client install. *(User decision, 2026-08-31.)*
+
+### D2 — Run against `vite preview` on a production build, not the dev server
+
+The built artifact is what ships: real bundling, real TanStack Router code-splitting
+(`autoCodeSplitting` is on), real asset paths. The dev server has a different module graph, and HMR
+reconnects and error overlays are a documented flake source. The build runs as its own CI step, never
+inside the `webServer` `command` — otherwise the boot `timeout` silently covers compilation and
+produces misleading timeout failures.
+
+**Consequence, accepted:** `vite-plugin-pwa` only emits a service worker on build, so the preview
+build registers one. See D3.
+
+### D3 — `serviceWorkers: 'block'` globally; the SW's own behavior is out of scope
+
+`client/vite.config.ts` configures Workbox with `StaleWhileRevalidate` on `/api/v1/products` and
+`NetworkFirst` on `/api/v1/sales`, and `injectRegister` defaults to `'auto'`, so the built HTML
+registers it. Left unblocked, it breaks this suite in four distinct ways:
+
+**Correction on the scope of that caching, because the precise mechanism matters.** Neither
+`runtimeCaching` entry sets `method`, so Workbox's `registerRoute` default applies and **both routes
+handle GET only**. There is no `BackgroundSyncPlugin` and no `navigateFallback`. The checkout
+`POST /api/v1/sales` is therefore *never* touched by the service worker — the SW caches sales
+**reads**, not writes. Two claims that an earlier draft of this decision rested on are simply false,
+and are struck here rather than left to mislead a later reader: an offline checkout is *not* served a
+cached 200, and POST counting is *not* undercounted by the cache.
+
+What genuinely remains:
+
+| Failure | Mechanism | Holds? |
+|---|---|---|
+| `page.route()` mocks silently shadowed on **GET** | The SW answers `/api/v1/products` and `/api/v1/sales` reads from cache; the route handler never runs. The test exercises stale data while appearing to pass. | Yes |
+| Stale product/stock reads | `StaleWhileRevalidate` with `maxAgeSeconds: 86400` can serve 24-hour-old product rows, including stock — the exact input to Unit 6's search assertions and Unit 10's oversell scenario. | Yes |
+| Registration races | Activation timing differs between first and later navigations — the classic "passes alone, fails in the suite". | Yes |
+| Offline assertions inverted | Would require the SW to answer the checkout POST. It does not. | **No — struck** |
+| POST counts undercount | Same reason. | **No — struck** |
+
+The decision to block still stands on the surviving rows: a `StaleWhileRevalidate` product cache
+shadowing search and stock reads would undermine Unit 6 and Unit 10 directly.
+
+**The unresolved tension with D2, stated rather than glossed.** D2 pays for a production build
+because "the built artifact is what ships" — and D3 then disables the one capability that exists
+*only* in that artifact. The residue is not neutral: in production a real till can render 24-hour-old
+cached product rows, including stock, while this suite always sees live data. The suite therefore
+proves the POS works in a configuration no deployed till actually runs, which is a real qualification
+on R6's "real application." Compounding it, `registerType: 'autoUpdate'` with no `useRegisterSW`
+hook, no update toast and no install-prompt handler anywhere in `client/src` means SW versions swap
+silently on reload with no user-visible surface at all — an unowned behavior this suite is now
+formally not looking at. Blocking is still the right default, because a suite whose money assertions
+are poisoned by a stale cache is worse than one with a documented gap. But "cost-free" would be the
+wrong word, and Unit 14 must record this gap prominently rather than as a footnote.
+
+### D4 — Namespaced, API-seeded, worker-scoped test data — not schema-per-worker
+
+The server test suite isolates by PostgreSQL schema (`setupRealPostgres`), which works because the
+test process owns the pool. E2E cannot reuse it: one long-lived server process holds one
+`search_path`, and the API exposes no tenant or schema header.
+
+Instead each worker seeds its own namespace (`e2e-w{workerIndex}-…`) **through the real HTTP API**,
+so fixture data passes the same validation and invariants as production data. Three rules keep it
+honest:
+
+1. Every test creates the rows it mutates. Never mutate shared seed rows.
+2. Assert on scoped locators (`getByRole('row', { name: sku })`), never "the first row" or "3 items".
+3. Never assert on global aggregates (dashboard revenue) from a parallel worker.
+
+Register sessions and shifts are **per user**, so a per-worker cashier account isolates them for
+free. Truncate-between-tests is rejected: it forces `workers: 1` and defeats `fullyParallel`.
+
+### D5 — A separate serial project for the specs that mutate global settings
+
+This is the sharpest hazard the research surfaced, and it is easy to miss. Tax and loyalty are **not**
+per-sale inputs — `CartPanel.tsx` reads them from `appSettings` (`tax_enabled`, `tax_rate`,
+`tax_mode`, `loyalty_enabled`, `loyalty_points_per_egp`, `loyalty_egp_per_point`), and
+`PUT /api/v1/settings` writes a single global row. A worker that flips `tax_enabled` to test
+inclusive mode silently changes the totals every other worker is asserting on.
+
+Mitigation is two-part:
+
+- `globalSetup` pins a **known settings baseline** — **tax disabled**, loyalty enabled with fixed
+  `points_per_egp` / `egp_per_point` (see D5a for why tax is off). The parallel project asserts
+  against that baseline and never writes settings.
+- Only the *mode variants* — inclusive, disabled, loyalty off — live in a `pos-settings` project
+  with `workers: 1`, `test.describe.configure({ mode: 'serial' })`,
+  `dependencies: ['setup', 'pos-parallel']` so it cannot overlap, and an `afterAll` that restores the
+  baseline.
+
+Pinning the baseline in setup is what keeps this project down to a single spec file of three or four
+scenarios instead of a third of the suite.
+
+**A settings write is not visible to an already-loaded page, and this nearly makes Unit 8
+worthless.** The server holds no settings cache — `repository.ts` re-reads on every call — so a `PUT`
+is instantly visible over HTTP. The *client* is the problem: `CartPanel.tsx:211-213` reads settings
+through `useApiQuery(['settings'], …)` over a query client configured `staleTime: 5 * 60 * 1000`,
+`gcTime: 15min`, `refetchOnWindowFocus: false` (`client/src/shared/lib/queryClient.ts:26-33`). A page
+loaded before the write keeps rendering and submitting under the **old** settings for up to five
+minutes.
+
+The consequence is precisely inverted from what a reader would assume: the inclusive-tax case — which
+this plan calls "the case most likely to be silently wrong" — becomes the case most likely to
+**silently pass**, because the page under test never picked up the mode it claims to be testing. The
+loyalty controls are gated on `appSettings?.loyalty_enabled === 'true'`, so a stale cache also hides
+the very controls the loyalty cases need to click.
+
+Therefore: every settings write in `e2e/fixtures/settings.ts` is followed by a full `page.reload()`
+(or an explicit `queryClient` invalidation via `page.evaluate`) before any assertion, and the
+`afterAll` restore reloads any context that stays open. Unit 8 carries a scenario asserting the UI
+*visibly* reflects the written mode, so that a stale-cache pass is impossible by construction.
+
+### D5a — The baseline is pinned tax-*disabled*, and every tax variant is serial
+
+D5 and D7 initially over-constrained each other, and the resolution shapes which specs live in which
+project. Six of the contract's ten cases specify `tax.enabled: false` — `no-adjustments-tax-disabled`,
+`fixed-manual-discount`, `percentage-manual-discount`, `coupon-discount`,
+`loyalty-redemption-and-earning`, `tip-after-tax-regression` — and `half-minor-unit-rounding-boundary`
+needs a 50% rate. Under a tax-*enabled* baseline the parallel project may never change, entering those
+inputs through the UI yields a different `amountDueMinor` than the case records, so Unit 7's discount,
+coupon and tip specs could not satisfy their own verification rule. Only two cases would have
+survived, and only at exactly 14%.
+
+**Decision:** pin the baseline **tax disabled, loyalty enabled**. This matches the contract's dominant
+configuration, so the parallel project reads six cases directly and D7 needs no exception. Every
+tax-mode case — inclusive, exclusive, and the 50% rounding boundary — moves into the serial
+`pos-settings` project, which is where D5 already routes tax variants, so this costs no additional
+machinery. The only consequence is that Unit 6's smoke cash sale asserts a tax-free total, which is
+if anything the simpler assertion.
+
+| Project | Baseline | Contract cases |
+| --- | --- | --- |
+| `pos-parallel` | tax off, loyalty on | `no-adjustments-tax-disabled`, `fixed-manual-discount`, `percentage-manual-discount`, `coupon-discount`, `loyalty-redemption-and-earning`, `tip-after-tax-regression` |
+| `pos-settings` (serial) | writes and restores | `inclusive-tax`, `exclusive-tax`, `full-combination-exclusive-tax`, `half-minor-unit-rounding-boundary` |
+
+Rejected: adding tax-enabled variants to `contracts/checkout-totals.v1.json` (edits a shared artifact
+both calculators must reproduce, for the test layer's convenience), and deriving expectations by
+running the contract's calculator in the suite (a third implementation of the money rules — exactly
+what D7 exists to prevent).
+
+### D6 — i18n-catalog-driven role locators; test ids only for the genuinely nameless
+
+R5 asks for test ids only where accessible queries are insufficient. Two facts make this a real
+design question rather than a formality: the app defaults to Arabic RTL, and there is effectively
+**no test-id surface in shipped UI today** — 19 occurrences repo-wide, 17 of which are test-local
+fixtures, and none in POS, cart, checkout, or login.
+
+The suite drives accessible names through the **same `shared/i18n/*.json` catalogs the app uses**, so
+a locator reads `t('pos.checkout')` rather than a hardcoded string. This keeps selectors valid in
+both locales and makes the translation itself part of what is tested. Where a role query cannot
+find an element, the first move is to **fix the accessible name** — a missing name is a real a11y
+defect, and reaching for a test id buries it. Test ids are reserved for surfaces with no meaningful
+accessible name: cart line containers, Recharts internals, virtualized rows.
+
+The bulk of the suite runs with locale pinned to `en` (via a seeded `moon-settings`) for readable
+diagnostics, with one Arabic-RTL smoke spec proving the shipped default renders and completes a sale.
+
+### D7 — The suite verifies wiring, not arithmetic
+
+`contracts/checkout-totals.v1.json` is already consumed by both calculators, and
+`client/src/shared/lib/checkout.test.ts` (34 cases) plus `server/tests/sales.test.ts` prove each side
+against it. Re-deriving those expectations in E2E would duplicate the contract in a third place and
+create a two-way maintenance burden the contract file exists to prevent.
+
+E2E instead asserts that a specific fixture case, **entered through the UI**, produces the contract's
+`amountDueMinor` on screen *and* the matching persisted row. Where an E2E spec needs an expected
+total, it reads the named case from `contracts/checkout-totals.v1.json` rather than hardcoding a
+number.
+
+### D8 — Both halves of every financial assertion (R7)
+
+Every money-path spec asserts twice, because the two failures are different bugs:
+
+- **Visible cashier state** — the total in the checkout sheet, the receipt, the toast.
+- **Persisted server state** — read back via the API (`GET /api/v1/sales/:id`), and via a direct
+  `pg` client for tables the API does not expose (`idempotency_keys`, raw `products.stock`).
+
+One POST on the wire with two rows in the database, and two POSTs with one row, are distinct
+defects. Asserting only the wire, or only the screen, catches neither reliably.
+
+### Scope clarification — "rejected payments" (R3)
+
+There is no payment processor in this system: `PaymentMethod` is `'Cash' | 'Card' | 'Other'`, a label
+persisted on the sale, and a repo-wide search for `stripe|paymob|gateway|payment_provider` returns
+nothing. "Rejected payment" is therefore read as **server-rejected sale** — insufficient stock, an
+invalid coupon, a validation failure, or a 5xx — which is the failure a cashier actually experiences.
+Unit 10 covers it under that reading. If a gateway is later introduced, gateway-decline coverage is
+new work, not a gap in this plan.
+
+## Alternative Approaches Considered
+
+### A cheaper real-server integration suite instead of a browser (the main fork)
+
+The most serious alternative, and the one worth stating plainly because it is genuinely cheaper: add
+`supertest` (or `app.listen(0)`) to the existing server vitest suites and drive the real Express app
+against real PostgreSQL, with no browser at all. It would need no new npm project, no browser
+binaries, no `webServer` orchestration, no service-worker problem, no locator strategy, and no
+sharding — perhaps a tenth of the setup in this plan. It would cover R7 and R8 well, and it is
+independently a good idea (`server/tests/verification/endpointHealth.test.ts` currently hand-rolls
+fake `req`/`res` objects and would benefit from a real socket regardless).
+
+**Rejected as a substitute** because it cannot see the layer where the actual risk lives. Every bug
+this plan exists to catch is on the client side of the wire:
+
+- Whether the browser attaches `Idempotency-Key` on a double-click (`transport/http.ts:39`) — a
+  server-side test supplies the header itself and so can never detect its absence.
+- Whether a genuinely offline browser queues and a genuinely reconnected one replays once — the
+  `online`/`offline` events, `localStorage` persistence across reload, and the scheduler's timers have
+  no server-side representation at all.
+- Whether the refresh interceptor's request queue replays in-flight calls after a 401.
+- Whether a correct `409 IDEMPOTENCY_KEY_REUSED` renders as a message a cashier can act on.
+
+The server already has real-PostgreSQL concurrency suites (`server/tests/concurrency/`, seven files)
+proving its half. Adding an HTTP layer to them would deepen coverage of the half that is already
+covered while leaving the untested half untested. R6's "real application **and** API test environment"
+reads as both, not either.
+
+**Partially adopted:** where this plan needs to assert server state or seed data, it uses an
+`APIRequestContext` rather than the UI (D4, D8) — so the cheap layer is used for what it is good at,
+inside the browser suite rather than instead of it. Promoting `supertest` into the server suites
+remains worthwhile follow-up work on its own merits; it is simply not a substitute for this plan.
+
+### Cypress instead of Playwright
+
+Comparable capability for the happy paths. Rejected on four specifics this plan depends on: the
+`webServer` array for orchestrating two servers with independent readiness probes; worker-scoped
+fixtures, which are the mechanism behind the D4 isolation model; `serviceWorkers: 'block'`, which is
+load-bearing for D3; and blob-report sharding with `merge-reports` for the CI shape. Cypress's
+one-browser-context-per-spec model also makes the concurrent double-submit assertions in Unit 9
+harder to express.
+
+### Truncate the database between tests instead of namespacing
+
+Simpler to reason about and eliminates a class of isolation bugs outright. Rejected because it makes
+the database global mutable state, forcing `workers: 1` and serialization across the whole suite —
+which conflicts directly with R11's fast PR subset. Namespacing costs more design (D4) but keeps
+`fullyParallel` available.
+
+### Run E2E against the Vite dev server
+
+Faster feedback, readable stacks, and no service worker to block. Rejected as the default because it
+does not test the artifact that ships: different module graph, no minification, no real
+`autoCodeSplitting` route chunks, plus HMR reconnects and error overlays as a documented flake
+source. Kept as an opt-in local debugging mode rather than the CI path (D2).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Runner?** Playwright 1.62.1, Chromium-only to start. (D1)
+- **Where does the suite live?** New top-level `e2e/`. *(User decision.)*
+- **CI shape?** `@smoke` on PRs, full 4-way-sharded suite on `main` with merged reports. *(User decision.)*
+- **Dev server or preview build?** Preview build, with the SW blocked. (D2, D3)
+- **How is data isolated across workers?** API-seeded per-worker namespaces. (D4)
+- **What about global settings?** Pinned baseline + a serial settings project. (D5)
+- **Test ids or accessible queries?** i18n-driven role locators first. (D6)
+- **Does E2E re-check the money math?** No — it reads `contracts/checkout-totals.v1.json`. (D7)
+- **How do the D5 baseline and the D7 contract rule stop over-constraining each other?** The baseline
+  is pinned **tax-disabled**, matching the contract's own dominant configuration; every tax variant
+  moves to the serial project. See D5a. *(User decision, 2026-08-31.)*
+- **What is a "rejected payment" with no gateway?** A server-rejected sale. (Scope clarification.)
+
+### Deferred to Implementation
+
+- **How many role storageState files are actually needed.** Admin and Cashier are certain; Delivery
+  is only needed if a POS path turns out to touch fulfillment. Decide when Unit 4 lands.
+- **Whether the worker-scoped auth variant is required.** The plain setup-project pattern is simpler,
+  but the access token is 15 minutes and a long full run relies on the refresh interceptor firing on
+  the first 401. Start with the setup project; if `storageState` staleness flakes, move to the
+  worker-scoped variant, which re-authenticates once per worker. (Unit 11 tests the refresh path
+  deliberately either way.)
+- **Whether project `dependencies` compose cleanly with 4-way sharding.** `dependencies:
+  ['pos-parallel']` is the documented mechanism for ordering the settings project, but its
+  interaction with `--shard` needs to be confirmed empirically. Fallback: run the settings project
+  as a separate unsharded CI step.
+- **Exact accessible-name gaps in `CartPanel.tsx` / `POS.tsx` / `Login.tsx`.** Unit 5 is an audit;
+  the specific elements needing `aria-label` or a `<label>` association are only knowable by running
+  role queries against the rendered page.
+- **Whether the 30s `REPLAY_TIMEOUT_MS` makes the offline specs uncomfortably slow.** If so, the
+  timeout may need to become injectable rather than a module constant. Do not pre-emptively change
+  it — measure first.
+- **Whether `seedDatabase()` is fast enough to run per-shard**, or whether the E2E database should be
+  migrated and seeded once per CI job. Measure in Unit 3. Note this is now a *speed* question only —
+  the correctness side (each shard needs its own database) is settled as an invariant in Unit 13.
+- **What a retried spec is allowed to assume.** `retryStrategy: 'isolated'` replays a spec at the end
+  of the run, against a database mutated by everything that ran in between, while the only reset is
+  in `globalSetup`. Specs written against a fresh worker namespace may or may not survive that.
+  Establish the rule when the first retry actually fires rather than guessing now.
+- **Whether the local iteration loop is fast enough to be used.** The plan budgets CI precisely (~3
+  min for smoke) and says nothing about the developer loop: change a line, re-run one spec, see a
+  result. If that is slow, developers stop running E2E locally, PRs go red on a suite nobody can
+  reproduce, and muting becomes the fastest fix. Measure it during Phase 2 and record it beside the
+  CI budget.
+
+## High-Level Technical Design
+
+Directional only — these sketches communicate shape, not implementation.
+
+### Harness topology
+
+```mermaid
+flowchart LR
+  subgraph PW["e2e/ (Playwright 1.62.1)"]
+    GS["globalSetup<br/>migrate + seed + pin settings"]
+    SETUP["project: setup<br/>auth.setup.ts -> storageState"]
+    PAR["project: pos-parallel<br/>fullyParallel, SW blocked"]
+    SER["project: pos-settings<br/>workers:1, serial<br/>depends on pos-parallel"]
+  end
+  subgraph APP["real application"]
+    WEB["vite preview :4173<br/>production build"]
+    API["Express :3001<br/>tsx index.ts"]
+  end
+  DB[("PostgreSQL<br/>moon_store_e2e")]
+
+  GS --> SETUP --> PAR --> SER
+  PAR -->|browser| WEB
+  SER -->|browser| WEB
+  WEB -->|VITE_API_URL| API
+  PAR -.->|"APIRequestContext<br/>seed + verify"| API
+  PAR -.->|"pg client<br/>idempotency_keys, stock"| DB
+  API --> DB
+  GS --> DB
+```
+
+The dotted edges are D8: every money-path spec closes the loop against server state, not just the
+screen.
+
+### Worker-scoped fixture lifecycle
+
+```
+worker starts
+  |- authenticate admin (or reuse storageState)
+  |- POST /api/v1/users        -> cashier "e2e-w{N}@moon.test"
+  |- authenticate that cashier -> per-worker storageState
+  |- POST /api/v1/shifts/clock-in
+  |- POST /api/v1/register/open { opening_float }
+  |
+  +-- test: POST /api/v1/products -> "E2E-W{N}-T{testId}-SKU" (owned by this test)
+  |     ... drive UI, assert screen + assert server state ...
+  +-- test: ...
+  |
+  worker ends -> best-effort cleanup (CI database is disposable)
+```
+
+### Unit dependency graph
+
+```mermaid
+flowchart TD
+  U1["1. Scaffold + config"]
+  U2["2. Rate limit env knob"]
+  U3["3. DB lifecycle + settings baseline"]
+  U4["4. Worker fixtures + auth"]
+  U5["5. Locator affordances"]
+  U6["6. Cash sale @smoke"]
+  U7["7. Payment variants"]
+  U8["8. Tax + loyalty (serial)"]
+  U9["9. Duplicate submit"]
+  U10["10. Stock conflict / rejection"]
+  U11["11. Session expiry"]
+  U12["12. Offline replay"]
+  U13["13. CI workflow"]
+  U14["14. Docs"]
+
+  U1 --> U3 --> U4 --> U5 --> U6
+  U2 -.->|"unblocks full runs"| U6
+  U6 --> U7 --> U8
+  U6 --> U9 --> U10
+  U6 --> U11
+  U9 --> U12
+  U11 --> U12
+  U8 --> U13
+  U10 --> U13
+  U12 --> U13 --> U14
+```
+
+Units 1 and 2 are independent and can land in parallel.
+
+### Spec-to-requirement coverage matrix
+
+| Spec file | Covers | Project | `@smoke` |
+|---|---|---|---|
+| `specs/checkout-cash.spec.ts` | R1 (login, register, search, cart, sale), R2 (cash), R7 | parallel | yes |
+| `specs/locale-rtl.spec.ts` | R1 in the shipped Arabic default | parallel | yes |
+| `specs/payments.spec.ts` | R2 (card, split, discount, tip, coupon), R7 | parallel | partial |
+| `specs/cart-operations.spec.ts` | R1 (cart changes), R9 (held-cart persistence) | parallel | no |
+| `specs/tax-loyalty.spec.ts` | R2 (tax modes, loyalty) | **settings/serial** | no |
+| `specs/duplicate-submit.spec.ts` | R3, R8 | parallel | yes |
+| `specs/failures.spec.ts` | R3 (stock, rejection), R9 | parallel | no |
+| `specs/session.spec.ts` | R3 (expiry), R9 | parallel | no |
+| `specs/offline.spec.ts` | R4, R8 | parallel | yes (one case) |
+
+## Implementation Units
+
+### Phase 1 — Harness
+
+- [ ] **Unit 1: Scaffold the `e2e/` project and Playwright config**
+
+**Goal:** A runnable, empty Playwright project that boots both servers and produces artifacts.
+
+**Requirements:** R6, R10
+
+**Dependencies:** None
+
+**Files:**
+- Create: `e2e/package.json`, `e2e/package-lock.json`, `e2e/tsconfig.json`, `e2e/playwright.config.ts`, `e2e/.gitignore`, `e2e/README.md`
+- Modify: `.gitignore` (ignore `e2e/playwright-report/`, `e2e/blob-report/`, `e2e/test-results/`, `e2e/playwright/.auth/`)
+
+**Approach:**
+- Pin `@playwright/test` to `1.62.1` exactly (1.62.0 has monorepo config-resolution regressions).
+- `webServer` as an **array**: an `API` entry (`npm run start` in `server/`, readiness `url`
+  `http://localhost:3001/api/health` — that route does a real `SELECT 1`) and a `Web` entry
+  (`vite preview --port 4173 --strictPort` in `client/`). `reuseExistingServer: !process.env.CI`.
+  The client build is **not** part of `command` (D2).
+- **The API entry's `env` block is load-bearing and must be explicit.** `webServer.env` *inherits*
+  `process.env`, and `server/index.ts` additionally calls `dotenv/config` — so without an explicit
+  override the server under test picks up the developer's `server/.env` and connects to their **dev
+  database**, while `globalSetup` and `e2e/support/db.ts` operate on `E2E_DATABASE_URL`. That
+  combination is not a confusing test failure; it is the suite writing sales and users into a live
+  database while the assertions read an empty one. Set at minimum:
+
+  | Variable | Value | Why |
+  |---|---|---|
+  | `DATABASE_URL` | `process.env.E2E_DATABASE_URL` | Binds the server to the same database the suite migrates, seeds and reads. Without this the D8 assertions are meaningless. |
+  | `CLIENT_URL` | `http://localhost:4173` | The CORS allowlist is `CLIENT_URL` + `localhost:5173/5174/5175` under `credentials: true`; the preview origin is on no list, so **every** API call fails preflight without this. |
+  | `RATE_LIMIT_MAX` | a high ceiling | Unit 2. |
+  | `AUTH_RATE_LIMIT_MAX` | a high ceiling | Unit 2 — the 10/15min limiter is the binding one. |
+  | `JWT_SECRET`, `JWT_REFRESH_SECRET` | test values | `server/index.ts` hard-exits without them; mirror the literals already in `.github/workflows/ci.yml`'s `server` job rather than reaching for repository secrets. |
+  | `NODE_ENV` | `test` | — |
+
+  The fix for a CORS failure is to set `CLIENT_URL` for the test run — **never** to widen
+  `allowedOrigins` in `server/index.ts` or set `origin: true`. Pinning the preview to 5173 instead
+  would also work and needs no variable; 4173 plus an explicit `CLIENT_URL` is preferred so the
+  suite cannot collide with a dev server the developer already has running.
+- `reuseExistingServer: !process.env.CI` is a convenience with teeth: locally it attaches to whatever
+  server is already listening, pointed at whatever database that server uses. Unit 3's preflight
+  check is what makes this safe.
+- `use`: `baseURL` the preview origin, `serviceWorkers: 'block'` (D3),
+  `testIdAttribute: 'data-testid'`, `trace: 'on-first-retry'`, `video: 'retain-on-failure'`,
+  `screenshot: 'only-on-failure'`.
+- Projects: `setup`, `pos-parallel` (`dependencies: ['setup']`), `pos-settings`
+  (`dependencies: ['setup', 'pos-parallel']`, `workers: 1`) — D5.
+- CI knobs: `forbidOnly`, `retries: 2`, `retryStrategy: 'isolated'`, `workers: 2`,
+  `reporter: [['blob'], ['github']]` on CI and `[['html', { open: 'on-failure' }]]` locally.
+- Add `lint`/`typecheck` scripts so `e2e/` is held to the same bar as its siblings.
+
+**Patterns to follow:** `client/package.json` and `server/package.json` script naming (`lint`,
+`lint:fix`, `format`, `test`), plus `server/package.json`'s `typecheck` — the client has none, and
+the comment in `.github/workflows/ci.yml` explains why (`tsc --noEmit` on `client/` reports
+pre-existing errors). The root `lint-staged` glob list needs an `e2e/` entry.
+
+**Before writing the config, verify the pinned Playwright API surface.** The version claims here come
+from research, not from an installed package: `@playwright/test` 1.62.1, the 1.62.0
+config-resolution regression, and in particular `retryStrategy: 'isolated'`, which is recent. If
+`retryStrategy` does not exist at the pinned version the whole config fails to load. Confirm against
+the installed package and drop or substitute anything that does not resolve.
+
+**Test scenarios:**
+- Test expectation: none — pure scaffolding with no behavior of its own. Its verification is that
+  Unit 6's first spec runs at all.
+
+**Verification:**
+- `npx playwright test --list` enumerates projects and exits clean.
+- A throwaway spec navigating to `/login` passes against the preview build, with both servers booted
+  by Playwright.
+- Killing the API mid-run produces a readiness failure with a clear message, not a hang.
+
+---
+
+- [ ] **Unit 2: Make the server's rate limits test-operable**
+
+**Goal:** Stop **both** rate limiters from throttling the suite, without weakening production defaults.
+
+**Requirements:** R6
+
+**Dependencies:** None (parallel with Unit 1)
+
+**Files:**
+- Modify: `server/index.ts` (the `rateLimit` block at lines 70-77)
+- Modify: `server/src/modules/core/auth/routes.ts` (the `authLimiter` block at lines 9-18)
+- Modify: `server/.env.example` if one exists; otherwise document in `e2e/README.md`
+- Test: `server/tests/http/rateLimit.test.ts` (create)
+
+**Approach:**
+- **There are two limiters, and the plan originally saw only one.** `server/index.ts` hardcodes
+  `max: 200`/15 min globally. But `server/src/modules/core/auth/routes.ts:9-18` mounts `authLimiter`
+  at **`max: 10`/15 min on `POST /login` and `POST /refresh`** — and *that* is the binding
+  constraint, not the 200. Neither sets a `keyGenerator`, so both key on `req.ip`, and every
+  Playwright worker connects from `127.0.0.1` into one in-process `MemoryStore` that persists for the
+  server's lifetime.
+- The suite spends that budget of 10 almost immediately: `auth.setup.ts` logs in per role, each
+  worker authenticates its own cashier, Unit 6 adds a wrong-password case, and Unit 11 exercises
+  `/auth/refresh` deliberately — all multiplied by `retries: 2`. The eleventh auth request onward
+  returns `RATE_LIMITED`, and it will land on **Unit 11**, whose whole purpose is distinguishing one
+  correct refresh from a refresh storm. A 429 there is indistinguishable from the bug the spec exists
+  to catch.
+- Read each ceiling from its **own** variable — `RATE_LIMIT_MAX` (default 200) and
+  `AUTH_RATE_LIMIT_MAX` (default 10) — so production behavior is byte-identical when both are unset.
+  **Do not fold the auth ceiling into `RATE_LIMIT_MAX`**: they guard different things, and one
+  variable raising both means a config intended to unblock a test suite silently relaxes the
+  credential brute-force ceiling too.
+- Bound the suite's own appetite as well as raising the ceiling: reuse `storageState` so the suite
+  logs in roughly once per role per worker rather than per test. Raising a brute-force limit is the
+  mitigation of last resort, not the first move.
+- Do **not** disable either limiter under `NODE_ENV=test` — an env-driven ceiling keeps the
+  middleware in the request path, so a misconfiguration surfaces as a slow test rather than as
+  untested middleware in production.
+- **Make an override observable.** Once `RATE_LIMIT_MAX=100000` exists in a workflow file it is one
+  copy-paste from a deploy environment, where a 500x-raised abuse ceiling would produce no signal
+  whatsoever. Log a warning at boot naming the effective ceiling whenever either variable differs
+  from its default — the same posture `server/index.ts` already takes for missing JWT secrets.
+
+**Execution note:** Test-first. This is a production file, the change is small, and a test asserting
+"unset env reproduces the current 200/15min" is what makes the change provably non-behavioral.
+
+**Patterns to follow:** `server/src/http/idempotency.ts`'s treatment of `IDEMPOTENCY_REQUIRED` —
+env-driven, defaulting to the pre-existing behavior, documented in `CLAUDE.md`.
+
+**Test scenarios:**
+- *Happy path:* With `RATE_LIMIT_MAX` unset, the 200th request succeeds and the 201st returns the
+  `RATE_LIMITED` error envelope — identical to today.
+- *Happy path:* With `RATE_LIMIT_MAX=100000`, 500 sequential requests all succeed.
+- *Edge case:* `RATE_LIMIT_MAX` set to a non-numeric string falls back to 200 rather than `NaN`
+  (which would reject every request).
+- *Edge case:* `RATE_LIMIT_MAX=0` — decide and assert one behavior explicitly (treat as unset, or as
+  "block everything"); do not leave it ambiguous.
+- *Happy path:* With `AUTH_RATE_LIMIT_MAX` unset, the 10th login succeeds and the 11th is rate
+  limited — the brute-force ceiling is unchanged.
+- *Error path (the one that matters):* Raising **only** `RATE_LIMIT_MAX` leaves the auth limiter at
+  its default of 10. This is the regression guard against the two ceilings being merged later.
+- *Edge case:* The auth limiter still applies to `/refresh` as well as `/login`.
+- *Integration:* Both limiters still sit ahead of their controllers, so a rate-limited request never
+  reaches one.
+- *Integration:* A boot with either variable overridden logs the effective ceiling; a default boot
+  logs nothing.
+
+**Verification:**
+- Existing server suites stay green.
+- Default-path behavior is unchanged with no env set.
+- A 500-request E2E run against the server with the ceiling raised produces zero 429s.
+
+---
+
+- [ ] **Unit 3: Database lifecycle, global setup, and the settings baseline**
+
+**Goal:** A deterministic, known-state E2E database and a pinned settings baseline before any spec runs.
+
+**Requirements:** R6, R7, and the precondition for D5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `e2e/support/globalSetup.ts`, `e2e/support/db.ts`, `e2e/support/settingsBaseline.ts`
+- Modify: `e2e/playwright.config.ts` (wire `globalSetup`)
+- Modify: `docker-compose.test.yml` (add a `moon_store_e2e` database, or document reusing the
+  existing service — prefer the latter if it avoids a second container)
+
+**Approach:**
+- `globalSetup` runs `runMigrationsUp` then `seedDatabase()` against `E2E_DATABASE_URL`.
+  `seedDatabase` issues `DELETE FROM` over a fixed list of **77 tables** inside a transaction and
+  restarts every public sequence at 1 before reseeding, so it is both the seed and the reset.
+- **`idempotency_keys` is not on that list, and nothing else clears it.** Its only user link is
+  `user_id … ON DELETE SET NULL`, so deleting users does not cascade either. Rows therefore
+  accumulate across runs, pointing at `resource_id`s of long-deleted sales — while Units 9 and 12
+  assert *"exactly one `idempotency_keys` row"* directly against that table. The reset story must
+  cover the table the sharpest assertions read: `globalSetup` clears it explicitly after
+  `seedDatabase()`. Prefer doing that from the E2E side (`e2e/support/db.ts`) rather than editing the
+  server's seed list, so the change stays inside the test project.
+- Note the sequence restart: primary keys are reused between runs. A `storageState` or browser
+  profile captured before a reseed can therefore reference an id that now belongs to a different row.
+- **Preflight the server's database before touching anything.** The destructive-write guard cannot
+  live only on `globalSetup`, because `globalSetup` is not the process that writes most of the data —
+  the Express server is, and it reads `DATABASE_URL` (Unit 1). After the servers report ready and
+  *before* any delete, assert the running API is actually on `E2E_DATABASE_URL` and abort otherwise.
+  This is what makes `reuseExistingServer` safe locally.
+- Immediately after seeding, write the **pinned settings baseline** — tax **disabled**, loyalty
+  enabled at fixed rates (D5a). Prefer writing it through
+  `e2e/support/db.ts` rather than `PUT /api/v1/settings`: the HTTP route needs the API listening and
+  an admin session, which entangles `globalSetup` with `webServer` boot ordering that Playwright does
+  not clearly guarantee. Settings are plain key/value rows, so a direct write is simpler and has no
+  ordering dependency. If the HTTP route is used instead, confirm the boot ordering empirically and
+  record it here.
+- `e2e/support/db.ts` exposes a small `pg` client for the assertions the API does not expose —
+  `idempotency_keys` rows and raw `products.stock` (D8). Read-only by contract; the suite mutates
+  only through the API.
+- Guard hard: if `E2E_DATABASE_URL` is unset, **fail loudly** rather than defaulting to a developer's
+  dev database. Seeding truncates 40 tables; a wrong URL destroys real local work.
+
+**Patterns to follow:** `server/tests/support/realPostgres.ts` — its `Pool` construction, its
+migration invocation, and above all its *skip-loudly* posture. `server/src/database/seed.ts`'s
+production refusal (`FORCE_SEED`) is the same instinct.
+
+**Test scenarios:**
+- *Happy path:* After `globalSetup`, `GET /api/v1/settings` returns exactly the baseline values —
+  `tax_enabled` false, loyalty enabled at the fixed rates.
+- *Happy path:* After `globalSetup`, the seeded admin/cashier/delivery logins from `AGENTS.md` all
+  authenticate successfully.
+- *Edge case:* Running `globalSetup` twice in a row leaves the same state — including an empty
+  `idempotency_keys`, which the seed path alone does **not** deliver.
+- *Error path:* `E2E_DATABASE_URL` unset aborts the run with an explicit message and touches no
+  database.
+- *Error path:* A running API pointed at a database other than `E2E_DATABASE_URL` aborts the run
+  **before** any delete. This is the guard that protects a developer's dev database.
+- *Error path:* `E2E_DATABASE_URL` pointing at an unreachable host fails during setup with a
+  connection error, not partway through the first spec.
+- *Integration:* `e2e/support/db.ts` and the API observe the same row — a product created over HTTP
+  is visible to the direct `pg` read.
+
+**Verification:**
+- Two consecutive full runs produce identical results with no manual cleanup between them.
+- No spec file imports `pg` directly; all direct reads route through `e2e/support/db.ts`.
+
+---
+
+- [ ] **Unit 4: Worker-scoped fixtures — auth, per-worker cashier, namespaced data**
+
+**Goal:** Every worker gets an isolated cashier, an open shift and register, and a namespace it owns.
+
+**Requirements:** R5, R6
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Create: `e2e/fixtures/test.ts` (the extended `test` every spec imports), `e2e/fixtures/auth.setup.ts`, `e2e/fixtures/seed.ts`, `e2e/fixtures/types.ts`
+- Modify: `e2e/playwright.config.ts` (setup project `testMatch`, per-project `storageState`)
+
+**Approach:**
+- `auth.setup.ts` logs in through the real login form (not by minting a JWT) and writes
+  `e2e/playwright/.auth/{admin,cashier}.json`. Driving the real form means the setup project is
+  itself the login smoke test.
+- A worker-scoped fixture then creates `e2e-w{workerIndex}@moon.test` as a Cashier via the admin API,
+  authenticates it, clocks in a shift, and opens a register. Register sessions and shifts are
+  per-user, so this isolates them for free (D4).
+- Seed `moon-settings` (localStorage) through `storageState` so locale is pinned to `en` (D6).
+- **`moon-startup-dismissed` needs a different mechanism.** It lives in `sessionStorage`
+  (`StartupPrompt.tsx:20`), and `storageState` serializes cookies and localStorage **only** — so
+  writing it into the storage state silently does nothing, and every spec meant to skip
+  `StartupPrompt` would instead sit behind the gate, looking like an application bug in the very
+  first specs written. Seed it with `context.addInitScript(...)` before the first navigation instead,
+  and keep the two mechanisms visibly distinct.
+- **A per-worker cashier is only isolating if the specs actually use it.** The rule is stronger than
+  "don't create rows you don't own": a spec may *authenticate* as a fixed seeded account, but must
+  never mutate its shift, register, or sale state. `register_sessions` allows one open session per
+  `cashier_id` and carries `expected_cash` as a running accumulator mutated by every sale; `shifts`
+  has the same one-active-per-user shape. Two workers driving the shared `sarah@moon.com` drawer
+  would have one worker's register-open fail outright and the other's balance assertions race — the
+  exact hazard D5 treats as first-class for settings.
+- **Do not authenticate every worker as the same admin simultaneously.** Refresh tokens are
+  `jwt.sign({ id }, …, { expiresIn: '7d' })` — user id plus second-resolution `iat`/`exp`, no jti —
+  stored in `refresh_tokens.token … UNIQUE`. Two logins as the same user inside one second produce a
+  byte-identical token and the second insert fails on `23505`; worse, because the tokens are
+  identical, a logout revokes every holder's session at once. Worker startup is exactly that burst.
+  Reuse the setup project's admin `storageState` rather than re-logging-in per worker, and stagger
+  any unavoidable same-identity logins. This is a pre-existing server defect, not one this plan
+  introduces — see Risks.
+- A test-scoped helper mints products named `E2E-W{worker}-{testId}-{sku}` via
+  `POST /api/v1/products`, so a spec never mutates a row another spec reads.
+- Cleanup is best-effort on worker teardown; the CI database is disposable and a failed cleanup must
+  never fail a passing test.
+
+**Execution note:** Write one throwaway spec that asserts fixture isolation *before* writing real
+specs. A fixture bug discovered later looks like a flaky application bug and costs far more.
+
+**Patterns to follow:** `server/tests/verification/authHelpers.ts` for the role/credential table;
+`client/src/shared/lib/storageKeys.ts` for the exact persist key names (these are literal
+`localStorage` keys under the global string-coupling contract — read them from the source, never
+retype them).
+
+**Test scenarios:**
+- *Happy path:* A spec using the cashier storage state loads `/pos` directly without a login redirect.
+- *Happy path:* The worker fixture's cashier has an open shift and an open register before the first
+  test body runs.
+- *Edge case:* Two workers running concurrently create distinct cashiers and distinct register
+  sessions; neither sees the other's open register.
+- *Edge case:* Product names/SKUs generated by two workers never collide (the barcode and SKU columns
+  are `UNIQUE` — a collision surfaces as a confusing 409 mid-test).
+- *Error path:* If per-worker cashier creation fails, the fixture throws with a message naming the
+  worker index, rather than leaving tests to fail later on a missing register.
+- *Integration:* `storageState` restores both the `moon-auth` localStorage entry **and** the httpOnly
+  refresh cookie — assert the cookie is present, since losing it silently breaks Unit 11.
+
+**Verification:**
+- Running the same spec file with `--workers=4` passes repeatedly with no cross-talk. This is a local
+  isolation stress check invoked by CLI override — the committed config stays at `workers: 2` until
+  the flake rate has been observed (Unit 13).
+- A spec may authenticate as a fixed seeded account, but no spec mutates a seeded account's shift,
+  register, or sale state.
+
+---
+
+- [ ] **Unit 5: Locator affordances — accessible names, i18n-driven selectors, minimal test ids**
+
+**Goal:** POS, cart, checkout and login are addressable by role and label in both locales.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Create: `e2e/support/locators.ts` (i18n-catalog-driven locator helpers), `e2e/support/i18n.ts`
+- Modify (as the audit requires): `client/src/features/auth/pages/Login.tsx`,
+  `client/src/features/pos/pages/POS.tsx`,
+  `client/src/features/pos/components/CartPanel.tsx`,
+  `client/src/features/pos/components/StartupPrompt.tsx`
+- Test: existing colocated client tests must stay green; add cases to
+  `client/src/features/pos/components/CartPanel.test.tsx` for any name added
+
+**Approach:**
+- Audit first, change second. Run role queries against the rendered POS and record what is
+  unreachable before editing a component.
+- Where an element has no accessible name, **add one** (`aria-label`, or a real `<label>`
+  association) — that is an accessibility improvement the app wants independently. Reaching for a
+  test id there would bury a genuine defect (D6).
+- `e2e/support/locators.ts` reads `client/src/shared/i18n/en.json` and `ar.json` and exposes
+  `byLabelKey('pos.checkout')`-style helpers, so a selector is locale-parameterized and a renamed
+  translation key fails loudly instead of silently matching nothing.
+- Add `data-testid` **only** to surfaces with no meaningful accessible name — the cart line
+  container, a virtualized row wrapper. Keep the existing kebab-case convention. Every test id added
+  gets a one-line comment saying why a role query was insufficient.
+- `CartPanel.tsx` is 1487 lines and holds cart, checkout sheet, payment UI and receipt. Do not
+  refactor it here; this unit adds names, nothing else.
+- **Bound this unit, because it sits on the critical path.** R5 authorizes test ids sparingly; it does
+  not commission an open-ended accessibility remediation of a 1487-line component, and everything in
+  Phases 2 and 3 is blocked behind this unit completing. Fix accessible names only for controls on
+  the Unit 6 critical path. Anything the audit turns up beyond that path is filed as a follow-up a11y
+  issue, not fixed inline. If the blocking set on the critical path exceeds roughly ten elements,
+  fall back to test ids with justification comments and file the a11y debt — Phase 2 must never be
+  blocked on an unsized remediation.
+- Adding an accessible name changes what assistive technology and page scrapers expose. If a role
+  query would need an element to carry customer or payment data in its accessible name, use a test id
+  instead.
+
+**Patterns to follow:** the existing single production test id at
+`client/src/shared/components/forms/ImageUploader.tsx:172` for naming style; `docs/CONVENTIONS.md`
+→ *i18n* → *Adding New Keys* for any key added.
+
+**Test scenarios:**
+- *Happy path:* Every interactive control on the checkout path resolves via `getByRole` with an
+  accessible name, in `en`.
+- *Happy path:* The same locators resolve in `ar` when driven through the i18n catalog.
+- *Edge case:* A locator helper given an i18n key that does not exist throws at construction with
+  the missing key named — it must not degrade to an empty-string match that silently matches everything.
+- *Edge case:* `en.json` and `ar.json` both contain every key the locator helpers reference (a
+  catalog-parity assertion).
+- *Integration:* Existing `CartPanel.test.tsx` (22 cases) and `POS.test.tsx` still pass after the
+  accessible-name additions — these are the same DOM the unit tests query.
+
+**Verification:**
+- No spec in `e2e/specs/` contains a hardcoded user-facing string or a CSS-class selector.
+- The count of production `data-testid` attributes added is small, and each carries its justification comment.
+
+### Phase 2 — Money paths
+
+- [ ] **Unit 6: The critical cash sale, end to end (`@smoke`)**
+
+**Goal:** The spine of R1 — login through receipt — proven against the real stack.
+
+**Requirements:** R1, R2 (cash), R6, R7, R11
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Create: `e2e/specs/checkout-cash.spec.ts`, `e2e/specs/locale-rtl.spec.ts`
+- Create: `e2e/support/assertSale.ts` (the D8 two-sided assertion helper)
+
+**Approach:**
+- One spec walks: login → `StartupPrompt` clock-in and register open → product search → add to cart →
+  adjust quantity → checkout as Cash → receipt visible. Tagged `@smoke`. `locale-rtl.spec.ts` is
+  tagged `@smoke` as well, matching the coverage matrix.
+- **The register-readiness path needs its own identity, and this is not a detail.** The worker fixture
+  already clocks in a shift and opens a register (Unit 4), so a worker-scoped cashier has nothing for
+  `StartupPrompt` to do — bypassing `moon-startup-dismissed` is not the same as having no open shift.
+  Driving the shared seeded `sarah@moon.com` instead would violate Unit 4's rule and race any other
+  worker on the same drawer. So this one spec mints its own throwaway cashier via the admin API, with
+  no shift and no register, and does **not** use the worker-scoped fixture. Every other spec uses the
+  worker cashier.
+- `assertSale.ts` is the shared shape for D8: given a sale id, assert the on-screen total, the
+  `GET /api/v1/sales/:id` payload, and the product's decremented stock read directly.
+- Expected totals come from a named case in `contracts/checkout-totals.v1.json`, never hardcoded (D7).
+  Under the tax-disabled baseline (D5a) the smoke sale asserts `no-adjustments-tax-disabled`.
+- `locale-rtl.spec.ts` runs the same happy path with `moon-settings` left at the shipped Arabic
+  default and asserts `<html dir="rtl">` plus a completed sale — the default configuration must be
+  covered, not just the convenient one.
+- **Product search has two paths, and R1 names both.** The text input (`POS.tsx:244`,
+  `t('pos.searchPlaceholder')`) is driven through the UI as normal. The barcode path
+  (`POS.tsx:154 handleBarcodeDetected`) is camera-only via Quagga `LiveStream`, so the optical decode
+  is out of scope — but the two steps that follow it are not. Cover
+  `GET /api/v1/products/barcode/:barcode` directly via the API, including its miss case, so the lookup
+  contract the scanner depends on is verified even though the decode is not. Note the seam explicitly
+  in the spec, so a future reader knows the gap is deliberate rather than overlooked.
+
+**Test scenarios:**
+- *Happy path:* Login as this spec's freshly-minted cashier lands on the till after clocking in a
+  shift and opening a register through `StartupPrompt`.
+- *Happy path:* Searching a worker-namespaced SKU returns that product and no other worker's.
+- *Happy path:* Adding an item, then raising quantity to 3, shows a subtotal of 3 x unit price.
+- *Happy path:* Completing a Cash sale shows a success toast and a receipt with the correct total,
+  line items, and payment method.
+- *Happy path (R7):* `GET /api/v1/sales/:id` returns matching `total`, `payment_method: 'Cash'`, and
+  one `sale_item` at the expected `unit_price`; `products.stock` read directly is down by exactly 3.
+- *Edge case:* Removing the last cart line returns the cart to its empty state and disables checkout.
+- *Edge case:* Searching a SKU that does not exist shows the empty-result state, not a spinner that
+  never resolves.
+- *Integration:* `GET /api/v1/products/barcode/:barcode` returns the worker's seeded product for a
+  known barcode — the lookup the scanner's `handleBarcodeDetected` depends on.
+- *Error path:* The same endpoint with an unknown barcode returns a not-found the caller can
+  distinguish, rather than a null product that would add an empty cart line.
+- *Error path:* Login with a wrong password shows the error and does not navigate.
+- *Integration:* Opening the register records an opening float retrievable at `register/current`.
+- *Integration (RTL):* With the Arabic default, `<html>` is `lang="ar" dir="rtl"` and a Cash sale
+  still completes and persists identically.
+
+**Verification:**
+- `npx playwright test --grep @smoke` passes from a clean database in under ~3 minutes.
+- The spec passes at `--workers=4` and at `--workers=1`.
+
+---
+
+- [ ] **Unit 7: Payment, adjustment, and cart-operation variants**
+
+**Goal:** R2's breadth (minus the two settings-driven modes), plus the cart operations R1 names.
+
+**Requirements:** R1 (cart changes), R2, R7, R9
+
+**Dependencies:** Unit 6
+
+**Files:**
+- Create: `e2e/specs/payments.spec.ts`, `e2e/specs/cart-operations.spec.ts`
+- Create: `e2e/fixtures/coupon.ts` (creates a worker-namespaced coupon via the API)
+
+**Approach:**
+- **Held carts belong here, and are easy to miss.** `handleHoldCart` (`CartPanel.tsx:574`) persists a
+  suspended cart — items, discount, notes, tip and coupon code — to `moon-held-carts` via
+  `heldCartsStore`. That is a persisted, money-adjacent surface with a client-only lifecycle and no
+  server record, which makes it exactly the kind of state a unit test proves in isolation and a real
+  browser breaks across reloads. `cart-operations.spec.ts` covers hold, resume, and survival across a
+  reload. Good news for D6: the hold control already carries an `aria-label` (`CartPanel.tsx:609`),
+  so no locator work is needed.
+- One spec per mode, each ending in the D8 two-sided assertion. Card and split are `@smoke`; the rest
+  are full-suite only, to keep the PR job under budget.
+- Split payment is the subtle one: `CartPanel.tsx:536` persists `payment_method: 'Cash'` whenever
+  `splitPayment` is on, while the individual `payments[]` entries carry the real breakdown. The spec
+  must assert the **persisted breakdown**, not just the summary label, or it will pass on a bug.
+- Coupons are created per worker (`E2E-W{N}-...`) so `max_uses` counting — which the server guards
+  with `SELECT ... FOR UPDATE` on `coupons` — cannot be perturbed by a parallel worker.
+
+**Test scenarios:**
+- *Happy path:* A Card sale persists `payment_method: 'Card'` and shows Card on the receipt.
+- *Happy path:* A split Cash + Card sale allocating a known amount to each persists both payment
+  entries summing to the total, with the cash portion recorded as a register movement.
+- *Happy path:* A percentage discount and a fixed discount each produce the contract's expected
+  `amountDueMinor` on screen and in the persisted row.
+- *Happy path:* A tip is added after tax, is never discounted or taxed, and appears separately on the
+  receipt and the sale row.
+- *Happy path:* A valid coupon applies its discount and records a `coupon_usage` row.
+- *Edge case:* A discount larger than the cart is capped at the remaining amount, not driven negative.
+- *Edge case:* A split allocation that does not sum to the total is refused before submission.
+- *Edge case:* A negative or malformed tip is clamped to zero.
+- *Error path:* An invalid coupon code shows an error, applies no discount, and leaves the cart intact.
+- *Error path:* An expired or fully-consumed coupon is refused with a distinguishable message.
+- *Integration:* The cash component of a split sale moves the register balance by exactly that
+  component — not by the full sale total.
+
+Cart operations (`cart-operations.spec.ts`):
+
+- *Happy path:* Holding a cart clears the active cart and lists the held cart by its generated name.
+- *Happy path:* Resuming a held cart restores its items, quantities, discount, notes, tip and coupon
+  code, and removes it from the held list.
+- *Happy path:* A resumed cart checks out normally and persists the same totals it would have before
+  being held.
+- *Edge case:* Two carts held in succession get distinct names and neither overwrites the other.
+- *Edge case:* Held carts survive a full page reload — `moon-held-carts` is persisted, and a cashier
+  losing a suspended order to a refresh is a real money loss.
+- *Edge case:* Holding an empty cart is refused rather than creating an empty held entry.
+- *Integration (R9):* Holding a cart does **not** create a sale or move stock — assert no new `sales`
+  row and unchanged stock.
+
+**Verification:**
+- Every expected total **for a case the contract names** traces to that case. The contract's own
+  notes state that caps are deliberately *not* exercised by its cases ("caps are exercised by Units
+  2/3, not by this fixture's simple cases"), so cap and clamp scenarios assert the documented cap
+  *behavior* — the total equals the remaining amount, the tip is zero, the base is not negative —
+  rather than a fixture number. Do not hardcode a total for a case the contract does not name; if a
+  cap case genuinely needs an exact figure, add a named case to the contract first.
+- No spec in this file writes `/api/v1/settings`.
+- The held-cart cases assert the persisted `moon-held-carts` contents, not only the rendered list.
+
+---
+
+- [ ] **Unit 8: Tax modes and loyalty (serial settings project)**
+
+**Goal:** The settings-driven half of R2, without destabilizing the parallel suite.
+
+**Requirements:** R2 (tax modes, loyalty), R7
+
+**Dependencies:** Unit 7
+
+**Files:**
+- Create: `e2e/specs/tax-loyalty.spec.ts`
+- Create: `e2e/fixtures/settings.ts` (set-and-restore helper)
+- Create: `e2e/fixtures/customer.ts` (namespaced customer with a known starting point balance)
+- Modify: `e2e/playwright.config.ts` (confirm the `pos-settings` project's `testMatch`)
+
+**Approach:**
+- **All four tax cases live here**, not just the mode variants: under the tax-disabled baseline
+  (D5a), `exclusive-tax`, `inclusive-tax`, `full-combination-exclusive-tax` and
+  `half-minor-unit-rounding-boundary` all require a settings write, so all four are serial.
+- This file is the **only** place in the suite that writes `PUT /api/v1/settings`. It runs in the
+  `pos-settings` project: `workers: 1`, `mode: 'serial'`, `dependencies: ['setup', 'pos-parallel']`
+  (the explicit form — it needs the setup project's admin `storageState`, not just the ordering).
+- `e2e/fixtures/settings.ts` captures the current settings in `beforeAll` and restores them in
+  `afterAll` — including on failure, so a crashed spec does not strand the database in inclusive-tax
+  mode for the next run.
+- Loyalty units are direction-sensitive and easy to invert: per the contract file, `pointsPerEgp` is
+  points earned per 1 EGP, and `egpPerPointMinor` is minor units redeemed per 1 point. Neither is
+  "per 100 points." Assert both directions explicitly, and take the expected `earnedPoints` from the
+  contract's named case rather than restating the formula here — D7 applies to points exactly as it
+  applies to totals.
+- **Loyalty needs a customer, which no other fixture creates.** Points live on
+  `customers.loyalty_points`, and the sale service refuses redemption outright without one
+  (`sales/service.ts:495-496`), while every other spec in the suite rings up anonymous sales with a
+  null `customer_id`. `e2e/fixtures/customer.ts` creates a namespaced customer with a known starting
+  balance. `customers.phone` is `UNIQUE NOT NULL`, so the phone number must be namespaced too — a
+  hardcoded test number collides across re-runs and with anything `pos-parallel` left behind, even
+  though this project runs serially.
+- Every settings write is followed by a reload before assertions (D5) — without it the page under
+  test keeps rendering the previous mode for up to five minutes.
+
+**Execution note:** Write the restore-on-failure path before the first assertion. A settings spec
+that fails without restoring poisons every subsequent run, and that failure is far more expensive to
+diagnose than the bug it was chasing.
+
+**Test scenarios:**
+- *Happy path:* Exclusive tax at a known rate adds tax on top of the discounted base, matching the
+  contract case on screen and in the persisted `tax_amount`.
+- *Happy path:* Inclusive tax at the same rate leaves the displayed total unchanged but persists a
+  different `tax_amount` — the case most likely to be silently wrong.
+- *Happy path:* Tax disabled produces zero tax and a total equal to the discounted subtotal.
+- *Happy path:* Loyalty earn — a completed sale with a customer attached credits the contract case's
+  `earnedPoints`, read from `contracts/checkout-totals.v1.json`.
+- *Edge case:* An anonymous sale (no customer) earns nothing and does not error — this is what every
+  other spec in the suite does, so the negative must hold.
+- *Happy path:* Loyalty redeem — spending N points reduces the total by `N * egpPerPointMinor` and
+  debits exactly N points.
+- *Edge case:* Redemption is capped by the customer's balance; requesting more than they hold redeems
+  their balance, not a negative one.
+- *Edge case:* Redemption is capped by the remaining taxable amount after manual and coupon discounts,
+  and cannot drive the total below zero.
+- *Edge case:* Tax is computed on a taxable base clamped at zero when discounts exceed the subtotal.
+- *Error path:* A non-Admin attempting `PUT /api/v1/settings` is refused — the fixture must fail
+  loudly rather than silently proceeding under the wrong settings.
+- *Integration:* After `afterAll`, `GET /api/v1/settings` equals the Unit 3 baseline exactly — every
+  key, not just the ones this spec wrote.
+- *Integration (anti-stale-pass guard):* After a settings write and reload, the **UI visibly** shows
+  the new mode (the tax line changes, the loyalty controls appear/disappear) before any total is
+  asserted. Without this, a stale React Query cache makes the inclusive-tax case pass while testing
+  the old mode.
+
+**Verification:**
+- The parallel project's specs pass unchanged before and after this project runs.
+- Deliberately failing a spec mid-file still restores the baseline.
+- No assertion in this file runs against a page loaded before the settings write it depends on.
+
+### Phase 3 — Failure and resilience
+
+- [ ] **Unit 9: Duplicate submission and idempotent retry**
+
+**Goal:** R8 — prove in a real browser that a double interaction cannot create two sales.
+
+**Requirements:** R3, R7, R8
+
+**Dependencies:** Unit 6
+
+**Files:**
+- Create: `e2e/specs/duplicate-submit.spec.ts`
+- Create: `e2e/support/network.ts` (request counting, response gating)
+
+**Approach:**
+- Counting must be exact, so attach the `page.on('request')` counter **before** the action and filter
+  on `method === 'POST'` and the exact pathname. `page.waitForRequest` proves presence and is useless
+  for proving absence; use counting plus `expect.poll`.
+- A real double-click rarely reproduces the bug — the first request completes in milliseconds. Widen
+  the window deliberately: `page.route` the sales endpoint and hold the response behind a promise,
+  click twice while the first is in flight, then release.
+- The second click needs `force: true`. If the button correctly disables itself, actionability would
+  block the click forever and the test would be measuring its own timeout rather than the guard.
+- Separately, drive the **server's** contract directly from the page via `page.evaluate` with two
+  concurrent `fetch` calls sharing one `Idempotency-Key`, so the session and cookies are real. Assert
+  one sale id and exactly one `Idempotent-Replay: true`.
+- Close the loop on state (D8): one `sales` row, one `idempotency_keys` row, stock decremented once.
+- **Label which scenarios are cashier-reachable and which are server-contract only.** The key is
+  derived from a payload fingerprint: `idempotencyKeyFor` (`CartPanel.tsx:372-390`) returns the
+  stored key only while `JSON.stringify(saleData)` matches the previous attempt and mints a fresh one
+  otherwise, persisting the attempt in `cartStore` so it survives a reload. The key is therefore
+  stable *per payload*, not per attempt — which means **the till can never send one key with a
+  different payload**, and the `IDEMPOTENCY_KEY_REUSED` conflict is unreachable through any cashier
+  interaction. The same applies to "a corrected retry under the same key": correcting the cart
+  changes the fingerprint and so changes the key. Those two cases are legitimate and worth keeping,
+  but they are **server-contract assertions driven by raw `page.evaluate` fetches**, and the spec must
+  say so — otherwise a later reader takes them as proof of UI behavior the UI does not have. Only the
+  double-click and offline-replay paths are genuinely cashier-visible.
+
+**Test scenarios:**
+- *Happy path:* Two rapid checkout clicks with the response gated produce exactly one
+  `POST /api/v1/sales` and one success toast.
+- *Happy path (R7):* Exactly one `sales` row exists for the cart, and the product's stock decreased by
+  the cart quantity — once, not twice.
+- *Happy path:* Two concurrent `fetch` calls with the same key return the same sale id, and exactly
+  one carries `Idempotent-Replay: true`.
+- *Edge case:* Replaying the same key after the first completes returns the original outcome
+  byte-identically with the replay header set.
+- *Edge case:* A replay does **not** re-fire side effects — assert no duplicate register movement,
+  loyalty credit, or coupon usage row.
+- *Error path (server contract, raw fetch):* The same key with a **different payload** returns `409`
+  with code `IDEMPOTENCY_KEY_REUSED`. Not reachable through the till — see the note above.
+- *Error path (server contract, raw fetch):* A failed mutation releases its key — a corrected retry
+  under the same key succeeds (the documented "key identifies a committed outcome" semantic;
+  regressing it would strand cashiers).
+- *Edge case:* Every checkout POST carries a non-simple `Idempotency-Key` header and is therefore
+  preceded by a CORS preflight. Count `method === 'POST'` only, so the `OPTIONS` requests do not
+  register as phantom duplicates.
+- *Integration:* `idempotency_keys` holds exactly one row for the key after all of the above.
+
+**Verification:**
+- The spec fails if `Idempotency-Key` is stripped from `client/src/shared/lib/transport/http.ts` —
+  confirm by temporarily removing it. A spec that passes without the header is not testing anything.
+
+---
+
+- [ ] **Unit 10: Stock conflicts, rejected sales, and cart preservation**
+
+**Goal:** R3's rejection paths and R9's recovery guarantee.
+
+**Requirements:** R3, R7, R9
+
+**Dependencies:** Unit 9
+
+**Files:**
+- Create: `e2e/specs/failures.spec.ts`
+
+**Approach:**
+- Oversell is created for real, not mocked: seed a product with `stock: 1`, add 1 to the cart in the
+  browser, consume the unit out-of-band via the API, then check out. The server's guarded relative
+  write (`decrementProductStock` returning `null`) is what must reject it, and the till must show that
+  clearly.
+- R9 is the assertion that matters most here and is the easiest to get wrong: after **every**
+  rejection, the cart must still hold its items. A till that silently empties on a failed sale makes
+  the cashier re-ring the order, and that is a worse outcome than the original error.
+- Server-side rejection variants use `page.route().fulfill()` for the 5xx and network-abort cases,
+  where producing a genuine server fault is not practical.
+
+**Test scenarios:**
+- *Happy path:* A sale for exactly the available stock succeeds and leaves stock at zero.
+- *Error path:* Checking out for more than available shows an insufficient-stock message naming the
+  product; no `sales` row is created and stock is unchanged.
+- *Error path (R9):* After that rejection the cart still holds its lines at their quantities, and a
+  retry after restocking succeeds.
+- *Error path:* A concurrent consumption between add-to-cart and checkout is rejected at checkout
+  rather than overselling — stock never goes negative.
+- *Error path:* A 500 from `POST /api/v1/sales` shows an error, creates no sale, and preserves the cart.
+- *Error path:* An aborted (network-failure) checkout while **online** surfaces as an error rather
+  than silently entering the offline queue path — the two must not be conflated.
+- *Edge case:* A validation rejection (e.g. a malformed split allocation) is refused client-side
+  without a network round trip.
+- *Integration (R7):* After every rejection above, `GET /api/v1/sales` shows no new row, stock is
+  unchanged, and no register movement was recorded — a partial write is the failure this asserts against.
+
+**Verification:**
+- Every error-path case asserts cart preservation explicitly; none relies on it implicitly.
+- No case leaves the worker's product stock in a state a later test depends on.
+
+---
+
+- [ ] **Unit 11: Expired session, token refresh, and cart recovery**
+
+**Goal:** R3's session-expiry path, and R9 across a forced logout.
+
+**Requirements:** R1, R3, R9
+
+**Dependencies:** Unit 6
+
+**Files:**
+- Create: `e2e/specs/session.spec.ts`
+
+**Approach:**
+- The access token is 15 minutes and lives in the `moon-auth` persist key; the refresh token is an
+  httpOnly cookie. Two distinct scenarios, and they must not be conflated:
+  - **Recoverable:** access token expired, refresh cookie valid → the interceptor refreshes silently
+    and the cashier's action completes. The cashier should never see this happen.
+  - **Terminal:** both gone → redirect to `/login`, and the cart must survive via `moon-cart-recovery`.
+- Rather than waiting 15 minutes, corrupt or expire the stored access token directly in
+  `localStorage` and let the next request 401. This is also the scenario the deferred worker-scoped
+  auth question hinges on.
+- Assert that concurrent in-flight requests during a refresh are queued and replayed, not dropped —
+  `client/src/shared/lib/transport/client.ts` implements that queue and it is untested end to end.
+
+**Test scenarios:**
+- *Happy path:* With a stale access token and a valid refresh cookie, adding to the cart succeeds and
+  the cashier sees no interruption; a `POST /api/v1/auth/refresh` occurs exactly once.
+- *Happy path:* After a silent refresh, `moon-auth` holds a new access token.
+- *Edge case:* Two requests firing simultaneously against a stale token trigger exactly **one**
+  refresh, and both original requests are replayed and succeed.
+- *Error path:* With both the access token and the refresh cookie cleared, the next action redirects
+  to `/login`.
+- *Error path (R9):* After that redirect, logging back in restores the cart from `moon-cart-recovery`
+  with its lines and quantities intact.
+- *Edge case:* A refresh that itself fails does not loop — assert a bounded number of refresh attempts.
+- *Integration:* No sale is created during any expiry scenario.
+
+**Verification:**
+- The refresh-count assertions are exact (`toBe(1)`), not `toBeGreaterThan(0)` — a refresh storm is
+  precisely the bug worth catching.
+
+---
+
+- [ ] **Unit 12: Offline queueing and reconnection replay**
+
+**Goal:** R4 — prove the queue in a real browser, closing the loop on issues #30 and #42 together.
+
+**Requirements:** R3, R4, R7, R8, R9
+
+**Dependencies:** Unit 9, Unit 11
+
+**Files:**
+- Create: `e2e/specs/offline.spec.ts`
+
+**Approach:**
+- Use `context.setOffline(true)` — that is what `useOffline.ts` actually listens to. `page.route()`
+  aborts are a *different* failure (one endpoint dies while the app is healthy) and belong in Unit 10.
+- The service worker is blocked suite-wide (D3), which is what makes these assertions meaningful at
+  all: with Workbox's `NetworkFirst` on `/api/v1/sales` active, an offline checkout could be served
+  from cache and never reach the queue.
+- The single most valuable assertion is exactly-once replay: a sale queued offline, replayed on
+  reconnect, must produce **one** `sales` row. The queued entry carries an `Idempotency-Key`
+  (`CartPanel.tsx:383` → `useOffline.ts:190`), which is the mechanism that makes the generous retry
+  budget safe. Assert the key is actually on the wire, not merely present in `localStorage`.
+- Terminal-failure parking: per the replay contract, a deterministic rejection parks immediately and
+  is never dropped, keeping its payload **and** its key until a cashier's explicit Retry.
+- Tag one basic queue-and-replay case `@smoke`; leave backoff-timing cases out of the PR job.
+
+**Test scenarios:**
+- *Happy path:* Offline, a completed checkout is queued, the offline banner appears, and the cashier
+  sees the sale as pending rather than failed.
+- *Happy path:* On reconnect, the queue drains, exactly one `POST /api/v1/sales` is sent, and the
+  entry is removed.
+- *Happy path (R7, R8):* Exactly one `sales` row exists after replay, stock decremented once, and one
+  `idempotency_keys` row.
+- *Happy path:* The replayed request carries the same `Idempotency-Key` the entry was queued with.
+- *Edge case:* Two sales queued offline replay as two distinct sales with distinct keys — the
+  queue-id uniqueness fix from #30 means neither silently deletes the other.
+- *Edge case:* A sale that committed server-side but whose response was lost does not double-charge
+  on replay — the server returns the original outcome with `Idempotent-Replay: true` and the entry
+  clears.
+- *Error path:* A deterministically-rejected sale (e.g. a `409` the server will always repeat) parks
+  immediately rather than retrying, and surfaces a visible failed-to-sync state.
+- *Error path (R9):* A parked entry keeps its payload and its idempotency key across a page reload —
+  `moon-offline-queue` is persisted, and money must not be lost to a refresh.
+- *Error path:* An explicit cashier Retry on a parked entry re-attempts it, and a now-valid entry succeeds.
+- *Edge case:* Going offline and online repeatedly does not burn the retry budget in seconds — the
+  reconnect throttle (`RECONNECT_RETRY_THROTTLE_MS`) holds.
+- *Integration:* Nothing is queued while online; a normal sale never touches `moon-offline-queue`.
+
+**Verification:**
+- Read `docs/CONVENTIONS.md` → *Offline queue replay contract* and confirm each of its four
+  invariants has a corresponding assertion here.
+- The exactly-once assertion fails if the idempotency key is stripped from the replay path.
+
+### Phase 4 — CI and documentation
+
+- [ ] **Unit 13: CI workflow — smoke on PRs, sharded full suite on `main`**
+
+**Goal:** R10 and R11, with the smoke subset genuinely fast and the full suite genuinely enforced.
+
+**Requirements:** R10, R11
+
+**Dependencies:** **13a depends on Unit 6 only; 13b depends on Units 8, 10, 12.**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Create: `e2e/scripts/assertSmokeTestsRan.mjs`
+
+**Approach:**
+- **Land this unit in two halves, because R10 and R11 should not wait for the whole suite.** Unit 6
+  already produces `@smoke`-tagged specs, so the PR gate is deliverable as soon as Phase 2 opens.
+  Gating it behind the serial tax/loyalty project — which contributes zero smoke cases — means the
+  suite enforces nothing for the entire span of Phases 2 and 3, and the plan's own cut-short
+  fallback ("Phases 1-2 plus Unit 9") would deliver R10 and R11 not at all.
+  - **13a — the PR gate.** The `e2e-smoke` job, `assertSmokeTestsRan.mjs`, and artifact upload.
+    Depends on Unit 6. Lands immediately after the first specs exist, so every subsequent unit is
+    developed against a live gate.
+  - **13b — the full matrix.** The sharded `main` job and `merge-reports`. Depends on Units 8, 10
+    and 12, since it runs everything.
+- `e2e-smoke` runs on pull requests: one unsharded job, `--grep @smoke`, targeting under ~3 minutes.
+  `e2e-full` runs on pushes to `main`: a 4-way `--shard` matrix with `fail-fast: false`, plus a
+  `merge-reports` job producing one HTML report.
+- **State the sharding invariant D5 depends on.** `dependencies: ['setup', 'pos-parallel']` orders
+  projects *within one Playwright process*; a 4-way shard matrix is four independent processes, each
+  running its own `globalSetup`. If those shards ever shared one database, shard 3's `pos-settings`
+  project could write global settings while shard 1's `pos-parallel` asserts totals — reintroducing
+  exactly the hazard D5 exists to remove — and each shard's reseed would wipe the others mid-run,
+  restarting sequences under the direct `pg` reads D8 relies on. On GitHub Actions a matrix gives
+  each shard its own service container, so this holds today. Record it as a **required invariant**,
+  not an accident: *each shard gets its own server process and its own database.* Consolidating to
+  one shared service to save CI minutes silently breaks D5.
+- Steps: `npm ci` in `server/`, `client/` and `e2e/` → `npx playwright install --with-deps chromium`
+  → **`npm run build` in `client/` as its own step** (D2) → `npx playwright test`.
+- The `merge-reports` job needs `if: ${{ !cancelled() }}`, or the report is lost exactly when a
+  failure makes it valuable. Upload traces, videos and screenshots too — R10 asks for diagnostics,
+  and a bare pass/fail from a browser suite is close to useless.
+- **These artifacts contain live credentials, and this repository is public.** A Playwright trace
+  records full request and response headers and bodies: the `Authorization: Bearer <JWT>` on every
+  call, the `Set-Cookie` carrying the 7-day refresh token, and the login POST body with the password.
+  Videos and screenshots capture the same on screen. Actions artifacts on a public repo are
+  downloadable by anyone. Against a disposable CI database seeded with credentials already published
+  in `CLAUDE.md` the live exposure is small — which is exactly why it would go unexamined — but this
+  is the repo's first `actions/upload-artifact` and it sets the precedent for every artifact after
+  it. Therefore: set a short `retention-days` (7), keep `e2e/playwright/.auth/` outside `outputDir`
+  so auth state is never swept into an artifact, and record in `e2e/README.md` that **this suite and
+  its artifacts are for disposable environments only** — never point it at staging or production. If
+  a shared environment is ever targeted, traces must be disabled or scrubbed first.
+- Reuse the existing Postgres 16 service pattern from the `server` job, pointed at a separate
+  `moon_store_e2e` database.
+- Do not cache Playwright browser binaries — restore costs about as much as download, and OS deps
+  are not cacheable.
+- `assertSmokeTestsRan.mjs` guards the tag the way
+  `server/scripts/assertRealPostgresSuitesRan.mjs` guards `describeWithPostgres`: a typo in a tag
+  silently empties the PR job, and a green CI that ran zero tests is the failure mode most likely to
+  go unnoticed for months.
+- Add `--fail-on-flaky-tests` to the full run so retries surface flakes instead of absorbing them.
+
+**Patterns to follow:** `.github/workflows/ci.yml`'s existing service block, env block, and the
+"Fail if the real-PostgreSQL suites did not actually run" step — the same instinct, applied to tags.
+
+**Test scenarios:**
+- *Happy path:* A PR touching client code runs `e2e-smoke` and it passes in under ~3 minutes.
+- *Happy path:* A push to `main` runs all four shards and produces one merged HTML report artifact.
+- *Error path:* A deliberately failing spec uploads a trace, a video and a screenshot, and the trace
+  opens in the Playwright trace viewer.
+- *Error path:* Renaming the `@smoke` tag so nothing matches fails the job via
+  `assertSmokeTestsRan.mjs` instead of passing green with zero tests.
+- *Edge case:* A cancelled run still produces whatever reports exist (`if: ${{ !cancelled() }}`).
+- *Integration:* The existing `server` and `client` jobs are unaffected and still run in parallel
+  with the new job.
+
+**Verification:**
+- Smoke job wall-clock measured and recorded in `e2e/README.md`; if it exceeds ~3 minutes, cases are
+  moved out of `@smoke` rather than the budget being quietly raised.
+- Full-suite flake rate observed over several `main` runs before considering `workers: 4`.
+
+---
+
+- [ ] **Unit 14: Documentation**
+
+**Goal:** The suite is runnable and extendable by someone who did not write it.
+
+**Requirements:** R11, and the repo's standing "update docs when changing code" rule
+
+**Dependencies:** Unit 13
+
+**Files:**
+- Modify: `e2e/README.md` (created in Unit 1; extended by Units 2 and 13 — do not overwrite)
+- Modify: `CLAUDE.md`, `AGENTS.md` (both carry the same Quick Start / Testing content — keep them in sync)
+- Modify: `docs/CONVENTIONS.md` (a new *E2E test conventions* section)
+- Modify: `docker-compose.test.yml` (document the E2E database alongside the existing note)
+
+**Approach:**
+- `CLAUDE.md` and `AGENTS.md` gain an **E2E** subsection under Testing: how to run locally; the
+  required `E2E_DATABASE_URL`; `CLIENT_URL`, `RATE_LIMIT_MAX` and `AUTH_RATE_LIMIT_MAX`, each
+  optional for the server but all of which the E2E run must set; and the explicit warning that the
+  suite **deletes every row in 77 tables and restarts their sequences** — the same loud posture
+  `CLAUDE.md` already takes for the real-PostgreSQL suites.
+- `docs/CONVENTIONS.md` records the rules that will otherwise erode: locators come from the i18n
+  catalog; a new test id needs a justification comment; only `tax-loyalty.spec.ts` writes settings;
+  every money assertion is two-sided (D8); expected totals come from
+  `contracts/checkout-totals.v1.json`, never hardcoded.
+- Document the `@smoke` subset explicitly (R11): what qualifies, the time budget, and that adding to
+  it is a deliberate decision with a cost.
+- Record what this suite does **not** cover — service-worker caching, cross-browser, camera barcode
+  decode, gateway declines — so a future reader does not mistake blocked-SW green for SW-tested
+  green, or a green barcode-lookup case for a tested scanner.
+
+**Test scenarios:**
+- Test expectation: none — documentation. Verified by the fresh-clone walkthrough below.
+
+**Verification:**
+- A fresh clone, following only `e2e/README.md`, gets to a passing `@smoke` run.
+- `CLAUDE.md` and `AGENTS.md` do not drift from each other.
+
+## System-Wide Impact
+
+- **Interaction graph.** The suite reaches almost everything: TanStack Router guards, the auth
+  refresh interceptor, React Query caches, the transport seam, `withIdempotency`, `withTransaction`,
+  register/shift services, and the offline scheduler. That breadth is the point, and it is also why
+  a fixture bug will masquerade as an application bug — hence Unit 4's isolation spec before any real
+  spec is written.
+- **Error propagation.** Specs assert the *cashier-visible* error, not just the HTTP status. A
+  correct 409 rendered as "Something went wrong" is a real defect for a till operator, and this suite
+  is the only layer positioned to catch it.
+- **State lifecycle risks.** The three obvious *server-side* shared mutable surfaces are the global
+  settings rows (D5), product stock (namespaced per test), and register sessions plus shifts
+  (per-user, so per-worker cashiers isolate them). **But that list is not the whole boundary, and
+  stating it as though it were is itself the hazard** — a reader takes an audited-sounding count and
+  stops looking. Others already exist in this repo and are *not* addressed by D4:
+  - Three in-process rate-limiter `MemoryStore`s, keyed on `req.ip` (all workers are `127.0.0.1`) and
+    unresettable for the server's lifetime — Unit 2.
+  - `stock_reservations` has no user or session column, so `available = stock - reservedTotal` is
+    computed across every worker, and a process-global `setInterval(cleanupExpiredReservations, 5min)`
+    (`server/index.ts:131`) mutates it on a wall clock.
+  - `branches.is_main` is a global exclusive flag: creating or updating any branch with `is_main`
+    demotes every other branch.
+  - `GET /products/generate-sku/:categoryId` and `/generate-barcode` are unlocked `MAX(...)+1` reads,
+    so two workers requesting one get the same value and the loser's `POST /products` 409s. Unit 4's
+    fixtures must mint SKUs and barcodes from the worker namespace, never from these endpoints.
+  - `audit_log` accumulates a row per mutation, and notifications fan out to every admin with
+    `userId: null` — shared counters no spec should assert totals against.
+
+  Treat this as a live list to extend, not a closed audit. Any new spec touching a surface not
+  namespaced per worker or per test needs the D5 treatment.
+
+  Separately, four *client-side* persisted
+  surfaces carry state across reloads and are asserted directly rather than inferred from the
+  rendering: `moon-offline-queue` (Unit 12), `moon-cart-recovery` (Unit 11), `moon-held-carts`
+  (Unit 7), and `moon-auth` (Unit 4). These are per-browser-context, so they are not a parallelism
+  hazard — but each one holds money-adjacent state that survives a refresh, which is precisely why a
+  browser suite can see failures the jsdom suites cannot.
+- **API surface parity.** None. The suite consumes the existing API and adds no endpoints. The only
+  production change is Unit 2's rate-limit ceiling, which defaults to today's value.
+- **Integration coverage.** This plan exists specifically for what mocks cannot prove: that the
+  browser attaches `Idempotency-Key`, that a genuinely offline browser queues, that a genuinely
+  reconnected browser replays once, and that serialization across the wire preserves the money
+  contract both calculators already satisfy in isolation.
+- **Unchanged invariants.** No API contract, response envelope, database schema, or client behavior
+  changes. `server/index.ts`'s limiter keeps its 200/15-min default when `RATE_LIMIT_MAX` is unset.
+  Unit 5 adds accessible names and a small number of test ids to POS components — additive
+  attributes, no logic or layout change, with the existing colocated unit tests as the guard.
+
+## Pre-existing defects this planning pass surfaced
+
+None of these are introduced by this plan, and none are in its scope to fix. They are recorded
+because the suite will collide with them, and because a reader who meets them mid-implementation
+should know they are known.
+
+1. **Refresh tokens are not unique per session** — filed as **#62**. `auth/service.ts:30-35` signs
+   `{ id }` with `expiresIn: '7d'` — user id plus second-resolution `iat`/`exp`, no jti or nonce —
+   into `refresh_tokens.token … UNIQUE`. Two logins by the same user in the same second produce a
+   byte-identical token: the second insert fails on `23505`, and because the tokens are identical, a
+   logout revokes every holder's session. Two tills logging the same account in together would hit
+   this in production, not only in tests. **Worth its own issue.**
+2. **The global rate limit may be too tight for a real shop** — filed as **#63**. 200 requests / 15 min keyed on
+   `req.ip`, with no `trust proxy` configured, is a *per-shop* budget, not per-till — several tills
+   behind one NAT share it. If a scripted run of the happy path exhausts it, so plausibly does a busy
+   Saturday, and the cashier-visible result is `RATE_LIMITED` mid-checkout. Unit 2 deliberately
+   changes only the test-time ceiling and leaves production behavior byte-identical; whether the
+   production value is right is a separate question that should not be settled inside a test PR.
+   **Worth its own issue.**
+3. **SKU and barcode generation races.** `productService.ts:88-140` derives both from an unlocked
+   `MAX(...)+1`, so concurrent callers collide on a `UNIQUE` column. Unit 4 routes around it; the
+   endpoint itself is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Flaky E2E erodes trust and gets ignored.** The most common way a suite like this dies. | High | High | Chromium only; `fullyParallel` with per-worker isolation; `retryStrategy: 'isolated'`; `--fail-on-flaky-tests` on the full run; role-based auto-waiting locators; no `waitForTimeout`. Watch the flake rate before raising `workers` past 2. |
+| **A parallel worker mutates global settings and corrupts another's totals.** Silent, and produces wrong-total failures that look like money bugs. | High | High | D5: pinned baseline in `globalSetup`; a single serial project owns settings and restores on failure; no other spec writes them. |
+| **The service worker shadows route mocks and inverts offline assertions.** Would compromise exactly the assertions this suite exists to make. | High | High | D3: `serviceWorkers: 'block'` globally; SW behavior explicitly out of scope and documented as such. |
+| **The 200-req/15-min rate limiter throttles the suite**, producing failures that look like app bugs. | High | Med | Unit 2, env-driven with the current value as default, test-first. |
+| **The suite pointed at a real database.** `seedDatabase()` deletes every row in 77 tables and restarts their sequences — and the *server*, not `globalSetup`, is what writes most test data, so guarding only the setup path protects the wrong process. | Med | High | Unit 1 binds the server's `DATABASE_URL` to `E2E_DATABASE_URL` explicitly; Unit 3 aborts if it is unset **and** preflights that the running API is on that database before any delete; never defaults to `DATABASE_URL`; documented loudly in `e2e/README.md` and `CLAUDE.md`. |
+| **Both rate limiters throttle the suite** — especially `authLimiter` at 10/15 min on `/login` and `/refresh`, shared across all workers on one IP. A 429 lands on Unit 11 and is indistinguishable from the refresh-storm bug it exists to catch. | High | High | Unit 2 gives each limiter its own env knob defaulting to today's value, and bounds the suite's login count via `storageState` reuse. |
+| **A settings write is invisible to an already-loaded page** for up to 5 minutes (React Query `staleTime`), turning Unit 8's inclusive-tax case into a silent pass. | High | High | D5 requires a reload after every settings write, plus a scenario asserting the UI visibly reflects the new mode. |
+| **Arabic-RTL default makes text selectors locale-dependent.** | Med | Med | D6: locators driven from the i18n catalog; suite pinned to `en` with one RTL spec on the shipped default. |
+| **`CartPanel.tsx` is 1487 lines** and holds cart, checkout, payment and receipt — a tempting refactor target mid-plan. | Med | Med | Unit 5 adds accessible names only. Splitting `CartPanel` is legitimate follow-up work with its own plan. |
+| **Smoke budget creeps** until the PR job is no longer fast, defeating R11. | Med | Med | Budget documented in `e2e/README.md` and measured in Unit 13; exceeding it moves cases out of `@smoke` rather than raising the budget. |
+| **Playwright 1.62.0's config-resolution regression** breaks monorepo config discovery. | Low | Med | Pin `1.62.1` exactly. |
+| **CI time and cost grow** with a browser suite plus a Postgres service. | High | Low | Smoke-only on PRs; sharded full suite on `main` only; no browser-binary caching (it does not pay). |
+
+## Phased Delivery
+
+Each phase is independently valuable and independently mergeable.
+
+- **Phase 1 (Units 1-5) — Harness.** Ships no coverage, but produces a runnable Playwright project
+  with isolation and locators proven. Worth merging alone: nothing after it is possible without it,
+  and its correctness is easiest to verify while the suite is empty.
+- **Phase 2 (Units 6-8) — Money paths.** Ships R1, R2, R7. The point at which the suite starts
+  earning its keep.
+- **Phase 3 (Units 9-12) — Failure and resilience.** Ships R3, R4, R8, R9 — the coverage that
+  actually protects the invariants from #30 and #42.
+- **Phase 4 (Units 13-14) — CI and docs.** Ships R10, R11. Until this lands the suite is a local
+  tool; after it, it is a gate.
+
+If the work must be cut short, Phases 1-2 plus Unit 9 is the minimum that justifies the
+infrastructure: the critical path plus the double-charge guard.
+
+## Documentation / Operational Notes
+
+- Environment variables the E2E run sets, all documented in `e2e/README.md` and `CLAUDE.md`:
+
+  | Variable | Default | Set by the E2E run because |
+  |---|---|---|
+  | `E2E_DATABASE_URL` | none — **run aborts if unset** | The database the suite owns and resets. Also passed to the server as its `DATABASE_URL`. |
+  | `CLIENT_URL` | `http://localhost:5173` | The preview origin `:4173` is otherwise rejected by CORS. |
+  | `RATE_LIMIT_MAX` | 200 | Global ceiling. |
+  | `AUTH_RATE_LIMIT_MAX` | 10 | The binding ceiling on `/login` and `/refresh`. |
+  | `JWT_SECRET`, `JWT_REFRESH_SECRET` | none — server hard-exits | Mirror the literals in `ci.yml`'s `server` job. |
+
+  Only `RATE_LIMIT_MAX` and `AUTH_RATE_LIMIT_MAX` are new production-facing knobs; both default to
+  today's values, so an unset server behaves exactly as it does now.
+- CI gains a Postgres 16 service on the E2E jobs and, for the first time in this repo,
+  `actions/upload-artifact` steps. **Required invariant:** each shard gets its own server process and
+  its own database (Unit 13).
+- `e2e/playwright/.auth/` holds real session state — gitignored, kept outside `outputDir`, and never
+  uploaded as an artifact.
+- **This suite runs against disposable databases only.** Never point it at staging or production:
+  it deletes every row in 77 tables, creates privileged accounts cleaned up only best-effort, and
+  uploads traces containing live session tokens.
+- **Ownership and response, which the plan otherwise leaves unowned.** The top-rated risk here is
+  that the suite is ignored rather than that it fails, and every mitigation listed for it is a
+  build-time decision. Before Unit 13b merges, record in `e2e/README.md`: who owns the suite, what
+  flake rate triggers fixing rather than muting, and what happens when `e2e-full` goes red on `main`
+  (revert, block deploy, notify — but something). A post-merge job with no defined response is not a
+  gate, and two thirds of this suite's coverage lives behind one.
+- No production rollout, migration, or feature-flag impact.
+
+## Sources & References
+
+- **Origin issue:** #50 — *test: Add end-to-end coverage for critical POS workflows*
+- **Coordinating issues:** #30 (offline queue, closed — commit `49f29e8`), #42 (server concurrency and
+  idempotency, closed — commit `1c8d7fb`)
+- **Spun out of this planning pass:** #62 (refresh tokens not unique per session), #63 (global rate
+  limit is per-shop, not per-till). Neither is in this plan's scope; the suite works around both.
+- **Prior plans:** `docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md`,
+  `docs/plans/2026-08-30-002-fix-pos-concurrency-idempotency-plan.md`,
+  `docs/plans/2026-08-31-001-fix-offline-queue-backoff-and-identity-plan.md`
+- **Contracts:** `contracts/checkout-totals.v1.json`
+- **Conventions:** `docs/CONVENTIONS.md` (*Offline queue replay contract*, *Concurrency and
+  idempotency*), `CLAUDE.md` (*Idempotency compatibility window*, *Real-PostgreSQL suites*)
+- **External:** [Playwright release notes](https://playwright.dev/docs/release-notes) ·
+  [webServer](https://playwright.dev/docs/test-webserver) ·
+  [Parallelism](https://playwright.dev/docs/test-parallel) ·
+  [Fixtures](https://playwright.dev/docs/test-fixtures) ·
+  [Auth](https://playwright.dev/docs/auth) ·
+  [Service workers](https://playwright.dev/docs/service-workers) ·
+  [Network](https://playwright.dev/docs/network) ·
+  [Locators](https://playwright.dev/docs/locators) ·
+  [Best practices](https://playwright.dev/docs/best-practices) ·
+  [CI](https://playwright.dev/docs/ci) ·
+  [Sharding](https://playwright.dev/docs/test-sharding) ·
+  [Retries](https://playwright.dev/docs/test-retries)

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+playwright-report/
+blob-report/
+test-results/
+playwright/.auth/
+.env.e2e.local

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,7 +25,9 @@ npm ci --prefix e2e
 npx --prefix e2e playwright install --with-deps chromium
 
 # 3. Build the client. Deliberately a separate step, not part of webServer.
-npm run build --prefix client
+#    VITE_API_URL is baked in HERE, at build time — setting it on `vite preview` does
+#    nothing. If your client/.env points somewhere else, pass it explicitly:
+VITE_API_URL=http://localhost:3001 npm run build --prefix client
 
 # 4. Run
 cd e2e
@@ -44,6 +46,8 @@ why the preflight below exists.
 | Variable | Default | Why the E2E run sets it |
 | --- | --- | --- |
 | `E2E_DATABASE_URL` | **none — the run aborts** | The database the suite owns and resets. Also passed to the server as its `DATABASE_URL`. |
+| `E2E_ALLOW_SHARED_DB` | unset | Set to `1` to allow it to name the same database as `DATABASE_URL`. |
+| `PGAPPNAME` | `moon-api` | Tags the server's PostgreSQL backends; the preflight requires `moon-e2e-server`. Set automatically. |
 | `CLIENT_URL` | `http://localhost:5173` | The preview origin `:4173` is otherwise rejected by CORS. Set automatically by the config. |
 | `RATE_LIMIT_MAX` | `200` | Global ceiling, per 15 min. Set automatically. |
 | `AUTH_RATE_LIMIT_MAX` | `10` | The *binding* ceiling, on `/login` and `/refresh`. Set automatically. |
@@ -59,19 +63,32 @@ bucket. The binding constraint is the **auth** ceiling of 10 per 15 minutes, not
 land on the session-expiry specs, where it is indistinguishable from the refresh-storm bug
 those specs exist to catch.
 
-## Safety: the two guards
+## Safety: four guards
 
 Seeding is destructive, and the process that writes almost all test data is the **server**,
 not this one. Guarding only the setup path would guard the wrong process. So:
 
 1. **`E2E_DATABASE_URL` has no default.** Resolved at config load, so an unset variable
    aborts before any server starts. It never falls back to `DATABASE_URL`.
-2. **A preflight asserts the running API is on that same database**, before any delete.
-   The API exposes no database identity, so the check asks PostgreSQL: after `/api/health`
-   (a real `SELECT 1`) succeeds, the server's pool must be visible in `pg_stat_activity`
-   for the target database. Zero connections means the server is somewhere else — the
-   realistic case being `reuseExistingServer` attaching to a dev server — and the run
-   aborts rather than resetting a database nothing under test is reading.
+2. **It is refused when it names the database the dev server uses.** Having no default
+   protects against *forgetting* to set it; it protects against nothing once it is set to
+   the wrong value, and the obvious wrong value is the connection string copied out of
+   `server/.env` because a database already existed and `createdb` looked skippable. The
+   value is compared against `DATABASE_URL` (environment, else `server/.env`). Override
+   with `E2E_ALLOW_SHARED_DB=1` if sharing is genuinely intended.
+3. **A preflight asserts the running API is on that same database**, before any delete.
+   The check is *identity-based, not count-based* — and that distinction is the guard.
+   Playwright starts the server with `PGAPPNAME=moon-e2e-server`, and the preflight
+   requires a `pg_stat_activity` backend on the target database carrying that name.
+   Counting anonymous connections instead would pass as soon as any `psql` or GUI client
+   held an idle session on the E2E database — which is common on exactly the machine where
+   someone is debugging E2E, and is exactly when `reuseExistingServer` may have attached
+   to a dev server on the dev database.
+4. **A PostgreSQL advisory lock refuses a second concurrent run.** Ports are fixed and
+   `reuseExistingServer` is true locally, so a second invocation does not collide on a
+   port — it attaches to the first run's servers and resets the database underneath it.
+   The preflight cannot catch that (the first run's server genuinely is on the target
+   database), so the lock is what makes it fail loudly. It releases if the process dies.
 
 ## Layout
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,150 @@
+# E2E — critical POS workflows
+
+Playwright (Chromium) driving the **real client production build** against the **real
+Express server** and a **real PostgreSQL database**.
+
+The repo already has strong unit coverage on both halves: the client's money math is proven
+against `contracts/checkout-totals.v1.json` through an in-process transport, and the server's
+idempotency and stock invariants are proven against real PostgreSQL through direct service
+calls. Nothing exercises the wire between them. This suite is that third layer.
+
+> **⚠️ Disposable databases only.**
+> `globalSetup` deletes every row in **77 tables** and restarts every public sequence.
+> Never point this suite at staging or production. Its failure artifacts (traces, videos)
+> record live session tokens and login request bodies — see [Artifacts](#artifacts).
+
+## Running it
+
+```bash
+# 1. A disposable database. Any PostgreSQL you can CREATE on.
+createdb moon_store_e2e
+# ...or reuse the compose service:  docker compose -f docker-compose.test.yml up -d
+
+# 2. Install once
+npm ci --prefix e2e
+npx --prefix e2e playwright install --with-deps chromium
+
+# 3. Build the client. Deliberately a separate step, not part of webServer.
+npm run build --prefix client
+
+# 4. Run
+cd e2e
+E2E_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/moon_store_e2e npm test
+
+# The documented PR subset
+E2E_DATABASE_URL=... npm run test:smoke
+```
+
+Playwright starts both servers itself (`webServer`), so nothing needs to be running first.
+Locally `reuseExistingServer` attaches to a server already on port 3001 — which is exactly
+why the preflight below exists.
+
+### Environment
+
+| Variable | Default | Why the E2E run sets it |
+| --- | --- | --- |
+| `E2E_DATABASE_URL` | **none — the run aborts** | The database the suite owns and resets. Also passed to the server as its `DATABASE_URL`. |
+| `CLIENT_URL` | `http://localhost:5173` | The preview origin `:4173` is otherwise rejected by CORS. Set automatically by the config. |
+| `RATE_LIMIT_MAX` | `200` | Global ceiling, per 15 min. Set automatically. |
+| `AUTH_RATE_LIMIT_MAX` | `10` | The *binding* ceiling, on `/login` and `/refresh`. Set automatically. |
+| `JWT_SECRET`, `JWT_REFRESH_SECRET` | none — the server hard-exits | Test literals, set automatically. |
+
+Only `E2E_DATABASE_URL` is yours to provide; the config sets the rest for the server it
+starts. `RATE_LIMIT_MAX` and `AUTH_RATE_LIMIT_MAX` are the only new production-facing
+knobs, and both default to today's values, so an unset server behaves exactly as before.
+
+Both limiters key on `req.ip` and every worker is `127.0.0.1` sharing one in-process
+bucket. The binding constraint is the **auth** ceiling of 10 per 15 minutes, not the global
+200: the suite would exhaust it within its first few logins, and the resulting `429` would
+land on the session-expiry specs, where it is indistinguishable from the refresh-storm bug
+those specs exist to catch.
+
+## Safety: the two guards
+
+Seeding is destructive, and the process that writes almost all test data is the **server**,
+not this one. Guarding only the setup path would guard the wrong process. So:
+
+1. **`E2E_DATABASE_URL` has no default.** Resolved at config load, so an unset variable
+   aborts before any server starts. It never falls back to `DATABASE_URL`.
+2. **A preflight asserts the running API is on that same database**, before any delete.
+   The API exposes no database identity, so the check asks PostgreSQL: after `/api/health`
+   (a real `SELECT 1`) succeeds, the server's pool must be visible in `pg_stat_activity`
+   for the target database. Zero connections means the server is somewhere else — the
+   realistic case being `reuseExistingServer` attaching to a dev server — and the run
+   aborts rather than resetting a database nothing under test is reading.
+
+## Layout
+
+```
+e2e/
+├── playwright.config.ts   projects, webServer, the server env block
+├── support/
+│   ├── config.ts          paths, ports, the E2E_DATABASE_URL guard
+│   ├── db.ts              read-only pg access for assertions the API does not expose
+│   ├── settingsBaseline.ts the pinned tax/loyalty baseline
+│   └── globalSetup.ts     migrate → seed → clear idempotency_keys → pin baseline
+├── fixtures/              worker-scoped fixtures and the auth setup project
+└── specs/                 the specs themselves
+```
+
+## Projects
+
+| Project | Shape | What runs there |
+| --- | --- | --- |
+| `setup` | once | Logs in through the real form and writes `storageState`. Is itself the login smoke test. |
+| `pos-parallel` | `fullyParallel` | Everything else. Asserts against the pinned settings baseline and **never writes settings**. |
+| `pos-settings` | `workers: 1`, serial, ordered after `pos-parallel` | The only place that writes `PUT /api/v1/settings` — tax modes and loyalty. |
+
+Tax and loyalty are **global** key/value rows, not per-sale inputs. A worker that flipped
+`tax_enabled` would silently change the totals every other worker is asserting on, which is
+why the mode variants are quarantined in their own serial project.
+
+The baseline is pinned **tax disabled, loyalty enabled** — matching the dominant
+configuration in `contracts/checkout-totals.v1.json`, six of whose ten cases specify
+`tax.enabled: false`. Under a tax-enabled baseline those six could not be entered through
+the UI and still reach the total the contract records.
+
+## Conventions
+
+- **Expected totals come from `contracts/checkout-totals.v1.json`, never hardcoded.** Both
+  calculators are already proven against that file; re-deriving the numbers here would put
+  the money rules in a third place.
+- **Every money assertion is two-sided**: the cashier-visible state *and* the persisted
+  server state. One POST with two rows, and two POSTs with one row, are different bugs.
+- **Locators come from the i18n catalog**, not hardcoded strings — the app ships Arabic RTL
+  by default. Where a role query cannot find an element, fix the accessible name; reaching
+  for a test id there buries a real accessibility defect. Every test id added to production
+  code carries a one-line comment saying why a role query was insufficient.
+- **Every test creates the rows it mutates**, namespaced per worker. Never mutate shared
+  seed rows, never assert on "the first row" or a global aggregate.
+
+## Artifacts
+
+Traces, videos and screenshots are captured on failure. **They contain live credentials** —
+a trace records full request and response headers, including `Authorization: Bearer <JWT>`,
+the `Set-Cookie` carrying the refresh token, and the login POST body. On a public repository
+Actions artifacts are downloadable by anyone. Against a disposable database seeded with
+credentials already published in `CLAUDE.md` the live exposure is small, which is exactly
+why it would go unexamined. `e2e/playwright/.auth/` is gitignored and kept outside
+`outputDir` so session state is never swept into an artifact.
+
+## Not covered
+
+Deliberate gaps, recorded so a green run is not mistaken for coverage it does not have:
+
+- **The service worker's own behavior.** The production build registers Workbox with
+  `StaleWhileRevalidate` on `/api/v1/products` and `NetworkFirst` on `/api/v1/sales`
+  *reads*. The suite sets `serviceWorkers: 'block'`, because a stale product cache would
+  shadow route mocks and feed 24-hour-old stock into the very assertions this suite exists
+  to make. The residue is real: a deployed till can render cached stock rows and this suite
+  never sees that. Compounding it, `registerType: 'autoUpdate'` with no update prompt
+  anywhere in `client/src` means SW versions swap silently on reload with no user-visible
+  surface at all. That behavior is unowned and this suite is formally not looking at it.
+- **Camera barcode decoding.** `useScanner` drives Quagga2 against a real camera in
+  `LiveStream` mode and there is no keyboard-wedge path. The *consequence* of a scan —
+  the `GET /api/v1/products/barcode/:barcode` lookup and the resulting cart line — is
+  covered; only the optical decode is not.
+- **Cross-browser.** Chromium only until the suite is stable.
+- **Gateway declines.** There is no payment processor: `PaymentMethod` is a label on the
+  sale record. "Rejected payment" is read as a server-rejected sale.
+- **Visual regression, performance, and load.**

--- a/e2e/eslint.config.mjs
+++ b/e2e/eslint.config.mjs
@@ -1,0 +1,24 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  { ignores: ['node_modules/', 'playwright-report/', 'blob-report/', 'test-results/', 'playwright/'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    files: ['**/*.{ts,mjs}'],
+    languageOptions: {
+      globals: globals.node,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+    },
+  }
+);

--- a/e2e/fixtures/adminToken.ts
+++ b/e2e/fixtures/adminToken.ts
@@ -47,5 +47,55 @@ export function readAdminAccessToken(): string {
       `Admin storage state holds no accessToken. Shape of ${AUTH_STORAGE_KEY} changed.`
     );
   }
+
+  assertNotExpired(token);
   return token;
+}
+
+/** Seconds of remaining life below which the token is treated as unusable. */
+const EXPIRY_MARGIN_SECONDS = 120;
+
+/**
+ * Access tokens live 15 minutes. This token is minted once by the setup project and held
+ * for a worker's entire lifetime, so a run longer than that — a full suite, or a CI run
+ * whose `retryStrategy: 'isolated'` replays failures at the end — would start seeing 401s
+ * from `createProduct` and friends. That surfaces inside whichever spec happens to be
+ * running, and reads as an application bug rather than an expired fixture.
+ *
+ * A stale `playwright/.auth/admin.json` left by an earlier run is the same failure with no
+ * elapsed time at all, which is why `fs.existsSync` alone is not a sufficient guard.
+ *
+ * Failing loudly here is the Phase 1 answer. If runs grow past 15 minutes, the fix is to
+ * build `adminApi` from the admin `storageState` so it carries the refresh cookie — not
+ * to re-login per worker, which collides on `refresh_tokens.token UNIQUE` (issue #62).
+ */
+function assertNotExpired(token: string): void {
+  const payload = token.split('.')[1];
+  if (!payload) return;
+
+  let exp: number | undefined;
+  try {
+    exp = (JSON.parse(Buffer.from(payload, 'base64url').toString()) as { exp?: number }).exp;
+  } catch {
+    return; // Not our business to validate the token's shape; the server will reject it.
+  }
+  if (exp === undefined) return;
+
+  const secondsLeft = exp - Math.floor(Date.now() / 1000);
+  if (secondsLeft > EXPIRY_MARGIN_SECONDS) return;
+
+  throw new Error(
+    [
+      `The admin access token from ${adminStatePath} expires in ${secondsLeft}s.`,
+      '',
+      secondsLeft <= 0
+        ? 'It is already expired — usually a stale .auth file from an earlier run, since'
+        : 'It is about to expire mid-run, so seeding calls would start returning 401 in',
+      secondsLeft <= 0
+        ? 'that directory is not cleaned between runs.'
+        : 'whichever spec happened to be running.',
+      '',
+      'Re-run the full suite so the `setup` project mints a fresh one.',
+    ].join('\n')
+  );
 }

--- a/e2e/fixtures/adminToken.ts
+++ b/e2e/fixtures/adminToken.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import { BASE_URL } from '../support/config';
+import { adminStatePath } from './authPaths';
+import { AUTH_STORAGE_KEY } from './storage';
+
+interface StorageStateFile {
+  origins?: { origin: string; localStorage: { name: string; value: string }[] }[];
+}
+
+/**
+ * The admin access token, read from the setup project's `storageState` — **not** by
+ * logging in again.
+ *
+ * This is not an optimization. Refresh tokens are `jwt.sign({ id }, …, { expiresIn: '7d' })`:
+ * user id plus second-resolution `iat`/`exp`, no jti, stored in
+ * `refresh_tokens.token UNIQUE`. Two logins as the same user inside one second produce a
+ * byte-identical token, the second insert fails on 23505, and the endpoint returns 500.
+ * Worker startup is exactly that burst, and it reproduces reliably at two workers.
+ *
+ * Worse than the 500: because the tokens are identical, a logout by one holder revokes
+ * every holder's session. This is a pre-existing server defect (issue #62), not one the
+ * suite introduces — the suite routes around it by logging the shared admin in exactly
+ * once, in the setup project, for the whole run.
+ */
+export function readAdminAccessToken(): string {
+  if (!fs.existsSync(adminStatePath)) {
+    throw new Error(
+      `No admin storage state at ${adminStatePath}. The \`setup\` project writes it; run ` +
+        'the whole suite rather than a single project, or check that `setup` passed.'
+    );
+  }
+
+  const state = JSON.parse(fs.readFileSync(adminStatePath, 'utf8')) as StorageStateFile;
+  const origin = state.origins?.find((o) => o.origin === BASE_URL);
+  const entry = origin?.localStorage.find((item) => item.name === AUTH_STORAGE_KEY);
+  if (!entry) {
+    throw new Error(
+      `Admin storage state at ${adminStatePath} has no "${AUTH_STORAGE_KEY}" entry for ` +
+        `${BASE_URL}. The persist key or the preview origin changed.`
+    );
+  }
+
+  const parsed = JSON.parse(entry.value) as { state?: { accessToken?: string } };
+  const token = parsed.state?.accessToken;
+  if (!token) {
+    throw new Error(
+      `Admin storage state holds no accessToken. Shape of ${AUTH_STORAGE_KEY} changed.`
+    );
+  }
+  return token;
+}

--- a/e2e/fixtures/auth.setup.ts
+++ b/e2e/fixtures/auth.setup.ts
@@ -1,0 +1,66 @@
+/**
+ * The setup project: authenticates the fixed roles through the **real login form** and
+ * writes their `storageState`.
+ *
+ * Driving the form rather than minting a JWT means this project is itself the login smoke
+ * test — if login breaks, the whole suite fails here with an obvious message instead of
+ * failing everywhere at once.
+ *
+ * It also bounds the suite's appetite for the auth rate limiter: one login per role for
+ * the entire run rather than one per test. Raising the ceiling (Unit 2) is the mitigation
+ * of last resort; logging in less is the first move.
+ */
+import { expect, test as setup, type BrowserContext, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import { AUTH_DIR, adminStatePath, cashierStatePath } from './authPaths';
+import { SEEDED } from './seed';
+import { seedLocale } from './storage';
+import { DEFAULT_TEST_LOCALE } from '../support/i18n';
+import { loginPage } from '../support/locators';
+
+setup.beforeAll(() => {
+  fs.mkdirSync(AUTH_DIR, { recursive: true });
+});
+
+async function authenticate(
+  page: Page,
+  context: BrowserContext,
+  email: string,
+  password: string,
+  statePath: string
+): Promise<void> {
+  // The app ships Arabic RTL, so the locale must be pinned before the first render or the
+  // en-catalog locators match nothing.
+  await seedLocale(context, DEFAULT_TEST_LOCALE);
+  await page.goto('/login');
+
+  const form = loginPage(page);
+  await form.email.fill(email);
+  await form.password.fill(password);
+  await form.submit.click();
+
+  // Landing anywhere but /login is the proof the session took: the app routes by role
+  // (Admin to /, Cashier to /pos, Delivery to /deliveries).
+  await expect(page).not.toHaveURL(/\/login/);
+
+  // The httpOnly refresh cookie is half of the session and is easy to lose silently —
+  // without it the token-refresh path cannot work at all.
+  const cookies = await context.cookies();
+  expect(cookies.map((c) => c.name)).toContain('refreshToken');
+
+  await context.storageState({ path: statePath });
+}
+
+setup('authenticate as admin', async ({ page, context }) => {
+  await authenticate(page, context, SEEDED.admin.email, SEEDED.admin.password, adminStatePath);
+});
+
+setup('authenticate as cashier', async ({ page, context }) => {
+  await authenticate(
+    page,
+    context,
+    SEEDED.cashier.email,
+    SEEDED.cashier.password,
+    cashierStatePath
+  );
+});

--- a/e2e/fixtures/authPaths.ts
+++ b/e2e/fixtures/authPaths.ts
@@ -1,0 +1,12 @@
+import path from 'node:path';
+
+/**
+ * Session state lives outside `outputDir` on purpose: it holds a real access token and
+ * the httpOnly refresh cookie, and anything under `outputDir` is swept into the CI
+ * failure artifacts, which are downloadable by anyone on a public repository.
+ */
+const AUTH_DIR = path.join(__dirname, '..', 'playwright', '.auth');
+
+export const adminStatePath = path.join(AUTH_DIR, 'admin.json');
+export const cashierStatePath = path.join(AUTH_DIR, 'cashier.json');
+export { AUTH_DIR };

--- a/e2e/fixtures/seed.ts
+++ b/e2e/fixtures/seed.ts
@@ -54,6 +54,13 @@ async function unwrap<T>(
     throw new Error(`${what} failed: ${response.status()} ${await response.text()}`);
   }
   const body = (await response.json()) as Envelope<T>;
+  if (body.data === null || body.data === undefined) {
+    // `shifts/current` and `register/current` legitimately answer 200 with `{ data: null }`
+    // when nothing is open. Returning that as T would surface later as a null dereference
+    // inside a spec — which reads as an application bug rather than "nothing is open".
+    // Callers that treat null as a real answer should use `getJsonOrNull`.
+    throw new Error(`${what}: server returned 200 with no data.`);
+  }
   return body.data;
 }
 
@@ -146,6 +153,19 @@ export async function createProduct(
     },
   });
   return unwrap<Product>(response, `create product ${unique}`);
+}
+
+/** For endpoints where `{ data: null }` is a meaningful answer, not an error. */
+export async function getJsonOrNull<T>(
+  request: APIRequestContext,
+  token: string,
+  path: string
+): Promise<T | null> {
+  const response = await request.get(`${API_BASE}/${path}`, { headers: authHeaders(token) });
+  if (!response.ok()) {
+    throw new Error(`GET ${path} failed: ${response.status()} ${await response.text()}`);
+  }
+  return ((await response.json()) as Envelope<T | null>).data ?? null;
 }
 
 export async function getJson<T>(

--- a/e2e/fixtures/seed.ts
+++ b/e2e/fixtures/seed.ts
@@ -74,17 +74,20 @@ export async function login(
 }
 
 /**
- * An empty token means the caller's request context already carries the header (the
- * worker-scoped `adminApi` does), so no per-call override is needed.
+ * Omit the token when the caller's request context already carries the header — the
+ * worker-scoped `adminApi` does. Optional rather than an empty-string sentinel, so
+ * "deliberately omitted" is visible in the type and cannot be confused with a token
+ * variable that happened to be empty (which would send no Authorization at all and
+ * surface as a 401 that reads like an auth bug).
  */
-function authHeaders(token: string): Record<string, string> {
+function authHeaders(token?: string): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 export async function createUser(
   request: APIRequestContext,
-  adminToken: string,
-  user: { name: string; email: string; password: string; role: Role }
+  user: { name: string; email: string; password: string; role: Role },
+  adminToken?: string
 ): Promise<CreatedUser> {
   const response = await request.post(`${API_BASE}/users`, {
     headers: authHeaders(adminToken),
@@ -133,12 +136,18 @@ export interface ProductSeed {
  * workers asking for one get the same value and the loser's create fails with a confusing
  * 409 mid-test.
  */
+export interface CreateProductOptions extends ProductSeed {
+  /** Worker+test namespace the SKU is derived from. */
+  namespace: string;
+  /** Short label distinguishing products within one test. */
+  label: string;
+  /** Omit when the request context already carries an admin header. */
+  adminToken?: string;
+}
+
 export async function createProduct(
   request: APIRequestContext,
-  adminToken: string,
-  namespace: string,
-  label: string,
-  seed: ProductSeed = {}
+  { namespace, label, adminToken, ...seed }: CreateProductOptions
 ): Promise<Product> {
   const unique = `${namespace}-${label}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
   const response = await request.post(`${API_BASE}/products`, {

--- a/e2e/fixtures/seed.ts
+++ b/e2e/fixtures/seed.ts
@@ -1,0 +1,158 @@
+/**
+ * API-seeded fixture data, namespaced per worker.
+ *
+ * Everything is created through the real HTTP API rather than by direct insert, so
+ * fixture data passes the same validation and invariants as production data. Three rules
+ * keep the parallel model honest:
+ *
+ *   1. Every test creates the rows it mutates. Never mutate shared seed rows.
+ *   2. Assert on scoped locators, never "the first row" or "3 items".
+ *   3. Never assert on a global aggregate from a parallel worker.
+ */
+import type { APIRequestContext } from '@playwright/test';
+import { API_URL } from '../support/config';
+import type {
+  CreatedUser,
+  Envelope,
+  LoginData,
+  Product,
+  RegisterSession,
+  Role,
+  Shift,
+} from './types';
+
+export const API_BASE = `${API_URL}/api/v1`;
+
+/** Cashier password for every worker-owned account. Disposable database, published creds. */
+export const WORKER_PASSWORD = 'e2e-cashier-password';
+
+export interface SeededAccounts {
+  admin: { email: string; password: string };
+  cashier: { email: string; password: string };
+  delivery: { email: string; password: string };
+}
+
+/**
+ * The accounts `server/src/database/seed.ts` creates. A spec may *authenticate* as one of
+ * these, but must never mutate its shift, register, or sale state: `register_sessions`
+ * allows one open session per cashier and carries `expected_cash` as a running
+ * accumulator, and `shifts` has the same one-active-per-user shape. Two workers driving
+ * the shared cashier would have one register-open fail outright and the other's balance
+ * assertions race.
+ */
+export const SEEDED: SeededAccounts = {
+  admin: { email: 'admin@moon.com', password: 'admin123' },
+  cashier: { email: 'sarah@moon.com', password: 'cashier123' },
+  delivery: { email: 'james@moon.com', password: 'delivery123' },
+};
+
+async function unwrap<T>(
+  response: Awaited<ReturnType<APIRequestContext['post']>>,
+  what: string
+): Promise<T> {
+  if (!response.ok()) {
+    throw new Error(`${what} failed: ${response.status()} ${await response.text()}`);
+  }
+  const body = (await response.json()) as Envelope<T>;
+  return body.data;
+}
+
+export async function login(
+  request: APIRequestContext,
+  email: string,
+  password: string
+): Promise<LoginData> {
+  const response = await request.post(`${API_BASE}/auth/login`, { data: { email, password } });
+  return unwrap<LoginData>(response, `login as ${email}`);
+}
+
+/**
+ * An empty token means the caller's request context already carries the header (the
+ * worker-scoped `adminApi` does), so no per-call override is needed.
+ */
+function authHeaders(token: string): Record<string, string> {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function createUser(
+  request: APIRequestContext,
+  adminToken: string,
+  user: { name: string; email: string; password: string; role: Role }
+): Promise<CreatedUser> {
+  const response = await request.post(`${API_BASE}/users`, {
+    headers: authHeaders(adminToken),
+    data: user,
+  });
+  return unwrap<CreatedUser>(response, `create user ${user.email}`);
+}
+
+export async function clockIn(request: APIRequestContext, token: string): Promise<Shift> {
+  // `branch_id` is optional and FKs to `branches`; omitted deliberately so the fixture
+  // does not depend on a seeded branch.
+  const response = await request.post(`${API_BASE}/shifts/clock-in`, {
+    headers: authHeaders(token),
+    data: {},
+  });
+  return unwrap<Shift>(response, 'clock in');
+}
+
+export async function openRegister(
+  request: APIRequestContext,
+  token: string,
+  openingFloat: number
+): Promise<RegisterSession> {
+  // `opening_float` is a JSON number, not a string — the Zod schema is `z.number().min(0)`.
+  const response = await request.post(`${API_BASE}/register/open`, {
+    headers: authHeaders(token),
+    data: { opening_float: openingFloat },
+  });
+  return unwrap<RegisterSession>(response, 'open register');
+}
+
+export interface ProductSeed {
+  name?: string;
+  price?: number;
+  stock?: number;
+  minStock?: number;
+  /** Omit to leave the product without a barcode; `products.barcode` is UNIQUE. */
+  barcode?: string;
+}
+
+/**
+ * Mints a product owned by one test.
+ *
+ * SKU and barcode are derived from the worker namespace rather than from
+ * `GET /products/generate-sku/:categoryId`, which is an unlocked `MAX(...)+1` read: two
+ * workers asking for one get the same value and the loser's create fails with a confusing
+ * 409 mid-test.
+ */
+export async function createProduct(
+  request: APIRequestContext,
+  adminToken: string,
+  namespace: string,
+  label: string,
+  seed: ProductSeed = {}
+): Promise<Product> {
+  const unique = `${namespace}-${label}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  const response = await request.post(`${API_BASE}/products`, {
+    headers: authHeaders(adminToken),
+    data: {
+      name: seed.name ?? unique,
+      sku: unique.toUpperCase(),
+      barcode: seed.barcode ?? null,
+      price: seed.price ?? 100,
+      stock: seed.stock ?? 10,
+      min_stock: seed.minStock ?? 0,
+    },
+  });
+  return unwrap<Product>(response, `create product ${unique}`);
+}
+
+export async function getJson<T>(
+  request: APIRequestContext,
+  token: string,
+  path: string
+): Promise<T> {
+  const response = await request.get(`${API_BASE}/${path}`, { headers: authHeaders(token) });
+  return unwrap<T>(response, `GET ${path}`);
+}

--- a/e2e/fixtures/storage.ts
+++ b/e2e/fixtures/storage.ts
@@ -15,14 +15,22 @@ import type { BrowserContext } from '@playwright/test';
 import { DEFAULT_TEST_LOCALE, type Locale } from '../support/i18n';
 import type { AuthUser } from './types';
 
-/** Literal persist keys, mirroring `client/src/shared/lib/storageKeys.ts`. */
-export const AUTH_STORAGE_KEY = 'moon-auth';
-export const SETTINGS_STORAGE_KEY = 'moon-settings';
-export const CART_RECOVERY_STORAGE_KEY = 'moon-cart-recovery';
-export const HELD_CARTS_STORAGE_KEY = 'moon-held-carts';
-export const OFFLINE_QUEUE_STORAGE_KEY = 'moon-offline-queue';
+/**
+ * Imported from the client rather than retyped. These are literal `localStorage` keys
+ * under the global string-coupling contract, and a stale copy fails quietly — the app
+ * would boot unauthenticated or in Arabic and the specs would report locator misses
+ * rather than "the key changed". `support/i18n.ts` crosses the same boundary the same
+ * way for the translation catalogs.
+ */
+import { AUTH_STORAGE_KEY, SETTINGS_STORAGE_KEY } from '../../client/src/shared/lib/storageKeys';
 
-/** sessionStorage, not localStorage — see the note above. */
+export { AUTH_STORAGE_KEY, SETTINGS_STORAGE_KEY };
+
+/**
+ * Not in `storageKeys.ts`: it is a `sessionStorage` key private to `StartupPrompt.tsx`,
+ * which declares its own `SESSION_KEY` literal. Duplicated here because there is nothing
+ * to import — the coupling is real and is asserted by the startup-prompt spec.
+ */
 export const STARTUP_DISMISSED_KEY = 'moon-startup-dismissed';
 
 /** The zustand-persist envelope both stores are written in. */

--- a/e2e/fixtures/storage.ts
+++ b/e2e/fixtures/storage.ts
@@ -1,0 +1,69 @@
+/**
+ * Browser storage seeding.
+ *
+ * Two mechanisms, kept visibly distinct because they are not interchangeable:
+ *
+ * - **`storageState`** serializes cookies and **localStorage** only. That covers
+ *   `moon-auth` and `moon-settings`.
+ * - **`sessionStorage`** is not in `storageState` at all. `moon-startup-dismissed` lives
+ *   there (`StartupPrompt.tsx`), so writing it into a storage state silently does
+ *   nothing, and every spec meant to skip the startup gate would instead sit behind it,
+ *   looking like an application bug. It must be seeded with `addInitScript` before the
+ *   first navigation.
+ */
+import type { BrowserContext } from '@playwright/test';
+import { DEFAULT_TEST_LOCALE, type Locale } from '../support/i18n';
+import type { AuthUser } from './types';
+
+/** Literal persist keys, mirroring `client/src/shared/lib/storageKeys.ts`. */
+export const AUTH_STORAGE_KEY = 'moon-auth';
+export const SETTINGS_STORAGE_KEY = 'moon-settings';
+export const CART_RECOVERY_STORAGE_KEY = 'moon-cart-recovery';
+export const HELD_CARTS_STORAGE_KEY = 'moon-held-carts';
+export const OFFLINE_QUEUE_STORAGE_KEY = 'moon-offline-queue';
+
+/** sessionStorage, not localStorage — see the note above. */
+export const STARTUP_DISMISSED_KEY = 'moon-startup-dismissed';
+
+/** The zustand-persist envelope both stores are written in. */
+function persisted(state: unknown): string {
+  return JSON.stringify({ state, version: 0 });
+}
+
+export function authStorageValue(user: AuthUser, accessToken: string): string {
+  return persisted({ user, accessToken, isAuthenticated: true });
+}
+
+export function settingsStorageValue(locale: Locale = DEFAULT_TEST_LOCALE): string {
+  return persisted({ locale, theme: 'light' });
+}
+
+/**
+ * Pins the locale before the app's first render.
+ *
+ * The app defaults to Arabic RTL, so without this every locator built from the `en`
+ * catalog silently fails to match. The bulk of the suite runs pinned to `en` for readable
+ * diagnostics; `locale-rtl.spec.ts` deliberately omits this and covers the shipped
+ * default.
+ */
+export async function seedLocale(context: BrowserContext, locale: Locale): Promise<void> {
+  const value = settingsStorageValue(locale);
+  await context.addInitScript(
+    ([key, json]) => {
+      window.localStorage.setItem(key as string, json as string);
+    },
+    [SETTINGS_STORAGE_KEY, value]
+  );
+}
+
+/**
+ * Skips the shift/register gate for a cashier that already has both open.
+ *
+ * Note this is *not* the same as having no shift: `checkout-cash.spec.ts` deliberately
+ * mints a cashier with neither and drives the prompt for real.
+ */
+export async function dismissStartupPrompt(context: BrowserContext): Promise<void> {
+  await context.addInitScript((key) => {
+    window.sessionStorage.setItem(key as string, '1');
+  }, STARTUP_DISMISSED_KEY);
+}

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -1,0 +1,201 @@
+/**
+ * The extended `test` every spec imports.
+ *
+ * The isolation model (D4): each worker owns a cashier, a shift, a register and a
+ * namespace. Register sessions and shifts are per *user*, so a per-worker cashier
+ * isolates them for free — which is why sharing the seeded `sarah@moon.com` is
+ * forbidden rather than merely discouraged.
+ */
+import {
+  test as base,
+  expect,
+  request as playwrightRequest,
+  type APIRequestContext,
+  type BrowserContext,
+} from '@playwright/test';
+import { API_URL } from '../support/config';
+import { DEFAULT_TEST_LOCALE, type Locale } from '../support/i18n';
+import { readAdminAccessToken } from './adminToken';
+import { adminStatePath } from './authPaths';
+import {
+  WORKER_PASSWORD,
+  clockIn,
+  createProduct,
+  createUser,
+  login,
+  openRegister,
+  type ProductSeed,
+} from './seed';
+import { authStorageValue, dismissStartupPrompt, seedLocale, AUTH_STORAGE_KEY } from './storage';
+import type { Product, RegisterSession, Shift, WorkerCashier } from './types';
+
+export const OPENING_FLOAT = 500;
+
+export interface WorkerFixtures {
+  /** An API context carrying an admin bearer token, for seeding and read-back. */
+  adminApi: APIRequestContext;
+  /** This worker's own cashier, with an open shift and register. */
+  workerCashier: WorkerCashier;
+  workerShift: Shift;
+  workerRegister: RegisterSession;
+}
+
+export interface TestFixtures {
+  /**
+   * App locale the browser context is pinned to. Named `appLocale`, not `locale`:
+   * Playwright already owns a `locale` option for the browser's Accept-Language, and
+   * this is the app's own `moon-settings` value. Override per spec for the RTL case.
+   */
+  appLocale: Locale;
+  /** Skip the shift/register gate. Off for the spec that drives the prompt for real. */
+  skipStartupPrompt: boolean;
+  /** A context already authenticated as this worker's cashier. */
+  cashierContext: BrowserContext;
+  /** Mints a product owned by this test, namespaced so no other spec can see it. */
+  seedProduct: (label: string, seed?: ProductSeed) => Promise<Product>;
+}
+
+export const test = base.extend<TestFixtures, WorkerFixtures>({
+  adminApi: [
+    // Playwright inspects this parameter's destructuring pattern to discover fixture
+    // dependencies, so it must stay an object pattern even when it depends on nothing.
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      // Reads the token the setup project already obtained rather than logging in again.
+      // Concurrent logins as the same user collide on the refresh token's UNIQUE
+      // constraint and return 500 — see `adminToken.ts` and issue #62.
+      const accessToken = readAdminAccessToken();
+      const context = await playwrightRequest.newContext({
+        baseURL: API_URL,
+        extraHTTPHeaders: { Authorization: `Bearer ${accessToken}` },
+      });
+      await use(context);
+      await context.dispose();
+    },
+    { scope: 'worker' },
+  ],
+
+  workerCashier: [
+    async ({ adminApi }, use, workerInfo) => {
+      const index = workerInfo.workerIndex;
+      const namespace = `e2e-w${index}`;
+      const email = `${namespace}@moon.test`;
+      const name = `E2E Worker ${index}`;
+
+      /**
+       * Refresh tokens are `jwt.sign({ id }, …, { expiresIn: '7d' })` — user id plus
+       * second-resolution `iat`/`exp`, no jti — stored in `refresh_tokens.token UNIQUE`.
+       * Two logins as the *same* user inside one second produce a byte-identical token,
+       * so the second insert fails on 23505, and because the tokens are identical a
+       * logout would revoke every holder's session. Worker startup is exactly that burst.
+       *
+       * Each worker logging in as its *own* cashier sidesteps this entirely. This is a
+       * pre-existing server defect (issue #62), not one the suite introduces.
+       */
+      let cashier;
+      try {
+        cashier = await createUser(adminApi, '', {
+          name,
+          email,
+          password: WORKER_PASSWORD,
+          role: 'Cashier',
+        });
+      } catch (err) {
+        throw new Error(
+          `Worker ${index}: could not create its cashier (${email}). ` +
+            'Every other fixture depends on it, so failing here rather than letting the ' +
+            `specs fail later on a missing register.\n${String(err)}`
+        );
+      }
+
+      const session = await login(adminApi, email, WORKER_PASSWORD);
+
+      await use({
+        id: cashier.id,
+        name,
+        email,
+        password: WORKER_PASSWORD,
+        workerIndex: index,
+        namespace,
+        accessToken: session.accessToken,
+      });
+    },
+    { scope: 'worker' },
+  ],
+
+  workerShift: [
+    async ({ workerCashier }, use) => {
+      const context = await playwrightRequest.newContext({ baseURL: API_URL });
+      const shift = await clockIn(context, workerCashier.accessToken);
+      await use(shift);
+      await context.dispose();
+    },
+    { scope: 'worker' },
+  ],
+
+  workerRegister: [
+    async ({ workerCashier, workerShift: _shift }, use) => {
+      const context = await playwrightRequest.newContext({ baseURL: API_URL });
+      const register = await openRegister(context, workerCashier.accessToken, OPENING_FLOAT);
+      await use(register);
+      await context.dispose();
+    },
+    { scope: 'worker' },
+  ],
+
+  appLocale: [DEFAULT_TEST_LOCALE, { option: true }],
+  skipStartupPrompt: [true, { option: true }],
+
+  cashierContext: async (
+    { browser, appLocale, skipStartupPrompt, workerCashier, workerRegister: _register },
+    use
+  ) => {
+    const context = await browser.newContext();
+    await seedLocale(context, appLocale);
+    if (skipStartupPrompt) await dismissStartupPrompt(context);
+
+    const authValue = authStorageValue(
+      {
+        id: workerCashier.id,
+        name: workerCashier.name,
+        email: workerCashier.email,
+        role: 'Cashier',
+      },
+      workerCashier.accessToken
+    );
+    await context.addInitScript(
+      ([key, json]) => {
+        window.localStorage.setItem(key as string, json as string);
+      },
+      [AUTH_STORAGE_KEY, authValue]
+    );
+
+    await use(context);
+    await context.close();
+  },
+
+  seedProduct: async ({ adminApi, workerCashier }, use, testInfo) => {
+    const created: Product[] = [];
+    const testTag = testInfo.testId.slice(0, 8);
+
+    await use(async (label, seed) => {
+      const product = await createProduct(
+        adminApi,
+        '',
+        `${workerCashier.namespace}-t${testTag}`,
+        label,
+        seed
+      );
+      created.push(product);
+      return product;
+    });
+
+    // Best-effort: the E2E database is disposable, and a failed cleanup must never fail a
+    // passing test.
+    for (const product of created) {
+      await adminApi.delete(`/api/v1/products/${product.id}`).catch(() => {});
+    }
+  },
+});
+
+export { expect, adminStatePath };

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -13,7 +13,7 @@ import {
   type APIRequestContext,
   type BrowserContext,
 } from '@playwright/test';
-import { API_URL } from '../support/config';
+import { API_URL, BASE_URL } from '../support/config';
 import { DEFAULT_TEST_LOCALE, type Locale } from '../support/i18n';
 import { readAdminAccessToken } from './adminToken';
 import { adminStatePath } from './authPaths';
@@ -27,7 +27,7 @@ import {
   type ProductSeed,
 } from './seed';
 import { authStorageValue, dismissStartupPrompt, seedLocale, AUTH_STORAGE_KEY } from './storage';
-import type { Product, RegisterSession, Shift, WorkerCashier } from './types';
+import type { Product, RegisterSession, Shift, StorageState, WorkerCashier } from './types';
 
 export const OPENING_FLOAT = 500;
 
@@ -108,7 +108,40 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         );
       }
 
-      const session = await login(adminApi, email, WORKER_PASSWORD);
+      // Logged in through its own context so the `Set-Cookie` carrying the refresh token
+      // lands in a jar this fixture can read. `adminApi` would swallow it into the admin
+      // context's jar, and the browser would then have no way to refresh.
+      const loginContext = await playwrightRequest.newContext({ baseURL: API_URL });
+      const session = await login(loginContext, email, WORKER_PASSWORD);
+      const { cookies } = await loginContext.storageState();
+      await loginContext.dispose();
+
+      const refreshCookie = cookies.find((c) => c.name === 'refreshToken');
+      if (!refreshCookie) {
+        throw new Error(
+          `Worker ${index}: login as ${email} returned no refreshToken cookie. ` +
+            'Without it the client cannot refresh an expired access token, and specs ' +
+            'would redirect to /login partway through the run.'
+        );
+      }
+
+      const storageState: StorageState = {
+        cookies,
+        origins: [
+          {
+            origin: BASE_URL,
+            localStorage: [
+              {
+                name: AUTH_STORAGE_KEY,
+                value: authStorageValue(
+                  { id: cashier.id, name, email, role: 'Cashier' },
+                  session.accessToken
+                ),
+              },
+            ],
+          },
+        ],
+      };
 
       await use({
         id: cashier.id,
@@ -118,6 +151,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         workerIndex: index,
         namespace,
         accessToken: session.accessToken,
+        storageState,
       });
     },
     { scope: 'worker' },
@@ -146,29 +180,25 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   appLocale: [DEFAULT_TEST_LOCALE, { option: true }],
   skipStartupPrompt: [true, { option: true }],
 
+  /**
+   * A context holding a *complete* session: the `moon-auth` localStorage entry **and**
+   * the httpOnly `refreshToken` cookie.
+   *
+   * Both halves matter. Seeding only the access token would leave the app unable to
+   * refresh — `client.ts`'s 401 interceptor would POST to `/auth/refresh` with no cookie,
+   * fail, and redirect to `/login` mid-spec once the 15-minute token expired. And
+   * `addInitScript` re-runs on *every* navigation, so injecting the token that way would
+   * additionally overwrite any rotated token the app had just stored, defeating refresh
+   * even when the cookie was present. `storageState` is applied once at context creation,
+   * which is the behavior this needs.
+   */
   cashierContext: async (
     { browser, appLocale, skipStartupPrompt, workerCashier, workerRegister: _register },
     use
   ) => {
-    const context = await browser.newContext();
+    const context = await browser.newContext({ storageState: workerCashier.storageState });
     await seedLocale(context, appLocale);
     if (skipStartupPrompt) await dismissStartupPrompt(context);
-
-    const authValue = authStorageValue(
-      {
-        id: workerCashier.id,
-        name: workerCashier.name,
-        email: workerCashier.email,
-        role: 'Cashier',
-      },
-      workerCashier.accessToken
-    );
-    await context.addInitScript(
-      ([key, json]) => {
-        window.localStorage.setItem(key as string, json as string);
-      },
-      [AUTH_STORAGE_KEY, authValue]
-    );
 
     await use(context);
     await context.close();
@@ -190,10 +220,19 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       return product;
     });
 
-    // Best-effort: the E2E database is disposable, and a failed cleanup must never fail a
-    // passing test.
+    // `DELETE /products/:id` is a *soft* delete — it sets status='discontinued'. The rows,
+    // SKUs and barcodes survive the whole run, which is safe only because every seeded SKU
+    // carries a timestamp+random suffix. A spec needing a fixed barcode must namespace it
+    // the same way rather than assuming this removed anything.
+    //
+    // Best-effort: the E2E database is disposable and a failed cleanup must never fail a
+    // passing test. `.delete()` resolves for any HTTP status, so a broken cleanup would
+    // otherwise be completely silent — hence the explicit status check.
     for (const product of created) {
-      await adminApi.delete(`/api/v1/products/${product.id}`).catch(() => {});
+      const response = await adminApi.delete(`/api/v1/products/${product.id}`).catch(() => null);
+      if (response && !response.ok()) {
+        console.warn(`[e2e] could not discontinue product ${product.sku}: ${response.status()}`);
+      }
     }
   },
 });

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -94,7 +94,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
        */
       let cashier;
       try {
-        cashier = await createUser(adminApi, '', {
+        cashier = await createUser(adminApi, {
           name,
           email,
           password: WORKER_PASSWORD,
@@ -209,13 +209,11 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     const testTag = testInfo.testId.slice(0, 8);
 
     await use(async (label, seed) => {
-      const product = await createProduct(
-        adminApi,
-        '',
-        `${workerCashier.namespace}-t${testTag}`,
+      const product = await createProduct(adminApi, {
+        namespace: `${workerCashier.namespace}-t${testTag}`,
         label,
-        seed
-      );
+        ...seed,
+      });
       created.push(product);
       return product;
     });

--- a/e2e/fixtures/types.ts
+++ b/e2e/fixtures/types.ts
@@ -1,0 +1,78 @@
+/**
+ * The API shapes the fixtures depend on. Narrow on purpose — these mirror only the fields
+ * the suite reads, so an unrelated response change does not ripple through the harness.
+ *
+ * The success envelope is `{ data }` (plus `meta` on list endpoints). There is no
+ * `success` boolean; errors are `{ error: { code, message, details? } }`.
+ */
+
+export type Role = 'Admin' | 'Cashier' | 'Delivery';
+
+export interface Envelope<T> {
+  data: T;
+}
+
+export interface AuthUser {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+}
+
+export interface LoginData {
+  accessToken: string;
+  user: AuthUser;
+}
+
+export interface CreatedUser {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+  created_at: string;
+}
+
+export interface Shift {
+  id: number;
+  user_id: number;
+  clock_in: string;
+  clock_out: string | null;
+  status: 'active' | 'on_break' | 'completed';
+}
+
+export interface RegisterSession {
+  id: number;
+  cashier_id: number;
+  /** pg NUMERIC — arrives as a string. Never compare it to a JS number directly. */
+  opening_float: string | number;
+  expected_cash: string | number;
+  status: 'open' | 'closed';
+  opened_at: string;
+}
+
+export interface Product {
+  id: number;
+  name: string;
+  sku: string;
+  barcode: string | null;
+  price: number | string;
+  stock: number;
+  category_id: number | null;
+  min_stock: number;
+}
+
+/** Credentials for one of the accounts the fixtures authenticate as. */
+export interface Credentials {
+  email: string;
+  password: string;
+}
+
+/** A cashier owned by exactly one worker, with its own shift and register. */
+export interface WorkerCashier extends Credentials {
+  id: number;
+  name: string;
+  workerIndex: number;
+  /** `e2e-w{N}` — the prefix every row this worker creates must carry. */
+  namespace: string;
+  accessToken: string;
+}

--- a/e2e/fixtures/types.ts
+++ b/e2e/fixtures/types.ts
@@ -67,6 +67,21 @@ export interface Credentials {
   password: string;
 }
 
+/** Playwright's storage-state shape, narrowed to what the fixtures build. */
+export interface StorageState {
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: 'Strict' | 'Lax' | 'None';
+  }>;
+  origins: Array<{ origin: string; localStorage: Array<{ name: string; value: string }> }>;
+}
+
 /** A cashier owned by exactly one worker, with its own shift and register. */
 export interface WorkerCashier extends Credentials {
   id: number;
@@ -75,4 +90,6 @@ export interface WorkerCashier extends Credentials {
   /** `e2e-w{N}` — the prefix every row this worker creates must carry. */
   namespace: string;
   accessToken: string;
+  /** A complete session: the moon-auth entry AND the httpOnly refresh cookie. */
+  storageState: StorageState;
 }

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,1800 @@
+{
+  "name": "moon-store-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "moon-store-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@eslint/js": "^9.39.5",
+        "@playwright/test": "1.62.1",
+        "@types/node": "^22.10.2",
+        "@types/pg": "^8.11.10",
+        "eslint": "^9.17.0",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.11.0",
+        "pg": "^8.13.1",
+        "prettier": "^3.4.2",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.18.1"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.23.1.tgz",
+      "integrity": "sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
+      "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/type-utils": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.68.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.68.0",
+        "@typescript-eslint/types": "^8.68.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
+      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.68.0",
+        "@typescript-eslint/tsconfig-utils": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
+      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.68.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
+      "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.68.0",
+        "@typescript-eslint/parser": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -16,6 +16,7 @@
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.11.0",
         "pg": "^8.13.1",
+        "pg-connection-string": "^2.7.0",
         "prettier": "^3.4.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.1"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -22,6 +22,7 @@
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.11.0",
     "pg": "^8.13.1",
+    "pg-connection-string": "^2.7.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.1"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "moon-store-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end coverage for critical POS workflows (Playwright, Chromium).",
+  "scripts": {
+    "test": "playwright test",
+    "test:smoke": "playwright test --grep @smoke",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"**/*.ts\"",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.5",
+    "@playwright/test": "1.62.1",
+    "@types/node": "^22.10.2",
+    "@types/pg": "^8.11.10",
+    "eslint": "^9.17.0",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.11.0",
+    "pg": "^8.13.1",
+    "prettier": "^3.4.2",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.18.1"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,6 +3,7 @@ import {
   API_URL,
   BASE_URL,
   CLIENT_DIR,
+  E2E_SERVER_APP_NAME,
   PREVIEW_PORT,
   SERVER_DIR,
   requireE2eDatabaseUrl,
@@ -26,6 +27,10 @@ const serverEnv: Record<string, string> = {
   NODE_ENV: 'test',
   PORT: '3001',
   DATABASE_URL: E2E_DATABASE_URL,
+  // Tags this server's PostgreSQL backends so `globalSetup`'s preflight can identify
+  // them by name. Without it the guard could only count anonymous connections, and any
+  // idle psql session would let a reused dev server pass as the server under test.
+  PGAPPNAME: E2E_SERVER_APP_NAME,
   // The CORS allowlist is `CLIENT_URL` plus localhost:5173/5174/5175 under
   // `credentials: true`, so the preview origin is on no list by default and every API
   // call would fail preflight. The fix is this variable — never widening
@@ -36,10 +41,11 @@ const serverEnv: Record<string, string> = {
   // bucket. The binding constraint is the auth ceiling of 10, not the global 200.
   RATE_LIMIT_MAX: '100000',
   AUTH_RATE_LIMIT_MAX: '100000',
-  // Mirrors the literals in `.github/workflows/ci.yml`'s server job rather than reaching
-  // for repository secrets — this is a disposable database with published credentials.
-  JWT_SECRET: 'test-secret-key-for-e2e-at-least-32-characters-long',
-  JWT_REFRESH_SECRET: 'test-refresh-secret-key-for-e2e-at-least-32-chars',
+  // The same literals `.github/workflows/ci.yml`'s server job uses, so one rotation
+  // covers both. Deliberately not repository secrets: this is a throwaway server on a
+  // disposable database whose seeded credentials are already published in CLAUDE.md.
+  JWT_SECRET: 'ci-jwt-secret-key-at-least-32-characters-long',
+  JWT_REFRESH_SECRET: 'ci-jwt-refresh-secret-key-at-least-32-chars',
 };
 
 export default defineConfig({
@@ -123,7 +129,9 @@ export default defineConfig({
       command: `npx vite preview --port ${PREVIEW_PORT} --strictPort`,
       cwd: CLIENT_DIR,
       url: BASE_URL,
-      env: { VITE_API_URL: API_URL },
+      // No `VITE_API_URL` here: `import.meta.env` is substituted at BUILD time, so setting
+      // it on the preview process does nothing while reading as though it binds the
+      // browser to this API. It belongs on the build step — see README.
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       stdout: 'pipe',

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,133 @@
+import { defineConfig, devices } from '@playwright/test';
+import {
+  API_URL,
+  BASE_URL,
+  CLIENT_DIR,
+  PREVIEW_PORT,
+  SERVER_DIR,
+  requireE2eDatabaseUrl,
+} from './support/config';
+
+/**
+ * Resolved at config load, so an unset variable aborts the run before any server starts
+ * rather than partway through the first spec. There is deliberately no fallback to
+ * `DATABASE_URL`: `globalSetup` deletes every row in 77 tables, and a default that
+ * pointed that at a developer's dev database would fail silently and destructively.
+ */
+const E2E_DATABASE_URL = requireE2eDatabaseUrl();
+
+/**
+ * `webServer.env` inherits `process.env`, and `server/index.ts` additionally calls
+ * `dotenv/config` — so without explicit overrides the server under test picks up the
+ * developer's `server/.env` and writes into their dev database while the assertions read
+ * the E2E one. Every variable here is load-bearing; none is a default worth trusting.
+ */
+const serverEnv: Record<string, string> = {
+  NODE_ENV: 'test',
+  PORT: '3001',
+  DATABASE_URL: E2E_DATABASE_URL,
+  // The CORS allowlist is `CLIENT_URL` plus localhost:5173/5174/5175 under
+  // `credentials: true`, so the preview origin is on no list by default and every API
+  // call would fail preflight. The fix is this variable — never widening
+  // `allowedOrigins` in `server/index.ts` or setting `origin: true`.
+  CLIENT_URL: BASE_URL,
+  ALLOWED_ORIGINS: BASE_URL,
+  // Both limiters key on `req.ip`, and every worker is 127.0.0.1 sharing one in-process
+  // bucket. The binding constraint is the auth ceiling of 10, not the global 200.
+  RATE_LIMIT_MAX: '100000',
+  AUTH_RATE_LIMIT_MAX: '100000',
+  // Mirrors the literals in `.github/workflows/ci.yml`'s server job rather than reaching
+  // for repository secrets — this is a disposable database with published credentials.
+  JWT_SECRET: 'test-secret-key-for-e2e-at-least-32-characters-long',
+  JWT_REFRESH_SECRET: 'test-refresh-secret-key-for-e2e-at-least-32-chars',
+};
+
+export default defineConfig({
+  testDir: './specs',
+  outputDir: './test-results',
+  globalSetup: './support/globalSetup.ts',
+
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // Replays failures at the end of the run in a single worker rather than immediately,
+  // which is the right shape for a suite sharing one database.
+  retryStrategy: 'isolated',
+  workers: process.env.CI ? 2 : undefined,
+
+  reporter: process.env.CI ? [['blob'], ['github']] : [['html', { open: 'on-failure' }], ['list']],
+
+  use: {
+    baseURL: BASE_URL,
+    testIdAttribute: 'data-testid',
+    /**
+     * The production build registers a Workbox service worker with
+     * `StaleWhileRevalidate` on `/api/v1/products` and `NetworkFirst` on `/api/v1/sales`
+     * reads. Left active it shadows route mocks on GET and can serve 24-hour-old stock
+     * rows into the very assertions this suite exists to make. The service worker's own
+     * behavior is explicitly out of scope — see README.md.
+     */
+    serviceWorkers: 'block',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'setup',
+      testDir: './fixtures',
+      testMatch: /.*\.setup\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'pos-parallel',
+      dependencies: ['setup'],
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: /tax-loyalty\.spec\.ts/,
+    },
+    {
+      /**
+       * Tax and loyalty are global settings rows, not per-sale inputs. A worker that
+       * flips `tax_enabled` changes the totals every other worker is asserting on, so
+       * the mode variants are quarantined here: one worker, serial, ordered after the
+       * parallel project has finished.
+       */
+      name: 'pos-settings',
+      dependencies: ['setup', 'pos-parallel'],
+      workers: 1,
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: /tax-loyalty\.spec\.ts/,
+    },
+  ],
+
+  webServer: [
+    {
+      name: 'API',
+      command: 'npm run start',
+      cwd: SERVER_DIR,
+      // `url` rather than `port`: /api/health does a real `SELECT 1`, so this proves the
+      // app answers and reaches its database, not merely that a socket is bound.
+      url: `${API_URL}/api/health`,
+      env: serverEnv,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    {
+      name: 'Web',
+      // The client build is deliberately NOT part of this command. Folding it in would
+      // let the boot timeout silently cover compilation and report a build failure as a
+      // readiness timeout. Run `npm run build --prefix client` as its own step.
+      command: `npx vite preview --port ${PREVIEW_PORT} --strictPort`,
+      cwd: CLIENT_DIR,
+      url: BASE_URL,
+      env: { VITE_API_URL: API_URL },
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  ],
+});

--- a/e2e/specs/fixture-isolation.spec.ts
+++ b/e2e/specs/fixture-isolation.spec.ts
@@ -7,6 +7,7 @@
  */
 import { dbOne, dbQuery } from '../support/db';
 import { getJson } from '../fixtures/seed';
+import { AUTH_STORAGE_KEY, STARTUP_DISMISSED_KEY } from '../fixtures/storage';
 import { OPENING_FLOAT, expect, test } from '../fixtures/test';
 import type { RegisterSession, Shift } from '../fixtures/types';
 
@@ -66,13 +67,34 @@ test.describe('worker isolation', () => {
     expect(Number(rows[0]?.n)).toBe(1);
   });
 
-  test('every worker cashier is a distinct user row', async ({ workerCashier }) => {
-    const rows = await dbQuery<{ id: number; email: string }>(
-      `SELECT id, email FROM users WHERE email LIKE 'e2e-w%@moon.test'`
+  test('this worker’s cashier owns its own shift and register, not a shared one', async ({
+    workerCashier,
+    workerShift,
+    workerRegister,
+  }) => {
+    // Deliberately not "all worker emails are unique" — `users.email` is UNIQUE, so the
+    // database makes that impossible to violate and the assertion could never fail. What
+    // *can* break is two workers ending up on the same cashier's drawer, so assert the
+    // ownership chain instead.
+    const shiftOwners = await dbQuery<{ user_id: number }>(
+      'SELECT user_id FROM shifts WHERE id = $1',
+      [workerShift.id]
     );
-    const emails = rows.map((r) => r.email);
-    expect(new Set(emails).size).toBe(emails.length);
-    expect(emails).toContain(workerCashier.email);
+    expect(shiftOwners[0]?.user_id).toBe(workerCashier.id);
+
+    const registerOwners = await dbQuery<{ cashier_id: number }>(
+      'SELECT cashier_id FROM register_sessions WHERE id = $1',
+      [workerRegister.id]
+    );
+    expect(registerOwners[0]?.cashier_id).toBe(workerCashier.id);
+
+    // And no other e2e worker account shares this cashier's id.
+    const sharing = await dbQuery<{ n: string }>(
+      `SELECT count(*)::text AS n FROM users
+        WHERE id = $1 AND email <> $2 AND email LIKE 'e2e-w%@moon.test'`,
+      [workerCashier.id, workerCashier.email]
+    );
+    expect(Number(sharing[0]?.n)).toBe(0);
   });
 });
 
@@ -120,16 +142,34 @@ test.describe('browser context seeding', () => {
     await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
   });
 
-  test('the startup prompt is dismissed via sessionStorage, not storageState', async ({
+  test('the session carries the refresh cookie, not just the access token', async ({
     cashierContext,
   }) => {
-    // `storageState` serializes cookies and localStorage only. If this ever regresses to
-    // being seeded through storage state it will silently do nothing, and every spec
-    // meant to skip the gate would sit behind it looking like an app bug.
+    // Half a session is worse than none: without the httpOnly refresh cookie the client's
+    // 401 interceptor cannot refresh, and every spec still running after the 15-minute
+    // access token expires would redirect to /login and fail as an auth regression.
+    const cookies = await cashierContext.cookies();
+    expect(cookies.map((c) => c.name)).toContain('refreshToken');
+
     const page = await cashierContext.newPage();
     await page.goto('/pos');
-    const dismissed = await page.evaluate(() =>
-      window.sessionStorage.getItem('moon-startup-dismissed')
+    const stored = await page.evaluate((key) => window.localStorage.getItem(key), AUTH_STORAGE_KEY);
+    expect(stored).toBeTruthy();
+  });
+
+  test('the startup gate is actually skipped, not merely flagged', async ({ cashierContext }) => {
+    // Asserting the sessionStorage value would only prove the init script ran — it would
+    // stay green if `StartupPrompt` renamed its key or changed its sentinel, while every
+    // POS spec sat behind an undismissed modal. Assert the observable effect instead, and
+    // read the key from the shared constant rather than a fourth copy of the literal.
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+
+    const dismissed = await page.evaluate(
+      (key) => window.sessionStorage.getItem(key),
+      STARTUP_DISMISSED_KEY
     );
     expect(dismissed).toBe('1');
   });

--- a/e2e/specs/fixture-isolation.spec.ts
+++ b/e2e/specs/fixture-isolation.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * The isolation spec, written *before* any real spec on purpose.
+ *
+ * A fixture bug discovered later does not look like a fixture bug — it looks like a flaky
+ * application bug, and costs far more to diagnose than to prevent. Everything in Phases 2
+ * and 3 assumes what this file asserts.
+ */
+import { dbOne, dbQuery } from '../support/db';
+import { getJson } from '../fixtures/seed';
+import { OPENING_FLOAT, expect, test } from '../fixtures/test';
+import type { RegisterSession, Shift } from '../fixtures/types';
+
+test.describe('worker isolation', () => {
+  test('the worker owns a cashier with an open shift and register before any test body', async ({
+    workerCashier,
+    workerShift,
+    workerRegister,
+  }) => {
+    expect(workerCashier.email).toBe(`e2e-w${workerCashier.workerIndex}@moon.test`);
+    expect(workerShift.status).toBe('active');
+    expect(workerShift.user_id).toBe(workerCashier.id);
+    expect(workerRegister.status).toBe('open');
+    expect(workerRegister.cashier_id).toBe(workerCashier.id);
+    // pg NUMERIC arrives as a string; compare numerically, never by identity.
+    expect(Number(workerRegister.opening_float)).toBe(OPENING_FLOAT);
+  });
+
+  test('the register is retrievable at register/current with its opening float', async ({
+    workerCashier,
+    workerRegister,
+    request,
+  }) => {
+    const current = await getJson<RegisterSession>(
+      request,
+      workerCashier.accessToken,
+      'register/current'
+    );
+    expect(current.id).toBe(workerRegister.id);
+    expect(Number(current.opening_float)).toBe(OPENING_FLOAT);
+  });
+
+  test('the shift is retrievable at shifts/current', async ({
+    workerCashier,
+    // Declared even though it is not read: Playwright fixtures are lazy, so without this
+    // no shift is clocked in and `shifts/current` correctly returns `{ data: null }` —
+    // which reads as an application bug rather than as a missing dependency.
+    workerShift: _shift,
+    request,
+  }) => {
+    const current = await getJson<Shift>(request, workerCashier.accessToken, 'shifts/current');
+    expect(current.status).toBe('active');
+    expect(current.user_id).toBe(workerCashier.id);
+  });
+
+  test('no other worker shares this cashier’s open register', async ({
+    workerCashier,
+    workerRegister: _register,
+  }) => {
+    // Scoped to this cashier — never "the count of open registers", which is a global
+    // aggregate and would race every other worker.
+    const rows = await dbQuery<{ n: string }>(
+      `SELECT count(*)::text AS n FROM register_sessions
+        WHERE cashier_id = $1 AND status = 'open'`,
+      [workerCashier.id]
+    );
+    expect(Number(rows[0]?.n)).toBe(1);
+  });
+
+  test('every worker cashier is a distinct user row', async ({ workerCashier }) => {
+    const rows = await dbQuery<{ id: number; email: string }>(
+      `SELECT id, email FROM users WHERE email LIKE 'e2e-w%@moon.test'`
+    );
+    const emails = rows.map((r) => r.email);
+    expect(new Set(emails).size).toBe(emails.length);
+    expect(emails).toContain(workerCashier.email);
+  });
+});
+
+test.describe('per-test data ownership', () => {
+  test('a seeded product is namespaced to this worker and test', async ({
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('alpha', { price: 250, stock: 7 });
+
+    expect(product.sku).toContain(workerCashier.namespace.toUpperCase());
+    expect(product.stock).toBe(7);
+
+    // The direct read and the API must observe the same row — this is the D8 loop the
+    // money specs depend on.
+    const row = await dbOne<{ sku: string; stock: number }>(
+      'SELECT sku, stock FROM products WHERE id = $1',
+      [product.id]
+    );
+    expect(row?.sku).toBe(product.sku);
+    expect(Number(row?.stock)).toBe(7);
+  });
+
+  test('two products seeded in one test never collide on SKU', async ({ seedProduct }) => {
+    // `products.sku` and `products.barcode` are UNIQUE; a collision surfaces as a
+    // confusing 409 mid-test rather than as an obvious fixture bug.
+    const [a, b] = await Promise.all([seedProduct('one'), seedProduct('two')]);
+    expect(a.sku).not.toBe(b.sku);
+  });
+});
+
+test.describe('browser context seeding', () => {
+  test('the cashier context loads /pos without a login redirect', async ({ cashierContext }) => {
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await expect(page).toHaveURL(/\/pos/);
+  });
+
+  test('locale is pinned to en, overriding the shipped Arabic default', async ({
+    cashierContext,
+  }) => {
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  });
+
+  test('the startup prompt is dismissed via sessionStorage, not storageState', async ({
+    cashierContext,
+  }) => {
+    // `storageState` serializes cookies and localStorage only. If this ever regresses to
+    // being seeded through storage state it will silently do nothing, and every spec
+    // meant to skip the gate would sit behind it looking like an app bug.
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const dismissed = await page.evaluate(() =>
+      window.sessionStorage.getItem('moon-startup-dismissed')
+    );
+    expect(dismissed).toBe('1');
+  });
+});

--- a/e2e/specs/harness.spec.ts
+++ b/e2e/specs/harness.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Unit 1's own verification: the production client build is served, the API answers, and
+ * the app renders. Deliberately asserts nothing about POS behavior — that arrives with
+ * Unit 6.
+ */
+test('the preview build serves the login page', async ({ page }) => {
+  await page.goto('/login');
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.locator('form')).toBeVisible();
+});
+
+test('the API answers its health check against the E2E database', async ({ request }) => {
+  const response = await request.get('http://localhost:3001/api/health');
+  expect(response.ok()).toBe(true);
+  expect(await response.json()).toMatchObject({ data: { status: 'ok' } });
+});

--- a/e2e/specs/harness.spec.ts
+++ b/e2e/specs/harness.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { API_URL } from '../support/config';
 
 /**
  * Unit 1's own verification: the production client build is served, the API answers, and
@@ -12,7 +13,7 @@ test('the preview build serves the login page', async ({ page }) => {
 });
 
 test('the API answers its health check against the E2E database', async ({ request }) => {
-  const response = await request.get('http://localhost:3001/api/health');
+  const response = await request.get(`${API_URL}/api/health`);
   expect(response.ok()).toBe(true);
   expect(await response.json()).toMatchObject({ data: { status: 'ok' } });
 });

--- a/e2e/specs/locator-audit.spec.ts
+++ b/e2e/specs/locator-audit.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+import { LOCALES, keysOf, tr } from '../support/i18n';
+import { seedLocale } from '../fixtures/storage';
+import { loginPage } from '../support/locators';
+
+/**
+ * Unit 5's audit, kept as a spec rather than as a one-off script: it is the regression
+ * guard for the accessible names the rest of the suite's locators depend on. A name that
+ * disappears in a refactor fails here, on its own, instead of failing every money spec at
+ * once with a misleading message.
+ */
+test.describe('locator affordances', () => {
+  test('every login control resolves by role or label', async ({ page, context }) => {
+    // The app ships Arabic RTL by default, so the locale must be pinned before the first
+    // render or every en-catalog locator matches nothing.
+    await seedLocale(context, 'en');
+    await page.goto('/login');
+    const form = loginPage(page);
+
+    await expect(form.heading).toBeVisible();
+    await expect(form.email).toBeVisible();
+    await expect(form.password).toBeVisible();
+    await expect(form.submit).toBeEnabled();
+  });
+
+  test('the same controls resolve under the shipped Arabic default', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+
+    const form = loginPage(page, { locale: 'ar' });
+    await expect(form.email).toBeVisible();
+    await expect(form.password).toBeVisible();
+    await expect(form.submit).toBeEnabled();
+  });
+});
+
+test.describe('i18n catalog', () => {
+  test('en and ar carry exactly the same keys', () => {
+    const [en, ar] = [keysOf('en'), keysOf('ar')];
+    expect(en.filter((k) => !ar.includes(k))).toEqual([]);
+    expect(ar.filter((k) => !en.includes(k))).toEqual([]);
+  });
+
+  test('a missing key throws at construction rather than matching everything', () => {
+    // An empty-string fallback in a locator matches every element on the page, so a
+    // renamed key would silently pass. This is the guard against that.
+    expect(() => tr('pos.thisKeyDoesNotExist')).toThrow(/missing from en\.json/);
+  });
+
+  test('every key a locator helper references exists in both catalogs', () => {
+    const referenced = [
+      'login.email',
+      'login.password',
+      'login.submit',
+      'login.title',
+      'pos.searchPlaceholder',
+      'pos.title',
+    ];
+    for (const locale of LOCALES) {
+      for (const key of referenced) {
+        expect(() => tr(key, locale), `${key} in ${locale}.json`).not.toThrow();
+      }
+    }
+  });
+});

--- a/e2e/support/config.ts
+++ b/e2e/support/config.ts
@@ -1,0 +1,40 @@
+import path from 'node:path';
+
+// Playwright transpiles config and support files to CommonJS, so `__dirname` is
+// available and `import.meta.url` is not.
+const here = __dirname;
+
+export const REPO_ROOT = path.resolve(here, '../..');
+export const SERVER_DIR = path.join(REPO_ROOT, 'server');
+export const CLIENT_DIR = path.join(REPO_ROOT, 'client');
+
+export const PREVIEW_PORT = 4173;
+export const BASE_URL = `http://localhost:${PREVIEW_PORT}`;
+export const API_URL = 'http://localhost:3001';
+
+const GUIDANCE = [
+  'E2E_DATABASE_URL is required and has no default.',
+  '',
+  'This suite deletes every row in 77 tables and restarts their sequences. Defaulting to',
+  'DATABASE_URL would point that reset at a developer’s dev database, and the loss would',
+  'be silent. Point it at a disposable database instead, e.g.',
+  '',
+  '  E2E_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/moon_store_e2e',
+  '',
+  'See e2e/README.md.',
+].join('\n');
+
+/**
+ * The database this suite owns. Resolved at config load so an unset variable aborts the
+ * run before any server starts, rather than partway through the first spec.
+ */
+export function requireE2eDatabaseUrl(): string {
+  const url = process.env.E2E_DATABASE_URL?.trim();
+  if (!url) throw new Error(GUIDANCE);
+  return url;
+}
+
+/** True when the URL is resolvable, for callers that must not throw (e.g. `--list`). */
+export function hasE2eDatabaseUrl(): boolean {
+  return Boolean(process.env.E2E_DATABASE_URL?.trim());
+}

--- a/e2e/support/config.ts
+++ b/e2e/support/config.ts
@@ -1,4 +1,6 @@
+import fs from 'node:fs';
 import path from 'node:path';
+import { parse as parseConnectionString } from 'pg-connection-string';
 
 // Playwright transpiles config and support files to CommonJS, so `__dirname` is
 // available and `import.meta.url` is not.
@@ -11,6 +13,16 @@ export const CLIENT_DIR = path.join(REPO_ROOT, 'client');
 export const PREVIEW_PORT = 4173;
 export const BASE_URL = `http://localhost:${PREVIEW_PORT}`;
 export const API_URL = 'http://localhost:3001';
+
+/**
+ * `application_name` the E2E server's PostgreSQL backends carry, set via `PGAPPNAME` in
+ * `webServer.env`. The preflight looks for exactly this, so a reused dev server — which
+ * carries the plain `moon-api` default — cannot be mistaken for the server under test.
+ */
+export const E2E_SERVER_APP_NAME = 'moon-e2e-server';
+
+/** Set to `1` to allow pointing the suite at the same database the dev server uses. */
+const ALLOW_SHARED_DB = 'E2E_ALLOW_SHARED_DB';
 
 const GUIDANCE = [
   'E2E_DATABASE_URL is required and has no default.',
@@ -25,16 +37,85 @@ const GUIDANCE = [
 ].join('\n');
 
 /**
+ * The database a connection string names.
+ *
+ * Parsed with pg's own parser rather than `new URL`, because this value gates a
+ * destructive reset: a password containing `@`, `/` or `#` makes the URL parser yield a
+ * wrong host and an empty database, and the guard would then abort with a message
+ * blaming the wrong thing — or compare the wrong name.
+ */
+export function databaseNameOf(connectionString: string): string {
+  let database: string | null | undefined;
+  try {
+    database = parseConnectionString(connectionString).database;
+  } catch (err) {
+    throw new Error(`E2E_DATABASE_URL is not a valid PostgreSQL connection string: ${String(err)}`);
+  }
+  if (!database) {
+    throw new Error(
+      'E2E_DATABASE_URL names no database. Expected postgresql://user:pass@host:port/<dbname>.'
+    );
+  }
+  return database;
+}
+
+/** Host:port/database identity, for comparing two connection strings. */
+function targetOf(connectionString: string): string | null {
+  try {
+    const { host, port, database } = parseConnectionString(connectionString);
+    if (!database) return null;
+    return `${host ?? 'localhost'}:${port ?? '5432'}/${database}`;
+  } catch {
+    return null;
+  }
+}
+
+/** The dev `DATABASE_URL`, from the environment or `server/.env`, if discoverable. */
+function developerDatabaseUrl(): string | undefined {
+  if (process.env.DATABASE_URL?.trim()) return process.env.DATABASE_URL.trim();
+  try {
+    const envFile = fs.readFileSync(path.join(SERVER_DIR, '.env'), 'utf8');
+    const match = envFile.match(/^\s*DATABASE_URL\s*=\s*(.+)$/m);
+    return match?.[1]?.trim().replace(/^["']|["']$/g, '');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * The database this suite owns. Resolved at config load so an unset variable aborts the
  * run before any server starts, rather than partway through the first spec.
+ *
+ * Having no default protects against *forgetting* to set it. It protects against nothing
+ * once it is set to the wrong value — and the obvious wrong value is the developer's own
+ * `DATABASE_URL`, copied out of `server/.env` because a database already existed and the
+ * `createdb` step looked skippable. The preflight cannot catch that case either: the dev
+ * server genuinely is on that database, so its identity check would pass by construction.
+ * Hence the explicit comparison here.
  */
 export function requireE2eDatabaseUrl(): string {
   const url = process.env.E2E_DATABASE_URL?.trim();
   if (!url) throw new Error(GUIDANCE);
-  return url;
-}
 
-/** True when the URL is resolvable, for callers that must not throw (e.g. `--list`). */
-export function hasE2eDatabaseUrl(): boolean {
-  return Boolean(process.env.E2E_DATABASE_URL?.trim());
+  if (process.env[ALLOW_SHARED_DB] === '1') return url;
+
+  const devUrl = developerDatabaseUrl();
+  const target = targetOf(url);
+  if (devUrl && target && targetOf(devUrl) === target) {
+    throw new Error(
+      [
+        `E2E_DATABASE_URL points at "${target}", which is also this machine’s`,
+        'DATABASE_URL — the database the dev server uses.',
+        '',
+        'The suite deletes every row in 77 tables and restarts their sequences. Running',
+        'would destroy your local products, sales, customers and users with no prompt and',
+        'no backup.',
+        '',
+        'Point it at a disposable database (e.g. moon_store_e2e). If sharing really is',
+        `what you want, set ${ALLOW_SHARED_DB}=1.`,
+      ].join('\n')
+    );
+  }
+
+  return url;
 }

--- a/e2e/support/db.ts
+++ b/e2e/support/db.ts
@@ -1,0 +1,77 @@
+/**
+ * Direct database access for the assertions the API does not expose — `idempotency_keys`
+ * rows and raw `products.stock`.
+ *
+ * Read-only by contract. The suite mutates only through the real HTTP API, so fixture
+ * data passes the same validation and invariants as production data. The two exceptions
+ * are the reset and the settings baseline in `globalSetup`, which are setup rather than
+ * test behavior and are confined to this module.
+ */
+import { Pool, type QueryResultRow } from 'pg';
+import { requireE2eDatabaseUrl } from './config';
+
+let pool: Pool | null = null;
+
+export function getE2ePool(): Pool {
+  if (!pool) {
+    pool = new Pool({ connectionString: requireE2eDatabaseUrl(), max: 4 });
+  }
+  return pool;
+}
+
+export async function closeE2ePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+export async function dbQuery<T extends QueryResultRow = QueryResultRow>(
+  text: string,
+  params: unknown[] = []
+): Promise<T[]> {
+  const result = await getE2ePool().query<T>(text, params);
+  return result.rows;
+}
+
+export async function dbOne<T extends QueryResultRow = QueryResultRow>(
+  text: string,
+  params: unknown[] = []
+): Promise<T | undefined> {
+  const rows = await dbQuery<T>(text, params);
+  return rows[0];
+}
+
+/** Raw stock, bypassing any client or service-worker cache. */
+export async function readStock(productId: number): Promise<number | undefined> {
+  const row = await dbOne<{ stock: string }>('SELECT stock FROM products WHERE id = $1', [
+    productId,
+  ]);
+  return row ? Number(row.stock) : undefined;
+}
+
+/** Idempotency rows for a key. The suite's sharpest assertions read this table directly. */
+export async function readIdempotencyKeys(key: string): Promise<QueryResultRow[]> {
+  return dbQuery('SELECT * FROM idempotency_keys WHERE key = $1', [key]);
+}
+
+/**
+ * `seedDatabase()` deletes 77 tables but `idempotency_keys` is not among them, and its
+ * only user link is `ON DELETE SET NULL`, so nothing else clears it either. Rows
+ * accumulate across runs pointing at `resource_id`s of long-deleted sales — while the
+ * duplicate-submit and offline specs assert *exactly one* row against this table.
+ *
+ * Cleared from the E2E side rather than by editing the server's seed list, so the change
+ * stays inside the test project.
+ */
+export async function clearIdempotencyKeys(): Promise<void> {
+  await dbQuery('DELETE FROM idempotency_keys');
+}
+
+/**
+ * The database name the given connection string points at, used by the preflight guard
+ * to compare the suite's target against the one the running API actually holds open.
+ */
+export function databaseNameOf(connectionString: string): string {
+  return decodeURIComponent(new URL(connectionString).pathname.replace(/^\//, ''));
+}

--- a/e2e/support/db.ts
+++ b/e2e/support/db.ts
@@ -42,19 +42,6 @@ export async function dbOne<T extends QueryResultRow = QueryResultRow>(
   return rows[0];
 }
 
-/** Raw stock, bypassing any client or service-worker cache. */
-export async function readStock(productId: number): Promise<number | undefined> {
-  const row = await dbOne<{ stock: string }>('SELECT stock FROM products WHERE id = $1', [
-    productId,
-  ]);
-  return row ? Number(row.stock) : undefined;
-}
-
-/** Idempotency rows for a key. The suite's sharpest assertions read this table directly. */
-export async function readIdempotencyKeys(key: string): Promise<QueryResultRow[]> {
-  return dbQuery('SELECT * FROM idempotency_keys WHERE key = $1', [key]);
-}
-
 /**
  * `seedDatabase()` deletes 77 tables but `idempotency_keys` is not among them, and its
  * only user link is `ON DELETE SET NULL`, so nothing else clears it either. Rows
@@ -66,12 +53,4 @@ export async function readIdempotencyKeys(key: string): Promise<QueryResultRow[]
  */
 export async function clearIdempotencyKeys(): Promise<void> {
   await dbQuery('DELETE FROM idempotency_keys');
-}
-
-/**
- * The database name the given connection string points at, used by the preflight guard
- * to compare the suite's target against the one the running API actually holds open.
- */
-export function databaseNameOf(connectionString: string): string {
-  return decodeURIComponent(new URL(connectionString).pathname.replace(/^\//, ''));
 }

--- a/e2e/support/globalSetup.ts
+++ b/e2e/support/globalSetup.ts
@@ -1,0 +1,151 @@
+/**
+ * Brings the E2E database to a known state before any spec runs: migrate, seed (which
+ * doubles as the reset), clear the one table the seed misses, and pin the settings
+ * baseline.
+ *
+ * Runs in the Playwright process, but the process that writes almost all test data is the
+ * Express server. A guard that only checked *this* process's configuration would guard
+ * the wrong one — hence the preflight below.
+ */
+import { spawn } from 'node:child_process';
+import { Client } from 'pg';
+import { API_URL, SERVER_DIR, requireE2eDatabaseUrl } from './config';
+import { clearIdempotencyKeys, closeE2ePool, databaseNameOf, dbQuery } from './db';
+import { BASELINE_KEYS, SETTINGS_BASELINE } from './settingsBaseline';
+
+const PREFLIGHT_APP_NAME = 'moon-e2e-preflight';
+
+/**
+ * Asserts the *running* API is on the database this setup is about to reset.
+ *
+ * The API exposes no database identity, so this asks PostgreSQL instead: after
+ * `/api/health` (a real `SELECT 1`) succeeds, the server's pool holds at least one
+ * connection, and it will be visible in `pg_stat_activity` for the target database. Zero
+ * connections there means the server answered from somewhere else — a stale
+ * `reuseExistingServer` attach to a dev server being the realistic case — and the reset
+ * would then destroy a database nothing under test is even reading.
+ */
+async function preflightServerDatabase(connectionString: string): Promise<void> {
+  const dbName = databaseNameOf(connectionString);
+
+  const health = await fetch(`${API_URL}/api/health`).catch((err: unknown) => {
+    throw new Error(
+      `E2E preflight: the API at ${API_URL} is not answering (${String(err)}). ` +
+        'Playwright starts it via the webServer config; check its output above.'
+    );
+  });
+  if (!health.ok) {
+    throw new Error(`E2E preflight: ${API_URL}/api/health returned ${health.status}.`);
+  }
+
+  const client = new Client({ connectionString, application_name: PREFLIGHT_APP_NAME });
+  await client.connect();
+  let connections = 0;
+  try {
+    const { rows } = await client.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_stat_activity
+        WHERE datname = $1
+          AND pid <> pg_backend_pid()
+          AND (application_name IS DISTINCT FROM $2)`,
+      [dbName, PREFLIGHT_APP_NAME]
+    );
+    connections = Number(rows[0]?.n ?? '0');
+  } finally {
+    await client.end();
+  }
+
+  if (connections === 0) {
+    throw new Error(
+      [
+        `E2E preflight FAILED — refusing to reset "${dbName}".`,
+        '',
+        `The API answered /api/health but holds no connection to "${dbName}", so it is`,
+        'connected to a different database. Resetting now would delete every row in 77',
+        'tables of a database nothing under test is reading.',
+        '',
+        'The usual cause is `reuseExistingServer` attaching to a dev server already',
+        'listening on port 3001. Stop it and re-run, or set E2E_DATABASE_URL to the',
+        'database that server actually uses.',
+      ].join('\n')
+    );
+  }
+}
+
+async function pinSettingsBaseline(): Promise<void> {
+  // Written directly rather than through `PUT /api/v1/settings`: the HTTP route needs an
+  // admin session, which entangles setup with webServer boot ordering for no benefit.
+  // Settings are plain key/value rows.
+  for (const [key, value] of Object.entries(SETTINGS_BASELINE)) {
+    await dbQuery(
+      `INSERT INTO settings (key, value) VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [key, value]
+    );
+  }
+
+  const rows = await dbQuery<{ key: string; value: string }>(
+    'SELECT key, value FROM settings WHERE key = ANY($1)',
+    [BASELINE_KEYS]
+  );
+  const written = new Map(rows.map((r) => [r.key, r.value]));
+  for (const [key, expected] of Object.entries(SETTINGS_BASELINE)) {
+    if (written.get(key) !== expected) {
+      throw new Error(
+        `E2E setup: settings baseline "${key}" is ${String(written.get(key))}, expected ${expected}.`
+      );
+    }
+  }
+}
+
+/**
+ * Runs the server's own migration and seed scripts as child processes with
+ * `DATABASE_URL` overridden.
+ *
+ * Deliberately a subprocess rather than a cross-project import: those modules are
+ * TypeScript compiled by the server's own toolchain, and importing them into the
+ * Playwright process would couple two build setups for no gain. Shelling out also means
+ * the E2E database is migrated by exactly the command a developer runs by hand.
+ */
+function runServerScript(script: 'migrate' | 'seed', connectionString: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('npm', ['run', script], {
+      cwd: SERVER_DIR,
+      env: {
+        ...process.env,
+        DATABASE_URL: connectionString,
+        NODE_ENV: 'test',
+      },
+      shell: process.platform === 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    child.stdout?.on('data', (chunk: Buffer) => (output += chunk.toString()));
+    child.stderr?.on('data', (chunk: Buffer) => (output += chunk.toString()));
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`E2E setup: \`npm run ${script}\` exited ${code}.\n${output}`));
+    });
+  });
+}
+
+export default async function globalSetup(): Promise<void> {
+  const connectionString = requireE2eDatabaseUrl();
+
+  await preflightServerDatabase(connectionString);
+
+  try {
+    await runServerScript('migrate', connectionString);
+    // `seed` deletes every row in 77 tables and restarts every public sequence before
+    // reseeding, so it is both the seed and the reset. Note the sequence restart:
+    // primary keys are reused between runs, so any browser profile or storage state
+    // captured before a reseed may reference an id that now belongs to a different row.
+    await runServerScript('seed', connectionString);
+    await clearIdempotencyKeys();
+    await pinSettingsBaseline();
+  } finally {
+    await closeE2ePool();
+  }
+}

--- a/e2e/support/globalSetup.ts
+++ b/e2e/support/globalSetup.ts
@@ -9,8 +9,14 @@
  */
 import { spawn } from 'node:child_process';
 import { Client } from 'pg';
-import { API_URL, SERVER_DIR, requireE2eDatabaseUrl } from './config';
-import { clearIdempotencyKeys, closeE2ePool, databaseNameOf, dbQuery } from './db';
+import {
+  API_URL,
+  E2E_SERVER_APP_NAME,
+  SERVER_DIR,
+  databaseNameOf,
+  requireE2eDatabaseUrl,
+} from './config';
+import { clearIdempotencyKeys, closeE2ePool, dbQuery } from './db';
 import { BASELINE_KEYS, SETTINGS_BASELINE } from './settingsBaseline';
 
 const PREFLIGHT_APP_NAME = 'moon-e2e-preflight';
@@ -18,12 +24,17 @@ const PREFLIGHT_APP_NAME = 'moon-e2e-preflight';
 /**
  * Asserts the *running* API is on the database this setup is about to reset.
  *
- * The API exposes no database identity, so this asks PostgreSQL instead: after
- * `/api/health` (a real `SELECT 1`) succeeds, the server's pool holds at least one
- * connection, and it will be visible in `pg_stat_activity` for the target database. Zero
- * connections there means the server answered from somewhere else — a stale
- * `reuseExistingServer` attach to a dev server being the realistic case — and the reset
- * would then destroy a database nothing under test is even reading.
+ * The API exposes no database identity, so this asks PostgreSQL instead. The check is
+ * **identity-based, not count-based**, and that distinction is the whole guard: counting
+ * "any backend on this database" would pass as soon as a `psql`, a GUI client, or an
+ * orphaned process from an earlier run held an idle connection — which is common on the
+ * very machine where someone is debugging E2E, and is exactly when the dangerous case
+ * (`reuseExistingServer` attaching to a dev server on the dev database) occurs.
+ *
+ * So Playwright starts the server with `PGAPPNAME=E2E_SERVER_APP_NAME`, and this looks
+ * for a backend carrying *that* name. A reused dev server does not have it, and correctly
+ * aborts. `/api/health` runs a real `SELECT 1` and the pool's idle timeout is 30s, so a
+ * connection is guaranteed to be present by the time this query runs.
  */
 async function preflightServerDatabase(connectionString: string): Promise<void> {
   const dbName = databaseNameOf(connectionString);
@@ -40,35 +51,74 @@ async function preflightServerDatabase(connectionString: string): Promise<void> 
 
   const client = new Client({ connectionString, application_name: PREFLIGHT_APP_NAME });
   await client.connect();
-  let connections = 0;
+  let serverBackends = 0;
   try {
     const { rows } = await client.query<{ n: string }>(
       `SELECT count(*)::text AS n FROM pg_stat_activity
         WHERE datname = $1
           AND pid <> pg_backend_pid()
-          AND (application_name IS DISTINCT FROM $2)`,
-      [dbName, PREFLIGHT_APP_NAME]
+          AND application_name = $2`,
+      [dbName, E2E_SERVER_APP_NAME]
     );
-    connections = Number(rows[0]?.n ?? '0');
+    serverBackends = Number(rows[0]?.n ?? '0');
   } finally {
     await client.end();
   }
 
-  if (connections === 0) {
+  if (serverBackends === 0) {
     throw new Error(
       [
         `E2E preflight FAILED — refusing to reset "${dbName}".`,
         '',
-        `The API answered /api/health but holds no connection to "${dbName}", so it is`,
-        'connected to a different database. Resetting now would delete every row in 77',
-        'tables of a database nothing under test is reading.',
+        `The API answered /api/health, but no connection to "${dbName}" is tagged`,
+        `application_name="${E2E_SERVER_APP_NAME}". The API under test is therefore a`,
+        'different process, on a different database. Resetting now would delete every row',
+        'in 77 tables of a database nothing under test is reading.',
         '',
         'The usual cause is `reuseExistingServer` attaching to a dev server already',
-        'listening on port 3001. Stop it and re-run, or set E2E_DATABASE_URL to the',
-        'database that server actually uses.',
+        'listening on port 3001. Stop that server and re-run.',
       ].join('\n')
     );
   }
+}
+
+/**
+ * Refuses to run when a second E2E run already owns this database.
+ *
+ * Ports are fixed and `reuseExistingServer` is true locally, so a second invocation does
+ * not collide on a port — it attaches to the first run's servers and resets the database
+ * underneath it. The preflight cannot catch that: the first run's server genuinely *is*
+ * on the target database, so the identity check passes. A session-scoped advisory lock
+ * held for the run is the missing piece; it releases automatically if the process dies.
+ */
+const RUN_LOCK_ID = 0x4d4f4f4e; // 'MOON'
+let lockClient: Client | null = null;
+
+async function acquireRunLock(connectionString: string): Promise<void> {
+  const client = new Client({ connectionString, application_name: 'moon-e2e-runlock' });
+  await client.connect();
+  const { rows } = await client.query<{ locked: boolean }>(
+    'SELECT pg_try_advisory_lock($1) AS locked',
+    [RUN_LOCK_ID]
+  );
+  if (!rows[0]?.locked) {
+    await client.end();
+    throw new Error(
+      [
+        'E2E run ABORTED — another run already owns this database.',
+        '',
+        'Resetting it now would delete the other run’s worker cashiers, open registers',
+        'and in-flight sales, and its failures would look like application bugs.',
+        '',
+        'Wait for that run to finish, or point this one at a different database.',
+      ].join('\n')
+    );
+  }
+  // Held for the lifetime of the Playwright process; released on exit.
+  lockClient = client;
+  process.once('exit', () => {
+    void lockClient?.end();
+  });
 }
 
 async function pinSettingsBaseline(): Promise<void> {
@@ -134,6 +184,7 @@ function runServerScript(script: 'migrate' | 'seed', connectionString: string): 
 export default async function globalSetup(): Promise<void> {
   const connectionString = requireE2eDatabaseUrl();
 
+  await acquireRunLock(connectionString);
   await preflightServerDatabase(connectionString);
 
   try {

--- a/e2e/support/i18n.ts
+++ b/e2e/support/i18n.ts
@@ -1,0 +1,55 @@
+/**
+ * The app's own translation catalogs, read straight from `client/src/shared/i18n`.
+ *
+ * Locators are built from these rather than from hardcoded strings for two reasons. The
+ * app ships **Arabic RTL by default**, so an English string literal would be testing a
+ * configuration most tills never run. And a renamed or deleted translation key then fails
+ * loudly here instead of silently matching nothing — which makes the translation itself
+ * part of what the suite tests.
+ */
+import en from '../../client/src/shared/i18n/en.json';
+import ar from '../../client/src/shared/i18n/ar.json';
+
+export type Locale = 'en' | 'ar';
+
+const catalogs: Record<Locale, Record<string, string>> = { en, ar };
+
+export const LOCALES: Locale[] = ['en', 'ar'];
+
+/**
+ * The bulk of the suite runs pinned to `en` for readable diagnostics; `locale-rtl.spec.ts`
+ * covers the shipped Arabic default.
+ */
+export const DEFAULT_TEST_LOCALE: Locale = 'en';
+
+/**
+ * Resolves a key, mirroring the app's own `{param}` interpolation.
+ *
+ * Throws on a missing key rather than falling back. The app falls back to the key name at
+ * runtime, which is right for users but wrong here: a locator built from a fallback would
+ * match nothing and report as an application bug.
+ */
+export function tr(
+  key: string,
+  locale: Locale = DEFAULT_TEST_LOCALE,
+  params?: Record<string, string | number>
+): string {
+  const value = catalogs[locale][key];
+  if (value === undefined) {
+    throw new Error(
+      `i18n key "${key}" is missing from ${locale}.json. Locators are built from the ` +
+        'catalog on purpose — fix the key or the catalog, do not hardcode the string.'
+    );
+  }
+  if (!params) return value;
+  return value.replace(/\{(\w+)\}/g, (_, name: string) => String(params[name] ?? ''));
+}
+
+/** Every key present in a catalog, for the parity assertion. */
+export function keysOf(locale: Locale): string[] {
+  return Object.keys(catalogs[locale]);
+}
+
+export function hasKey(key: string, locale: Locale): boolean {
+  return key in catalogs[locale];
+}

--- a/e2e/support/i18n.ts
+++ b/e2e/support/i18n.ts
@@ -49,7 +49,3 @@ export function tr(
 export function keysOf(locale: Locale): string[] {
   return Object.keys(catalogs[locale]);
 }
-
-export function hasKey(key: string, locale: Locale): boolean {
-  return key in catalogs[locale];
-}

--- a/e2e/support/locators.ts
+++ b/e2e/support/locators.ts
@@ -25,27 +25,3 @@ export function loginPage(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOp
     heading: page.getByRole('heading', { name: tr('login.title', locale) }),
   };
 }
-
-export function posPage(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
-  return {
-    search: page.getByPlaceholder(tr('pos.searchPlaceholder', locale)),
-    heading: page.getByRole('heading', { name: tr('pos.title', locale) }),
-  };
-}
-
-/**
- * Logs in through the real form rather than by minting a token, so every path that uses
- * this is also exercising the login flow the cashier actually uses.
- */
-export async function loginThroughForm(
-  page: Page,
-  email: string,
-  password: string,
-  options: LocaleOptions = {}
-): Promise<void> {
-  const form = loginPage(page, options);
-  await page.goto('/login');
-  await form.email.fill(email);
-  await form.password.fill(password);
-  await form.submit.click();
-}

--- a/e2e/support/locators.ts
+++ b/e2e/support/locators.ts
@@ -1,0 +1,51 @@
+/**
+ * Locator helpers, built from the app's own i18n catalogs.
+ *
+ * The priority is Playwright's documented one — role, then label, then text — with test
+ * ids reserved for surfaces that have no meaningful accessible name at all (a cart line
+ * container, a virtualized row wrapper). Where a role query cannot find a control, the
+ * first move is to **fix the accessible name** in the component: a missing name is a real
+ * accessibility defect, and reaching for a test id buries it.
+ *
+ * Every helper here takes the locale, so the same spec body can run against the shipped
+ * Arabic default and against the `en` the bulk of the suite is pinned to.
+ */
+import type { Page } from '@playwright/test';
+import { DEFAULT_TEST_LOCALE, type Locale, tr } from './i18n';
+
+export interface LocaleOptions {
+  locale?: Locale;
+}
+
+export function loginPage(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  return {
+    email: page.getByLabel(tr('login.email', locale), { exact: true }),
+    password: page.getByLabel(tr('login.password', locale), { exact: true }),
+    submit: page.getByRole('button', { name: tr('login.submit', locale) }),
+    heading: page.getByRole('heading', { name: tr('login.title', locale) }),
+  };
+}
+
+export function posPage(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  return {
+    search: page.getByPlaceholder(tr('pos.searchPlaceholder', locale)),
+    heading: page.getByRole('heading', { name: tr('pos.title', locale) }),
+  };
+}
+
+/**
+ * Logs in through the real form rather than by minting a token, so every path that uses
+ * this is also exercising the login flow the cashier actually uses.
+ */
+export async function loginThroughForm(
+  page: Page,
+  email: string,
+  password: string,
+  options: LocaleOptions = {}
+): Promise<void> {
+  const form = loginPage(page, options);
+  await page.goto('/login');
+  await form.email.fill(email);
+  await form.password.fill(password);
+  await form.submit.click();
+}

--- a/e2e/support/settingsBaseline.ts
+++ b/e2e/support/settingsBaseline.ts
@@ -1,0 +1,32 @@
+/**
+ * The pinned settings baseline (D5, D5a).
+ *
+ * Tax and loyalty are *global* key/value rows, not per-sale inputs — `CartPanel` reads
+ * them from `appSettings`, and `PUT /api/v1/settings` writes rows every worker shares. A
+ * worker that flipped `tax_enabled` to test inclusive mode would silently change the
+ * totals every other worker is asserting on. So the baseline is pinned once here, the
+ * parallel project asserts against it and never writes settings, and only the mode
+ * variants live in the serial `pos-settings` project.
+ *
+ * Tax is pinned *disabled* rather than enabled because six of the ten cases in
+ * `contracts/checkout-totals.v1.json` specify `tax.enabled: false`. Under a tax-enabled
+ * baseline those six could not be entered through the UI and still reach the total the
+ * contract records, so the parallel project would have had almost nothing it could
+ * assert. Every tax variant moves to the serial project instead, where a settings write
+ * is already the point.
+ *
+ * The loyalty rates match the contract's `loyalty-redemption-and-earning` case:
+ * `pointsPerEgp: 2` (points earned per 1 EGP) and `egpPerPointMinor: 10` (10 minor units
+ * — 0.10 EGP — redeemed per 1 point). Neither is "per 100 points"; the direction is easy
+ * to invert and the contract is the authority.
+ */
+export const SETTINGS_BASELINE: Readonly<Record<string, string>> = Object.freeze({
+  tax_enabled: 'false',
+  tax_rate: '0',
+  tax_mode: 'exclusive',
+  loyalty_enabled: 'true',
+  loyalty_points_per_egp: '2',
+  loyalty_egp_per_point: '0.1',
+});
+
+export const BASELINE_KEYS = Object.keys(SETTINGS_BASELINE);

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "playwright-report", "blob-report", "test-results"]
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "server/**/*.ts": [
       "eslint --fix --config server/eslint.config.mjs",
       "prettier --write"
+    ],
+    "e2e/**/*.ts": [
+      "eslint --fix --config e2e/eslint.config.mjs",
+      "prettier --write"
     ]
   }
 }

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,3 +13,11 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
 # Idempotency-Key behaves exactly as it did before idempotency existed, so an unpatched
 # till keeps working. See CLAUDE.md for the flip criterion.
 IDEMPOTENCY_REQUIRED=false
+
+# Rate limit ceilings, per 15-minute window. Both are optional: unset reproduces
+# today's production values exactly (global 200, auth 10). A value that is not a
+# positive integer falls back to the default rather than blocking every request.
+# Raise them only for automated test runs — the E2E suite exhausts the auth budget of
+# 10 within its first few logins. An override is warned about at boot.
+RATE_LIMIT_MAX=200
+AUTH_RATE_LIMIT_MAX=10

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
-import rateLimit from 'express-rate-limit';
+import { createGlobalLimiter, logRateLimitOverrides } from './src/http/rateLimits';
 import cookieParser from 'cookie-parser';
 import path from 'path';
 import { apiReference } from '@scalar/express-api-reference';
@@ -67,14 +67,8 @@ app.use(
 );
 
 // Rate limiting
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 200,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: errorResponse('RATE_LIMITED'),
-});
-app.use(limiter);
+logRateLimitOverrides();
+app.use(createGlobalLimiter());
 
 // Parsing
 app.use(express.json({ limit: '10mb' }));

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -22,6 +22,16 @@ const envSchema = z.object({
     .enum(['true', 'false', '1', '0'])
     .default('false')
     .transform((v) => v === 'true' || v === '1'),
+  /**
+   * Ceilings for the two rate limiters, resolved by `src/http/rateLimits.ts`. Kept as
+   * raw strings here so a typo falls back to today's value instead of failing the whole
+   * environment parse. They are deliberately separate variables: the global ceiling and
+   * the credential brute-force ceiling guard different things, and one variable raising
+   * both would let a config written to unblock a test suite silently relax the login
+   * limit too.
+   */
+  RATE_LIMIT_MAX: z.string().optional(),
+  AUTH_RATE_LIMIT_MAX: z.string().optional(),
   CLIENT_URL: z.string().optional().default('http://localhost:5173'),
   ALLOWED_ORIGINS: z.string().optional(),
   TWILIO_ACCOUNT_SID: z.string().optional(),

--- a/server/src/database/pool.ts
+++ b/server/src/database/pool.ts
@@ -10,6 +10,14 @@ export function getPoolConfig() {
 
   return {
     connectionString: env.DATABASE_URL,
+    /**
+     * Names this process's backends in `pg_stat_activity`. Useful for ordinary ops
+     * triage, and load-bearing for the E2E suite: its preflight identifies the server's
+     * own connections by this name before it resets the database, so a count of
+     * anonymous backends cannot be mistaken for the API being present.
+     * `PGAPPNAME` lets a caller override it.
+     */
+    application_name: process.env.PGAPPNAME || 'moon-api',
     max: isProduction ? 20 : 10,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 5000,

--- a/server/src/http/rateLimits.ts
+++ b/server/src/http/rateLimits.ts
@@ -1,0 +1,72 @@
+import rateLimit, { type RateLimitRequestHandler } from 'express-rate-limit';
+import { getEnv } from '../config/env';
+import { errorResponse } from './errors';
+import logger from '../../lib/logger';
+
+export const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+/** Today's global ceiling. An unset `RATE_LIMIT_MAX` reproduces it exactly. */
+export const DEFAULT_RATE_LIMIT_MAX = 200;
+
+/** Today's credential ceiling on `/auth/login` and `/auth/refresh`. */
+export const DEFAULT_AUTH_RATE_LIMIT_MAX = 10;
+
+/**
+ * A ceiling is only honoured when it is a positive integer. Anything else — a typo, an
+ * empty string, `0`, a negative — falls back to the default rather than to `NaN`, which
+ * express-rate-limit would treat as "reject everything" and which reads as an outage
+ * rather than as a misconfiguration.
+ */
+export function resolveCeiling(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return fallback;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function globalRateLimitMax(): number {
+  return resolveCeiling(getEnv().RATE_LIMIT_MAX, DEFAULT_RATE_LIMIT_MAX);
+}
+
+export function authRateLimitMax(): number {
+  return resolveCeiling(getEnv().AUTH_RATE_LIMIT_MAX, DEFAULT_AUTH_RATE_LIMIT_MAX);
+}
+
+export function createGlobalLimiter(): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    max: globalRateLimitMax(),
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: errorResponse('RATE_LIMITED'),
+  });
+}
+
+export function createAuthLimiter(): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    max: authRateLimitMax(),
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: errorResponse('RATE_LIMITED', 'Too many login attempts, please try again later'),
+  });
+}
+
+/**
+ * Once `RATE_LIMIT_MAX=100000` exists in a workflow file it is one copy-paste from a
+ * deploy environment, where a 500x-raised abuse ceiling would otherwise produce no
+ * signal at all. Say so at boot — the same posture the server already takes for a
+ * missing JWT secret.
+ */
+export function logRateLimitOverrides(): void {
+  const global = globalRateLimitMax();
+  const auth = authRateLimitMax();
+  if (global === DEFAULT_RATE_LIMIT_MAX && auth === DEFAULT_AUTH_RATE_LIMIT_MAX) return;
+
+  logger.warn(
+    `Rate limit ceilings overridden: global=${global}/15min (default ${DEFAULT_RATE_LIMIT_MAX}), ` +
+      `auth=${auth}/15min (default ${DEFAULT_AUTH_RATE_LIMIT_MAX}). ` +
+      'Expected for test runs only.'
+  );
+}

--- a/server/src/http/rateLimits.ts
+++ b/server/src/http/rateLimits.ts
@@ -33,10 +33,20 @@ export function authRateLimitMax(): number {
   return resolveCeiling(getEnv().AUTH_RATE_LIMIT_MAX, DEFAULT_AUTH_RATE_LIMIT_MAX);
 }
 
+/**
+ * `max` is passed as a resolver rather than a number so that `getEnv()` is not called
+ * while modules are still being imported.
+ *
+ * `auth/routes.ts` builds its limiter at module scope, and imports are hoisted above
+ * `server/index.ts`'s body — so an eagerly-resolved ceiling would run the full Zod
+ * environment parse before the explicit `requiredEnvVars` check, and a server missing
+ * `JWT_SECRET` would die with an uncaught validation stack trace instead of the clean
+ * `FATAL: Missing required environment variable` message and `exit(1)`.
+ */
 export function createGlobalLimiter(): RateLimitRequestHandler {
   return rateLimit({
     windowMs: RATE_LIMIT_WINDOW_MS,
-    max: globalRateLimitMax(),
+    max: () => globalRateLimitMax(),
     standardHeaders: true,
     legacyHeaders: false,
     message: errorResponse('RATE_LIMITED'),
@@ -46,7 +56,7 @@ export function createGlobalLimiter(): RateLimitRequestHandler {
 export function createAuthLimiter(): RateLimitRequestHandler {
   return rateLimit({
     windowMs: RATE_LIMIT_WINDOW_MS,
-    max: authRateLimitMax(),
+    max: () => authRateLimitMax(),
     standardHeaders: true,
     legacyHeaders: false,
     message: errorResponse('RATE_LIMITED', 'Too many login attempts, please try again later'),
@@ -60,6 +70,15 @@ export function createAuthLimiter(): RateLimitRequestHandler {
  * missing JWT secret.
  */
 export function logRateLimitOverrides(): void {
+  const env = getEnv();
+
+  // An ignored value is the quieter and more dangerous case: `AUTH_RATE_LIMIT_MAX=1O`
+  // (letter O) resolves to the default, so comparing effective-to-default would produce a
+  // boot log byte-identical to an unset server, and the operator's intended ceiling never
+  // takes effect. Say so explicitly.
+  warnIfIgnored('RATE_LIMIT_MAX', env.RATE_LIMIT_MAX, DEFAULT_RATE_LIMIT_MAX);
+  warnIfIgnored('AUTH_RATE_LIMIT_MAX', env.AUTH_RATE_LIMIT_MAX, DEFAULT_AUTH_RATE_LIMIT_MAX);
+
   const global = globalRateLimitMax();
   const auth = authRateLimitMax();
   if (global === DEFAULT_RATE_LIMIT_MAX && auth === DEFAULT_AUTH_RATE_LIMIT_MAX) return;
@@ -68,5 +87,15 @@ export function logRateLimitOverrides(): void {
     `Rate limit ceilings overridden: global=${global}/15min (default ${DEFAULT_RATE_LIMIT_MAX}), ` +
       `auth=${auth}/15min (default ${DEFAULT_AUTH_RATE_LIMIT_MAX}). ` +
       'Expected for test runs only.'
+  );
+}
+
+function warnIfIgnored(name: string, raw: string | undefined, fallback: number): void {
+  if (raw === undefined) return;
+  if (resolveCeiling(raw, fallback) !== fallback) return;
+  if (raw.trim() === String(fallback)) return; // Explicitly set to the default; not ignored.
+
+  logger.warn(
+    `${name}="${raw}" is not a positive integer — ignored, using the default of ${fallback}/15min.`
   );
 }

--- a/server/src/modules/core/auth/routes.ts
+++ b/server/src/modules/core/auth/routes.ts
@@ -1,18 +1,11 @@
 import { Router } from 'express';
-import rateLimit from 'express-rate-limit';
 import { verifyToken } from '../../../../middleware/auth';
-import { errorResponse } from '../../../http/errors';
+import { createAuthLimiter } from '../../../http/rateLimits';
 import { authController } from './controller';
 
 const router: Router = Router();
 
-const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 10,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: errorResponse('RATE_LIMITED', 'Too many login attempts, please try again later'),
-});
+const authLimiter = createAuthLimiter();
 
 router.post('/login', authLimiter, (req, res, next) => authController.login(req, res, next));
 router.post('/refresh', authLimiter, (req, res, next) => authController.refresh(req, res, next));

--- a/server/tests/http/rateLimit.test.ts
+++ b/server/tests/http/rateLimit.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Rate-limit ceilings — env-operable, defaulting to today's production values.
+ *
+ * Two limiters guard this API and they guard different things: a global 200/15min on
+ * every route, and a tighter 10/15min on `POST /auth/login` and `POST /auth/refresh`.
+ * The E2E suite exhausts the auth budget almost immediately, so both need a test-time
+ * ceiling — but folding them into one variable would mean a config written to unblock a
+ * test suite silently relaxes the credential brute-force ceiling too. The tests below
+ * pin that separation, and pin that an unset environment reproduces today's behavior
+ * byte-for-byte.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express, { type Express } from 'express';
+import type { Server } from 'http';
+import { AddressInfo } from 'net';
+import { resetEnvCache } from '../../src/config/env';
+import {
+  DEFAULT_AUTH_RATE_LIMIT_MAX,
+  DEFAULT_RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+  createAuthLimiter,
+  createGlobalLimiter,
+  logRateLimitOverrides,
+  resolveCeiling,
+} from '../../src/http/rateLimits';
+
+const ENV_KEYS = ['RATE_LIMIT_MAX', 'AUTH_RATE_LIMIT_MAX'] as const;
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  resetEnvCache();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  resetEnvCache();
+  vi.restoreAllMocks();
+});
+
+/** Tracks how many times a request actually reached the handler behind the limiter. */
+interface Harness {
+  url: string;
+  reached: () => number;
+  close: () => Promise<void>;
+}
+
+async function serve(build: (app: Express) => void, counter: { n: number }): Promise<Harness> {
+  const app = express();
+  build(app);
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    reached: () => counter.n,
+    close: () =>
+      new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+/** A global limiter ahead of a counting handler, mirroring `server/index.ts`'s ordering. */
+async function globalHarness(): Promise<Harness> {
+  const counter = { n: 0 };
+  return serve((app) => {
+    app.use(createGlobalLimiter());
+    app.get('/ping', (_req, res) => {
+      counter.n += 1;
+      res.json({ ok: true });
+    });
+  }, counter);
+}
+
+/** The auth limiter on the same two routes `auth/routes.ts` mounts it on. */
+async function authHarness(): Promise<Harness> {
+  const counter = { n: 0 };
+  return serve((app) => {
+    const limiter = createAuthLimiter();
+    const handler = (_req: express.Request, res: express.Response) => {
+      counter.n += 1;
+      res.json({ ok: true });
+    };
+    app.post('/login', limiter, handler);
+    app.post('/refresh', limiter, handler);
+  }, counter);
+}
+
+async function hit(url: string, method: 'GET' | 'POST' = 'GET'): Promise<Response> {
+  return fetch(url, { method });
+}
+
+async function hitMany(url: string, times: number, method: 'GET' | 'POST' = 'GET') {
+  const statuses: number[] = [];
+  for (let i = 0; i < times; i += 1) {
+    statuses.push((await hit(url, method)).status);
+  }
+  return statuses;
+}
+
+describe('resolveCeiling', () => {
+  it('returns the fallback when the variable is unset', () => {
+    expect(resolveCeiling(undefined, 200)).toBe(200);
+  });
+
+  it('returns the parsed value for a positive integer', () => {
+    expect(resolveCeiling('100000', 200)).toBe(100000);
+  });
+
+  it('falls back rather than producing NaN for a non-numeric string', () => {
+    // A NaN ceiling makes express-rate-limit reject every request, which would look
+    // like an outage rather than a typo.
+    expect(resolveCeiling('lots', 200)).toBe(200);
+    expect(resolveCeiling('', 200)).toBe(200);
+    expect(resolveCeiling('  ', 200)).toBe(200);
+  });
+
+  it('treats zero and negatives as unset rather than as "block everything"', () => {
+    // Decided explicitly: a ceiling of 0 is far more likely to be a mistake than an
+    // intent to reject all traffic, and rejecting all traffic has no legitimate caller.
+    expect(resolveCeiling('0', 200)).toBe(200);
+    expect(resolveCeiling('-5', 200)).toBe(200);
+  });
+
+  it('falls back for a fractional value', () => {
+    expect(resolveCeiling('12.5', 200)).toBe(200);
+  });
+});
+
+describe('global limiter', () => {
+  it('keeps today’s 200/15min ceiling when RATE_LIMIT_MAX is unset', async () => {
+    expect(DEFAULT_RATE_LIMIT_MAX).toBe(200);
+    expect(RATE_LIMIT_WINDOW_MS).toBe(15 * 60 * 1000);
+
+    const h = await globalHarness();
+    try {
+      const statuses = await hitMany(`${h.url}/ping`, DEFAULT_RATE_LIMIT_MAX);
+      expect(statuses.every((s) => s === 200)).toBe(true);
+
+      const over = await hit(`${h.url}/ping`);
+      expect(over.status).toBe(429);
+      expect(await over.json()).toEqual({
+        error: expect.objectContaining({ code: 'RATE_LIMITED' }),
+      });
+    } finally {
+      await h.close();
+    }
+  }, 30_000);
+
+  it('never reaches the handler once the ceiling is exhausted', async () => {
+    process.env.RATE_LIMIT_MAX = '3';
+    resetEnvCache();
+
+    const h = await globalHarness();
+    try {
+      await hitMany(`${h.url}/ping`, 5);
+      expect(h.reached()).toBe(3);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('admits every request under a raised ceiling', async () => {
+    process.env.RATE_LIMIT_MAX = '100000';
+    resetEnvCache();
+
+    const h = await globalHarness();
+    try {
+      const statuses = await hitMany(`${h.url}/ping`, 500);
+      expect(statuses.filter((s) => s !== 200)).toEqual([]);
+    } finally {
+      await h.close();
+    }
+  }, 60_000);
+
+  it('falls back to the default ceiling for a non-numeric override', async () => {
+    process.env.RATE_LIMIT_MAX = 'unlimited';
+    resetEnvCache();
+
+    const h = await globalHarness();
+    try {
+      await hitMany(`${h.url}/ping`, 3);
+      expect(h.reached()).toBe(3);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe('auth limiter', () => {
+  it('keeps today’s 10/15min ceiling when AUTH_RATE_LIMIT_MAX is unset', async () => {
+    expect(DEFAULT_AUTH_RATE_LIMIT_MAX).toBe(10);
+
+    const h = await authHarness();
+    try {
+      const statuses = await hitMany(`${h.url}/login`, DEFAULT_AUTH_RATE_LIMIT_MAX, 'POST');
+      expect(statuses.every((s) => s === 200)).toBe(true);
+
+      const over = await hit(`${h.url}/login`, 'POST');
+      expect(over.status).toBe(429);
+      expect(h.reached()).toBe(DEFAULT_AUTH_RATE_LIMIT_MAX);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('shares one budget across /login and /refresh', async () => {
+    const h = await authHarness();
+    try {
+      await hitMany(`${h.url}/login`, DEFAULT_AUTH_RATE_LIMIT_MAX, 'POST');
+      const refresh = await hit(`${h.url}/refresh`, 'POST');
+      expect(refresh.status).toBe(429);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('is NOT relaxed by RATE_LIMIT_MAX — the two ceilings stay separate', async () => {
+    // The regression guard against a later refactor folding these into one variable:
+    // unblocking a test suite must never widen the credential brute-force ceiling.
+    process.env.RATE_LIMIT_MAX = '100000';
+    resetEnvCache();
+
+    const h = await authHarness();
+    try {
+      await hitMany(`${h.url}/login`, DEFAULT_AUTH_RATE_LIMIT_MAX, 'POST');
+      const over = await hit(`${h.url}/login`, 'POST');
+      expect(over.status).toBe(429);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('honours its own raised ceiling', async () => {
+    process.env.AUTH_RATE_LIMIT_MAX = '50';
+    resetEnvCache();
+
+    const h = await authHarness();
+    try {
+      const statuses = await hitMany(`${h.url}/login`, 25, 'POST');
+      expect(statuses.filter((s) => s !== 200)).toEqual([]);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe('override visibility', () => {
+  it('logs nothing when both ceilings are at their defaults', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logRateLimitOverrides();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns with the effective ceiling when either is overridden', () => {
+    process.env.RATE_LIMIT_MAX = '100000';
+    resetEnvCache();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logRateLimitOverrides();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain('100000');
+    expect(message).toMatch(/rate limit/i);
+  });
+
+  it('warns when only the auth ceiling is overridden', () => {
+    process.env.AUTH_RATE_LIMIT_MAX = '500';
+    resetEnvCache();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logRateLimitOverrides();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('500');
+  });
+});

--- a/server/tests/http/rateLimit.test.ts
+++ b/server/tests/http/rateLimit.test.ts
@@ -19,7 +19,9 @@ import {
   DEFAULT_RATE_LIMIT_MAX,
   RATE_LIMIT_WINDOW_MS,
   createAuthLimiter,
+  authRateLimitMax,
   createGlobalLimiter,
+  globalRateLimitMax,
   logRateLimitOverrides,
   resolveCeiling,
 } from '../../src/http/rateLimits';
@@ -205,6 +207,15 @@ describe('auth limiter', () => {
       const over = await hit(`${h.url}/login`, 'POST');
       expect(over.status).toBe(429);
       expect(h.reached()).toBe(DEFAULT_AUTH_RATE_LIMIT_MAX);
+
+      // The credential path has its own message. Asserting it here is what would fail if
+      // the two factories were ever collapsed into one parameterized helper.
+      expect(await over.json()).toEqual({
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Too many login attempts, please try again later',
+        },
+      });
     } finally {
       await h.close();
     }
@@ -237,6 +248,16 @@ describe('auth limiter', () => {
     }
   });
 
+  it('does NOT relax the global limiter — separation holds in both directions', async () => {
+    // The mirror of the test above. A resolver bug where `globalRateLimitMax()` read
+    // AUTH_RATE_LIMIT_MAX — a plausible copy-paste in a two-line function — would
+    // silently raise the global abuse ceiling with every other test still green.
+    process.env.AUTH_RATE_LIMIT_MAX = '100000';
+    resetEnvCache();
+    expect(globalRateLimitMax()).toBe(DEFAULT_RATE_LIMIT_MAX);
+    expect(authRateLimitMax()).toBe(100000);
+  });
+
   it('honours its own raised ceiling', async () => {
     process.env.AUTH_RATE_LIMIT_MAX = '50';
     resetEnvCache();
@@ -245,6 +266,48 @@ describe('auth limiter', () => {
     try {
       const statuses = await hitMany(`${h.url}/login`, 25, 'POST');
       expect(statuses.filter((s) => s !== 200)).toEqual([]);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe('production wiring', () => {
+  /**
+   * The tests above prove the factories. This one proves they are actually *mounted* —
+   * which is the change under review. Without it, reverting `auth/routes.ts` to an inline
+   * `rateLimit({ max: 10 })` would leave the whole file green while the env knob the E2E
+   * suite depends on silently stopped working.
+   */
+  it('the real auth router rate-limits /login and /refresh through the env-driven ceiling', async () => {
+    process.env.AUTH_RATE_LIMIT_MAX = '3';
+    resetEnvCache();
+
+    // Imported after the env is set: the router builds its limiter at module scope.
+    const { default: authRouter } = await import('../../src/modules/core/auth/routes');
+
+    const counter = { n: 0 };
+    const h = await serve((app) => {
+      app.use('/api/v1/auth', authRouter);
+      // A route past the router, to prove a limited request never reaches a handler.
+      app.post('/api/v1/auth/login', (_req, res) => {
+        counter.n += 1;
+        res.json({ ok: true });
+      });
+    }, counter);
+
+    try {
+      // The controller rejects these bodies, but the limiter sits ahead of it and counts
+      // every attempt — which is exactly the brute-force property being asserted.
+      const statuses = await hitMany(`${h.url}/api/v1/auth/login`, 3, 'POST');
+      expect(statuses).not.toContain(429);
+
+      const overLogin = await hit(`${h.url}/api/v1/auth/login`, 'POST');
+      expect(overLogin.status).toBe(429);
+
+      // The budget is shared with /refresh, on the real router's own mounting.
+      const overRefresh = await hit(`${h.url}/api/v1/auth/refresh`, 'POST');
+      expect(overRefresh.status).toBe(429);
     } finally {
       await h.close();
     }
@@ -269,6 +332,30 @@ describe('override visibility', () => {
     const message = String(warn.mock.calls[0]?.[0]);
     expect(message).toContain('100000');
     expect(message).toMatch(/rate limit/i);
+  });
+
+  it('warns that an unparseable override was ignored', () => {
+    // The quiet failure: without this, a typo produces a boot log identical to an unset
+    // server, and the ceiling the operator thought they set never applies.
+    process.env.AUTH_RATE_LIMIT_MAX = '1O';
+    resetEnvCache();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logRateLimitOverrides();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain('AUTH_RATE_LIMIT_MAX');
+    expect(message).toMatch(/ignored/i);
+  });
+
+  it('does not warn when a variable is explicitly set to its default', () => {
+    process.env.RATE_LIMIT_MAX = String(DEFAULT_RATE_LIMIT_MAX);
+    resetEnvCache();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logRateLimitOverrides();
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('warns when only the auth ceiling is overridden', () => {


### PR DESCRIPTION
Phase 1 (Units 1–5) of `docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md` (issue #50).

Ships the harness, not the coverage. The plan calls Phase 1 independently mergeable and easiest to verify while the suite is still empty, which is exactly what this is: a runnable Playwright project with isolation, locators and a guarded database lifecycle proven, and 20 tests that assert the harness itself works. The money-path and failure-path specs are Phases 2–3.

## What lands

**A new top-level `e2e/` npm project** (Playwright 1.62.1, Chromium) running the client *production build* under `vite preview` against the real Express server and a real PostgreSQL database. Third project alongside `client/` and `server/`, with its own lockfile, lint, and typecheck.

**Two production-facing env knobs**, `RATE_LIMIT_MAX` (global, 200/15min) and `AUTH_RATE_LIMIT_MAX` (`/auth/login` and `/auth/refresh`, 10/15min). Both default to today's values, so an unset server is byte-identical. They are deliberately separate variables — one raising both would let a config written to unblock a test run silently relax the credential brute-force ceiling. The binding constraint for the suite is the auth ceiling of 10, not the global 200.

**A destructive database lifecycle with four guards** (see below), a pinned tax-disabled/loyalty-enabled settings baseline, and worker-scoped fixtures giving each worker its own cashier, shift, register and namespace.

**Locators driven from the app's own i18n catalogs.** The app ships Arabic RTL by default, so hardcoded English strings would test a configuration most tills never run. A missing key throws at construction rather than degrading to an empty-string match that silently matches everything.

## Two pre-existing defects the work ran into

Both were predicted by the plan and confirmed in practice; neither is fixed here.

- **#62 — refresh tokens are not unique per session.** Logging every worker in as the shared admin returns **500**: tokens are signed from user id plus second-resolution `iat`/`exp` with no jti into a `UNIQUE` column, so simultaneous same-user logins collide. Worse, because the tokens are identical, one holder's logout would revoke every session. The suite routes around it — one admin login for the whole run, per-worker cashiers thereafter.
- **#63 — the global rate limit is per-shop, not per-till.** Unchanged here; this PR only makes the ceiling configurable.

## Review

Four review passes (correctness, security, testing+maintainability, adversarial+standards). They converged on one defect rated highest by two independent reviewers, and it was real:

> The preflight proved only that *some* backend was open on the target database, not that the API under test was. An idle `psql` or GUI session on the E2E database — common on exactly the machine where someone is debugging E2E — would let a reused dev server pass, and the suite would wipe one database while asserting against another.

Fixed by making the check identity-based: the server tags its backends via `PGAPPNAME` and the preflight requires that name. **Verified by reproducing the false-pass scenario** (API on a decoy database, idle client on the E2E one) and confirming it now aborts.

Also fixed from review: `E2E_DATABASE_URL` is refused when it names the dev database; an advisory lock refuses a second concurrent run; the cashier fixture no longer builds half a session (access token with no refresh cookie, re-injected on every navigation); `VITE_API_URL` was inert on `vite preview` (it is substituted at build time) and now lives on the build step; a wiring test was added because reverting the limiter change left the whole suite green; two assertions that could not fail were replaced with the properties they were meant to cover; nine speculative exports removed.

## Testing

| Suite | Result |
|---|---|
| `server` (vitest) | 273 passed, 77 skipped (real-PostgreSQL suites, no `TEST_DATABASE_URL`) |
| `client` (vitest) | 380 passed |
| `e2e` (Playwright) | 20 passed |
| typecheck / lint | clean in all three (server's 390 warnings are pre-existing) |

The e2e suite was run three consecutive times at `--workers=4` with no flakes and no manual cleanup between runs. The 4-worker stress check caught two lazy-fixture bugs that passed at 2 workers, which is the isolation spec doing its job.

Both destructive-path guards were verified by deliberately triggering them, each against a throwaway decoy database so a failure could not touch anything real.

## Deliberately not in this PR

- **CI wiring** (Unit 13) and **`docs/CONVENTIONS.md`** (Unit 14) are Phase 4. This suite is a local tool until then.
- **Sharding namespaces.** `workerIndex` restarts at 0 per shard, so shards must not share a database — the plan already records "each shard gets its own server process and its own database" as a required invariant for Unit 13. Nothing enforces it yet because there is no CI job yet.
- **`retryStrategy: 'isolated'` vs. the settings project.** Deferred retries would run after `pos-settings` mutated global settings. Not yet reachable: `pos-settings` has no specs until Unit 8, which is where the baseline-restore lands.
- **Admin token lifetime.** Access tokens live 15 minutes and one is held per worker for the run. Phase 1 fails loudly with an actionable message rather than 401ing inside an unrelated spec; if runs grow past 15 minutes the fix is to build `adminApi` from the admin `storageState` so the refresh cookie is present.

## Post-Deploy Monitoring & Validation

**No production runtime impact from the E2E project** — `e2e/` is a test-only package that ships in no build and is imported by no production code.

The one production surface is the rate-limit refactor. It is behavior-preserving when both variables are unset, which is the deployed state.

- **What to watch:** boot logs for the new `Rate limit ceilings overridden:` and `... is not a positive integer — ignored` warnings. On a normal deploy **neither should ever appear** — their presence means an env var leaked into a real environment.
- **Healthy signal:** unchanged 429 rate on `/api/v1/auth/login` and `/api/v1/auth/refresh`, and unchanged overall 429 volume.
- **Failure signal / rollback trigger:** any `Rate limit ceilings overridden` line in a deploy environment, or 429s dropping to zero on the auth endpoints (which would mean the brute-force ceiling was raised). Mitigation is to unset `RATE_LIMIT_MAX` / `AUTH_RATE_LIMIT_MAX` — a config change, reversible without a deploy; revert this PR only if the defaults themselves look wrong.
- **Window / owner:** first deploy plus 24h, owned by whoever merges.

The `application_name` added to the connection pool is cosmetic in production — it labels backends in `pg_stat_activity`, which is useful for ops triage independently of this suite.

> ⚠️ The E2E suite deletes every row in 77 tables. It is for disposable databases only, and its failure artifacts contain live session tokens. See `e2e/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
