### PR TITLE
test(e2e): complete the POS suite — payments, tax, idempotency, failures, offline, CI (Units 7–14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,186 @@ jobs:
       # pre-existing errors unrelated to this workflow. Add the step once they are cleared.
 
       - run: npm test
+
+  e2e-smoke:
+    name: E2E smoke (pull requests)
+    # The PR gate: the money paths that would be catastrophic to break silently, held to
+    # a ~3 minute budget so it stays a gate people wait for rather than learn to skip.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: moon_store_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      E2E_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/moon_store_e2e
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            server/package-lock.json
+            client/package-lock.json
+            e2e/package-lock.json
+
+      - run: npm ci --prefix server
+      - run: npm ci --prefix client
+      - run: npm ci --prefix e2e
+
+      # Browser binaries are deliberately not cached: restore costs about as much as the
+      # download, and the OS dependencies are not cacheable anyway.
+      - run: npx --prefix e2e playwright install --with-deps chromium
+
+      # Its own step, never folded into webServer.command — otherwise the boot timeout
+      # silently covers compilation and a build failure reports as a readiness timeout.
+      # VITE_API_URL is baked in HERE; setting it on `vite preview` would do nothing.
+      - name: Build the client
+        run: npm run build --prefix client
+        env:
+          VITE_API_URL: http://localhost:3001
+
+      - name: Run @smoke
+        working-directory: e2e
+        run: npx playwright test --grep @smoke --reporter=list,json
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: smoke-report.json
+
+      - name: Fail if the @smoke subset ran nothing
+        # A renamed tag would otherwise turn this gate into a green no-op.
+        if: always()
+        run: node e2e/scripts/assertSmokeTestsRan.mjs e2e/smoke-report.json
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: e2e-smoke-artifacts
+          path: |
+            e2e/playwright-report/
+            e2e/test-results/
+          # Traces record Authorization headers, Set-Cookie and login bodies. This repo is
+          # public, so keep the window short. `e2e/playwright/.auth/` sits outside
+          # outputDir and is never collected here.
+          retention-days: 7
+
+  e2e-full:
+    name: E2E full (main)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    services:
+      postgres:
+        # REQUIRED INVARIANT: each shard gets its own server process and its own database.
+        # A matrix gives every shard its own service container, which is what makes that
+        # true here. Consolidating to one shared service to save CI minutes would silently
+        # break the settings isolation: shard 3's pos-settings project could rewrite global
+        # settings while shard 1's pos-parallel asserted totals against them, and each
+        # shard's reseed would wipe the others mid-run.
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: moon_store_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      E2E_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/moon_store_e2e
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            server/package-lock.json
+            client/package-lock.json
+            e2e/package-lock.json
+
+      - run: npm ci --prefix server
+      - run: npm ci --prefix client
+      - run: npm ci --prefix e2e
+      - run: npx --prefix e2e playwright install --with-deps chromium
+
+      - name: Build the client
+        run: npm run build --prefix client
+        env:
+          VITE_API_URL: http://localhost:3001
+
+      - name: Run shard ${{ matrix.shard }}/4
+        working-directory: e2e
+        # --fail-on-flaky-tests so retries surface flakes instead of absorbing them.
+        run: npx playwright test --shard=${{ matrix.shard }}/4 --fail-on-flaky-tests
+        env:
+          # Namespaces this shard's worker accounts. workerIndex restarts at 0 per shard,
+          # so without this two shards would collide on the same cashier email.
+          E2E_RUN_ID: s${{ matrix.shard }}
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: e2e-blob-${{ matrix.shard }}
+          path: e2e/blob-report/
+          retention-days: 7
+
+  e2e-report:
+    name: E2E merged report
+    # `!cancelled()` rather than `always()`: the report is most valuable precisely when a
+    # shard failed, and without this it would be lost exactly then.
+    if: ${{ !cancelled() && github.event_name == 'push' }}
+    needs: [e2e-full]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - run: npm ci --prefix e2e
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: e2e/all-blob-reports
+          pattern: e2e-blob-*
+          merge-multiple: true
+
+      - name: Merge into one HTML report
+        working-directory: e2e
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: e2e-html-report
+          path: e2e/playwright-report/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,10 +120,18 @@ adding specs.
 
 ## Offline queue
 
-Sales rung up offline are queued in `localStorage` and replayed by
-`client/src/shared/hooks/useOffline.ts`. A failed replay backs off, and a rejection the server will
-repeat parks for a cashier rather than retrying forever — see the **Offline queue replay contract**
-in `docs/CONVENTIONS.md` before changing the hook or its store.
+The queue in `localStorage` is replayed by `client/src/shared/hooks/useOffline.ts`. A failed
+replay backs off, and a rejection the server will repeat parks for a cashier rather than
+retrying forever — see the **Offline queue replay contract** in `docs/CONVENTIONS.md`
+before changing the hook or its store.
+
+> **The checkout path does not currently reach that queue.** `queryClient` sets no
+> `networkMode`, so React Query's default pauses a mutation fired while `navigator.onLine`
+> is false rather than failing it. No request goes out, `onError` never runs, and
+> `CartPanel`'s offline fallback — the only writer to `moon-offline-queue`— is unreachable.
+> The sale resumes and completes on reconnect if the tab stays open, but does not survive a
+> reload. Measured in `e2e/specs/offline.spec.ts`; the machinery above is sound, what is
+> missing is the path into it.
 
 ## Idempotency compatibility window
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,17 @@ They are deliberately separate: one variable raising both would let a config wri
 unblock a test run silently relax the credential brute-force ceiling. A value that is not a
 positive integer falls back to the default, and any override is warned about at boot.
 
+The suite is Chromium-only and split into three projects: a `setup` project that logs in
+through the real form, a `fullyParallel` `pos-parallel` project, and a serial
+`pos-settings` project that is the **only** place permitted to write
+`PUT /api/v1/settings` — tax and loyalty are global rows, so a write from a parallel
+worker changes the totals every other worker is asserting on.
+
+`@smoke` is the pull-request gate, budgeted under three minutes; the full sharded suite
+runs on `main`. See `e2e/README.md` for ownership, the flake policy, and the findings the
+suite has already produced, and `docs/CONVENTIONS.md` → *E2E test conventions* before
+adding specs.
+
 ## Offline queue
 
 Sales rung up offline are queued in `localStorage` and replayed by

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -555,6 +555,63 @@ When adding routes in `server/index.ts`, order doesn't matter since each route f
 
 ---
 
+## E2E test conventions
+
+Rules for `e2e/` that will otherwise erode. Full detail and the run instructions live in
+`e2e/README.md`.
+
+### Locators
+
+- **Build them from the i18n catalog**, never from hardcoded user-facing strings. The app
+  ships Arabic RTL by default, so an English literal tests a configuration most tills never
+  run. `support/i18n.ts` throws on a missing key rather than falling back, so a rename fails
+  loudly instead of matching nothing.
+- **A missing accessible name is a defect, not a reason for a test id.** Fix the name first.
+  A test id is for surfaces that genuinely have none — a cart line container, a bare number.
+- **Every production `data-testid` carries a one-line comment** saying why a role query was
+  insufficient. There are six; adding a seventh should feel like a decision.
+- Some `aria-label`s in `CartPanel` are hardcoded English rather than `t()` calls
+  ("Increase quantity", "Remove item", "Remove coupon"). Those are deliberately *not* read
+  from the catalog — they do not change under `ar`, and pretending otherwise breaks the RTL
+  spec.
+
+### Assertions
+
+- **Every money assertion is two-sided**: the value the cashier sees *and* the persisted
+  row. One POST that writes two rows and two POSTs that write one are different bugs, and
+  each looks fine from one side.
+- **Expected totals come from `contracts/checkout-totals.v1.json`**, never hardcoded. Both
+  calculators are already proven against that file; restating a number here would put the
+  money rules in a third place. Where the contract deliberately names no case — caps and
+  clamps — assert the documented *behaviour* instead.
+- **Complete a sale through `completeSaleAndReadId`.** Reading "the latest sale for this
+  cashier" is unsafe on its own: a confirm click that lands before the drawer opens creates
+  no sale, and the assertion then reads a neighbouring test's row and reports a money
+  mismatch. The helper pins the count either side.
+- **Never assert on a global aggregate.** Scope every count to the worker's own cashier,
+  product or session, or it races every other worker.
+
+### Isolation
+
+- Every test creates the rows it mutates. A spec may *authenticate* as a seeded account but
+  must never mutate its shift, register or sale state — those are one-per-user and two
+  workers on the same drawer will race.
+- Worker accounts are namespaced by `E2E_RUN_ID` as well as worker index, because
+  `--shard` restarts `workerIndex` at 0 per shard and `users.email` is UNIQUE.
+- **Only `tax-loyalty.spec.ts` writes `PUT /api/v1/settings`,** and only from the serial
+  `pos-settings` project. Tax and loyalty are global rows; a write from a parallel worker
+  silently changes the totals every other worker is asserting on. Every settings write is
+  followed by a reload — the client caches settings for five minutes, so a page loaded
+  before the write keeps submitting under the old mode and the assertion passes for the
+  wrong reason.
+
+### The `@smoke` subset
+
+The pull-request gate, budgeted under three minutes. Adding to it is a deliberate decision
+with a cost; if it grows past the budget, move cases out rather than raising the budget.
+`scripts/assertSmokeTestsRan.mjs` fails the build if the tag ever matches nothing, because
+a green run of zero tests is the failure mode most likely to go unnoticed.
+
 ## Git Workflow
 
 - **Always branch from `main`** before starting a feature

--- a/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
+++ b/docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'test: End-to-end coverage for critical POS workflows'
 type: test
-status: phase-1-complete
+status: completed
 date: 2026-08-31
 deepened: 2026-08-31
 issue: 50
@@ -1008,7 +1008,7 @@ retype them).
 
 ---
 
-- [ ] **Unit 7: Payment, adjustment, and cart-operation variants**
+- [x] **Unit 7: Payment, adjustment, and cart-operation variants**
 
 **Goal:** R2's breadth (minus the two settings-driven modes), plus the cart operations R1 names.
 
@@ -1079,7 +1079,7 @@ Cart operations (`cart-operations.spec.ts`):
 
 ---
 
-- [ ] **Unit 8: Tax modes and loyalty (serial settings project)**
+- [x] **Unit 8: Tax modes and loyalty (serial settings project)**
 
 **Goal:** The settings-driven half of R2, without destabilizing the parallel suite.
 
@@ -1155,7 +1155,7 @@ diagnose than the bug it was chasing.
 
 ### Phase 3 — Failure and resilience
 
-- [ ] **Unit 9: Duplicate submission and idempotent retry**
+- [x] **Unit 9: Duplicate submission and idempotent retry**
 
 **Goal:** R8 — prove in a real browser that a double interaction cannot create two sales.
 
@@ -1219,7 +1219,7 @@ diagnose than the bug it was chasing.
 
 ---
 
-- [ ] **Unit 10: Stock conflicts, rejected sales, and cart preservation**
+- [x] **Unit 10: Stock conflicts, rejected sales, and cart preservation**
 
 **Goal:** R3's rejection paths and R9's recovery guarantee.
 
@@ -1263,7 +1263,7 @@ diagnose than the bug it was chasing.
 
 ---
 
-- [ ] **Unit 11: Expired session, token refresh, and cart recovery**
+- [x] **Unit 11: Expired session, token refresh, and cart recovery**
 
 **Goal:** R3's session-expiry path, and R9 across a forced logout.
 
@@ -1305,7 +1305,7 @@ diagnose than the bug it was chasing.
 
 ---
 
-- [ ] **Unit 12: Offline queueing and reconnection replay**
+- [x] **Unit 12: Offline queueing and reconnection replay**
 
 **Goal:** R4 — prove the queue in a real browser, closing the loop on issues #30 and #42 together.
 
@@ -1359,7 +1359,7 @@ diagnose than the bug it was chasing.
 
 ### Phase 4 — CI and documentation
 
-- [ ] **Unit 13: CI workflow — smoke on PRs, sharded full suite on `main`**
+- [x] **Unit 13: CI workflow — smoke on PRs, sharded full suite on `main`**
 
 **Goal:** R10 and R11, with the smoke subset genuinely fast and the full suite genuinely enforced.
 
@@ -1441,7 +1441,7 @@ diagnose than the bug it was chasing.
 
 ---
 
-- [ ] **Unit 14: Documentation**
+- [x] **Unit 14: Documentation**
 
 **Goal:** The suite is runnable and extendable by someone who did not write it.
 

--- a/docs/reports/api-verification-report.md
+++ b/docs/reports/api-verification-report.md
@@ -1,6 +1,6 @@
 # API Endpoint Health & Verification Diagnostic Report
 
-**Execution Date:** 2026-08-30T10:59:16.891Z
+**Execution Date:** 2026-08-31T20:52:28.754Z
 
 ## Summary
 
@@ -18,203 +18,203 @@
 
 | Method | Path | Role | Status | Duration | Result |
 |---|---|---|---|---|---|
-| `POST` | `/api/v1/auth/login` | `Public` | `200` | 179ms | ✅ |
-| `POST` | `/api/v1/auth/refresh` | `Public` | `401` | 10ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/auth/logout` | `Admin` | `204` | 6ms | ✅ |
-| `GET` | `/api/v1/auth/me` | `Admin` | `200` | 8ms | ✅ |
-| `GET` | `/api/v1/users` | `Admin` | `200` | 18ms | ✅ |
-| `GET` | `/api/v1/users/delivery` | `Admin` | `200` | 9ms | ✅ |
+| `POST` | `/api/v1/auth/login` | `Public` | `200` | 184ms | ✅ |
+| `POST` | `/api/v1/auth/refresh` | `Public` | `401` | 7ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/auth/logout` | `Admin` | `204` | 7ms | ✅ |
+| `GET` | `/api/v1/auth/me` | `Admin` | `200` | 10ms | ✅ |
+| `GET` | `/api/v1/users` | `Admin` | `200` | 19ms | ✅ |
+| `GET` | `/api/v1/users/delivery` | `Admin` | `200` | 6ms | ✅ |
 | `POST` | `/api/v1/users` | `Admin` | `201` | 163ms | ✅ |
 | `GET` | `/api/v1/users/me/favorites` | `Admin` | `200` | 7ms | ✅ |
-| `PUT` | `/api/v1/users/me/favorites` | `Admin` | `400` | 8ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/users/1` | `Admin` | `200` | 11ms | ✅ |
+| `PUT` | `/api/v1/users/me/favorites` | `Admin` | `400` | 9ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/users/1` | `Admin` | `200` | 16ms | ✅ |
 | `DELETE` | `/api/v1/users/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/settings` | `Admin` | `200` | 5ms | ✅ |
-| `PUT` | `/api/v1/settings` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/audit-log` | `Admin` | `200` | 10ms | ✅ |
-| `GET` | `/api/v1/audit-log/actions` | `Admin` | `200` | 8ms | ✅ |
-| `GET` | `/api/v1/audit-log/entity-types` | `Admin` | `200` | 5ms | ✅ |
-| `GET` | `/api/v1/branches` | `Admin` | `200` | 35ms | ✅ |
-| `POST` | `/api/v1/branches` | `Admin` | `201` | 12ms | ✅ |
-| `GET` | `/api/v1/branches/consolidated` | `Admin` | `200` | 42ms | ✅ |
-| `GET` | `/api/v1/branches/transfers` | `Admin` | `200` | 23ms | ✅ |
-| `POST` | `/api/v1/branches/transfers` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/branches/transfers/1/status` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/branches/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/sales` | `Admin` | `200` | 30ms | ✅ |
-| `POST` | `/api/v1/sales` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/sales/1` | `Admin` | `404` | 11ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/sales/1/refund` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/register/current` | `Admin` | `200` | 45ms | ✅ |
-| `POST` | `/api/v1/register/open` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/register/movement` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/register/close` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/register/history` | `Admin` | `200` | 44ms | ✅ |
-| `GET` | `/api/v1/register/1/report` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/register/1/force-close` | `Admin` | `404` | 13ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/shifts/current` | `Admin` | `200` | 10ms | ✅ |
-| `POST` | `/api/v1/shifts/clock-in` | `Admin` | `201` | 16ms | ✅ |
-| `POST` | `/api/v1/shifts/clock-out` | `Admin` | `400` | 17ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/shifts/break/start` | `Admin` | `200` | 8ms | ✅ |
-| `POST` | `/api/v1/shifts/break/end` | `Admin` | `400` | 18ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/shifts` | `Admin` | `200` | 15ms | ✅ |
-| `POST` | `/api/v1/exchanges` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/exchanges` | `Admin` | `200` | 21ms | ✅ |
-| `GET` | `/api/v1/exchanges/1` | `Admin` | `404` | 23ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/layaway` | `Admin` | `400` | 7ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/layaway` | `Admin` | `200` | 18ms | ✅ |
-| `GET` | `/api/v1/layaway/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/layaway/1/pay` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/layaway/1/cancel` | `Admin` | `404` | 8ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/reservations` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/reservations/1` | `Admin` | `404` | 8ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/reservations/source/:sourceId` | `Admin` | `200` | 7ms | ✅ |
-| `GET` | `/api/v1/products` | `Admin` | `200` | 51ms | ✅ |
-| `GET` | `/api/v1/products/categories` | `Admin` | `200` | 8ms | ✅ |
-| `GET` | `/api/v1/products/lookup` | `Admin` | `400` | 9ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/generate-sku/1` | `Admin` | `200` | 15ms | ✅ |
+| `GET` | `/api/v1/settings` | `Admin` | `200` | 7ms | ✅ |
+| `PUT` | `/api/v1/settings` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/audit-log` | `Admin` | `200` | 12ms | ✅ |
+| `GET` | `/api/v1/audit-log/actions` | `Admin` | `200` | 7ms | ✅ |
+| `GET` | `/api/v1/audit-log/entity-types` | `Admin` | `200` | 7ms | ✅ |
+| `GET` | `/api/v1/branches` | `Admin` | `200` | 39ms | ✅ |
+| `POST` | `/api/v1/branches` | `Admin` | `201` | 15ms | ✅ |
+| `GET` | `/api/v1/branches/consolidated` | `Admin` | `200` | 38ms | ✅ |
+| `GET` | `/api/v1/branches/transfers` | `Admin` | `200` | 32ms | ✅ |
+| `POST` | `/api/v1/branches/transfers` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/branches/transfers/1/status` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/branches/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/sales` | `Admin` | `200` | 37ms | ✅ |
+| `POST` | `/api/v1/sales` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/sales/1` | `Admin` | `404` | 16ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/sales/1/refund` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/register/current` | `Admin` | `200` | 32ms | ✅ |
+| `POST` | `/api/v1/register/open` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/register/movement` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/register/close` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/register/history` | `Admin` | `200` | 37ms | ✅ |
+| `GET` | `/api/v1/register/1/report` | `Admin` | `404` | 11ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/register/1/force-close` | `Admin` | `404` | 12ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/shifts/current` | `Admin` | `200` | 12ms | ✅ |
+| `POST` | `/api/v1/shifts/clock-in` | `Admin` | `201` | 18ms | ✅ |
+| `POST` | `/api/v1/shifts/clock-out` | `Admin` | `400` | 21ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/shifts/break/start` | `Admin` | `200` | 10ms | ✅ |
+| `POST` | `/api/v1/shifts/break/end` | `Admin` | `400` | 13ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/shifts` | `Admin` | `200` | 19ms | ✅ |
+| `POST` | `/api/v1/exchanges` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/exchanges` | `Admin` | `200` | 16ms | ✅ |
+| `GET` | `/api/v1/exchanges/1` | `Admin` | `404` | 13ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/layaway` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/layaway` | `Admin` | `200` | 21ms | ✅ |
+| `GET` | `/api/v1/layaway/1` | `Admin` | `404` | 13ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/layaway/1/pay` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/layaway/1/cancel` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/reservations` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/reservations/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/reservations/source/:sourceId` | `Admin` | `200` | 6ms | ✅ |
+| `GET` | `/api/v1/products` | `Admin` | `200` | 42ms | ✅ |
+| `GET` | `/api/v1/products/categories` | `Admin` | `200` | 6ms | ✅ |
+| `GET` | `/api/v1/products/lookup` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/generate-sku/1` | `Admin` | `200` | 13ms | ✅ |
 | `GET` | `/api/v1/products/generate-barcode` | `Admin` | `200` | 10ms | ✅ |
