### PR TITLE
test(e2e): critical cash sale end to end, and the zero-height Confirm button it found

### DIFF
--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -665,6 +665,9 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
           items.map((item) => (
             <div
               key={`${item.product_id}-${item.variant_id || 0}`}
+              /* E2E: a cart line has no role and shows only the product name, so there is
+                 no accessible name to scope its per-line controls by. */
+              data-testid={`cart-line-${item.product_id}-${item.variant_id || 0}`}
               className="flex items-center gap-3 p-3 bg-muted/20 hover:bg-muted/40 transition-colors rounded-lg border border-border/50"
             >
               <div className="flex-1 min-w-0">
@@ -722,7 +725,12 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                 >
                   <Minus className="h-3.5 w-3.5 text-primary" />
                 </Button>
-                <span className="w-7 text-center text-sm font-data font-medium text-foreground">
+                {/* E2E: a bare number with no accessible name. The +/- buttons are
+                    reachable by aria-label; the value itself is not. */}
+                <span
+                  data-testid="cart-line-qty"
+                  className="w-7 text-center text-sm font-data font-medium text-foreground"
+                >
                   {item.quantity}
                 </span>
                 <Button
@@ -895,7 +903,11 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
               use -- never a separately-derived figure (Unit 5 parity). */}
           <div className="flex justify-between text-lg font-semibold font-data text-foreground">
             <span>{t('cart.total')}</span>
-            <span className="text-primary font-bold">{formatCurrency(totals.amountDue)}</span>
+            {/* E2E: the amount is a nameless sibling of its label, and "Total" renders
+                simultaneously here, in the checkout drawer and on the receipt. */}
+            <span data-testid="cart-total" className="text-primary font-bold">
+              {formatCurrency(totals.amountDue)}
+            </span>
           </div>
         </div>
 
@@ -1001,7 +1013,10 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                   )}
                   <div className="flex justify-between text-base font-bold font-data text-foreground">
                     <span>{t('cart.total')}</span>
-                    <span className="text-primary">{formatCurrency(totals.amountDue)}</span>
+                    {/* E2E: see cart-total — same nameless sibling, same label collision. */}
+                    <span data-testid="checkout-total" className="text-primary">
+                      {formatCurrency(totals.amountDue)}
+                    </span>
                   </div>
                 </div>
 

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -1480,10 +1480,15 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                   )}
                 </div>
 
+                {/* `shrink-0` is load-bearing, not cosmetic. This button is the last child
+                    of a flex-column DrawerBody, and once the drawer's content is taller
+                    than the viewport the default `flex-shrink: 1` compresses it to zero
+                    height — leaving a cashier unable to complete a sale on any screen
+                    under roughly 1000px tall. Covered by checkout-cash.spec.ts. */}
                 <Button
                   color="primary"
                   size="md"
-                  className="w-full font-semibold shadow-sm"
+                  className="w-full shrink-0 font-semibold shadow-sm"
                   onClick={handleCheckout}
                   isDisabled={
                     checkoutMutation.isPending || needsReview || (splitPayment && !split.isBalanced)

--- a/client/src/features/pos/pages/POS.tsx
+++ b/client/src/features/pos/pages/POS.tsx
@@ -414,6 +414,10 @@ export default function POS() {
               {products?.map((product) => (
                 <Card
                   key={product.id}
+                  /* E2E: the card's accessible name concatenates stock badge, category,
+                     name, SKU and price, and it nests a favourite button — so an exact
+                     role+name query is not usable. */
+                  data-testid={`product-card-${product.sku}`}
                   isPressable={getEffectiveStock(product) > 0}
                   className={`relative transition-all border border-border bg-card shadow-sm ${
                     getEffectiveStock(product) === 0

--- a/client/src/shared/components/Receipt.tsx
+++ b/client/src/shared/components/Receipt.tsx
@@ -172,7 +172,9 @@ export default function Receipt({ data }: ReceiptProps) {
         <div className="border-t border-gray-300 my-1" />
         <div className="flex justify-between text-sm font-bold">
           <span>{t('cart.total')}</span>
-          <span>{formatCurrency(calc.amountDue)}</span>
+          {/* E2E: the server-confirmed total, nameless and sharing its label with the
+              cart footer and the checkout drawer. */}
+          <span data-testid="receipt-total">{formatCurrency(calc.amountDue)}</span>
         </div>
       </div>
 

--- a/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
+++ b/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
@@ -943,7 +943,7 @@ retype them).
 
 ### Phase 2 — Money paths
 
-- [ ] **Unit 6: The critical cash sale, end to end (`@smoke`)**
+- [x] **Unit 6: The critical cash sale, end to end (`@smoke`)**
 
 **Goal:** The spine of R1 — login through receipt — proven against the real stack.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -121,6 +121,20 @@ configuration in `contracts/checkout-totals.v1.json`, six of whose ten cases spe
 `tax.enabled: false`. Under a tax-enabled baseline those six could not be entered through
 the UI and still reach the total the contract records.
 
+## The `@smoke` subset
+
+`npm run test:smoke` runs the tag intended for the pull-request gate.
+
+**Budget: under 3 minutes.** Measured at 32s for 7 tests (2 workers, warm build, local
+PostgreSQL) — full suite 27 tests in ~30s at 4 workers. If the smoke subset ever exceeds
+the budget, move cases *out* of `@smoke` rather than raising the budget; a PR gate people
+wait on is a PR gate people learn to skip.
+
+What qualifies: the paths that carry money and would be catastrophic to break silently —
+the cash sale spine, the shipped Arabic default, duplicate submission, and one offline
+queue-and-replay case. Adding to the tag is a deliberate decision with a cost, not a
+default for new specs.
+
 ## Conventions
 
 - **Expected totals come from `contracts/checkout-totals.v1.json`, never hardcoded.** Both

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -51,6 +51,13 @@ export interface TestFixtures {
   skipStartupPrompt: boolean;
   /** A context already authenticated as this worker's cashier. */
   cashierContext: BrowserContext;
+  /** A throwaway cashier with no shift and no register, for the startup-gate path. */
+  freshCashierContext: {
+    context: BrowserContext;
+    id: number;
+    email: string;
+    accessToken: string;
+  };
   /** Mints a product owned by this test, namespaced so no other spec can see it. */
   seedProduct: (label: string, seed?: ProductSeed) => Promise<Product>;
 }
@@ -201,6 +208,61 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     if (skipStartupPrompt) await dismissStartupPrompt(context);
 
     await use(context);
+    await context.close();
+  },
+
+  /**
+   * A cashier with **no shift and no register**, and a context logged in as them.
+   *
+   * The register-readiness path needs its own identity, and this is not a detail. The
+   * worker cashier already has both open (that is the point of `workerRegister`), so it
+   * has nothing for `StartupPrompt` to do — and suppressing `moon-startup-dismissed` is
+   * not the same as genuinely having no open shift. Driving the shared seeded
+   * `sarah@moon.com` instead would violate the per-worker ownership rule and race any
+   * other worker on the same drawer.
+   *
+   * So this mints a throwaway cashier per test. Every *other* spec uses `cashierContext`.
+   */
+  freshCashierContext: async ({ adminApi, browser, appLocale }, use, testInfo) => {
+    const tag = `${testInfo.testId.slice(0, 8)}${Math.random().toString(36).slice(2, 6)}`;
+    const email = `e2e-fresh-${tag}@moon.test`;
+    const name = `E2E Fresh ${tag}`;
+
+    const cashier = await createUser(adminApi, {
+      name,
+      email,
+      password: WORKER_PASSWORD,
+      role: 'Cashier',
+    });
+
+    const loginContext = await playwrightRequest.newContext({ baseURL: API_URL });
+    const session = await login(loginContext, email, WORKER_PASSWORD);
+    const { cookies } = await loginContext.storageState();
+    await loginContext.dispose();
+
+    const context = await browser.newContext({
+      storageState: {
+        cookies,
+        origins: [
+          {
+            origin: BASE_URL,
+            localStorage: [
+              {
+                name: AUTH_STORAGE_KEY,
+                value: authStorageValue(
+                  { id: cashier.id, name, email, role: 'Cashier' },
+                  session.accessToken
+                ),
+              },
+            ],
+          },
+        ],
+      },
+    });
+    await seedLocale(context, appLocale);
+    // Deliberately NOT dismissing the startup prompt — this fixture exists to face it.
+
+    await use({ context, id: cashier.id, email, accessToken: session.accessToken });
     await context.close();
   },
 

--- a/e2e/specs/checkout-cash.spec.ts
+++ b/e2e/specs/checkout-cash.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * The spine of R1: login through receipt, proven against the real stack.
+ *
+ * Every money assertion here is two-sided (D8) — the total the cashier reads *and* the
+ * row the server persisted. One POST that writes two rows and two POSTs that write one
+ * are different bugs, and each looks fine from one side.
+ *
+ * Expected totals come from `contracts/checkout-totals.v1.json` (D7). Under the pinned
+ * tax-disabled baseline (D5a) the smoke sale is `no-adjustments-tax-disabled`.
+ */
+import {
+  assertPersistedSale,
+  countSalesForCashier,
+  latestSaleIdForCashier,
+  money,
+  readStock,
+} from '../support/assertSale';
+import { contractCase, toMajor } from '../support/contract';
+import { formatMoneyMinor } from '../support/money';
+import {
+  cartPanel,
+  checkoutDrawer,
+  posPage,
+  receiptDialog,
+  startupPrompt,
+} from '../support/locators';
+import { tr } from '../support/i18n';
+import { API_BASE, getJson } from '../fixtures/seed';
+import { expect, test } from '../fixtures/test';
+import type { Product } from '../fixtures/types';
+
+const SMOKE_CASE = contractCase('no-adjustments-tax-disabled');
+const UNIT_PRICE_MINOR = SMOKE_CASE.input.items[0]!.unitPriceMinor;
+
+test.describe('cash sale @smoke', () => {
+  test('a cashier with no shift opens the till through the startup prompt', async ({
+    freshCashierContext,
+    request,
+  }) => {
+    // This spec deliberately does NOT use the worker cashier: that one already has a
+    // shift and a register open, so the prompt would have nothing to do. Suppressing
+    // `moon-startup-dismissed` is not the same as genuinely having no shift.
+    const page = await freshCashierContext.context.newPage();
+    await page.goto('/pos');
+
+    const prompt = startupPrompt(page);
+    await expect(prompt.dialog).toBeVisible();
+
+    // Two sequential steps in one dialog, never both at once.
+    await prompt.clockIn.click();
+    await expect(prompt.openingFloat).toBeVisible();
+    await prompt.openingFloat.fill('250');
+    await prompt.openRegister.click();
+
+    await expect(prompt.dialog).toBeHidden();
+
+    // The float is not just a UI value — it seeds the drawer's expected cash.
+    const register = await getJson<{ opening_float: string | number; status: string }>(
+      request,
+      freshCashierContext.accessToken,
+      'register/current'
+    );
+    expect(register.status).toBe('open');
+    expect(money(register.opening_float)).toBe(250);
+  });
+
+  test('search, add, adjust quantity, and complete a cash sale', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    const product = await seedProduct('cash', {
+      price: toMajor(UNIT_PRICE_MINOR),
+      stock: 25,
+    });
+    const stockBefore = await readStock(product.id);
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    const pos = posPage(page);
+    const cart = cartPanel(page);
+
+    // The cart starts empty and checkout is unavailable until something is in it.
+    await expect(cart.empty).toBeVisible();
+    await expect(cart.checkout).toBeDisabled();
+
+    // Searching a worker-namespaced SKU returns that product and no other worker's.
+    await pos.search.fill(product.sku);
+    await expect(pos.productCard(product.sku)).toBeVisible();
+
+    await pos.productCard(product.sku).click();
+    await expect(cart.quantity(product.id)).toHaveText('1');
+
+    // Raise to 3 and the line, then the cart total, follow.
+    await cart.increaseQuantity(product.id).click();
+    await cart.increaseQuantity(product.id).click();
+    await expect(cart.quantity(product.id)).toHaveText('3');
+    await expect(cart.total).toHaveText(formatMoneyMinor(UNIT_PRICE_MINOR * 3));
+
+    // Back down to the contract case's quantity of 1, so the expected total is the
+    // contract's `amountDueMinor` rather than a number derived here.
+    await cart.decreaseQuantity(product.id).click();
+    await cart.decreaseQuantity(product.id).click();
+    await expect(cart.quantity(product.id)).toHaveText('1');
+    await expect(cart.total).toHaveText(formatMoneyMinor(SMOKE_CASE.expected.amountDueMinor));
+
+    await cart.checkout.click();
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+    await expect(drawer.total).toHaveText(formatMoneyMinor(SMOKE_CASE.expected.amountDueMinor));
+
+    // Regression guard, and the reason this suite exists. The confirm button is the last
+    // child of a flex-column drawer body; without `shrink-0` it was compressed to zero
+    // height whenever the drawer's content exceeded the viewport, so a sale could not be
+    // completed on any screen under roughly 1000px tall. jsdom has no layout engine, so
+    // all 380 client unit tests passed against it.
+    const confirmBox = await drawer.confirm.boundingBox();
+    expect(confirmBox?.height, 'the confirm button must have real height').toBeGreaterThan(0);
+
+    // Cash is already the default; selecting it explicitly is what a cashier does.
+    await drawer.paymentMethod('cash').check();
+    await drawer.confirm.click();
+
+    // --- Screen half of D8 -------------------------------------------------------
+    const receipt = receiptDialog(page);
+    await expect(receipt.dialog).toBeVisible();
+    await expect(receipt.total).toHaveText(formatMoneyMinor(SMOKE_CASE.expected.amountDueMinor));
+    await expect(receipt.dialog).toContainText(`${tr('receipt.paidWith')}: ${tr('cart.cash')}`);
+
+    // --- Persisted half of D8 ----------------------------------------------------
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore + 1);
+
+    const saleId = await latestSaleIdForCashier(workerCashier.id);
+    expect(saleId).toBeDefined();
+
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId!, {
+      amountDueMinor: SMOKE_CASE.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: UNIT_PRICE_MINOR }],
+    });
+    expect(sale.status).toBe('completed');
+
+    // Stock moved by exactly the quantity sold — once, not twice.
+    expect(await readStock(product.id)).toBe(stockBefore - 1);
+  });
+
+  test('removing the last line returns the cart to empty and disables checkout', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('remove', { price: 40, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const pos = posPage(page);
+    const cart = cartPanel(page);
+
+    await pos.search.fill(product.sku);
+    await pos.productCard(product.sku).click();
+    await expect(cart.line(product.id)).toBeVisible();
+
+    await cart.removeItem(product.id).click();
+
+    await expect(cart.line(product.id)).toBeHidden();
+    await expect(cart.empty).toBeVisible();
+    await expect(cart.checkout).toBeDisabled();
+  });
+
+  test('an unknown SKU shows the empty result state rather than spinning forever', async ({
+    cashierContext,
+  }) => {
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const pos = posPage(page);
+
+    await pos.search.fill('E2E-NO-SUCH-SKU-ZZZZ');
+
+    // The assertion that matters is that the grid settles with nothing in it — a spinner
+    // that never resolves would leave a card locator pending until timeout instead.
+    await expect(pos.productCard('E2E-NO-SUCH-SKU-ZZZZ')).toHaveCount(0);
+    await expect(page.getByTestId(/^product-card-/)).toHaveCount(0);
+  });
+});
+
+/**
+ * The barcode seam, stated explicitly so a later reader knows the gap is deliberate.
+ *
+ * `useScanner` drives Quagga2 against a real camera in `LiveStream` mode and there is no
+ * keyboard-wedge path, so decoding a barcode from a synthetic video stream in headless
+ * Chromium is disproportionate machinery for the one step it would prove. The optical
+ * decode is out of scope. What follows it is not: these cover the lookup that
+ * `handleBarcodeDetected` depends on, including the miss case that would otherwise add an
+ * empty cart line.
+ */
+test.describe('barcode lookup (the scan consequence, not the scan)', () => {
+  test('a known barcode resolves to this worker’s product', async ({
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    const barcode = `E2E${Date.now()}${Math.floor(Math.random() * 1000)}`;
+    const product = await seedProduct('barcode', { price: 60, stock: 3, barcode });
+
+    const found = await getJson<Product>(
+      request,
+      workerCashier.accessToken,
+      `products/barcode/${barcode}`
+    );
+    expect(found.id).toBe(product.id);
+    expect(found.sku).toBe(product.sku);
+  });
+
+  test('an unknown barcode returns a distinguishable not-found', async ({
+    workerCashier,
+    request,
+  }) => {
+    // A null product rather than a 404 would let the till add an empty cart line.
+    const response = await request.get(`${API_BASE}/products/barcode/E2E-DOES-NOT-EXIST`, {
+      headers: { Authorization: `Bearer ${workerCashier.accessToken}` },
+    });
+    expect(response.status()).toBe(404);
+    expect(await response.json()).toMatchObject({ error: { code: 'NOT_FOUND' } });
+  });
+});

--- a/e2e/specs/locale-rtl.spec.ts
+++ b/e2e/specs/locale-rtl.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * The same money path, in the configuration the app actually ships.
+ *
+ * `settingsStore` defaults to `locale: 'ar'` and `client/index.html` is
+ * `<html lang="ar" dir="rtl">`, so Arabic RTL is what a till runs unless someone changes
+ * it. The rest of the suite pins `en` for readable diagnostics, which means without this
+ * spec the default configuration would be the one configuration never tested.
+ *
+ * Every locator here comes from the `ar` catalog, so this also exercises the translations
+ * themselves: a missing or renamed Arabic key fails at construction.
+ */
+import {
+  assertPersistedSale,
+  countSalesForCashier,
+  latestSaleIdForCashier,
+  readStock,
+} from '../support/assertSale';
+import { contractCase, toMajor } from '../support/contract';
+import { formatMoneyMinor } from '../support/money';
+import { cartPanel, checkoutDrawer, posPage, receiptDialog } from '../support/locators';
+import { expect, test } from '../fixtures/test';
+
+const SMOKE_CASE = contractCase('no-adjustments-tax-disabled');
+const UNIT_PRICE_MINOR = SMOKE_CASE.input.items[0]!.unitPriceMinor;
+const AR = { locale: 'ar' } as const;
+
+// The whole file runs on the shipped default rather than the suite's pinned `en`.
+test.use({ appLocale: 'ar' });
+
+test.describe('Arabic RTL default @smoke', () => {
+  test('a cash sale completes and persists identically under the shipped default', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    const product = await seedProduct('rtl', {
+      price: toMajor(UNIT_PRICE_MINOR),
+      stock: 12,
+    });
+    const stockBefore = await readStock(product.id);
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    // The direction is the point: a locator that works in `en` can silently fail here.
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+
+    const pos = posPage(page, AR);
+    const cart = cartPanel(page, AR);
+
+    await pos.search.fill(product.sku);
+    await pos.productCard(product.sku).click();
+    await expect(cart.quantity(product.id)).toHaveText('1');
+
+    // Arabic renders the currency suffix as جم, with Latin digits (`numberingSystem`).
+    await expect(cart.total).toHaveText(formatMoneyMinor(SMOKE_CASE.expected.amountDueMinor, 'ar'));
+
+    await cart.checkout.click();
+    const drawer = checkoutDrawer(page, AR);
+    await expect(drawer.dialog).toBeVisible();
+
+    // The checkout sheet flips side under RTL (`side={isRtl ? 'left' : 'right'}`), which
+    // is exactly the kind of thing that renders but is unclickable if it regresses.
+    const confirmBox = await drawer.confirm.boundingBox();
+    expect(confirmBox?.height, 'the confirm button must have real height in RTL').toBeGreaterThan(
+      0
+    );
+
+    await drawer.paymentMethod('cash').check();
+    await drawer.confirm.click();
+
+    const receipt = receiptDialog(page, AR);
+    await expect(receipt.dialog).toBeVisible();
+    await expect(receipt.total).toHaveText(
+      formatMoneyMinor(SMOKE_CASE.expected.amountDueMinor, 'ar')
+    );
+
+    // The persisted row must be byte-identical to the `en` path — locale is presentation,
+    // and a total that differs by locale would be a money bug.
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore + 1);
+    const saleId = await latestSaleIdForCashier(workerCashier.id);
+    expect(saleId).toBeDefined();
+
+    await assertPersistedSale(request, workerCashier.accessToken, saleId!, {
+      amountDueMinor: SMOKE_CASE.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: UNIT_PRICE_MINOR }],
+    });
+
+    expect(await readStock(product.id)).toBe(stockBefore - 1);
+  });
+});

--- a/e2e/support/assertSale.ts
+++ b/e2e/support/assertSale.ts
@@ -1,0 +1,124 @@
+/**
+ * The D8 two-sided assertion: every money path is checked on the **screen** and in the
+ * **persisted server state**.
+ *
+ * These are different bugs. One POST on the wire that writes two rows, and two POSTs that
+ * write one, both look fine from one side and wrong from the other. Asserting only the
+ * cashier's view or only the database catches neither reliably.
+ */
+import { expect, type APIRequestContext } from '@playwright/test';
+import { dbOne } from './db';
+import { getJson } from '../fixtures/seed';
+
+export interface PersistedSaleItem {
+  product_id: number;
+  quantity: number;
+  unit_price: string | number;
+}
+
+export interface PersistedSale {
+  id: number;
+  total: string | number;
+  subtotal: string | number;
+  tax_amount: string | number;
+  discount: string | number;
+  tip_amount: string | number;
+  payment_method: string;
+  cashier_id: number | null;
+  customer_id: number | null;
+  status: string;
+  items: PersistedSaleItem[];
+  payments: Array<{ method: string; amount: string | number }>;
+}
+
+/**
+ * pg returns NUMERIC as a string to preserve exactness. Comparing one to a JS number
+ * silently fails, so every money read goes through this.
+ */
+export function money(value: string | number | null | undefined): number {
+  return Number(value ?? 0);
+}
+
+export async function fetchSale(
+  request: APIRequestContext,
+  token: string,
+  saleId: number
+): Promise<PersistedSale> {
+  return getJson<PersistedSale>(request, token, `sales/${saleId}`);
+}
+
+/** Raw stock, read past any client or React Query cache. */
+export async function readStock(productId: number): Promise<number> {
+  const row = await dbOne<{ stock: string }>('SELECT stock FROM products WHERE id = $1', [
+    productId,
+  ]);
+  if (!row) throw new Error(`No product row for id ${productId}.`);
+  return Number(row.stock);
+}
+
+/** How many `sales` rows this cashier has — scoped, never a global aggregate (D4). */
+export async function countSalesForCashier(cashierId: number): Promise<number> {
+  const row = await dbOne<{ n: string }>(
+    'SELECT count(*)::text AS n FROM sales WHERE cashier_id = $1',
+    [cashierId]
+  );
+  return Number(row?.n ?? '0');
+}
+
+/** The most recent sale this cashier rang up, or undefined. Scoped per worker cashier. */
+export async function latestSaleIdForCashier(cashierId: number): Promise<number | undefined> {
+  const row = await dbOne<{ id: number }>(
+    'SELECT id FROM sales WHERE cashier_id = $1 ORDER BY id DESC LIMIT 1',
+    [cashierId]
+  );
+  return row?.id;
+}
+
+export interface ExpectedSale {
+  /** From a named case in `contracts/checkout-totals.v1.json` — never hardcoded (D7). */
+  amountDueMinor: number;
+  paymentMethod: string;
+  cashierId: number;
+  items: Array<{ productId: number; quantity: number; unitPriceMinor: number }>;
+}
+
+/**
+ * Asserts the persisted half of a sale: the row, its line items, and the stock it moved.
+ *
+ * The screen half is asserted by the caller, which owns the locators — keeping this
+ * helper free of any dependency on how a particular spec renders its total.
+ */
+export async function assertPersistedSale(
+  request: APIRequestContext,
+  token: string,
+  saleId: number,
+  expected: ExpectedSale
+): Promise<PersistedSale> {
+  const sale = await fetchSale(request, token, saleId);
+
+  expect(money(sale.total), 'persisted sale total').toBeCloseTo(expected.amountDueMinor / 100, 2);
+  expect(sale.payment_method, 'persisted payment method').toBe(expected.paymentMethod);
+  expect(sale.cashier_id, 'sale belongs to this worker’s cashier').toBe(expected.cashierId);
+  expect(sale.items, 'persisted line items').toHaveLength(expected.items.length);
+
+  for (const item of expected.items) {
+    const line = sale.items.find((i) => i.product_id === item.productId);
+    expect(line, `line item for product ${item.productId}`).toBeDefined();
+    expect(line?.quantity, `quantity for product ${item.productId}`).toBe(item.quantity);
+    expect(money(line?.unit_price), `unit price for product ${item.productId}`).toBeCloseTo(
+      item.unitPriceMinor / 100,
+      2
+    );
+  }
+
+  return sale;
+}
+
+/** Stock moved by exactly the quantity sold — once, not twice, and not at all on failure. */
+export async function assertStockDecremented(
+  productId: number,
+  stockBefore: number,
+  soldQuantity: number
+): Promise<void> {
+  expect(await readStock(productId), 'stock after the sale').toBe(stockBefore - soldQuantity);
+}

--- a/e2e/support/contract.ts
+++ b/e2e/support/contract.ts
@@ -1,0 +1,70 @@
+/**
+ * The money contract, read rather than restated (D7).
+ *
+ * `contracts/checkout-totals.v1.json` is already consumed by both calculators —
+ * `client/src/shared/lib/checkout.ts` and `server/src/modules/pos/sales/service.ts` — and
+ * each side is proven against it by its own unit suite. This suite's job is the wire
+ * between them, not the arithmetic: it asserts that a named case *entered through the UI*
+ * produces that case's `amountDueMinor` on screen and in the persisted row.
+ *
+ * So expected totals come from here. Hardcoding one would put the money rules in a third
+ * place and create a two-way maintenance burden the contract file exists to prevent.
+ */
+import contract from '../../contracts/checkout-totals.v1.json';
+
+export interface ContractItem {
+  unitPriceMinor: number;
+  quantity: number;
+}
+
+export interface ContractExpected {
+  subtotalMinor: number;
+  manualDiscountMinor: number;
+  couponDiscountMinor: number;
+  pointsDiscountMinor: number;
+  taxableBaseMinor: number;
+  taxAmountMinor: number;
+  tipMinor: number;
+  amountDueMinor: number;
+  earnedPoints: number;
+}
+
+export interface ContractCase {
+  name: string;
+  input: {
+    items: ContractItem[];
+    tax: { enabled: boolean; ratePercent: number; mode: string };
+    loyalty: {
+      enabled: boolean;
+      pointsPerEgp: number;
+      egpPerPointMinor: number;
+      pointsRedeemed: number;
+    };
+    couponDiscountMinor: number;
+    manualDiscount: { type: string; valueMinor: number };
+    tipMinor: number;
+  };
+  expected: ContractExpected;
+}
+
+const cases = contract.cases as ContractCase[];
+
+/**
+ * A named case. Throws rather than returning undefined: a renamed case must fail loudly
+ * here, not silently turn an assertion into a comparison against `undefined`.
+ */
+export function contractCase(name: string): ContractCase {
+  const found = cases.find((c) => c.name === name);
+  if (!found) {
+    throw new Error(
+      `No case named "${name}" in contracts/checkout-totals.v1.json. ` +
+        `Available: ${cases.map((c) => c.name).join(', ')}.`
+    );
+  }
+  return found;
+}
+
+/** Minor units (piastres) to the major-unit number the UI and the API deal in. */
+export function toMajor(minor: number): number {
+  return minor / 100;
+}

--- a/e2e/support/locators.ts
+++ b/e2e/support/locators.ts
@@ -2,15 +2,16 @@
  * Locator helpers, built from the app's own i18n catalogs.
  *
  * The priority is Playwright's documented one — role, then label, then text — with test
- * ids reserved for surfaces that have no meaningful accessible name at all (a cart line
- * container, a virtualized row wrapper). Where a role query cannot find a control, the
- * first move is to **fix the accessible name** in the component: a missing name is a real
- * accessibility defect, and reaching for a test id buries it.
+ * ids reserved for surfaces that have no meaningful accessible name at all. Where a role
+ * query cannot find a control, the first move is to **fix the accessible name** in the
+ * component: a missing name is a real accessibility defect, and reaching for a test id
+ * buries it. The six test ids used below each carry a justification comment at their
+ * definition site in `client/src`.
  *
- * Every helper here takes the locale, so the same spec body can run against the shipped
- * Arabic default and against the `en` the bulk of the suite is pinned to.
+ * Every helper takes the locale, so the same spec body runs against the shipped Arabic
+ * default and against the `en` the bulk of the suite is pinned to.
  */
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { DEFAULT_TEST_LOCALE, type Locale, tr } from './i18n';
 
 export interface LocaleOptions {
@@ -24,4 +25,91 @@ export function loginPage(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOp
     submit: page.getByRole('button', { name: tr('login.submit', locale) }),
     heading: page.getByRole('heading', { name: tr('login.title', locale) }),
   };
+}
+
+/**
+ * The shift/register gate.
+ *
+ * One dialog with **two mutually exclusive steps**: a cashier with neither sees only
+ * "Clock In", and the register step replaces it once the shift query refetches. It is not
+ * two dialogs, and both controls are never on screen together.
+ */
+export function startupPrompt(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  const dialog = page.getByRole('dialog', { name: tr('startup.title', locale) });
+  return {
+    dialog,
+    clockIn: dialog.getByRole('button', { name: tr('startup.clockIn', locale) }),
+    openingFloat: dialog.getByLabel(tr('startup.openingFloat', locale)),
+    openRegister: dialog.getByRole('button', { name: tr('startup.openRegister', locale) }),
+    later: dialog.getByRole('button', { name: tr('startup.skip', locale) }),
+  };
+}
+
+export function posPage(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  return {
+    search: page.getByPlaceholder(tr('pos.searchPlaceholder', locale)),
+    /** Scoped by SKU: the card's own accessible name is an unusable concatenation. */
+    productCard: (sku: string): Locator => page.getByTestId(`product-card-${sku}`),
+    outOfStock: page.getByText(tr('pos.outOfStock', locale)),
+  };
+}
+
+export function cartPanel(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  /** One cart line. Keyed by product and variant, matching the component's own key. */
+  const line = (productId: number, variantId = 0): Locator =>
+    page.getByTestId(`cart-line-${productId}-${variantId}`);
+
+  return {
+    line,
+    /**
+     * The +/- and remove controls carry hardcoded English `aria-label`s rather than
+     * `t()` calls, so they are deliberately *not* read from the catalog — they do not
+     * change under `ar`, and pretending otherwise would break the RTL spec.
+     */
+    increaseQuantity: (productId: number, variantId = 0) =>
+      line(productId, variantId).getByRole('button', { name: 'Increase quantity' }),
+    decreaseQuantity: (productId: number, variantId = 0) =>
+      line(productId, variantId).getByRole('button', { name: 'Decrease quantity' }),
+    removeItem: (productId: number, variantId = 0) =>
+      line(productId, variantId).getByRole('button', { name: 'Remove item' }),
+    quantity: (productId: number, variantId = 0) =>
+      line(productId, variantId).getByTestId('cart-line-qty'),
+    total: page.getByTestId('cart-total'),
+    empty: page.getByText(tr('cart.empty', locale)),
+    checkout: page.getByRole('button', { name: tr('cart.checkout', locale) }),
+  };
+}
+
+/**
+ * The checkout sheet. Its accessible name is the header heading *and* subtitle
+ * concatenated, so it is matched by prefix rather than exactly.
+ */
+export function checkoutDrawer(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  const dialog = page.getByRole('dialog', {
+    name: new RegExp(escapeRegExp(tr('cart.completeSale', locale))),
+  });
+  return {
+    dialog,
+    paymentMethod: (method: 'cash' | 'card' | 'other') =>
+      dialog.getByRole('radio', { name: tr(`cart.${method}`, locale) }),
+    total: dialog.getByTestId('checkout-total'),
+    confirm: dialog.getByRole('button', { name: tr('cart.confirmSale', locale) }),
+  };
+}
+
+export function receiptDialog(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  const dialog = page.getByRole('dialog', { name: tr('receipt.title', locale) });
+  return {
+    dialog,
+    total: dialog.getByTestId('receipt-total'),
+    /**
+     * HeroUI renders its own dismiss button in addition to the footer one, so two
+     * elements share the name — `.last()` selects the footer control deliberately.
+     */
+    close: dialog.getByRole('button', { name: tr('common.close', locale) }).last(),
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/e2e/support/money.ts
+++ b/e2e/support/money.ts
@@ -1,0 +1,30 @@
+/**
+ * How the till *renders* money.
+ *
+ * This is presentation, not arithmetic — the amounts themselves still come from
+ * `contracts/checkout-totals.v1.json` (D7). It mirrors `formatCurrency` in
+ * `client/src/shared/lib/utils.ts`, and the one detail that catches people out is the
+ * first line of it: **whole numbers drop their decimals**. A 150.00 EGP total renders as
+ * `150 EG`, never `150.00 EGP`. Asserting the obvious-looking string would fail against a
+ * perfectly correct till.
+ *
+ * If the app's formatter changes, assertions built on this fail — which is the right
+ * outcome. What a cashier reads off the screen is part of what this suite covers.
+ */
+import type { Locale } from './i18n';
+
+export function formatMoney(amountMajor: number, locale: Locale = 'en'): string {
+  const isWholeNumber = amountMajor % 1 === 0;
+  const formatted = new Intl.NumberFormat(locale === 'ar' ? 'ar-SA' : 'en-US', {
+    style: 'decimal',
+    minimumFractionDigits: isWholeNumber ? 0 : 2,
+    maximumFractionDigits: 2,
+    numberingSystem: 'latn',
+  }).format(amountMajor);
+  return `${formatted} ${locale === 'ar' ? 'جم' : 'EG'}`;
+}
+
+/** The same, from the minor units the contract file speaks in. */
+export function formatMoneyMinor(amountMinor: number, locale: Locale = 'en'): string {
+  return formatMoney(amountMinor / 100, locale);
+}


### PR DESCRIPTION
Unit 6 of `docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md` (issue #50) — the first unit that tests the till rather than the harness.

> **Stacked on #64.** This branches off `zhamdy/test-e2e-pos-harness`; merge that first and this diff collapses to just Unit 6.

## It found a real bug on its first run

**At any viewport under ~1000px tall, the Confirm Sale button collapsed to zero height and a cash sale could not be completed.**

It is the last child of a flex-column `DrawerBody`, so once the checkout drawer's content exceeded the viewport the default `flex-shrink` compressed it to nothing. Measured:

| Viewport height | Button height |
|---|---|
| 720 | **0px** |
| 1000 | **0px** |
| 1400 | 40px |

That range covers essentially every real till — a 1080p screen leaves a browser viewport around 900px. `shrink-0` fixes it at every height tested (`5e5ec20`, a one-class change kept in its own commit so it is trivially revertable).

All 380 client unit tests passed against this bug, and always would have: jsdom has no layout engine, so a zero-height element is indistinguishable from a correct one. This is precisely the gap the plan exists to close — "a regression … can land with every suite green."

I confirmed it was pre-existing by reproducing it against an unmodified client build before attributing it, rather than assuming my own edits were innocent.

## What the specs cover

`checkout-cash.spec.ts` (@smoke) — the R1 spine: the startup gate, search, add, quantity up to 3 and back down, checkout, cash, receipt. Plus removing the last line, an unknown SKU, and the barcode lookup.

`locale-rtl.spec.ts` (@smoke) — the same money path on the **shipped Arabic default**, with locators from the `ar` catalog. Without it, the configuration a real till actually runs would be the one configuration the suite never exercises.

Three decisions worth flagging:

- **The startup-gate spec mints its own throwaway cashier.** The worker cashier has a shift and register open by construction, so it would have nothing to drive — and suppressing `moon-startup-dismissed` is not the same as genuinely having no shift.
- **Expected totals are read from `contracts/checkout-totals.v1.json`** (D7), never hardcoded. The quantity-3 step asserts a *behaviour* (3 × unit price); the final total is the contract's `no-adjustments-tax-disabled` case.
- **Barcode coverage stops where the plan says it should.** The optical decode needs a real camera and is out of scope; the lookup it feeds — and that lookup's 404 — are covered, so a miss cannot silently add an empty cart line.

## Six new test ids

Each carries a comment at its definition site saying why a role query was insufficient: the cart line and its quantity (no role, bare number), the three totals (nameless siblings whose "Total" label renders in three places at once), and the product card (accessible name is an unusable concatenation that also nests a button).

The audit also turned up a genuine formatting trap: `formatCurrency` **drops decimals on whole numbers**, so 150.00 EGP renders `150 EG` — not `150.00 EGP`. Asserting the obvious-looking string would have failed against a perfectly correct till.

## Testing

| Suite | Result |
|---|---|
| `e2e` | 27 passed, at `--workers=1` **and** `--workers=4`, three consecutive runs, no flakes |
| `@smoke` | 7 tests in **32s** against the plan's ~3 minute budget |
| `client` | 380 passed (unchanged by the test ids) |
| lint / typecheck | clean |

`server` is untouched by this unit.

## Post-Deploy Monitoring & Validation

One production behaviour change: the Confirm Sale button now has a real height on short viewports.

- **What to watch:** completed-sale volume per till, and any support reports of "the confirm button does nothing". The pre-fix symptom is a cashier who can open the checkout drawer but not complete the sale.
- **Healthy signal:** sale volume flat or up; no change in `POST /api/v1/sales` error rate (this was never a server-side failure — the request was simply never sent).
- **Failure signal / rollback trigger:** any layout regression in the checkout drawer, e.g. the drawer body no longer scrolling. Revert is a single class in one commit.
- **Worth checking after deploy:** whether other elements in the same flex column are also being compressed. This fix addresses the button, which is the one on the critical path; a broader audit of the drawer's layout is follow-up work, not something this PR claims to have done.
- **Window / owner:** first deploy plus 24h, owned by whoever merges.

The six `data-testid` attributes are inert at runtime — additive attributes, no logic or layout change, with the existing 380 client unit tests as the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