-| `GET` | `/api/v1/products/barcode/:barcode` | `Admin` | `404` | 16ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/products/batch-generate-barcodes` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/products/bulk-update` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/barcode/:barcode` | `Admin` | `404` | 19ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/products/batch-generate-barcodes` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/products/bulk-update` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/products/bulk-delete` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/products/import` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
 | `GET` | `/api/v1/products/1` | `Admin` | `200` | 12ms | ✅ |
-| `POST` | `/api/v1/products` | `Admin` | `201` | 14ms | ✅ |
-| `PUT` | `/api/v1/products/1` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/products/1/status` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/products/1` | `Admin` | `204` | 11ms | ✅ |
-| `POST` | `/api/v1/products/1/adjust-stock` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/1/stock-history` | `Admin` | `200` | 13ms | ✅ |
-| `POST` | `/api/v1/products/1/image` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/products/1/image` | `Admin` | `403` | 10ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/1/variants` | `Admin` | `200` | 12ms | ✅ |
-| `POST` | `/api/v1/products/1/variants` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/products/1/variants/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/products/1/variants/1` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/1/price-history` | `Admin` | `200` | 9ms | ✅ |
-| `GET` | `/api/v1/categories` | `Admin` | `200` | 22ms | ✅ |
-| `POST` | `/api/v1/categories` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/products` | `Admin` | `201` | 12ms | ✅ |
+| `PUT` | `/api/v1/products/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/products/1/status` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/products/1` | `Admin` | `204` | 10ms | ✅ |
+| `POST` | `/api/v1/products/1/adjust-stock` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/1/stock-history` | `Admin` | `200` | 10ms | ✅ |
+| `POST` | `/api/v1/products/1/image` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/products/1/image` | `Admin` | `403` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/1/variants` | `Admin` | `200` | 5ms | ✅ |
+| `POST` | `/api/v1/products/1/variants` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/products/1/variants/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/products/1/variants/1` | `Admin` | `404` | 11ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/1/price-history` | `Admin` | `200` | 10ms | ✅ |
+| `GET` | `/api/v1/categories` | `Admin` | `200` | 24ms | ✅ |
+| `POST` | `/api/v1/categories` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
 | `PUT` | `/api/v1/categories/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/categories/1` | `Admin` | `409` | 8ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/distributors` | `Admin` | `200` | 31ms | ✅ |
-| `POST` | `/api/v1/distributors` | `Admin` | `201` | 15ms | ✅ |
-| `PUT` | `/api/v1/distributors/1` | `Admin` | `200` | 6ms | ✅ |
-| `DELETE` | `/api/v1/distributors/1` | `Admin` | `409` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/stock-counts` | `Admin` | `200` | 44ms | ✅ |
-| `POST` | `/api/v1/stock-counts` | `Admin` | `201` | 169ms | ✅ |
-| `GET` | `/api/v1/stock-counts/1` | `Admin` | `200` | 33ms | ✅ |
-| `PUT` | `/api/v1/stock-counts/1/items/:itemId` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/stock-counts/1/complete` | `Admin` | `200` | 29ms | ✅ |
-| `POST` | `/api/v1/stock-counts/1/cancel` | `Admin` | `409` | 10ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/stock-adjustments` | `Admin` | `200` | 17ms | ✅ |
-| `GET` | `/api/v1/bundles` | `Admin` | `200` | 26ms | ✅ |
-| `GET` | `/api/v1/bundles/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/bundles` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/bundles/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/categories/1` | `Admin` | `409` | 7ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/distributors` | `Admin` | `200` | 28ms | ✅ |
+| `POST` | `/api/v1/distributors` | `Admin` | `201` | 12ms | ✅ |
+| `PUT` | `/api/v1/distributors/1` | `Admin` | `200` | 5ms | ✅ |
+| `DELETE` | `/api/v1/distributors/1` | `Admin` | `409` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/stock-counts` | `Admin` | `200` | 31ms | ✅ |
+| `POST` | `/api/v1/stock-counts` | `Admin` | `201` | 138ms | ✅ |
+| `GET` | `/api/v1/stock-counts/1` | `Admin` | `200` | 23ms | ✅ |
+| `PUT` | `/api/v1/stock-counts/1/items/:itemId` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/stock-counts/1/complete` | `Admin` | `200` | 22ms | ✅ |
+| `POST` | `/api/v1/stock-counts/1/cancel` | `Admin` | `409` | 7ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/stock-adjustments` | `Admin` | `200` | 12ms | ✅ |
+| `GET` | `/api/v1/bundles` | `Admin` | `200` | 33ms | ✅ |
+| `GET` | `/api/v1/bundles/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/bundles` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/bundles/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
 | `DELETE` | `/api/v1/bundles/1` | `Admin` | `404` | 8ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/collections` | `Admin` | `200` | 30ms | ✅ |
-| `GET` | `/api/v1/collections/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/collections` | `Admin` | `201` | 9ms | ✅ |
-| `PUT` | `/api/v1/collections/1` | `Admin` | `200` | 13ms | ✅ |
-| `DELETE` | `/api/v1/collections/1` | `Admin` | `204` | 12ms | ✅ |
-| `GET` | `/api/v1/label-templates` | `Admin` | `200` | 5ms | ✅ |
+| `GET` | `/api/v1/collections` | `Admin` | `200` | 26ms | ✅ |
+| `GET` | `/api/v1/collections/1` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/collections` | `Admin` | `201` | 10ms | ✅ |
+| `PUT` | `/api/v1/collections/1` | `Admin` | `200` | 15ms | ✅ |
+| `DELETE` | `/api/v1/collections/1` | `Admin` | `204` | 10ms | ✅ |
+| `GET` | `/api/v1/label-templates` | `Admin` | `200` | 4ms | ✅ |
 | `POST` | `/api/v1/label-templates` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/label-templates/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/label-templates/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/customers` | `Admin` | `200` | 11ms | ✅ |
-| `POST` | `/api/v1/customers` | `Admin` | `201` | 6ms | ✅ |
+| `PUT` | `/api/v1/label-templates/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/label-templates/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/customers` | `Admin` | `200` | 9ms | ✅ |
+| `POST` | `/api/v1/customers` | `Admin` | `201` | 4ms | ✅ |
 | `GET` | `/api/v1/customers/1` | `Admin` | `404` | 1ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/customers/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/customers/1/stats` | `Admin` | `200` | 16ms | ✅ |
-| `GET` | `/api/v1/customers/1/sales` | `Admin` | `200` | 36ms | ✅ |
-| `GET` | `/api/v1/customers/1/loyalty` | `Admin` | `200` | 14ms | ✅ |
+| `PUT` | `/api/v1/customers/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/customers/1/stats` | `Admin` | `200` | 13ms | ✅ |
+| `GET` | `/api/v1/customers/1/sales` | `Admin` | `200` | 30ms | ✅ |
+| `GET` | `/api/v1/customers/1/loyalty` | `Admin` | `200` | 17ms | ✅ |
 | `POST` | `/api/v1/customers/1/loyalty/adjust` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/customers/1` | `Admin` | `204` | 10ms | ✅ |
+| `DELETE` | `/api/v1/customers/1` | `Admin` | `204` | 12ms | ✅ |
 | `GET` | `/api/v1/coupons` | `Admin` | `200` | 17ms | ✅ |
-| `POST` | `/api/v1/coupons` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/coupons/validate` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/coupons` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/coupons/validate` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
 | `PUT` | `/api/v1/coupons/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
 | `DELETE` | `/api/v1/coupons/1` | `Admin` | `204` | 8ms | ✅ |
-| `GET` | `/api/v1/gift-cards` | `Admin` | `200` | 20ms | ✅ |
-| `POST` | `/api/v1/gift-cards` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/gift-cards/MOON10/balance` | `Admin` | `404` | 9ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/gift-cards/MOON10/redeem` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/gift-cards/1/transactions` | `Admin` | `200` | 16ms | ✅ |
-| `PUT` | `/api/v1/gift-cards/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/feedback` | `Admin` | `201` | 5ms | ✅ |
-| `GET` | `/api/v1/feedback` | `Admin` | `200` | 24ms | ✅ |
-| `GET` | `/api/v1/segments` | `Admin` | `200` | 11ms | ✅ |
-| `POST` | `/api/v1/segments` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/segments/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/gift-cards` | `Admin` | `200` | 21ms | ✅ |
+| `POST` | `/api/v1/gift-cards` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/gift-cards/MOON10/balance` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/gift-cards/MOON10/redeem` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/gift-cards/1/transactions` | `Admin` | `200` | 17ms | ✅ |
+| `PUT` | `/api/v1/gift-cards/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/feedback` | `Admin` | `201` | 3ms | ✅ |
+| `GET` | `/api/v1/feedback` | `Admin` | `200` | 22ms | ✅ |
+| `GET` | `/api/v1/segments` | `Admin` | `200` | 17ms | ✅ |
+| `POST` | `/api/v1/segments` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/segments/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
 | `DELETE` | `/api/v1/segments/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/storefront/banners` | `Public` | `200` | 4ms | ✅ |
-| `GET` | `/api/v1/storefront/banners/all` | `Admin` | `200` | 6ms | ✅ |
-| `POST` | `/api/v1/storefront/banners` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/storefront/banners` | `Public` | `200` | 5ms | ✅ |
+| `GET` | `/api/v1/storefront/banners/all` | `Admin` | `200` | 4ms | ✅ |
+| `POST` | `/api/v1/storefront/banners` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
 | `PUT` | `/api/v1/storefront/banners/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/storefront/banners/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/online-orders` | `Public` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/online-orders` | `Admin` | `200` | 30ms | ✅ |
-| `GET` | `/api/v1/online-orders/1` | `Admin` | `404` | 4ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/online-orders/1/status` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/vendors` | `Admin` | `200` | 26ms | ✅ |
-| `POST` | `/api/v1/vendors` | `Admin` | `201` | 11ms | ✅ |
-| `PUT` | `/api/v1/vendors/1` | `Admin` | `200` | 9ms | ✅ |
-| `GET` | `/api/v1/vendors/1/payouts` | `Admin` | `200` | 12ms | ✅ |
-| `POST` | `/api/v1/vendors/1/payouts` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/warranty` | `Admin` | `200` | 15ms | ✅ |
+| `DELETE` | `/api/v1/storefront/banners/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/online-orders` | `Public` | `400` | 1ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/online-orders` | `Admin` | `200` | 40ms | ✅ |
+| `GET` | `/api/v1/online-orders/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/online-orders/1/status` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/vendors` | `Admin` | `200` | 28ms | ✅ |
+| `POST` | `/api/v1/vendors` | `Admin` | `201` | 12ms | ✅ |
+| `PUT` | `/api/v1/vendors/1` | `Admin` | `200` | 11ms | ✅ |
+| `GET` | `/api/v1/vendors/1/payouts` | `Admin` | `200` | 13ms | ✅ |
+| `POST` | `/api/v1/vendors/1/payouts` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/warranty` | `Admin` | `200` | 12ms | ✅ |
 | `POST` | `/api/v1/warranty` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/warranty/1` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/delivery` | `Admin` | `200` | 13ms | ✅ |
-| `GET` | `/api/v1/delivery/analytics/performance` | `Admin` | `200` | 50ms | ✅ |
-| `GET` | `/api/v1/delivery/1` | `Admin` | `404` | 9ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/delivery` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/warranty/1` | `Admin` | `404` | 14ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/delivery` | `Admin` | `200` | 11ms | ✅ |
+| `GET` | `/api/v1/delivery/analytics/performance` | `Admin` | `200` | 35ms | ✅ |
+| `GET` | `/api/v1/delivery/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/delivery` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
 | `PUT` | `/api/v1/delivery/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
 | `PUT` | `/api/v1/delivery/1/status` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/delivery/1/history` | `Admin` | `200` | 14ms | ✅ |
-| `GET` | `/api/v1/shipping-companies` | `Admin` | `200` | 29ms | ✅ |
-| `POST` | `/api/v1/shipping-companies` | `Admin` | `201` | 12ms | ✅ |
-| `PUT` | `/api/v1/shipping-companies/1` | `Admin` | `200` | 17ms | ✅ |
-| `DELETE` | `/api/v1/shipping-companies/1` | `Admin` | `204` | 11ms | ✅ |
+| `GET` | `/api/v1/delivery/1/history` | `Admin` | `200` | 10ms | ✅ |
+| `GET` | `/api/v1/shipping-companies` | `Admin` | `200` | 20ms | ✅ |
+| `POST` | `/api/v1/shipping-companies` | `Admin` | `201` | 6ms | ✅ |
+| `PUT` | `/api/v1/shipping-companies/1` | `Admin` | `200` | 13ms | ✅ |
+| `DELETE` | `/api/v1/shipping-companies/1` | `Admin` | `204` | 8ms | ✅ |
 | `GET` | `/api/v1/purchase-orders` | `Admin` | `200` | 29ms | ✅ |
-| `GET` | `/api/v1/purchase-orders/1` | `Admin` | `404` | 12ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/purchase-orders` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/purchase-orders/1/status` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/purchase-orders/1/receive` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/purchase-orders/1` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/purchase-orders` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/purchase-orders/1/status` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/purchase-orders/1/receive` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
 | `DELETE` | `/api/v1/purchase-orders/1` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/expenses` | `Admin` | `200` | 16ms | ✅ |
-| `POST` | `/api/v1/expenses` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/expenses/pnl` | `Admin` | `200` | 41ms | ✅ |
-| `PUT` | `/api/v1/expenses/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/expenses/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/analytics/dashboard-all` | `Admin` | `200` | 233ms | ✅ |
-| `GET` | `/api/v1/analytics/dashboard` | `Admin` | `200` | 17ms | ✅ |
-| `GET` | `/api/v1/analytics/revenue` | `Admin` | `200` | 6ms | ✅ |
-| `GET` | `/api/v1/analytics/top-products` | `Admin` | `200` | 41ms | ✅ |
-| `GET` | `/api/v1/analytics/payment-methods` | `Admin` | `200` | 4ms | ✅ |
+| `GET` | `/api/v1/expenses` | `Admin` | `200` | 18ms | ✅ |
+| `POST` | `/api/v1/expenses` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/expenses/pnl` | `Admin` | `200` | 33ms | ✅ |
+| `PUT` | `/api/v1/expenses/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/expenses/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/analytics/dashboard-all` | `Admin` | `200` | 164ms | ✅ |
+| `GET` | `/api/v1/analytics/dashboard` | `Admin` | `200` | 12ms | ✅ |
+| `GET` | `/api/v1/analytics/revenue` | `Admin` | `200` | 5ms | ✅ |
+| `GET` | `/api/v1/analytics/top-products` | `Admin` | `200` | 34ms | ✅ |
+| `GET` | `/api/v1/analytics/payment-methods` | `Admin` | `200` | 5ms | ✅ |
 | `GET` | `/api/v1/analytics/orders-per-day` | `Admin` | `200` | 4ms | ✅ |
-| `GET` | `/api/v1/analytics/cashier-performance` | `Admin` | `200` | 57ms | ✅ |
+| `GET` | `/api/v1/analytics/cashier-performance` | `Admin` | `200` | 51ms | ✅ |
 | `GET` | `/api/v1/analytics/sales-by-category` | `Admin` | `200` | 46ms | ✅ |
-| `GET` | `/api/v1/analytics/sales-by-distributor` | `Admin` | `200` | 44ms | ✅ |
-| `GET` | `/api/v1/analytics/dead-stock` | `Admin` | `200` | 94ms | ✅ |
-| `GET` | `/api/v1/analytics/customer-ltv` | `Admin` | `200` | 75ms | ✅ |
-| `GET` | `/api/v1/analytics/hourly-heatmap` | `Admin` | `200` | 17ms | ✅ |
-| `GET` | `/api/v1/analytics/abc-classification` | `Admin` | `200` | 50ms | ✅ |
-| `GET` | `/api/v1/analytics/reorder-suggestions` | `Admin` | `200` | 56ms | ✅ |
-| `POST` | `/api/v1/analytics/inventory-snapshot` | `Admin` | `201` | 16ms | ✅ |
-| `GET` | `/api/v1/analytics/inventory-snapshots` | `Admin` | `200` | 15ms | ✅ |
-| `GET` | `/api/v1/reports/sales` | `Admin` | `200` | 54ms | ✅ |
-| `GET` | `/api/v1/reports/inventory` | `Admin` | `200` | 64ms | ✅ |
-| `GET` | `/api/v1/reports/profit-loss` | `Admin` | `200` | 54ms | ✅ |
-| `GET` | `/api/v1/exports/products` | `Admin` | `200` | 22ms | ✅ |
-| `GET` | `/api/v1/exports/sales` | `Admin` | `200` | 15ms | ✅ |
-| `GET` | `/api/v1/exports/customers` | `Admin` | `200` | 15ms | ✅ |
-| `GET` | `/api/v1/ai/forecast` | `Admin` | `200` | 19ms | ✅ |
-| `GET` | `/api/v1/ai/recommendations` | `Admin` | `200` | 36ms | ✅ |
-| `GET` | `/api/v1/ai/pricing-suggestions` | `Admin` | `200` | 105ms | ✅ |
-| `GET` | `/api/v1/ai/churn-risk` | `Admin` | `200` | 33ms | ✅ |
-| `GET` | `/api/v1/ai/anomalies` | `Admin` | `200` | 34ms | ✅ |
-| `GET` | `/api/v1/notifications` | `Admin` | `200` | 9ms | ✅ |
-| `GET` | `/api/v1/notifications/unread-count` | `Admin` | `200` | 2ms | ✅ |
+| `GET` | `/api/v1/analytics/sales-by-distributor` | `Admin` | `200` | 42ms | ✅ |
+| `GET` | `/api/v1/analytics/dead-stock` | `Admin` | `200` | 111ms | ✅ |
+| `GET` | `/api/v1/analytics/customer-ltv` | `Admin` | `200` | 98ms | ✅ |
+| `GET` | `/api/v1/analytics/hourly-heatmap` | `Admin` | `200` | 16ms | ✅ |
+| `GET` | `/api/v1/analytics/abc-classification` | `Admin` | `200` | 32ms | ✅ |
+| `GET` | `/api/v1/analytics/reorder-suggestions` | `Admin` | `200` | 57ms | ✅ |
+| `POST` | `/api/v1/analytics/inventory-snapshot` | `Admin` | `201` | 14ms | ✅ |
+| `GET` | `/api/v1/analytics/inventory-snapshots` | `Admin` | `200` | 13ms | ✅ |
+| `GET` | `/api/v1/reports/sales` | `Admin` | `200` | 51ms | ✅ |
+| `GET` | `/api/v1/reports/inventory` | `Admin` | `200` | 28ms | ✅ |
+| `GET` | `/api/v1/reports/profit-loss` | `Admin` | `200` | 39ms | ✅ |
+| `GET` | `/api/v1/exports/products` | `Admin` | `200` | 18ms | ✅ |
+| `GET` | `/api/v1/exports/sales` | `Admin` | `200` | 14ms | ✅ |
+| `GET` | `/api/v1/exports/customers` | `Admin` | `200` | 22ms | ✅ |
+| `GET` | `/api/v1/ai/forecast` | `Admin` | `200` | 42ms | ✅ |
+| `GET` | `/api/v1/ai/recommendations` | `Admin` | `200` | 52ms | ✅ |
+| `GET` | `/api/v1/ai/pricing-suggestions` | `Admin` | `200` | 116ms | ✅ |
+| `GET` | `/api/v1/ai/churn-risk` | `Admin` | `200` | 40ms | ✅ |
+| `GET` | `/api/v1/ai/anomalies` | `Admin` | `200` | 46ms | ✅ |
+| `GET` | `/api/v1/notifications` | `Admin` | `200` | 14ms | ✅ |
+| `GET` | `/api/v1/notifications/unread-count` | `Admin` | `200` | 4ms | ✅ |
 | `PUT` | `/api/v1/notifications/1/read` | `Admin` | `200` | 4ms | ✅ |
-| `PUT` | `/api/v1/notifications/read-all` | `Admin` | `200` | 4ms | ✅ |
+| `PUT` | `/api/v1/notifications/read-all` | `Admin` | `200` | 6ms | ✅ |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -125,8 +125,8 @@ the UI and still reach the total the contract records.
 
 `npm run test:smoke` runs the tag intended for the pull-request gate.
 
-**Budget: under 3 minutes.** Measured at 32s for 7 tests (2 workers, warm build, local
-PostgreSQL) — full suite 27 tests in ~30s at 4 workers. If the smoke subset ever exceeds
+**Budget: under 3 minutes.** Measured at ~35s for 11 tests (2 workers, warm build, local
+PostgreSQL); the full suite is 78 tests in ~1.4 min at 4 workers. If the smoke subset ever exceeds
 the budget, move cases *out* of `@smoke` rather than raising the budget; a PR gate people
 wait on is a PR gate people learn to skip.
 
@@ -158,6 +158,43 @@ Actions artifacts are downloadable by anyone. Against a disposable database seed
 credentials already published in `CLAUDE.md` the live exposure is small, which is exactly
 why it would go unexamined. `e2e/playwright/.auth/` is gitignored and kept outside
 `outputDir` so session state is never swept into an artifact.
+
+## Owning this suite
+
+A post-merge job with no defined response is not a gate, and two thirds of this suite's
+coverage lives behind one. So, explicitly:
+
+- **Who owns it.** Whoever merges a change that turns `e2e-full` red on `main` owns getting
+  it green — by fix or by revert, same day. It is not "the test suite's" problem.
+- **What counts as flaky.** A spec that fails on `main` without a code change, more than
+  once in ten runs, is flaky. Fix it or delete it; **do not `test.skip` it**. A skipped
+  money spec is worse than a missing one, because the suite still reports green.
+- **When `e2e-full` is red.** Treat it as a blocked deploy until someone has looked. The
+  suite exists to catch double-charges and lost sales; "probably flaky" is not a diagnosis.
+- **When `@smoke` is red on a PR.** It is a real gate. Do not merge past it.
+
+## Known findings
+
+Things this suite established that are worth acting on, recorded here so they are not
+rediscovered from scratch:
+
+- **Offline sales are not persisted.** `queryClient` sets no `networkMode`, so React Query
+  pauses a mutation fired while `navigator.onLine` is false rather than failing it. No
+  request goes out, `onError` never runs, and `CartPanel`'s offline fallback — the only
+  writer to `moon-offline-queue` — is unreachable. The sale resumes and completes on
+  reconnect if the tab stays open, but does not survive a reload. See
+  `specs/offline.spec.ts`.
+- **A Cashier cannot attach a customer to a sale.** `GET /api/v1/customers` is Admin-only
+  while `POST /customers` and the loyalty read allow Cashier, so loyalty redemption is not
+  reachable from a real till. Pinned in `specs/tax-loyalty.spec.ts`.
+- **The checkout drawer's layout is fragile.** Its confirm button lives at the end of a
+  flex-column scrolling body inside a `w-screen overflow-x-auto` wrapper. It was compressed
+  to zero height until `shrink-0` was added, and its layout position still sits about a
+  viewport width right of the visible area, which is why the offline specs dispatch the
+  click rather than performing one.
+- **`Idempotent-Replay` is not readable cross-origin.** The server sets it, but `cors()`
+  declares no `exposedHeaders`. No client code reads it today; anything that wants to will
+  need the header exposed.
 
 ## Not covered
 

--- a/e2e/fixtures/coupon.ts
+++ b/e2e/fixtures/coupon.ts
@@ -1,0 +1,55 @@
+/**
+ * Worker-namespaced coupons.
+ *
+ * `max_uses` counting is guarded server-side with `SELECT ... FOR UPDATE` on `coupons`,
+ * so a coupon shared between workers would have its usage count perturbed by whoever else
+ * happened to redeem it. Every coupon here belongs to exactly one test.
+ */
+import type { APIRequestContext } from '@playwright/test';
+import { API_BASE } from './seed';
+
+export interface CouponSeed {
+  type?: 'percentage' | 'fixed';
+  value: number;
+  maxUses?: number;
+  expiresAt?: string;
+  minPurchase?: number;
+}
+
+export interface Coupon {
+  id: number;
+  code: string;
+  type: string;
+  value: number | string;
+}
+
+/**
+ * Codes are uppercased and trimmed by the server's own schema, so the code this returns
+ * is what the server stored — not what was sent.
+ */
+export async function createCoupon(
+  request: APIRequestContext,
+  namespace: string,
+  label: string,
+  seed: CouponSeed
+): Promise<Coupon> {
+  const code = `${namespace}-${label}-${Math.random().toString(36).slice(2, 7)}`
+    .toUpperCase()
+    .slice(0, 50);
+
+  const response = await request.post(`${API_BASE}/coupons`, {
+    data: {
+      code,
+      type: seed.type ?? 'fixed',
+      value: seed.value,
+      ...(seed.maxUses !== undefined ? { max_uses: seed.maxUses } : {}),
+      ...(seed.expiresAt !== undefined ? { expires_at: seed.expiresAt } : {}),
+      ...(seed.minPurchase !== undefined ? { min_purchase: seed.minPurchase } : {}),
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`create coupon ${code} failed: ${response.status()} ${await response.text()}`);
+  }
+  return ((await response.json()) as { data: Coupon }).data;
+}

--- a/e2e/fixtures/customer.ts
+++ b/e2e/fixtures/customer.ts
@@ -1,0 +1,66 @@
+/**
+ * A namespaced customer with a known loyalty balance.
+ *
+ * Loyalty needs one and no other fixture creates one: points live on
+ * `customers.loyalty_points`, and the sale service refuses redemption outright without a
+ * customer, while every other spec in the suite rings up anonymous sales.
+ *
+ * `customers.phone` is `UNIQUE NOT NULL`, so the phone is namespaced too — a hardcoded
+ * test number collides across re-runs and with anything a parallel worker left behind,
+ * even though this fixture is only used from the serial project.
+ */
+import type { APIRequestContext } from '@playwright/test';
+import { API_BASE } from './seed';
+
+export interface Customer {
+  id: number;
+  name: string;
+  phone: string;
+  loyalty_points?: number;
+}
+
+export async function createCustomer(
+  request: APIRequestContext,
+  namespace: string,
+  label: string
+): Promise<Customer> {
+  const unique = `${namespace}-${label}-${Date.now().toString(36)}`;
+  // Digits only, and namespaced by a monotonic clock plus randomness so two runs cannot
+  // generate the same number.
+  const phone = `01${String(Date.now()).slice(-9)}${Math.floor(Math.random() * 10)}`;
+
+  const response = await request.post(`${API_BASE}/customers`, {
+    data: { name: unique, phone },
+  });
+  if (!response.ok()) {
+    throw new Error(`create customer failed: ${response.status()} ${await response.text()}`);
+  }
+  return ((await response.json()) as { data: Customer }).data;
+}
+
+/** Credits a known starting balance. Admin-only, and the only way to seed points. */
+export async function grantLoyaltyPoints(
+  request: APIRequestContext,
+  customerId: number,
+  points: number
+): Promise<number> {
+  const response = await request.post(`${API_BASE}/customers/${customerId}/loyalty/adjust`, {
+    data: { points, note: 'e2e seed' },
+  });
+  if (!response.ok()) {
+    throw new Error(`loyalty adjust failed: ${response.status()} ${await response.text()}`);
+  }
+  return ((await response.json()) as { data: { loyalty_points: number } }).data.loyalty_points;
+}
+
+export async function readLoyaltyPoints(
+  request: APIRequestContext,
+  customerId: number
+): Promise<number> {
+  const response = await request.get(`${API_BASE}/customers/${customerId}/loyalty`);
+  if (!response.ok()) {
+    throw new Error(`read loyalty failed: ${response.status()} ${await response.text()}`);
+  }
+  const body = (await response.json()) as { data: { loyalty_points?: number; points?: number } };
+  return body.data.loyalty_points ?? body.data.points ?? 0;
+}

--- a/e2e/fixtures/settings.ts
+++ b/e2e/fixtures/settings.ts
@@ -1,0 +1,51 @@
+/**
+ * Set-and-restore for the global settings rows (D5).
+ *
+ * Only `tax-loyalty.spec.ts` may use this, and only from the serial `pos-settings`
+ * project. Tax and loyalty are not per-sale inputs: `CartPanel` reads them from
+ * `appSettings`, and `PUT /api/v1/settings` writes rows every worker shares. A write from
+ * a parallel worker silently changes the totals every other worker is asserting on.
+ *
+ * **A settings write is not visible to an already-loaded page.** The server holds no
+ * cache, so a `PUT` is instantly visible over HTTP — but the client reads settings through
+ * `useApiQuery(['settings'])` under a five-minute `staleTime`, so a page loaded before the
+ * write keeps rendering and submitting under the *old* settings. The consequence is
+ * exactly inverted from what a reader expects: the inclusive-tax case, the one most likely
+ * to be silently wrong, becomes the one most likely to silently *pass*. Every write here
+ * is therefore followed by a reload before any assertion.
+ */
+import type { APIRequestContext } from '@playwright/test';
+import { API_BASE } from './seed';
+import { SETTINGS_BASELINE } from '../support/settingsBaseline';
+
+export type SettingsMap = Record<string, string>;
+
+export async function readSettings(request: APIRequestContext): Promise<SettingsMap> {
+  const response = await request.get(`${API_BASE}/settings`);
+  if (!response.ok()) {
+    throw new Error(`GET settings failed: ${response.status()} ${await response.text()}`);
+  }
+  return ((await response.json()) as { data: SettingsMap }).data;
+}
+
+/** Admin-only. A non-Admin token must fail loudly rather than proceed under old settings. */
+export async function writeSettings(
+  request: APIRequestContext,
+  values: SettingsMap
+): Promise<void> {
+  const response = await request.put(`${API_BASE}/settings`, { data: values });
+  if (!response.ok()) {
+    throw new Error(`PUT settings failed: ${response.status()} ${await response.text()}`);
+  }
+}
+
+/**
+ * Restores every baseline key.
+ *
+ * Written to run in `afterAll` **including on failure**: a spec that dies mid-file without
+ * restoring leaves the database in inclusive-tax mode for the next run, and that failure
+ * is far more expensive to diagnose than whatever bug was being chased.
+ */
+export async function restoreBaseline(request: APIRequestContext): Promise<void> {
+  await writeSettings(request, { ...SETTINGS_BASELINE });
+}

--- a/e2e/fixtures/storage.ts
+++ b/e2e/fixtures/storage.ts
@@ -25,10 +25,16 @@ import type { AuthUser } from './types';
 import {
   AUTH_STORAGE_KEY,
   HELD_CARTS_STORAGE_KEY,
+  OFFLINE_QUEUE_STORAGE_KEY,
   SETTINGS_STORAGE_KEY,
 } from '../../client/src/shared/lib/storageKeys';
 
-export { AUTH_STORAGE_KEY, HELD_CARTS_STORAGE_KEY, SETTINGS_STORAGE_KEY };
+export {
+  AUTH_STORAGE_KEY,
+  HELD_CARTS_STORAGE_KEY,
+  OFFLINE_QUEUE_STORAGE_KEY,
+  SETTINGS_STORAGE_KEY,
+};
 
 /**
  * Not in `storageKeys.ts`: it is a `sessionStorage` key private to `StartupPrompt.tsx`,

--- a/e2e/fixtures/storage.ts
+++ b/e2e/fixtures/storage.ts
@@ -22,9 +22,13 @@ import type { AuthUser } from './types';
  * rather than "the key changed". `support/i18n.ts` crosses the same boundary the same
  * way for the translation catalogs.
  */
-import { AUTH_STORAGE_KEY, SETTINGS_STORAGE_KEY } from '../../client/src/shared/lib/storageKeys';
+import {
+  AUTH_STORAGE_KEY,
+  HELD_CARTS_STORAGE_KEY,
+  SETTINGS_STORAGE_KEY,
+} from '../../client/src/shared/lib/storageKeys';
 
-export { AUTH_STORAGE_KEY, SETTINGS_STORAGE_KEY };
+export { AUTH_STORAGE_KEY, HELD_CARTS_STORAGE_KEY, SETTINGS_STORAGE_KEY };
 
 /**
  * Not in `storageKeys.ts`: it is a `sessionStorage` key private to `StartupPrompt.tsx`,

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -85,9 +85,17 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   workerCashier: [
     async ({ adminApi }, use, workerInfo) => {
       const index = workerInfo.workerIndex;
-      const namespace = `e2e-w${index}`;
+      /**
+       * Namespaced by run as well as worker. `--shard` is a separate Playwright process
+       * per shard and `workerIndex` restarts at 0 in each, so shard 1's worker 0 and
+       * shard 2's worker 0 would otherwise both claim `e2e-w0@moon.test` — and
+       * `users.email` is UNIQUE, so the loser fails with a confusing 409 mid-run.
+       * CI sets E2E_RUN_ID per shard; locally it is absent and the name is unchanged.
+       */
+      const runId = process.env.E2E_RUN_ID?.trim();
+      const namespace = runId ? `e2e-${runId}w${index}` : `e2e-w${index}`;
       const email = `${namespace}@moon.test`;
-      const name = `E2E Worker ${index}`;
+      const name = `E2E Worker ${runId ? `${runId}/` : ''}${index}`;
 
       /**
        * Refresh tokens are `jwt.sign({ id }, …, { expiresIn: '7d' })` — user id plus

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -60,6 +60,18 @@ export interface TestFixtures {
   };
   /** Mints a product owned by this test, namespaced so no other spec can see it. */
   seedProduct: (label: string, seed?: ProductSeed) => Promise<Product>;
+  /**
+   * A browser context signed in as the seeded Admin, reusing the setup project's
+   * storage state so no second login is needed (issue #62).
+   *
+   * Needed only where a path is genuinely Admin-gated. `GET /api/v1/customers` is one:
+   * a Cashier can create a customer and read their loyalty balance but cannot *search*
+   * for one, so attaching a customer to a sale — and therefore loyalty redemption — is
+   * not reachable from a cashier's till. That asymmetry looks like an oversight rather
+   * than a policy, but widening an authorization rule is not this suite's call, so the
+   * loyalty specs drive it as Admin and `tax-loyalty.spec.ts` pins the gap explicitly.
+   */
+  adminContext: BrowserContext;
 }
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
@@ -271,6 +283,14 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     // Deliberately NOT dismissing the startup prompt — this fixture exists to face it.
 
     await use({ context, id: cashier.id, email, accessToken: session.accessToken });
+    await context.close();
+  },
+
+  adminContext: async ({ browser, appLocale }, use) => {
+    const context = await browser.newContext({ storageState: adminStatePath });
+    await seedLocale(context, appLocale);
+    await dismissStartupPrompt(context);
+    await use(context);
     await context.close();
   },
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,6 +6,7 @@ import {
   E2E_SERVER_APP_NAME,
   PREVIEW_PORT,
   SERVER_DIR,
+  TEST_JWT_ENV,
   requireE2eDatabaseUrl,
 } from './support/config';
 
@@ -41,11 +42,8 @@ const serverEnv: Record<string, string> = {
   // bucket. The binding constraint is the auth ceiling of 10, not the global 200.
   RATE_LIMIT_MAX: '100000',
   AUTH_RATE_LIMIT_MAX: '100000',
-  // The same literals `.github/workflows/ci.yml`'s server job uses, so one rotation
-  // covers both. Deliberately not repository secrets: this is a throwaway server on a
-  // disposable database whose seeded credentials are already published in CLAUDE.md.
-  JWT_SECRET: 'ci-jwt-secret-key-at-least-32-characters-long',
-  JWT_REFRESH_SECRET: 'ci-jwt-refresh-secret-key-at-least-32-chars',
+  // Shared with the migrate/seed child processes in `globalSetup` — see TEST_JWT_ENV.
+  ...TEST_JWT_ENV,
 };
 
 export default defineConfig({

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -53,6 +53,16 @@ export default defineConfig({
   outputDir: './test-results',
   globalSetup: './support/globalSetup.ts',
 
+  /**
+   * Generous next to a unit suite, and deliberately so. Every assertion here waits on a
+   * real browser rendering a real production bundle against a real server and database,
+   * under whatever parallel load the run has. The default 5s expect timeout produced
+   * timeouts that looked like application bugs but were pure contention — a slow machine
+   * is not a failing till.
+   */
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -74,6 +84,8 @@ export default defineConfig({
      * behavior is explicitly out of scope — see README.md.
      */
     serviceWorkers: 'block',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
     trace: 'on-first-retry',
     video: 'retain-on-failure',
     screenshot: 'only-on-failure',

--- a/e2e/scripts/assertSmokeTestsRan.mjs
+++ b/e2e/scripts/assertSmokeTestsRan.mjs
@@ -1,0 +1,56 @@
+/**
+ * CI guard: fail the build if the `@smoke` subset matched nothing.
+ *
+ * `--grep @smoke` filters by title. A typo in a tag, a renamed describe block, or a spec
+ * file that stops being collected turns the pull-request gate into a green no-op that
+ * runs zero tests — the failure mode most likely to go unnoticed for months, because
+ * every signal it produces looks like success.
+ *
+ * Same instinct as `server/scripts/assertRealPostgresSuitesRan.mjs`, applied to a tag
+ * rather than to a `describe` wrapper.
+ */
+import fs from 'fs';
+
+const reportPath = process.argv[2];
+/** Raised deliberately when specs are added; lowered only with a reason. */
+const MINIMUM_SMOKE_TESTS = Number(process.argv[3] ?? '5');
+
+if (!reportPath || !fs.existsSync(reportPath)) {
+  console.error(`[e2e-guard] Playwright JSON report not found at "${reportPath}".`);
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+} catch (err) {
+  console.error(`[e2e-guard] Could not parse "${reportPath}": ${err.message}`);
+  process.exit(1);
+}
+
+/** Playwright nests suites arbitrarily deep; collect every spec leaf. */
+function collectSpecs(suites, found = []) {
+  for (const suite of suites ?? []) {
+    for (const spec of suite.specs ?? []) found.push(spec);
+    collectSpecs(suite.suites, found);
+  }
+  return found;
+}
+
+const specs = collectSpecs(report.suites);
+const executed = specs.filter((spec) => (spec.tests ?? []).some((t) => t.status !== 'skipped'));
+
+if (executed.length < MINIMUM_SMOKE_TESTS) {
+  console.error(
+    [
+      `[e2e-guard] The @smoke subset ran ${executed.length} test(s); at least ` +
+        `${MINIMUM_SMOKE_TESTS} were expected.`,
+      '',
+      'A green run of zero tests is not a passing gate. The usual causes are a renamed or',
+      'mistyped @smoke tag, or a spec file that is no longer collected.',
+    ].join('\n')
+  );
+  process.exit(1);
+}
+
+console.log(`[e2e-guard] @smoke ran ${executed.length} test(s).`);

--- a/e2e/specs/cart-operations.spec.ts
+++ b/e2e/specs/cart-operations.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * Cart changes (R1) and held-cart persistence (R9).
+ *
+ * Held carts are the sharpest thing in this file. A suspended cart — items, discount,
+ * notes, tip and coupon code — lives only in `moon-held-carts` in the browser, with no
+ * server record at all. That is exactly the shape a jsdom test proves in isolation and a
+ * real browser breaks across a reload, and losing one is a real money loss for a cashier
+ * mid-order.
+ */
+import {
+  completeSaleAndReadId,
+  countSalesForCashier,
+  money,
+  readStock,
+} from '../support/assertSale';
+import { formatMoneyMinor } from '../support/money';
+import {
+  cartPanel,
+  checkoutDrawer,
+  footerDiscount,
+  heldCarts,
+  posPage,
+  receiptDialog,
+  reviewBanner,
+} from '../support/locators';
+import { HELD_CARTS_STORAGE_KEY } from '../fixtures/storage';
+import { expect, test } from '../fixtures/test';
+import type { Page } from '@playwright/test';
+
+interface HeldCartEntry {
+  id: string;
+  name: string;
+  items: Array<{ product_id: number; quantity: number }>;
+  discount: number;
+  discountType: string;
+  notes: string;
+  tip: number;
+  couponCode: string;
+}
+
+/** The persisted store, read from the browser rather than inferred from the rendering. */
+async function readHeldCarts(page: Page): Promise<HeldCartEntry[]> {
+  const raw = await page.evaluate(
+    (key) => window.localStorage.getItem(key),
+    HELD_CARTS_STORAGE_KEY
+  );
+  if (!raw) return [];
+  return (JSON.parse(raw) as { state?: { carts?: HeldCartEntry[] } }).state?.carts ?? [];
+}
+
+async function addToCart(page: Page, sku: string, productId: number) {
+  await posPage(page).search.fill(sku);
+  await posPage(page).productCard(sku).click();
+  await expect(cartPanel(page).quantity(productId)).toHaveText('1');
+}
+
+test.describe('cart quantity and removal', () => {
+  test('quantity changes move the line total and the cart total together', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('qty', { price: 25, stock: 10 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const cart = cartPanel(page);
+    await addToCart(page, product.sku, product.id);
+
+    await cart.increaseQuantity(product.id).click();
+    await expect(cart.quantity(product.id)).toHaveText('2');
+    await expect(cart.total).toHaveText(formatMoneyMinor(5000));
+
+    await cart.decreaseQuantity(product.id).click();
+    await expect(cart.quantity(product.id)).toHaveText('1');
+    await expect(cart.total).toHaveText(formatMoneyMinor(2500));
+  });
+
+  test('quantity cannot be raised past available stock', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('stockcap', { price: 10, stock: 2 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const cart = cartPanel(page);
+    await addToCart(page, product.sku, product.id);
+
+    await cart.increaseQuantity(product.id).click();
+    await expect(cart.quantity(product.id)).toHaveText('2');
+
+    // The control disables at the stock ceiling rather than letting the cart oversell.
+    await expect(cart.increaseQuantity(product.id)).toBeDisabled();
+  });
+});
+
+test.describe('held carts', () => {
+  test('holding clears the active cart, lists the held one, and creates no sale', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('hold', { price: 70, stock: 6 });
+    const stockBefore = await readStock(product.id);
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const cart = cartPanel(page);
+    const held = heldCarts(page);
+
+    await addToCart(page, product.sku, product.id);
+    await held.hold.click();
+
+    // The heading is the precise signal: exactly zero lines, not "some empty text exists".
+    await expect(cart.heading(0)).toBeVisible();
+
+    const stored = await readHeldCarts(page);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.items[0]).toMatchObject({ product_id: product.id, quantity: 1 });
+
+    // R9: holding is not selling. No sale row, no stock movement.
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore);
+    expect(await readStock(product.id)).toBe(stockBefore);
+  });
+
+  test('a held cart carries its discount, tip, notes and coupon code', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('holdextras', { price: 200, stock: 6 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await addToCart(page, product.sku, product.id);
+
+    const footer = footerDiscount(page);
+    await footer.fixedMode.click();
+    await footer.amount.fill('20');
+
+    await heldCarts(page).hold.click();
+
+    const [stored] = await readHeldCarts(page);
+    expect(stored?.discount).toBe(20);
+    expect(stored?.discountType).toBe('fixed');
+    // Present even when empty — the shape is what a resume depends on.
+    expect(stored).toHaveProperty('notes');
+    expect(stored).toHaveProperty('tip');
+    expect(stored).toHaveProperty('couponCode');
+  });
+
+  test('held carts survive a full page reload', async ({ cashierContext, seedProduct }) => {
+    const product = await seedProduct('holdreload', { price: 45, stock: 6 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await addToCart(page, product.sku, product.id);
+    await heldCarts(page).hold.click();
+
+    const before = await readHeldCarts(page);
+    expect(before).toHaveLength(1);
+
+    // The assertion that matters: a cashier who refreshes must not lose a suspended order.
+    await page.reload();
+    const after = await readHeldCarts(page);
+    expect(after).toHaveLength(1);
+    expect(after[0]?.id).toBe(before[0]?.id);
+    expect(after[0]?.items[0]).toMatchObject({ product_id: product.id, quantity: 1 });
+  });
+
+  test('two carts held in succession get distinct entries', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const first = await seedProduct('hold1', { price: 15, stock: 6 });
+    const second = await seedProduct('hold2', { price: 35, stock: 6 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const held = heldCarts(page);
+
+    await addToCart(page, first.sku, first.id);
+    await held.hold.click();
+    await addToCart(page, second.sku, second.id);
+    await held.hold.click();
+
+    const stored = await readHeldCarts(page);
+    expect(stored).toHaveLength(2);
+    expect(stored[0]?.id).not.toBe(stored[1]?.id);
+    expect(stored.map((c) => c.items[0]?.product_id).sort()).toEqual([first.id, second.id].sort());
+  });
+
+  test('holding an empty cart is refused', async ({ cashierContext }) => {
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    await expect(cartPanel(page).empty).toBeVisible();
+    // Disabled rather than creating a meaningless empty entry.
+    await expect(heldCarts(page).hold).toBeDisabled();
+    expect(await readHeldCarts(page)).toHaveLength(0);
+  });
+
+  test('a resumed cart must be acknowledged, then checks out to the same total', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    const product = await seedProduct('resume', { price: 90, stock: 6 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    const cart = cartPanel(page);
+    const held = heldCarts(page);
+
+    await addToCart(page, product.sku, product.id);
+    await expect(cart.total).toHaveText(formatMoneyMinor(9000));
+    await held.hold.click();
+    await expect(cart.empty).toBeVisible();
+
+    await held.open.click();
+    await expect(held.dialog).toBeVisible();
+    await held.retrieve.first().click();
+
+    // The items come back...
+    await expect(cart.line(product.id)).toBeVisible();
+    await expect(cart.total).toHaveText(formatMoneyMinor(9000));
+    // ...and the held entry is consumed, not duplicated.
+    await expect.poll(() => readHeldCarts(page).then((c) => c.length)).toBe(0);
+
+    // `restoreFromHeld` always sets needsReview, which blocks checkout *silently* in
+    // `handleCheckout`. Asserting the gate is what stops a later spec from mistaking a
+    // no-op confirm for a completed sale.
+    const review = reviewBanner(page);
+    await expect(review.warning).toBeVisible();
+    await expect(cart.checkout).toBeDisabled();
+
+    await review.acknowledge.click();
+    await expect(cart.checkout).toBeEnabled();
+
+    await cart.checkout.click();
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+
+    const sale = await (
+      await import('../support/assertSale')
+    ).fetchSale(request, workerCashier.accessToken, saleId);
+    expect(money(sale.total)).toBe(90);
+  });
+});

--- a/e2e/specs/duplicate-submit.spec.ts
+++ b/e2e/specs/duplicate-submit.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * R8: prove in a real browser that a double interaction cannot create two sales.
+ *
+ * This is the coverage the plan exists for. The server's idempotency invariants are
+ * already proven at the service layer against real PostgreSQL; what nothing proved is
+ * whether the *browser* attaches `Idempotency-Key` at all. A server-side test supplies the
+ * header itself and so can never detect its absence.
+ *
+ * **Which cases are cashier-reachable, and which are server-contract only.** The key is
+ * derived from a payload fingerprint (`idempotencyKeyFor`): the stored key is reused only
+ * while `JSON.stringify(saleData)` matches the previous attempt, and a changed cart mints
+ * a fresh one. So the till can never send one key with a different payload, and
+ * `IDEMPOTENCY_KEY_REUSED` is unreachable through any cashier interaction. Those cases are
+ * still worth keeping, but they are driven by raw `fetch` and labelled as such — a later
+ * reader must not mistake them for proof of UI behaviour the UI does not have.
+ */
+import { completeSaleAndReadId, countSalesForCashier, readStock } from '../support/assertSale';
+import { cartPanel, checkoutDrawer, posPage, receiptDialog } from '../support/locators';
+import { countPosts, gateResponses } from '../support/network';
+import { dbQuery } from '../support/db';
+import { API_BASE } from '../fixtures/seed';
+import { expect, test } from '../fixtures/test';
+
+const SALES_PATH = '/api/v1/sales';
+
+test.describe('duplicate submission @smoke', () => {
+  test('two rapid confirm clicks produce exactly one sale', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('double', { price: 55, stock: 10 });
+    const stockBefore = await readStock(product.id);
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+
+    const posts = countPosts(page, SALES_PATH);
+    const gate = await gateResponses(page, SALES_PATH);
+
+    // First click starts the request; the gate holds the response open so the second
+    // click lands while it is genuinely in flight.
+    await drawer.confirm.click();
+    await gate.waitForFirst();
+
+    // `confirmAny`, not `confirm`: the label has already swapped to "Processing…", so the
+    // strict-name locator no longer matches and this would wait out its own timeout
+    // instead of testing the guard. `force` for the same reason — a correctly-disabled
+    // button must not block the click on actionability.
+    await drawer.confirmAny.click({ force: true, timeout: 3000 }).catch(() => {});
+
+    await gate.release();
+    await expect(receiptDialog(page).dialog).toBeVisible();
+
+    // Exactly one POST on the wire...
+    await expect.poll(() => posts.count()).toBe(1);
+    posts.stop();
+
+    // ...exactly one row, and stock moved once.
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore + 1);
+    expect(await readStock(product.id)).toBe(stockBefore - 1);
+  });
+
+  test('every checkout POST carries an Idempotency-Key', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    // The single assertion a server-side test can never make. Strip the header from
+    // `transport/http.ts` and this fails; without it the suite would prove nothing about
+    // the browser's half of the idempotency contract.
+    const product = await seedProduct('idemheader', { price: 33, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+
+    const posts = countPosts(page, SALES_PATH);
+    await completeSaleAndReadId(page, workerCashier.id, drawer.confirm, receiptDialog(page).dialog);
+
+    expect(posts.count()).toBe(1);
+    const key = posts.headers()[0]?.['idempotency-key'];
+    expect(key, 'the checkout POST must carry an Idempotency-Key').toBeTruthy();
+    posts.stop();
+
+    // And the server recorded exactly one claim for it.
+    const rows = await dbQuery('SELECT key FROM idempotency_keys WHERE key = $1', [key]);
+    expect(rows).toHaveLength(1);
+  });
+});
+
+/**
+ * Server-contract assertions, driven by raw `fetch` from inside the page so the session
+ * and cookies are real. **None of these is reachable through the till** — see the file
+ * header — and treating them as UI coverage would be a mistake.
+ */
+test.describe('idempotency contract (raw fetch, not cashier-reachable)', () => {
+  test('two concurrent requests with one key return the same sale, replayed once', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('concurrent', { price: 20, stock: 10 });
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    const result = await page.evaluate(
+      async ({ base, token, productId, key }) => {
+        const body = JSON.stringify({
+          items: [{ product_id: productId, quantity: 1, unit_price: 20 }],
+          payment_method: 'Cash',
+        });
+        const send = () =>
+          fetch(`${base}/sales`, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              Authorization: `Bearer ${token}`,
+              'Idempotency-Key': key,
+            },
+            body,
+          }).then(async (r) => ({
+            status: r.status,
+            replay: r.headers.get('Idempotent-Replay'),
+            body: await r.json(),
+          }));
+        return Promise.all([send(), send()]);
+      },
+      {
+        base: API_BASE,
+        token: workerCashier.accessToken,
+        productId: product.id,
+        key: `e2e-concurrent-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      }
+    );
+
+    const ids = result.map((r) => r.body?.data?.id ?? r.body?.data?.sale?.id);
+    expect(new Set(ids.filter(Boolean)).size, 'both requests describe one sale').toBe(1);
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore + 1);
+  });
+
+  test('the same key with a different payload is refused as IDEMPOTENCY_KEY_REUSED', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('reuse', { price: 20, stock: 10 });
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    const key = `e2e-reuse-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const second = await page.evaluate(
+      async ({ base, token, productId, key: idemKey }) => {
+        const post = (quantity: number) =>
+          fetch(`${base}/sales`, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              Authorization: `Bearer ${token}`,
+              'Idempotency-Key': idemKey,
+            },
+            body: JSON.stringify({
+              items: [{ product_id: productId, quantity, unit_price: 20 }],
+              payment_method: 'Cash',
+            }),
+          }).then(async (r) => ({ status: r.status, body: await r.json() }));
+
+        await post(1);
+        return post(2);
+      },
+      { base: API_BASE, token: workerCashier.accessToken, productId: product.id, key }
+    );
+
+    expect(second.status).toBe(409);
+    expect(JSON.stringify(second.body)).toContain('IDEMPOTENCY_KEY_REUSED');
+  });
+
+  test('a replay does not re-fire side effects', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    // The assertion that matters most for money: a replayed response must not decrement
+    // stock again or move the register a second time.
+    const product = await seedProduct('replay', { price: 20, stock: 10 });
+    const stockBefore = await readStock(product.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    const key = `e2e-replay-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const responses = await page.evaluate(
+      async ({ base, token, productId, key: idemKey }) => {
+        const post = () =>
+          fetch(`${base}/sales`, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              Authorization: `Bearer ${token}`,
+              'Idempotency-Key': idemKey,
+            },
+            body: JSON.stringify({
+              items: [{ product_id: productId, quantity: 2, unit_price: 20 }],
+              payment_method: 'Cash',
+            }),
+          }).then(async (r) => ({
+            status: r.status,
+            replay: r.headers.get('Idempotent-Replay'),
+            body: await r.json(),
+          }));
+
+        const first = await post();
+        const replayed = await post();
+        return { first, replayed };
+      },
+      { base: API_BASE, token: workerCashier.accessToken, productId: product.id, key }
+    );
+
+    // The `Idempotent-Replay` header is set by the server but is NOT readable here: the
+    // browser is on the preview origin and `cors()` declares no `exposedHeaders`, so a
+    // cross-origin response's custom headers are hidden from JS. No client code reads it
+    // today, so this is a constraint on the test rather than a defect — but any future
+    // feature that wants it will need the header exposed. Assert the substance instead:
+    // both requests succeeded and the side effects happened exactly once.
+    expect(responses.first.status).toBeLessThan(300);
+    expect(responses.replayed.status).toBeLessThan(300);
+    expect(responses.replayed.body?.data?.id ?? responses.replayed.body?.data?.sale?.id).toBe(
+      responses.first.body?.data?.id ?? responses.first.body?.data?.sale?.id
+    );
+
+    // Stock moved once for two identical requests.
+    expect(await readStock(product.id)).toBe(stockBefore - 2);
+
+    const rows = await dbQuery('SELECT key FROM idempotency_keys WHERE key = $1', [key]);
+    expect(rows, 'exactly one claim row for the key').toHaveLength(1);
+  });
+
+  test('a failed mutation releases its key so a corrected retry succeeds', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    // The documented "a key identifies a committed outcome" semantic. Regressing it would
+    // strand a cashier whose first attempt was rejected.
+    const product = await seedProduct('release', { price: 20, stock: 1 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    const key = `e2e-release-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const result = await page.evaluate(
+      async ({ base, token, productId, key: idemKey }) => {
+        const post = (quantity: number) =>
+          fetch(`${base}/sales`, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              Authorization: `Bearer ${token}`,
+              'Idempotency-Key': idemKey,
+            },
+            body: JSON.stringify({
+              items: [{ product_id: productId, quantity, unit_price: 20 }],
+              payment_method: 'Cash',
+            }),
+          }).then(async (r) => ({ status: r.status, body: await r.json() }));
+
+        // Oversell first — the server must reject it and release the key.
+        const failed = await post(99);
+        // Then the same key with a payload that fits the stock.
+        const corrected = await post(1);
+        return { failed, corrected };
+      },
+      { base: API_BASE, token: workerCashier.accessToken, productId: product.id, key }
+    );
+
+    expect(result.failed.status, 'the oversell must be rejected').toBeGreaterThanOrEqual(400);
+    expect(result.corrected.status, 'the corrected retry must succeed').toBeLessThan(300);
+  });
+});

--- a/e2e/specs/failures.spec.ts
+++ b/e2e/specs/failures.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * R3's rejection paths and R9's recovery guarantee.
+ *
+ * The assertion that matters most here is the boring one: **after every rejection the cart
+ * still holds its lines.** A till that silently empties on a failed sale makes the cashier
+ * re-ring the whole order, which is a worse outcome than the original error — and it is
+ * the kind of regression that no unit test notices because the cart store is fine in
+ * isolation. Every error case below asserts preservation explicitly rather than relying
+ * on it implicitly.
+ *
+ * Oversell is created for real rather than mocked: the server's guarded relative write is
+ * what must reject it. Only the 5xx and network-abort cases use route interception, where
+ * producing a genuine server fault is not practical.
+ */
+import { countSalesForCashier, money, readStock } from '../support/assertSale';
+import { cartPanel, checkoutDrawer, posPage, receiptDialog } from '../support/locators';
+import { formatMoneyMinor } from '../support/money';
+import { dbOne } from '../support/db';
+import { API_BASE, getJson } from '../fixtures/seed';
+import { expect, test } from '../fixtures/test';
+import type { Page } from '@playwright/test';
+
+const SALES_PATH = '/api/v1/sales';
+
+async function ringUpAndOpenDrawer(page: Page, sku: string, productId: number) {
+  await page.goto('/pos');
+  await posPage(page).search.fill(sku);
+  await posPage(page).productCard(sku).click();
+  await expect(cartPanel(page).quantity(productId)).toHaveText('1');
+  await cartPanel(page).checkout.click();
+  const drawer = checkoutDrawer(page);
+  await expect(drawer.dialog).toBeVisible();
+  return drawer;
+}
+
+/** Consumes stock out of band, the way a second till would. */
+async function consumeStock(
+  request: Parameters<typeof getJson>[0],
+  token: string,
+  productId: number,
+  quantity: number,
+  unitPrice: number
+) {
+  const response = await request.post(`${API_BASE}/sales`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      items: [{ product_id: productId, quantity, unit_price: unitPrice }],
+      payment_method: 'Cash',
+    },
+  });
+  if (!response.ok()) {
+    throw new Error(`out-of-band consume failed: ${response.status()} ${await response.text()}`);
+  }
+}
+
+test.describe('stock conflicts', () => {
+  test('a sale for exactly the available stock succeeds and leaves zero', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('exact', { price: 40, stock: 1 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUpAndOpenDrawer(page, product.sku, product.id);
+
+    await drawer.confirm.click();
+    await expect(receiptDialog(page).dialog).toBeVisible();
+
+    expect(await readStock(product.id)).toBe(0);
+    void workerCashier;
+  });
+
+  test('stock consumed between add and checkout is rejected, and the cart survives', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    // The real race, created for real: one unit, in the cart, then taken by someone else.
+    const product = await seedProduct('oversell', { price: 40, stock: 1 });
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUpAndOpenDrawer(page, product.sku, product.id);
+
+    await consumeStock(request, workerCashier.accessToken, product.id, 1, 40);
+    expect(await readStock(product.id)).toBe(0);
+
+    await drawer.confirm.click();
+
+    // The receipt must NOT appear — that is the cashier-visible signal of rejection.
+    await expect(receiptDialog(page).dialog).toBeHidden();
+
+    // Stock never goes negative, and the till's own sale was not created. The count is
+    // +1 for the out-of-band sale this cashier made, and no more.
+    expect(await readStock(product.id)).toBe(0);
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore + 1);
+
+    // R9: the cashier must not have to re-ring the order.
+    await page.keyboard.press('Escape');
+    await expect(cartPanel(page).line(product.id)).toBeVisible();
+    await expect(cartPanel(page).quantity(product.id)).toHaveText('1');
+  });
+
+  test('a rejected sale can be completed after restocking', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    const product = await seedProduct('restock', { price: 40, stock: 1 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUpAndOpenDrawer(page, product.sku, product.id);
+
+    await consumeStock(request, workerCashier.accessToken, product.id, 1, 40);
+    await drawer.confirm.click();
+    await expect(receiptDialog(page).dialog).toBeHidden();
+
+    // Restock through the real API, then retry the same cart.
+    const update = await adminApi.put(`/api/v1/products/${product.id}`, {
+      data: { name: product.name, sku: product.sku, price: 40, stock: 5 },
+    });
+    expect(update.ok(), 'restock should succeed').toBe(true);
+    await expect.poll(() => readStock(product.id)).toBe(5);
+
+    await drawer.confirmAny.click();
+    await expect(receiptDialog(page).dialog).toBeVisible();
+    await expect.poll(() => readStock(product.id)).toBe(4);
+  });
+});
+
+test.describe('server rejection', () => {
+  test('a 500 shows an error, creates no sale, and preserves the cart', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('fivehundred', { price: 65, stock: 5 });
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+    const stockBefore = await readStock(product.id);
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUpAndOpenDrawer(page, product.sku, product.id);
+
+    // A genuine 5xx is impractical to provoke, so this one case is faked at the wire.
+    await page.route(
+      (url) => url.pathname.endsWith(SALES_PATH),
+      async (route) => {
+        if (route.request().method() !== 'POST') return route.continue();
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          headers: { 'Access-Control-Allow-Origin': '*' },
+          body: JSON.stringify({ error: { code: 'INTERNAL_ERROR', message: 'boom' } }),
+        });
+      }
+    );
+
+    await drawer.confirm.click();
+
+    await expect(receiptDialog(page).dialog).toBeHidden();
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore);
+    expect(await readStock(product.id)).toBe(stockBefore);
+
+    await page.keyboard.press('Escape');
+    await expect(cartPanel(page).line(product.id)).toBeVisible();
+    await expect(cartPanel(page).total).toHaveText(formatMoneyMinor(6500));
+  });
+
+  test('an invalid coupon rejection leaves the cart and its total untouched', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('badcode', { price: 75, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUpAndOpenDrawer(page, product.sku, product.id);
+    const adj = (await import('../support/locators')).adjustments(page);
+
+    await adj.couponInput.fill('E2E-DEFINITELY-NOT-A-COUPON');
+    await adj.applyCoupon.click();
+
+    await expect(drawer.total).toHaveText(formatMoneyMinor(7500));
+    await page.keyboard.press('Escape');
+    await expect(cartPanel(page).quantity(product.id)).toHaveText('1');
+  });
+
+  test('a partial write is never left behind by a rejected sale', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    workerRegister,
+  }) => {
+    // The integration assertion: no sale row, no stock movement, and no register movement.
+    // A rejection that moved the drawer but not the stock would be the worst outcome.
+    const product = await seedProduct('partial', { price: 90, stock: 3 });
+    const stockBefore = await readStock(product.id);
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+    const cashBefore = await readExpectedCash(workerRegister.id);
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUpAndOpenDrawer(page, product.sku, product.id);
+
+    await page.route(
+      (url) => url.pathname.endsWith(SALES_PATH),
+      async (route) => {
+        if (route.request().method() !== 'POST') return route.continue();
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          headers: { 'Access-Control-Allow-Origin': '*' },
+          body: JSON.stringify({
+            error: { code: 'VALIDATION_ERROR', message: 'Insufficient stock' },
+          }),
+        });
+      }
+    );
+
+    await drawer.confirm.click();
+    await expect(receiptDialog(page).dialog).toBeHidden();
+
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore);
+    expect(await readStock(product.id)).toBe(stockBefore);
+    expect(await readExpectedCash(workerRegister.id)).toBe(cashBefore);
+  });
+});
+
+test.describe('server-side stock guard', () => {
+  test('the API refuses to oversell even when asked directly', async ({
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    // The UI caps quantity at available stock, so this drives the API to prove the
+    // server's own guarded write rejects it rather than trusting a client-side cap.
+    const product = await seedProduct('apioversell', { price: 10, stock: 2 });
+
+    const response = await request.post(`${API_BASE}/sales`, {
+      headers: { Authorization: `Bearer ${workerCashier.accessToken}` },
+      data: {
+        items: [{ product_id: product.id, quantity: 99, unit_price: 10 }],
+        payment_method: 'Cash',
+      },
+    });
+
+    expect(response.ok(), 'overselling must be refused').toBe(false);
+    expect(await readStock(product.id), 'stock must never go negative').toBe(2);
+  });
+});
+
+async function readExpectedCash(sessionId: number): Promise<number> {
+  const row = await dbOne<{ expected_cash: string }>(
+    'SELECT expected_cash FROM register_sessions WHERE id = $1',
+    [sessionId]
+  );
+  return money(row?.expected_cash);
+}

--- a/e2e/specs/offline.spec.ts
+++ b/e2e/specs/offline.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * R4 — what actually happens to a sale rung up offline.
+ *
+ * This file was written expecting to prove the documented offline-queue contract: a sale
+ * queued to `moon-offline-queue`, replayed once on reconnect, surviving a reload. Driving
+ * it in a real browser showed something different, and the specs below pin what the
+ * application does rather than what it was expected to do.
+ *
+ * **The finding.** `queryClient` sets no `networkMode`, so React Query's default `'online'`
+ * applies: a mutation fired while `navigator.onLine` is false is **paused**, not executed.
+ * No request goes out, so it never fails, so `onError` never runs — and `CartPanel`'s
+ * offline fallback, the only code that writes to `moon-offline-queue`, lives entirely
+ * inside `onError`. The persisted queue therefore never receives a sale rung up offline.
+ *
+ * Measured rather than inferred, by the assertions below: offline, zero sale requests and
+ * an empty queue; on reconnect, the paused mutation resumes and the sale lands exactly once.
+ *
+ * **Why it still matters.** The common case is safe — reconnect with the tab open and the
+ * sale goes through, once. But an in-memory pause does not survive a reload or a closed
+ * tab, and surviving exactly that is why the persisted queue exists (issue #30). A cashier
+ * who rings up an order on a dead link and refreshes loses it silently.
+ *
+ * **On emulating offline.** `context.setOffline(true)` is deliberately not used: it was
+ * measured letting the checkout reach the server (a real `201`) while dropping the
+ * response, so the mutation neither resolved nor rejected — a spec built on it would assert
+ * an empty queue against a sale the server had already committed. Instead `navigator.onLine`
+ * is forced false and the `offline` event fired (what `useOffline.ts` and `CartPanel`
+ * observe), and the API origin is aborted (the real failure). The preview server is left
+ * alone so the already-loaded page keeps working.
+ */
+import { countSalesForCashier, readStock } from '../support/assertSale';
+import { cartPanel, checkoutDrawer, posPage, receiptDialog } from '../support/locators';
+import { countPosts } from '../support/network';
+import { OFFLINE_QUEUE_STORAGE_KEY } from '../fixtures/storage';
+import { expect, test } from '../fixtures/test';
+import type { Page } from '@playwright/test';
+
+const SALES_PATH = '/api/v1/sales';
+const API_ORIGIN = 'http://localhost:3001';
+
+interface QueueEntry {
+  id: string | number;
+  type: string;
+  idempotencyKey?: string;
+}
+
+/** The persisted queue, read from the browser rather than inferred from the banner. */
+async function readQueue(page: Page): Promise<QueueEntry[]> {
+  const raw = await page.evaluate(
+    (key) => window.localStorage.getItem(key),
+    OFFLINE_QUEUE_STORAGE_KEY
+  );
+  if (!raw) return [];
+  return (JSON.parse(raw) as { state?: { queue?: QueueEntry[] } }).state?.queue ?? [];
+}
+
+async function goOffline(page: Page) {
+  await page.route(`${API_ORIGIN}/**`, (route) => route.abort('internetdisconnected'));
+  await page.evaluate(() => {
+    Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
+    window.dispatchEvent(new Event('offline'));
+  });
+}
+
+async function goOnline(page: Page) {
+  await page.unroute(`${API_ORIGIN}/**`);
+  await page.evaluate(() => {
+    Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true });
+    window.dispatchEvent(new Event('online'));
+  });
+}
+
+/** Rings up one unit, opens the drawer, and confirms. */
+async function ringUpAndConfirm(page: Page, sku: string, productId: number) {
+  await posPage(page).search.fill(sku);
+  await posPage(page).productCard(sku).click();
+  await expect(cartPanel(page).quantity(productId)).toHaveText('1');
+  await cartPanel(page).checkout.click();
+  const drawer = checkoutDrawer(page);
+  await expect(drawer.dialog).toBeVisible();
+  /**
+   * A native click rather than Playwright's. HeroUI renders the drawer inside a
+   * `w-screen overflow-x-auto` wrapper, so the confirm button's layout position sits about
+   * a viewport width to the right of the visible area, and Playwright's actionability check
+   * refuses it once the offline banner is mounted. Real click mechanics on this button are
+   * covered online by `checkout-cash.spec.ts` and `duplicate-submit.spec.ts`; what this
+   * file needs is the handler, not the hit-testing.
+   */
+  await drawer.confirm.evaluate((el) => (el as HTMLElement).click());
+  return drawer;
+}
+
+test.describe('offline checkout @smoke', () => {
+  test('a sale rung up offline reaches the server exactly once on reconnect', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('offline', { price: 45, stock: 10 });
+    const stockBefore = await readStock(product.id);
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    // Load the catalogue before cutting the link.
+    await posPage(page).search.fill(product.sku);
+    await expect(posPage(page).productCard(product.sku)).toBeVisible();
+
+    const posts = countPosts(page, SALES_PATH);
+    await goOffline(page);
+    await ringUpAndConfirm(page, product.sku, product.id);
+
+    // Offline: nothing reaches the server and no stock moves.
+    await page.waitForTimeout(2_000);
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore);
+    expect(await readStock(product.id)).toBe(stockBefore);
+
+    await goOnline(page);
+
+    // On reconnect the paused mutation resumes — and the sale lands exactly once, which is
+    // the invariant that actually protects the shop from charging twice.
+    await expect
+      .poll(() => countSalesForCashier(workerCashier.id), { timeout: 45_000 })
+      .toBe(salesBefore + 1);
+    expect(await readStock(product.id)).toBe(stockBefore - 1);
+    expect(posts.count(), 'exactly one sale POST reached the server').toBe(1);
+    posts.stop();
+  });
+
+  test('a normal online sale never touches the offline queue', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    // The negative that keeps every queue assertion honest.
+    const product = await seedProduct('nonqueued', { price: 25, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await ringUpAndConfirm(page, product.sku, product.id);
+    await expect(receiptDialog(page).dialog).toBeVisible();
+
+    expect(await readQueue(page)).toHaveLength(0);
+  });
+});
+
+/**
+ * These pin the finding described in the file header. They assert **current behaviour**,
+ * not an endorsement of it: if the checkout mutation is ever changed to fail rather than
+ * pause while offline — `networkMode: 'always'` would do it — these are the tests that
+ * should fail, and the queue contract they currently contradict is the one to restore.
+ */
+test.describe('offline durability gap (pins current behaviour)', () => {
+  test('an offline checkout writes nothing to the persisted queue', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('nopersist', { price: 30, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await expect(posPage(page).productCard(product.sku)).toBeVisible();
+
+    await goOffline(page);
+    await ringUpAndConfirm(page, product.sku, product.id);
+    await page.waitForTimeout(3_000);
+
+    // The documented contract would put an entry here carrying an idempotency key. React
+    // Query pauses the mutation instead, so `onError` — the only writer — never runs.
+    expect(
+      await readQueue(page),
+      'offline sales are held in memory by React Query, not in moon-offline-queue'
+    ).toHaveLength(0);
+
+    await goOnline(page);
+  });
+
+  test('a reload while offline loses the pending sale', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    // The concrete consequence, and why the gap is worth reporting rather than shrugging
+    // at: an in-memory pause does not survive a refresh, and surviving exactly that is
+    // what the persisted queue was built for.
+    const product = await seedProduct('lostonreload', { price: 65, stock: 5 });
+    const stockBefore = await readStock(product.id);
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await expect(posPage(page).productCard(product.sku)).toBeVisible();
+
+    await goOffline(page);
+    await ringUpAndConfirm(page, product.sku, product.id);
+    await page.waitForTimeout(2_000);
+
+    // Refresh **while still disconnected** — reconnecting first would let the paused
+    // mutation resume and complete, which is the other test's scenario, not this one.
+    await page.reload();
+    // The reload restores a live `navigator.onLine`; drop the request block too, so the
+    // app has every opportunity to replay something if it had anything to replay.
+    await goOnline(page);
+    await page.waitForTimeout(5_000);
+
+    // Nothing was queued, so nothing replays: the order is simply gone.
+    expect(await readQueue(page)).toHaveLength(0);
+    expect(
+      await countSalesForCashier(workerCashier.id),
+      'the pending offline sale does not survive a reload'
+    ).toBe(salesBefore);
+    expect(await readStock(product.id)).toBe(stockBefore);
+  });
+
+  test('the cashier is at least told the link is down', async ({ cashierContext, seedProduct }) => {
+    // What makes this a durability problem rather than a silent-wrong-answer problem.
+    const product = await seedProduct('banner', { price: 20, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await expect(posPage(page).productCard(product.sku)).toBeVisible();
+
+    await goOffline(page);
+    await expect(page.getByText('You are offline.').first()).toBeVisible();
+
+    await goOnline(page);
+  });
+});

--- a/e2e/specs/payments.spec.ts
+++ b/e2e/specs/payments.spec.ts
@@ -1,0 +1,417 @@
+/**
+ * R2's breadth minus the two settings-driven modes: card, split, discount, tip, coupon.
+ *
+ * Every case ends in the D8 two-sided assertion, and every expected total that the
+ * contract names is read from `contracts/checkout-totals.v1.json` (D7). Cap and clamp
+ * cases assert documented *behaviour* instead, because the contract's own notes say caps
+ * are deliberately not exercised by its fixtures.
+ *
+ * Nothing in this file writes `PUT /api/v1/settings` — that is `tax-loyalty.spec.ts`'s
+ * exclusive job, and doing it here would change the totals every parallel worker asserts.
+ */
+import { assertPersistedSale, completeSaleAndReadId, money } from '../support/assertSale';
+import { contractCase, toMajor } from '../support/contract';
+import { dbOne, dbQuery } from '../support/db';
+import { formatMoneyMinor } from '../support/money';
+import {
+  adjustments,
+  cartPanel,
+  checkoutDrawer,
+  posPage,
+  receiptDialog,
+} from '../support/locators';
+import { createCoupon } from '../fixtures/coupon';
+import { getJson } from '../fixtures/seed';
+import { expect, test } from '../fixtures/test';
+import type { Page } from '@playwright/test';
+
+const FIXED_DISCOUNT = contractCase('fixed-manual-discount');
+const PERCENT_DISCOUNT = contractCase('percentage-manual-discount');
+const COUPON = contractCase('coupon-discount');
+const TIP = contractCase('tip-after-tax-regression');
+
+/** Adds one unit of a product to the cart and opens the checkout drawer. */
+async function ringUp(page: Page, sku: string, productId: number) {
+  const pos = posPage(page);
+  const cart = cartPanel(page);
+  await page.goto('/pos');
+  await pos.search.fill(sku);
+  await pos.productCard(sku).click();
+  await expect(cart.quantity(productId)).toHaveText('1');
+  await cart.checkout.click();
+  const drawer = checkoutDrawer(page);
+  await expect(drawer.dialog).toBeVisible();
+  return drawer;
+}
+
+test.describe('payment methods', () => {
+  test('a Card sale persists Card, and moves no cash @smoke', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    workerRegister,
+    request,
+  }) => {
+    const product = await seedProduct('card', { price: 120, stock: 5 });
+    const expectedBefore = await readExpectedCash(workerRegister.id);
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+
+    await drawer.paymentMethod('card').check();
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: 12000,
+      paymentMethod: 'Card',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: 12000 }],
+    });
+
+    // A card sale must not touch the drawer. The register only moves on cash.
+    expect(await readExpectedCash(workerRegister.id)).toBe(expectedBefore);
+    expect(await countMovements(workerRegister.id, saleId)).toBe(0);
+  });
+
+  test('a split Cash + Card sale persists both entries and moves only the cash part @smoke', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    workerRegister,
+    request,
+  }) => {
+    const product = await seedProduct('split', { price: 100, stock: 5 });
+    const expectedBefore = await readExpectedCash(workerRegister.id);
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+    const adj = adjustments(page);
+
+    await adj.splitToggle.check();
+    // Seeded as [Cash, Card]; allocate 40 / 60 against a 100.00 total.
+    await adj.splitAmount('Cash', 1).fill('40');
+    await adj.splitAmount('Card', 2).fill('60');
+
+    await expect(drawer.confirm).toBeEnabled();
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await getJson<{ payments: Array<{ method: string; amount: string | number }> }>(
+      request,
+      workerCashier.accessToken,
+      `sales/${saleId}`
+    );
+
+    // The summary label is a lie here by design: `payment_method` is hardcoded to 'Cash'
+    // whenever split is on, and `payments[]` carries the real breakdown. Asserting the
+    // label alone would pass on a bug that lost the split entirely.
+    const byMethod = Object.fromEntries(sale.payments.map((p) => [p.method, money(p.amount)]));
+    expect(byMethod).toEqual({ Cash: 40, Card: 60 });
+    expect(sale.payments.reduce((sum, p) => sum + money(p.amount), 0)).toBe(100);
+
+    // The register moves by the cash component only — not by the sale total.
+    expect(await readExpectedCash(workerRegister.id)).toBeCloseTo(expectedBefore + 40, 2);
+  });
+
+  test('a split that does not sum to the total cannot be submitted', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('unbalanced', { price: 100, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+    const adj = adjustments(page);
+
+    await adj.splitToggle.check();
+    await adj.splitAmount('Cash', 1).fill('30');
+    await adj.splitAmount('Card', 2).fill('20');
+
+    // Balance is exact integer-minor-unit equality; 50 of 100 is refused client-side.
+    await expect(drawer.confirm).toBeDisabled();
+  });
+});
+
+test.describe('adjustments', () => {
+  test('a percentage discount produces the contract’s total', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    const unit = PERCENT_DISCOUNT.input.items[0]!.unitPriceMinor;
+    const product = await seedProduct('pct', { price: toMajor(unit), stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+
+    // The drawer's quick-discount buttons force percentage mode.
+    await adjustments(page).discountPercent(15).click();
+    await expect(drawer.total).toHaveText(
+      formatMoneyMinor(PERCENT_DISCOUNT.expected.amountDueMinor)
+    );
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    await expect(receiptDialog(page).total).toHaveText(
+      formatMoneyMinor(PERCENT_DISCOUNT.expected.amountDueMinor)
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: PERCENT_DISCOUNT.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+    expect(sale.discount_type).toBe('percentage');
+  });
+
+  test('a fixed discount produces the contract’s total', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    const unit = FIXED_DISCOUNT.input.items[0]!.unitPriceMinor;
+    const product = await seedProduct('fixed', { price: toMajor(unit), stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const cart = cartPanel(page);
+    const footer = (await import('../support/locators')).footerDiscount(page);
+
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await expect(cart.quantity(product.id)).toHaveText('1');
+
+    // Only the cart footer offers fixed mode; the drawer's controls are percentage-only.
+    await footer.fixedMode.click();
+    await footer.amount.fill(String(toMajor(FIXED_DISCOUNT.input.manualDiscount.valueMinor!)));
+    await expect(cart.total).toHaveText(formatMoneyMinor(FIXED_DISCOUNT.expected.amountDueMinor));
+
+    await cart.checkout.click();
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: FIXED_DISCOUNT.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+    expect(sale.discount_type).toBe('fixed');
+    expect(money(sale.discount)).toBe(toMajor(FIXED_DISCOUNT.expected.manualDiscountMinor));
+  });
+
+  test('a discount larger than the cart is capped, never negative', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    // The contract deliberately does not name a cap case, so this asserts the documented
+    // behaviour — the total floors at zero — rather than a fixture number.
+    const product = await seedProduct('overdiscount', { price: 30, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const cart = cartPanel(page);
+    const footer = (await import('../support/locators')).footerDiscount(page);
+
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+
+    await footer.fixedMode.click();
+    await footer.amount.fill('500');
+
+    await expect(cart.total).toHaveText(formatMoneyMinor(0));
+
+    await cart.checkout.click();
+    await expect(checkoutDrawer(page).dialog).toBeVisible();
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      checkoutDrawer(page).confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await getJson<{ total: string | number }>(
+      request,
+      workerCashier.accessToken,
+      `sales/${saleId}`
+    );
+    expect(money(sale.total)).toBe(0);
+    expect(money(sale.total)).toBeGreaterThanOrEqual(0);
+  });
+
+  test('a tip is added after tax and is never discounted', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    request,
+  }) => {
+    const unit = TIP.input.items[0]!.unitPriceMinor;
+    const product = await seedProduct('tip', { price: toMajor(unit), stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+
+    await adjustments(page).tip.fill(String(toMajor(TIP.input.tipMinor)));
+    await expect(drawer.total).toHaveText(formatMoneyMinor(TIP.expected.amountDueMinor));
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    await expect(receiptDialog(page).total).toHaveText(
+      formatMoneyMinor(TIP.expected.amountDueMinor)
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: TIP.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+    // The tip is recorded separately, not folded into the discounted base.
+    expect(money(sale.tip_amount)).toBe(toMajor(TIP.expected.tipMinor));
+  });
+
+  test('a negative tip is clamped to zero', async ({ cashierContext, seedProduct }) => {
+    const product = await seedProduct('negtip', { price: 50, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+
+    await adjustments(page).tip.fill('-10');
+
+    // `setTip(Math.max(0, ...))` — the total must not fall below the subtotal.
+    await expect(drawer.total).toHaveText(formatMoneyMinor(5000));
+  });
+});
+
+test.describe('coupons', () => {
+  test('a valid coupon applies its discount and records a usage row', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    const unit = COUPON.input.items[0]!.unitPriceMinor;
+    const product = await seedProduct('coupon', { price: toMajor(unit), stock: 5 });
+    const coupon = await createCoupon(adminApi, workerCashier.namespace, 'ok', {
+      type: 'fixed',
+      value: toMajor(COUPON.input.couponDiscountMinor),
+    });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+    const adj = adjustments(page);
+
+    await adj.couponInput.fill(coupon.code);
+    await adj.applyCoupon.click();
+
+    await expect(drawer.total).toHaveText(formatMoneyMinor(COUPON.expected.amountDueMinor));
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: COUPON.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+
+    const usage = await dbOne<{ discount_applied: string }>(
+      'SELECT discount_applied FROM coupon_usage WHERE sale_id = $1 AND coupon_id = $2',
+      [saleId, coupon.id]
+    );
+    expect(usage, 'a coupon_usage row for this sale').toBeDefined();
+    expect(money(usage?.discount_applied)).toBe(toMajor(COUPON.expected.couponDiscountMinor));
+  });
+
+  test('an invalid code errors, applies nothing, and leaves the cart intact', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('badcoupon', { price: 80, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    const drawer = await ringUp(page, product.sku, product.id);
+    const adj = adjustments(page);
+
+    await adj.couponInput.fill('E2E-NO-SUCH-COUPON');
+    await adj.applyCoupon.click();
+
+    // R9 in miniature: a rejected adjustment must not cost the cashier the order.
+    await expect(drawer.total).toHaveText(formatMoneyMinor(8000));
+    await expect(adj.couponInput).toBeVisible();
+    await expect(cartPanel(page).line(product.id)).toBeAttached();
+  });
+
+  test('an exhausted coupon is refused with a distinguishable message', async ({
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    const coupon = await createCoupon(adminApi, workerCashier.namespace, 'used', {
+      type: 'fixed',
+      value: 5,
+      maxUses: 1,
+    });
+
+    // Consume the single use directly, then prove the *server* refuses the next attempt.
+    // Driving two full sales through the UI would prove the same thing far more slowly.
+    await dbQuery(
+      `INSERT INTO coupon_usage (coupon_id, sale_id, discount_applied)
+       SELECT $1, id, 5 FROM sales ORDER BY id DESC LIMIT 1`,
+      [coupon.id]
+    );
+
+    const response = await request.post(
+      `${(await import('../fixtures/seed')).API_BASE}/coupons/validate`,
+      {
+        headers: { Authorization: `Bearer ${workerCashier.accessToken}` },
+        data: { code: coupon.code, subtotal: 100, item_product_ids: [] },
+      }
+    );
+    expect(response.status()).toBe(400);
+    expect(await response.text()).toContain('usage limit');
+  });
+});
+
+async function readExpectedCash(sessionId: number): Promise<number> {
+  const row = await dbOne<{ expected_cash: string }>(
+    'SELECT expected_cash FROM register_sessions WHERE id = $1',
+    [sessionId]
+  );
+  return money(row?.expected_cash);
+}
+
+async function countMovements(sessionId: number, saleId: number): Promise<number> {
+  const row = await dbOne<{ n: string }>(
+    'SELECT count(*)::text AS n FROM register_movements WHERE session_id = $1 AND sale_id = $2',
+    [sessionId, saleId]
+  );
+  return Number(row?.n ?? '0');
+}

--- a/e2e/specs/session.spec.ts
+++ b/e2e/specs/session.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * R3's session-expiry path and R9 across a forced logout.
+ *
+ * Two scenarios that must never be conflated:
+ *
+ * - **Recoverable** — the access token expired but the refresh cookie is valid. The
+ *   interceptor refreshes silently and the cashier's action completes. They should never
+ *   see this happen.
+ * - **Terminal** — both are gone. The app redirects to `/login` and deliberately clears
+ *   the cart (see the note in the terminal test). The invariant that must hold either
+ *   way is that no sale is created anywhere in the sequence.
+ *
+ * Rather than waiting fifteen minutes, the stored access token is corrupted directly so
+ * the next request 401s. That is the same code path expiry takes.
+ */
+import { cartPanel, loginPage, posPage } from '../support/locators';
+import { AUTH_STORAGE_KEY } from '../fixtures/storage';
+import { countPosts } from '../support/network';
+import { countSalesForCashier } from '../support/assertSale';
+import { WORKER_PASSWORD } from '../fixtures/seed';
+import { expect, test } from '../fixtures/test';
+import type { Page } from '@playwright/test';
+
+const REFRESH_PATH = '/api/v1/auth/refresh';
+
+/** Replaces the stored access token with one the server will reject. */
+async function corruptAccessToken(page: Page): Promise<void> {
+  await page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) throw new Error(`No ${key} entry to corrupt.`);
+    const parsed = JSON.parse(raw) as { state: { accessToken: string } };
+    parsed.state.accessToken = 'e2e.invalid.token';
+    window.localStorage.setItem(key, JSON.stringify(parsed));
+  }, AUTH_STORAGE_KEY);
+}
+
+async function readAccessToken(page: Page): Promise<string | undefined> {
+  return page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return undefined;
+    return (JSON.parse(raw) as { state?: { accessToken?: string } }).state?.accessToken;
+  }, AUTH_STORAGE_KEY);
+}
+
+test.describe('recoverable expiry', () => {
+  test('a stale access token refreshes silently and the cashier is not interrupted', async ({
+    cashierContext,
+    seedProduct,
+  }) => {
+    const product = await seedProduct('refresh', { price: 30, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await expect(page).toHaveURL(/\/pos/);
+
+    const refreshes = countPosts(page, REFRESH_PATH);
+    await corruptAccessToken(page);
+
+    // Any action that hits the API will now 401 and drive the interceptor.
+    await page.reload();
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await expect(cartPanel(page).quantity(product.id)).toHaveText('1');
+
+    // The cashier stayed on the till — no redirect, no re-login.
+    await expect(page).toHaveURL(/\/pos/);
+
+    // Exactly one refresh, not a storm. `toBe(1)` on purpose: `toBeGreaterThan(0)` would
+    // pass on precisely the bug worth catching, and the queue in `client.ts` exists to
+    // collapse concurrent 401s into a single refresh.
+    await expect.poll(() => refreshes.count()).toBe(1);
+    refreshes.stop();
+
+    // And the rotated token was stored, not merely used for one request.
+    expect(await readAccessToken(page)).not.toBe('e2e.invalid.token');
+  });
+
+  test('concurrent requests against a stale token trigger exactly one refresh', async ({
+    cashierContext,
+  }) => {
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    const refreshes = countPosts(page, REFRESH_PATH);
+    await corruptAccessToken(page);
+
+    // Three API calls fired together. The interceptor must queue the followers behind one
+    // refresh and replay them, rather than refreshing three times or dropping two.
+    const statuses = await page.evaluate(async () => {
+      const paths = ['products?limit=1', 'shifts/current', 'register/current'];
+      return Promise.all(
+        paths.map((p) =>
+          fetch(`http://localhost:3001/api/v1/${p}`, {
+            headers: {
+              Authorization: `Bearer ${JSON.parse(localStorage.getItem('moon-auth')!).state.accessToken}`,
+            },
+          }).then((r) => r.status)
+        )
+      );
+    });
+
+    // Those raw fetches bypass the interceptor, so they legitimately 401 — their purpose
+    // is only to prove the token really is stale before the UI-driven refresh below.
+    expect(statuses.every((s) => s === 401)).toBe(true);
+
+    await page.reload();
+    await expect(page).toHaveURL(/\/pos/);
+    await expect.poll(() => refreshes.count()).toBe(1);
+    refreshes.stop();
+  });
+});
+
+test.describe('terminal expiry', () => {
+  test('losing both tokens redirects to login and clears the cart, deliberately', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+  }) => {
+    const product = await seedProduct('terminal', { price: 80, stock: 5 });
+    const salesBefore = await countSalesForCashier(workerCashier.id);
+
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await expect(cartPanel(page).quantity(product.id)).toHaveText('1');
+
+    // Both halves gone: no valid access token, no refresh cookie.
+    await corruptAccessToken(page);
+    await cashierContext.clearCookies();
+
+    await page.reload();
+    await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
+
+    await loginPage(page).email.fill(workerCashier.email);
+    await loginPage(page).password.fill(WORKER_PASSWORD);
+    await loginPage(page).submit.click();
+
+    await expect(page).not.toHaveURL(/\/login/);
+    await page.goto('/pos');
+
+    /**
+     * R9 reads "preserve **or recover** predictably", and this app's answer is an explicit
+     * clear rather than a restore: `app/session.ts` subscribes to the logout event and
+     * calls `clearCart()` — eagerly, so that a logout from a page which never loaded the
+     * POS chunk still clears it. That is a deliberate decision carrying its own comment,
+     * not an accident, so this pins the behaviour that exists.
+     *
+     * The cashier consequence is real and worth stating rather than burying: an order rung
+     * up when a session lapses has to be re-rung. Whether that is the right trade-off is a
+     * product question. Asserting the opposite here would only make the suite wrong.
+     */
+    await expect(cartPanel(page).heading(0)).toBeVisible();
+
+    // What must hold either way: no sale was created anywhere in that sequence.
+    expect(await countSalesForCashier(workerCashier.id)).toBe(salesBefore);
+  });
+
+  test('a failing refresh does not loop', async ({ cashierContext }) => {
+    const page = await cashierContext.newPage();
+    await page.goto('/pos');
+
+    const refreshes = countPosts(page, REFRESH_PATH);
+
+    // Refresh always fails: the interceptor must give up rather than retry forever.
+    await page.route(
+      (url) => url.pathname.endsWith(REFRESH_PATH),
+      async (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          headers: { 'Access-Control-Allow-Origin': '*' },
+          body: JSON.stringify({ error: { code: 'UNAUTHORIZED', message: 'nope' } }),
+        })
+    );
+
+    await corruptAccessToken(page);
+    await page.reload();
+    await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
+
+    // A bounded number of attempts. A refresh storm against a dead session would hammer
+    // the auth rate limiter and lock the account out for everyone else on that IP.
+    const attempts = refreshes.count();
+    expect(attempts, 'refresh attempts should be bounded').toBeLessThanOrEqual(3);
+    refreshes.stop();
+  });
+});

--- a/e2e/specs/tax-loyalty.spec.ts
+++ b/e2e/specs/tax-loyalty.spec.ts
@@ -1,0 +1,407 @@
+/**
+ * The settings-driven half of R2 — tax modes and loyalty.
+ *
+ * **This is the only file in the suite that writes `PUT /api/v1/settings`,** and it runs
+ * in the serial `pos-settings` project: one worker, `mode: 'serial'`, ordered after
+ * `pos-parallel` has finished. Tax and loyalty are global key/value rows, so a write from
+ * a parallel worker would silently change the totals every other worker asserts on.
+ *
+ * All four tax cases live here, not just the "variants": under the tax-disabled baseline
+ * (D5a) even `exclusive-tax` needs a settings write.
+ *
+ * The restore path is written before the first assertion on purpose. A spec that fails
+ * without restoring leaves the next run in inclusive-tax mode, and that is far more
+ * expensive to diagnose than the bug it was chasing.
+ */
+import {
+  adminUserId,
+  assertPersistedSale,
+  completeSaleAndReadId,
+  money,
+} from '../support/assertSale';
+import { contractCase, toMajor } from '../support/contract';
+import { formatMoneyMinor } from '../support/money';
+import {
+  cartPanel,
+  checkoutDrawer,
+  loyaltyControls,
+  posPage,
+  receiptDialog,
+} from '../support/locators';
+import { createCustomer, grantLoyaltyPoints, readLoyaltyPoints } from '../fixtures/customer';
+import { readSettings, restoreBaseline, writeSettings } from '../fixtures/settings';
+import { SETTINGS_BASELINE } from '../support/settingsBaseline';
+import { API_BASE } from '../fixtures/seed';
+import { expect, test } from '../fixtures/test';
+import type { Page } from '@playwright/test';
+
+const EXCLUSIVE = contractCase('exclusive-tax');
+const INCLUSIVE = contractCase('inclusive-tax');
+const ROUNDING = contractCase('half-minor-unit-rounding-boundary');
+const LOYALTY = contractCase('loyalty-redemption-and-earning');
+
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * Applies settings and returns a page that has actually *seen* them.
+ *
+ * The reload is not defensive padding. React Query holds settings for five minutes with
+ * `refetchOnWindowFocus: false`, so a page opened before the write keeps submitting under
+ * the previous mode — and the assertion then passes while testing the wrong thing.
+ */
+async function applySettingsAndOpen(
+  page: Page,
+  request: Parameters<typeof writeSettings>[0],
+  values: Record<string, string>
+) {
+  await writeSettings(request, values);
+  await page.goto('/pos');
+  await page.reload();
+}
+
+test.describe('tax modes', () => {
+  test.afterAll(async ({ adminApi }) => {
+    await restoreBaseline(adminApi);
+  });
+
+  test('exclusive tax adds tax on top of the discounted base', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    const unit = EXCLUSIVE.input.items[0]!.unitPriceMinor;
+    const product = await seedProduct('exclusive', { price: toMajor(unit), stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await applySettingsAndOpen(page, adminApi, {
+      tax_enabled: 'true',
+      tax_rate: String(EXCLUSIVE.input.tax.ratePercent),
+      tax_mode: 'exclusive',
+    });
+
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+
+    // Anti-stale-pass guard: the VAT line only renders when tax is on, so seeing it
+    // proves the page picked up the write rather than rendering the old mode.
+    await expect(loyaltyControls(page).vatLabel).toBeVisible();
+    await expect(drawer.total).toHaveText(formatMoneyMinor(EXCLUSIVE.expected.amountDueMinor));
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: EXCLUSIVE.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+    expect(money(sale.tax_amount)).toBeCloseTo(toMajor(EXCLUSIVE.expected.taxAmountMinor), 2);
+  });
+
+  test('inclusive tax leaves the total unchanged but persists a different tax amount', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    // The case most likely to be silently wrong, and — because of the settings cache —
+    // the one most likely to silently pass. The reload plus the VAT-line assertion above
+    // are what make a stale-cache pass impossible here.
+    const unit = INCLUSIVE.input.items[0]!.unitPriceMinor;
+    const product = await seedProduct('inclusive', { price: toMajor(unit), stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await applySettingsAndOpen(page, adminApi, {
+      tax_enabled: 'true',
+      tax_rate: String(INCLUSIVE.input.tax.ratePercent),
+      tax_mode: 'inclusive',
+    });
+
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+    await expect(loyaltyControls(page).vatLabel).toBeVisible();
+
+    // Inclusive: the customer pays the shelf price; the tax is carved out of it.
+    await expect(drawer.total).toHaveText(formatMoneyMinor(INCLUSIVE.expected.amountDueMinor));
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: INCLUSIVE.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+    // Same total as the exclusive case, different tax — which is the whole point.
+    expect(money(sale.tax_amount)).toBeCloseTo(toMajor(INCLUSIVE.expected.taxAmountMinor), 2);
+  });
+
+  test('the half-minor-unit rounding boundary matches the contract', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    // 3.33 at 50% is 1.665 — exactly the half-unit case where a naive round differs.
+    const unit = ROUNDING.input.items[0]!.unitPriceMinor;
+    const product = await seedProduct('rounding', { price: toMajor(unit), stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await applySettingsAndOpen(page, adminApi, {
+      tax_enabled: 'true',
+      tax_rate: String(ROUNDING.input.tax.ratePercent),
+      tax_mode: 'exclusive',
+    });
+
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+    await expect(drawer.total).toHaveText(formatMoneyMinor(ROUNDING.expected.amountDueMinor));
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: ROUNDING.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+    expect(money(sale.tax_amount)).toBeCloseTo(toMajor(ROUNDING.expected.taxAmountMinor), 2);
+  });
+
+  test('tax disabled produces zero tax and a total equal to the subtotal', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    const product = await seedProduct('notax', { price: 60, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await applySettingsAndOpen(page, adminApi, { ...SETTINGS_BASELINE });
+
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+    // The negative of the guard above: with tax off, the VAT line must be gone.
+    await expect(loyaltyControls(page).vatLabel).toHaveCount(0);
+    await expect(drawer.total).toHaveText(formatMoneyMinor(6000));
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: 6000,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: 6000 }],
+    });
+    expect(money(sale.tax_amount)).toBe(0);
+  });
+});
+
+test.describe('loyalty', () => {
+  test.afterAll(async ({ adminApi }) => {
+    await restoreBaseline(adminApi);
+  });
+
+  test('redeeming points discounts the total and debits exactly those points', async ({
+    adminContext,
+    seedProduct,
+    adminApi,
+  }) => {
+    const unit = LOYALTY.input.items[0]!.unitPriceMinor;
+    const pointsToRedeem = LOYALTY.input.loyalty.pointsRedeemed;
+
+    const product = await seedProduct('loyalty', { price: toMajor(unit), stock: 5 });
+    const customer = await createCustomer(adminApi, 'e2e-loyalty', 'loyal');
+    const startingPoints = await grantLoyaltyPoints(adminApi, customer.id, pointsToRedeem + 500);
+
+    // Driven as Admin, not as this worker's cashier: `GET /api/v1/customers` is
+    // Admin-only, so a cashier's customer search returns nothing and loyalty cannot be
+    // reached from a till at all. See the guardrail test at the bottom of this file.
+    const page = await adminContext.newPage();
+    await applySettingsAndOpen(page, adminApi, {
+      ...SETTINGS_BASELINE,
+      loyalty_enabled: 'true',
+      loyalty_points_per_egp: String(LOYALTY.input.loyalty.pointsPerEgp),
+      loyalty_egp_per_point: String(toMajor(LOYALTY.input.loyalty.egpPerPointMinor)),
+    });
+
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    const loyalty = loyaltyControls(page);
+    await expect(drawer.dialog).toBeVisible();
+
+    await loyalty.customerSearch.fill(customer.name);
+    await page.getByText(customer.name).last().click();
+
+    // The controls only render when loyalty is enabled — their presence is itself the
+    // proof the page is not rendering a stale settings snapshot.
+    await expect(loyalty.redeemToggle).toBeVisible();
+    await loyalty.redeemToggle.check();
+    await loyalty.pointsToRedeem.fill(String(pointsToRedeem));
+
+    await expect(drawer.total).toHaveText(formatMoneyMinor(LOYALTY.expected.amountDueMinor));
+
+    const adminId = await adminUserId(adminApi);
+    const saleId = await completeSaleAndReadId(
+      page,
+      adminId,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await assertPersistedSale(adminApi, '', saleId, {
+      amountDueMinor: LOYALTY.expected.amountDueMinor,
+      paymentMethod: 'Cash',
+      cashierId: adminId,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: unit }],
+    });
+    expect(sale.customer_id).toBe(customer.id);
+    expect(Number(sale.points_redeemed ?? 0)).toBe(pointsToRedeem);
+
+    // Both directions at once: N points spent, and the contract's earned points credited.
+    // `pointsPerEgp` is points earned per 1 EGP; `egpPerPointMinor` is minor units
+    // redeemed per 1 point. Neither is "per 100 points" — the direction is easy to invert.
+    const after = await readLoyaltyPoints(adminApi, customer.id);
+    expect(after).toBe(startingPoints - pointsToRedeem + LOYALTY.expected.earnedPoints);
+  });
+
+  test('an anonymous sale earns nothing and does not error', async ({
+    cashierContext,
+    seedProduct,
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    // Every other spec in the suite rings up anonymous sales, so this negative must hold.
+    const product = await seedProduct('anon', { price: 50, stock: 5 });
+
+    const page = await cashierContext.newPage();
+    await applySettingsAndOpen(page, adminApi, { ...SETTINGS_BASELINE });
+
+    await posPage(page).search.fill(product.sku);
+    await posPage(page).productCard(product.sku).click();
+    await cartPanel(page).checkout.click();
+
+    const drawer = checkoutDrawer(page);
+    await expect(drawer.dialog).toBeVisible();
+
+    const saleId = await completeSaleAndReadId(
+      page,
+      workerCashier.id,
+      drawer.confirm,
+      receiptDialog(page).dialog
+    );
+    const sale = await assertPersistedSale(request, workerCashier.accessToken, saleId, {
+      amountDueMinor: 5000,
+      paymentMethod: 'Cash',
+      cashierId: workerCashier.id,
+      items: [{ productId: product.id, quantity: 1, unitPriceMinor: 5000 }],
+    });
+    expect(sale.customer_id).toBeNull();
+    expect(Number(sale.points_redeemed ?? 0)).toBe(0);
+  });
+
+  test('redemption is capped by the customer’s balance', async ({
+    workerCashier,
+    adminApi,
+    request,
+  }) => {
+    // Driven at the API rather than the UI: the point is the *server's* cap, and the UI
+    // clamps its own input, which would hide a server-side regression.
+    const customer = await createCustomer(adminApi, workerCashier.namespace, 'poor');
+    await grantLoyaltyPoints(adminApi, customer.id, 10);
+
+    const response = await request.post(`${API_BASE}/sales`, {
+      headers: { Authorization: `Bearer ${workerCashier.accessToken}` },
+      data: {
+        items: [{ product_id: 1, quantity: 1, unit_price: 100 }],
+        payment_method: 'Cash',
+        customer_id: customer.id,
+        points_redeemed: 100000,
+      },
+    });
+
+    // Whatever the server does, it must not let a customer spend points they do not have.
+    expect(response.ok(), 'redeeming more points than held must be refused').toBe(false);
+    expect(await readLoyaltyPoints(adminApi, customer.id)).toBe(10);
+  });
+});
+
+test.describe('settings guardrails', () => {
+  test.afterAll(async ({ adminApi }) => {
+    await restoreBaseline(adminApi);
+  });
+
+  test('a Cashier cannot search customers, so loyalty is unreachable from a till', async ({
+    workerCashier,
+    request,
+  }) => {
+    // Recorded rather than worked around. `POST /customers` and `GET /customers/:id/loyalty`
+    // both allow Cashier, but the list/search endpoint the cart's customer picker uses is
+    // Admin-only — so a cashier can create a customer and read their points, yet cannot
+    // attach one to a sale. That asymmetry reads as an oversight, but widening an
+    // authorization rule is a product decision, not a test-suite decision, so this pins
+    // today's behaviour and the loyalty specs above run as Admin.
+    const response = await request.get(`${API_BASE}/customers?search=e2e`, {
+      headers: { Authorization: `Bearer ${workerCashier.accessToken}` },
+    });
+    expect(response.status(), 'GET /customers as Cashier').toBe(403);
+  });
+
+  test('a non-Admin cannot write settings', async ({ workerCashier, request }) => {
+    // If this ever succeeded, a cashier-token fixture could silently reconfigure the
+    // suite's baseline and every parallel worker's totals with it.
+    const response = await request.put(`${API_BASE}/settings`, {
+      headers: { Authorization: `Bearer ${workerCashier.accessToken}` },
+      data: { tax_enabled: 'true' },
+    });
+    expect(response.status()).toBe(403);
+  });
+
+  test('the baseline is restored exactly, key for key', async ({ adminApi }) => {
+    await restoreBaseline(adminApi);
+    const settings = await readSettings(adminApi);
+    for (const [key, expected] of Object.entries(SETTINGS_BASELINE)) {
+      expect(settings[key], `settings.${key} after restore`).toBe(expected);
+    }
+  });
+});

--- a/e2e/support/assertSale.ts
+++ b/e2e/support/assertSale.ts
@@ -146,6 +146,10 @@ export async function completeSaleAndReadId(
   const before = await countSalesForCashier(cashierId);
 
   await expect(confirm, 'the confirm control must be actionable before clicking').toBeEnabled();
+  // The confirm button is the last child of a scrollable drawer body, so anything that
+  // adds height above it — the offline banner, a coupon chip, a loyalty row — can push it
+  // out of view. Scroll it in explicitly rather than relying on the click's own attempt.
+  await confirm.scrollIntoViewIfNeeded();
   await confirm.click();
   await expect(receipt, 'the receipt confirms the server accepted the sale').toBeVisible();
 

--- a/e2e/support/assertSale.ts
+++ b/e2e/support/assertSale.ts
@@ -22,6 +22,7 @@ export interface PersistedSale {
   subtotal: string | number;
   tax_amount: string | number;
   discount: string | number;
+  discount_type: string;
   tip_amount: string | number;
   payment_method: string;
   cashier_id: number | null;
@@ -121,4 +122,39 @@ export async function assertStockDecremented(
   soldQuantity: number
 ): Promise<void> {
   expect(await readStock(productId), 'stock after the sale').toBe(stockBefore - soldQuantity);
+}
+
+/**
+ * Completes the sale in the open checkout drawer and returns *this sale's* id.
+ *
+ * Reading "the latest sale for this cashier" on its own is not safe: if the confirm click
+ * lands before the drawer has opened, or `handleCheckout` silently returns (it does that
+ * for an empty cart and for an unacknowledged recovered cart), no sale is created and the
+ * caller happily asserts against the previous test's row. That failure reads as a money
+ * bug in whichever spec is unlucky, which is far worse than a timeout.
+ *
+ * So this pins the count before and after, and refuses to return an id unless exactly one
+ * new sale exists.
+ */
+export async function completeSaleAndReadId(
+  page: import('@playwright/test').Page,
+  cashierId: number,
+  confirm: import('@playwright/test').Locator,
+  receipt: import('@playwright/test').Locator
+): Promise<number> {
+  const before = await countSalesForCashier(cashierId);
+
+  await expect(confirm, 'the confirm control must be actionable before clicking').toBeEnabled();
+  await confirm.click();
+  await expect(receipt, 'the receipt confirms the server accepted the sale').toBeVisible();
+
+  await expect
+    .poll(() => countSalesForCashier(cashierId), {
+      message: 'exactly one new sale should exist for this cashier',
+    })
+    .toBe(before + 1);
+
+  const saleId = await latestSaleIdForCashier(cashierId);
+  if (saleId === undefined) throw new Error('No sale row found after a confirmed checkout.');
+  return saleId;
 }

--- a/e2e/support/assertSale.ts
+++ b/e2e/support/assertSale.ts
@@ -27,6 +27,7 @@ export interface PersistedSale {
   payment_method: string;
   cashier_id: number | null;
   customer_id: number | null;
+  points_redeemed: number | string | null;
   status: string;
   items: PersistedSaleItem[];
   payments: Array<{ method: string; amount: string | number }>;
@@ -157,4 +158,11 @@ export async function completeSaleAndReadId(
   const saleId = await latestSaleIdForCashier(cashierId);
   if (saleId === undefined) throw new Error('No sale row found after a confirmed checkout.');
   return saleId;
+}
+
+/** The seeded Admin's user id and a live token, for the few Admin-gated paths. */
+export async function adminUserId(adminApi: APIRequestContext): Promise<number> {
+  const response = await adminApi.get('/api/v1/auth/me');
+  const body = (await response.json()) as { data: { id: number } };
+  return body.data.id;
 }

--- a/e2e/support/config.ts
+++ b/e2e/support/config.ts
@@ -119,3 +119,22 @@ export function requireE2eDatabaseUrl(): string {
 
   return url;
 }
+
+/**
+ * JWT secrets for anything this suite starts in the server's own runtime — the API under
+ * test, and the `migrate`/`seed` child processes in `globalSetup`.
+ *
+ * They are needed by more than the API. `server/src/config/env.ts` validates the whole
+ * environment the moment `pool.ts` is imported, so `npm run migrate` hard-fails without
+ * them. Locally `server/.env` supplies them and the omission is invisible; in CI there is
+ * no `.env` and setup dies before the first spec. Sharing one block is what keeps those
+ * two situations honest with each other.
+ *
+ * The same literals `.github/workflows/ci.yml`'s server job uses, so one rotation covers
+ * both. Deliberately not repository secrets: a throwaway server on a disposable database
+ * whose seeded credentials are already published in CLAUDE.md.
+ */
+export const TEST_JWT_ENV: Record<string, string> = {
+  JWT_SECRET: 'ci-jwt-secret-key-at-least-32-characters-long',
+  JWT_REFRESH_SECRET: 'ci-jwt-refresh-secret-key-at-least-32-chars',
+};

--- a/e2e/support/globalSetup.ts
+++ b/e2e/support/globalSetup.ts
@@ -13,6 +13,7 @@ import {
   API_URL,
   E2E_SERVER_APP_NAME,
   SERVER_DIR,
+  TEST_JWT_ENV,
   databaseNameOf,
   requireE2eDatabaseUrl,
 } from './config';
@@ -162,6 +163,7 @@ function runServerScript(script: 'migrate' | 'seed', connectionString: string): 
       cwd: SERVER_DIR,
       env: {
         ...process.env,
+        ...TEST_JWT_ENV,
         DATABASE_URL: connectionString,
         NODE_ENV: 'test',
       },

--- a/e2e/support/locators.ts
+++ b/e2e/support/locators.ts
@@ -187,3 +187,22 @@ export function reviewBanner(page: Page, { locale = DEFAULT_TEST_LOCALE }: Local
     acknowledge: page.getByRole('button', { name: tr('cart.needsReviewAcknowledge', locale) }),
   };
 }
+
+/** Customer selection and loyalty controls, both inside the checkout drawer. */
+export function loyaltyControls(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  const dialog = page.getByRole('dialog', {
+    name: new RegExp(escapeRegExp(tr('cart.completeSale', locale))),
+  });
+  return {
+    dialog,
+    customerSearch: dialog.getByPlaceholder(tr('cart.searchCustomer', locale)),
+    /**
+     * Gated on `appSettings.loyalty_enabled === 'true'`. A stale settings cache hides
+     * these entirely, which is why every settings write is followed by a reload.
+     */
+    redeemToggle: dialog.getByRole('checkbox', { name: tr('loyalty.redeemToggle', locale) }),
+    pointsToRedeem: dialog.getByRole('spinbutton', { name: tr('loyalty.pointsToRedeem', locale) }),
+    pointsDiscountLabel: dialog.getByText(tr('loyalty.pointsDiscount', locale)),
+    vatLabel: dialog.getByText(tr('tax.vat', locale)),
+  };
+}

--- a/e2e/support/locators.ts
+++ b/e2e/support/locators.ts
@@ -75,7 +75,15 @@ export function cartPanel(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOp
     quantity: (productId: number, variantId = 0) =>
       line(productId, variantId).getByTestId('cart-line-qty'),
     total: page.getByTestId('cart-total'),
-    empty: page.getByText(tr('cart.empty', locale)),
+    /**
+     * `.first()` because the cart list animates its exits: while a line is leaving, the
+     * animation library keeps a detached clone in the DOM, so the empty-state text can
+     * briefly match twice. The count assertion below is the precise one.
+     */
+    empty: page.getByText(tr('cart.empty', locale)).first(),
+    /** `Cart (N)` — a single heading, and the unambiguous way to assert the line count. */
+    heading: (count: number) =>
+      page.getByRole('heading', { name: `${tr('cart.title', locale)} (${count})` }),
     checkout: page.getByRole('button', { name: tr('cart.checkout', locale) }),
   };
 }
@@ -112,4 +120,70 @@ export function receiptDialog(page: Page, { locale = DEFAULT_TEST_LOCALE }: Loca
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Adjustment controls inside the checkout drawer (discount, tip, coupon, split). */
+export function adjustments(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  const dialog = page.getByRole('dialog', {
+    name: new RegExp(escapeRegExp(tr('cart.completeSale', locale))),
+  });
+  return {
+    /** Forces percentage mode — the drawer has no fixed-amount option. */
+    discountPercent: (percent: 5 | 10 | 15) =>
+      dialog.getByRole('button', { name: `${percent}%`, exact: true }),
+    discountCustom: dialog.getByRole('spinbutton', { name: tr('cart.quickDiscount', locale) }),
+    tip: dialog.getByRole('spinbutton', { name: tr('cart.tip', locale) }),
+    couponInput: dialog.getByPlaceholder(tr('cart.couponPlaceholder', locale)),
+    applyCoupon: dialog.getByRole('button', { name: tr('cart.applyCoupon', locale) }),
+    /** Hardcoded English aria-label in the component; deliberately not from the catalog. */
+    removeCoupon: dialog.getByRole('button', { name: 'Remove coupon' }),
+    splitToggle: dialog.getByRole('checkbox', { name: tr('cart.splitPayment', locale) }),
+    addPayment: dialog.getByRole('button', { name: tr('cart.addPayment', locale) }),
+    /**
+     * Split rows have no labelled `<select>`, so the method dropdown is positional. The
+     * amount input's accessible name embeds the row's *current* method, so it changes
+     * when the method does — read it after setting the method, never before.
+     */
+    splitMethod: (index: number) => dialog.getByRole('combobox').nth(index),
+    splitAmount: (method: 'Cash' | 'Card' | 'Gift Card' | 'Other', row: number) =>
+      dialog.getByRole('spinbutton', {
+        name: `${method} ${tr('cart.splitPayment', locale)} #${row}`,
+      }),
+  };
+}
+
+/** The cart footer's own discount controls, which offer fixed mode as well. */
+export function footerDiscount(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  return {
+    percentMode: page.getByRole('button', { name: '%', exact: true }),
+    fixedMode: page.getByRole('button', { name: '$', exact: true }),
+    amount: page.getByPlaceholder('0', { exact: true }),
+    clear: page.getByRole('button', { name: tr('cart.clearDiscount', locale) }),
+  };
+}
+
+/** Hold / resume. The hold control lives in the cart header. */
+export function heldCarts(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  const dialog = page.getByRole('dialog', { name: tr('cart.heldCarts', locale) });
+  return {
+    /**
+     * `exact` matters here: product cards are buttons whose accessible name folds in the
+     * SKU, so a substring match on "Hold" also matches any product whose SKU contains it.
+     */
+    hold: page.getByRole('button', { name: tr('cart.hold', locale), exact: true }),
+    open: page.getByRole('button', { name: tr('cart.heldCarts', locale), exact: true }),
+    dialog,
+    empty: dialog.getByText(tr('cart.noHeldCarts', locale)),
+    row: (name: string) => dialog.locator('li, div').filter({ hasText: name }).last(),
+    retrieve: dialog.getByRole('button', { name: tr('cart.retrieve', locale) }),
+    delete: dialog.getByRole('button', { name: tr('cart.deleteHeld', locale) }),
+  };
+}
+
+/** The recovered/restored-cart gate. Blocks checkout until acknowledged. */
+export function reviewBanner(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
+  return {
+    warning: page.getByText(tr('cart.needsReviewWarning', locale)),
+    acknowledge: page.getByRole('button', { name: tr('cart.needsReviewAcknowledge', locale) }),
+  };
 }

--- a/e2e/support/locators.ts
+++ b/e2e/support/locators.ts
@@ -102,6 +102,20 @@ export function checkoutDrawer(page: Page, { locale = DEFAULT_TEST_LOCALE }: Loc
       dialog.getByRole('radio', { name: tr(`cart.${method}`, locale) }),
     total: dialog.getByTestId('checkout-total'),
     confirm: dialog.getByRole('button', { name: tr('cart.confirmSale', locale) }),
+    /**
+     * The confirm control regardless of which label it is currently showing.
+     *
+     * `isLoading` swaps the text from "Confirm Sale" to "Processing…" while the checkout
+     * is in flight, so a strict-name locator stops matching the moment the button is
+     * clicked. Anything that interacts with it *during* a checkout — a double-click test,
+     * above all — must use this instead, or it waits out its timeout on an element that
+     * no longer answers to that name.
+     */
+    confirmAny: dialog.getByRole('button', {
+      name: new RegExp(
+        `${escapeRegExp(tr('cart.confirmSale', locale))}|${escapeRegExp(tr('cart.processing', locale))}`
+      ),
+    }),
   };
 }
 

--- a/e2e/support/network.ts
+++ b/e2e/support/network.ts
@@ -1,0 +1,90 @@
+/**
+ * Request counting and response gating.
+ *
+ * Counting has to be exact, because the whole point is proving a *second* request did not
+ * happen. `page.waitForRequest` proves presence and is useless for proving absence, so
+ * these attach a counter before the action and assert on it afterwards.
+ */
+import type { Page, Request, Route } from '@playwright/test';
+
+export interface RequestCounter {
+  /** Requests seen so far. */
+  count: () => number;
+  /** Every matching request's headers, in order. */
+  headers: () => Array<Record<string, string>>;
+  stop: () => void;
+}
+
+/**
+ * Counts POSTs to a path.
+ *
+ * Filtering on `method === 'POST'` is load-bearing rather than tidy: `Idempotency-Key` is
+ * a non-simple header, so every checkout is preceded by a CORS preflight. Counting all
+ * requests would see each sale twice and report phantom duplicates.
+ */
+export function countPosts(page: Page, pathname: string): RequestCounter {
+  const seen: Request[] = [];
+  const listener = (request: Request) => {
+    if (request.method() !== 'POST') return;
+    if (!new URL(request.url()).pathname.endsWith(pathname)) return;
+    seen.push(request);
+  };
+  page.on('request', listener);
+  return {
+    count: () => seen.length,
+    headers: () => seen.map((r) => r.headers()),
+    stop: () => page.off('request', listener),
+  };
+}
+
+export interface ResponseGate {
+  /** Resolves once the first matching request has been intercepted. */
+  waitForFirst: () => Promise<void>;
+  /** Lets every held request through. */
+  release: () => Promise<void>;
+}
+
+/**
+ * Holds responses to a path open until released.
+ *
+ * A real double-click rarely reproduces a double-submit: the first request completes in
+ * milliseconds, so the guard is never actually under test. Widening the window
+ * deliberately is what makes the assertion meaningful.
+ */
+export async function gateResponses(page: Page, pathname: string): Promise<ResponseGate> {
+  let releaseAll: () => void = () => {};
+  const held = new Promise<void>((resolve) => {
+    releaseAll = resolve;
+  });
+
+  let firstSeen: () => void = () => {};
+  const first = new Promise<void>((resolve) => {
+    firstSeen = resolve;
+  });
+
+  await page.route(
+    (url) => url.pathname.endsWith(pathname),
+    async (route: Route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      // Send it straight away and hold the *response*, rather than parking the request.
+      // The window this widens is the one that matters — the client believing a checkout
+      // is still in flight — and a long-parked `continue()` does not resume reliably.
+      const response = await route.fetch();
+      firstSeen();
+      await held;
+      await route.fulfill({ response });
+    }
+  );
+
+  return {
+    waitForFirst: () => first,
+    /**
+     * Deliberately does not `unroute`. Removing a handler while one of its invocations is
+     * still parked on `held` deadlocks, and the route is harmless once released — the
+     * page is closed at the end of the test either way.
+     */
+    release: async () => {
+      releaseAll();
+    },
+  };
+}


### PR DESCRIPTION
Completes `docs/plans/2026-08-31-002-test-e2e-pos-critical-workflows-plan.md` (issue #50). **All 14 units are now done.**

> **Stacked on #65, which is stacked on #64.** Merge those first and this diff collapses to Units 7–14.

## What this adds

| Unit | Coverage |
|---|---|
| 7 | Card, split tender, discounts, tip, coupons, held carts |
| 8 | All four tax cases + loyalty, in the serial settings project |
| 9 | Duplicate submission and the idempotency contract |
| 10 | Stock conflicts, rejections, cart preservation |
| 11 | Session expiry and token refresh |
| 12 | Offline checkout |
| 13 | CI: `@smoke` gate on PRs, 4-way sharded suite on `main` |
| 14 | Conventions, ownership, findings |

**78 e2e tests**, plus 273 server and 380 client tests unchanged.

## Four findings the suite produced

These are the point of the exercise — each was invisible to 653 passing unit tests.

**1. Offline sales are never persisted.** `queryClient` sets no `networkMode`, so React Query's default *pauses* a mutation fired while `navigator.onLine` is false rather than failing it. No request goes out, `onError` never runs, and `CartPanel`'s offline fallback — the only writer to `moon-offline-queue` — is unreachable. Measured: offline, zero requests and an empty queue; on reconnect the paused mutation resumes and the sale lands exactly once.

The common case is safe. The gap is durability: an in-memory pause does not survive a reload, and surviving exactly that is why the persisted queue exists (#30). A spec demonstrates the consequence — ring up offline, refresh, reconnect, and the order is gone. **This contradicted `CLAUDE.md`, which I corrected rather than leave standing.**

**2. A Cashier cannot attach a customer to a sale.** `GET /api/v1/customers` is Admin-only while `POST /customers` and the loyalty read allow Cashier — so loyalty redemption is unreachable from a real till. It looks like an oversight, but widening an authorization rule is a product decision, so the spec pins today's behaviour and the loyalty cases run as Admin.

**3. `Idempotent-Replay` is not readable cross-origin.** The server sets it; `cors()` declares no `exposedHeaders`. No client code reads it today, so the specs assert the substance instead.

**4. The checkout drawer's layout is fragile** in a second way beyond #65's zero-height bug: its confirm button sits about a viewport width right of the visible area inside a `w-screen overflow-x-auto` wrapper, which is why the offline specs dispatch the click rather than performing one.

## Assertions built to fail honestly

Several would have passed on real bugs if written the obvious way, and the specs say why:

- **Split payment** hardcodes `payment_method: 'Cash'` whenever split is on, so the summary label is by design not the truth — the spec asserts the persisted `payments[]` breakdown, and that a card-only split moves the register by nothing.
- **`completeSaleAndReadId`** replaced reading "the latest sale for this cashier". That was genuinely unsafe and this work proved it: a confirm click landing before the drawer opened created no sale, and the assertion read a neighbouring test's row and reported a money mismatch.
- **One refresh, not a storm** — `toBe(1)`, never `toBeGreaterThan(0)`.
- **`confirmAny`** exists because the button's label swaps to "Processing…" the moment it is clicked, so a strict-name locator waits out its own timeout instead of testing the guard.
- **Two vacuous assertions were deleted**, one guarded by a UNIQUE constraint and one round-tripping its own init script.

## A corrected expectation

I assumed the cart survived a forced logout. It does not — `app/session.ts` deliberately clears it. The spec now pins the real contract and records the cashier consequence rather than asserting one the app does not offer.

## Testing

| Suite | Result |
|---|---|
| `e2e` | **78 passed**, four consecutive runs at `--workers=4` |
| `@smoke` | 13 tests in ~58s against the 3-minute budget |
| `server` | 273 passed, 77 skipped (real-PostgreSQL, no `TEST_DATABASE_URL`) |
| `client` | 380 passed |
| lint / typecheck | clean everywhere |

Sharding verified locally with `--shard=1/2` and `E2E_RUN_ID`.

**One caveat I could not resolve:** an earlier run reported `77 passed` with zero failures — one test that did not execute. Four subsequent runs all reported 78. I could not reproduce it and do not know the cause; `--fail-on-flaky-tests` is on for the `main` job, and this is worth watching over the first few runs.

## Post-Deploy Monitoring & Validation

**No production runtime impact.** `e2e/` ships in no build and is imported by no production code. The two earlier production changes (rate-limit knobs in #64, the `shrink-0` fix in #65) carry their own monitoring notes; nothing in this PR touches production behaviour.

- **What to watch:** the new CI jobs. `e2e-smoke` on PRs should stay under ~3 minutes; `e2e-full` on `main` should be green and non-flaky.
- **Healthy signal:** `[e2e-guard] @smoke ran N test(s)` in the PR job with N ≥ 5.
- **Failure signal / trigger:** the guard failing means the tag matched nothing — a green run of zero tests. Treat as a broken gate, not a passing build. `e2e-full` red on `main` is a blocked deploy until someone looks; ownership and the flake policy are written down in `e2e/README.md`.
- **Required invariant:** each shard gets its own server process and its own database. Consolidating to one shared service to save CI minutes would silently break settings isolation.
- **Window / owner:** first week of `main` runs, owned by whoever merges.

> ⚠️ The suite deletes every row in 77 tables. Disposable databases only — four guards enforce it, and its failure artifacts contain live session tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
