### PR TITLE
fix(auth): give each refresh token a jti so concurrent logins do not collide

### DIFF
--- a/server/src/modules/core/auth/service.ts
+++ b/server/src/modules/core/auth/service.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
 import { IAuthRepository, authRepository as defaultRepo } from './repository';
 import { LoginDTO, AuthTokens } from './types';
 import { PublicError } from '../../../http/errors';
@@ -27,8 +28,14 @@ export class AuthService {
       { expiresIn: '15m' }
     );
 
+    // `jti` is what makes one login one session. Without it the payload is only the user
+    // id plus `iat`/`exp` at one-second resolution, so two logins by the same user in the
+    // same second sign byte-identical tokens: the second insert violates
+    // `refresh_tokens.token UNIQUE` (500 instead of a login), and a logout by either
+    // session deletes the single row both were relying on.
     const refreshToken = jwt.sign({ id: user.id }, process.env.JWT_REFRESH_SECRET as string, {
       expiresIn: '7d',
+      jwtid: randomUUID(),
     });
 
     const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();

--- a/server/tests/auth.test.ts
+++ b/server/tests/auth.test.ts
@@ -142,6 +142,61 @@ describe('Auth - Refresh Token Storage', () => {
   });
 });
 
+/**
+ * Regression cover for issue #62. The collision itself is a concurrency defect and its
+ * real proof lives in `tests/concurrency/auth.concurrency.test.ts`; these cases pin the
+ * claim that makes the fix work — one login is one session, even when the clock (which
+ * `iat`/`exp` resolve to whole seconds) cannot tell two logins apart.
+ */
+describe('Auth - refresh tokens are unique per session', () => {
+  // Frozen on a whole-second boundary at the current wall clock: freezing at a fixed
+  // literal instead would date the stored `expires_at` against the database's own NOW().
+  const sameSecond = new Date(Math.floor(Date.now() / 1000) * 1000);
+
+  it('signs different refresh tokens for two logins in the same second', async () => {
+    vi.setSystemTime(sameSecond);
+    try {
+      const first = await authService.login({ email: 'admin@moon.com', password: 'admin123' });
+      const second = await authService.login({ email: 'admin@moon.com', password: 'admin123' });
+
+      const firstClaims = jwt.verify(first.refreshToken, JWT_REFRESH_SECRET) as Record<
+        string,
+        unknown
+      >;
+      const secondClaims = jwt.verify(second.refreshToken, JWT_REFRESH_SECRET) as Record<
+        string,
+        unknown
+      >;
+
+      // Same user, same `iat` — the exact condition that used to produce equal tokens.
+      expect(firstClaims.id).toBe(secondClaims.id);
+      expect(firstClaims.iat).toBe(secondClaims.iat);
+
+      expect(firstClaims.jti).toEqual(expect.any(String));
+      expect(secondClaims.jti).not.toBe(firstClaims.jti);
+      expect(second.refreshToken).not.toBe(first.refreshToken);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('logging out of one same-second session leaves the other usable', async () => {
+    vi.setSystemTime(sameSecond);
+    try {
+      const till1 = await authService.login({ email: 'sarah@moon.com', password: 'cashier123' });
+      const till2 = await authService.login({ email: 'sarah@moon.com', password: 'cashier123' });
+
+      await authService.logout(till1.refreshToken);
+
+      await expect(authService.refresh(till1.refreshToken)).rejects.toBeInstanceOf(PublicError);
+      const refreshed = await authService.refresh(till2.refreshToken);
+      expect(refreshed.user.email).toBe('sarah@moon.com');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('Auth - Role Checking', () => {
   it('should enforce Admin role correctly', async () => {
     const result = await testPool.query('SELECT role FROM users WHERE email = $1', [

--- a/server/tests/concurrency/auth.concurrency.test.ts
+++ b/server/tests/concurrency/auth.concurrency.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Refresh-token session isolation under real concurrency (issue #62).
+ *
+ * The defect is a uniqueness race: two logins by the same user inside the same second
+ * used to sign a byte-identical refresh token, so the second `INSERT` hit
+ * `refresh_tokens.token UNIQUE` (23505 → 500) and, when both did land, a logout by
+ * either session deleted the one row both were using.
+ *
+ * pg-mem cannot prove this: its "concurrent" writers are really sequential, so two
+ * genuinely simultaneous logins — two tills opened together on a shared account at shift
+ * start, the realistic trigger — only exist against real PostgreSQL.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest';
+import bcrypt from 'bcrypt';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { AuthService } from '../../src/modules/core/auth/service';
+import { PublicError } from '../../src/http/errors';
+
+describeWithPostgres('refresh token session isolation under concurrency', () => {
+  let harness: RealPostgresHarness;
+  const service = new AuthService();
+  const credentials = { email: 'shared-till@moon.com', password: 'till123' };
+
+  beforeAll(async () => {
+    // Four simultaneous logins plus margin; a larger pool competes with the other
+    // real-PG files for max_connections.
+    harness = await setupRealPostgres('auth-concurrency', { maxConnections: 6 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    // Pin the clock to a whole-second boundary so every login in a case shares one
+    // `iat` — that is the collision condition, and leaving it to scheduling luck would
+    // make the regression cover intermittent. The boundary is taken from the current
+    // wall clock so the stored `expires_at` still sits in the future of the database's
+    // own NOW().
+    vi.setSystemTime(new Date(Math.floor(Date.now() / 1000) * 1000));
+
+    await harness.truncate();
+    const hash = await bcrypt.hash(credentials.password, 10);
+    await harness.pool.query(
+      'INSERT INTO users (name, email, password_hash, role) VALUES ($1, $2, $3, $4)',
+      ['Shared Till', credentials.email, hash, 'Cashier']
+    );
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await harness.pool.query('DELETE FROM refresh_tokens');
+  });
+
+  it('lets the same user log in twice simultaneously, with one row per session', async () => {
+    const [first, second] = await Promise.all([
+      service.login({ ...credentials }),
+      service.login({ ...credentials }),
+    ]);
+
+    expect(second.refreshToken).not.toBe(first.refreshToken);
+
+    const { rows } = await harness.pool.query<{ token: string }>(
+      'SELECT token FROM refresh_tokens ORDER BY id'
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.token)).size).toBe(2);
+  });
+
+  it('survives four simultaneous logins without a unique-constraint failure', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () => service.login({ ...credentials }))
+    );
+
+    const tokens = new Set(results.map((r) => r.refreshToken));
+    expect(tokens.size).toBe(4);
+
+    const { rows } = await harness.pool.query<{ count: string }>(
+      'SELECT COUNT(*)::int AS count FROM refresh_tokens'
+    );
+    expect(Number(rows[0].count)).toBe(4);
+  });
+
+  it('logging out of one concurrent session leaves the other one valid', async () => {
+    const [till1, till2] = await Promise.all([
+      service.login({ ...credentials }),
+      service.login({ ...credentials }),
+    ]);
+
+    await service.logout(till1.refreshToken);
+
+    await expect(service.refresh(till1.refreshToken)).rejects.toBeInstanceOf(PublicError);
+
+    const refreshed = await service.refresh(till2.refreshToken);
+    expect(refreshed.user.email).toBe(credentials.email);
+
+    const { rows } = await harness.pool.query<{ token: string }>(
+      'SELECT token FROM refresh_tokens'
+    );
+    expect(rows.map((r) => r.token)).toEqual([till2.refreshToken]);
+  });
+});


### PR DESCRIPTION
Closes #62.

## The defect

`jwt.sign({ id: user.id }, JWT_REFRESH_SECRET, { expiresIn: "7d" })` produced a payload of the user id plus `iat`/`exp` — both at one-second resolution, with no per-token entropy. Two logins by the same user inside the same second therefore signed a **byte-identical** token, and that token is stored in `refresh_tokens.token TEXT NOT NULL UNIQUE`.

Two consequences, the second worse:

1. The second login violated `UNIQUE`, raised `23505`, and surfaced as a 500 instead of a login.
2. Logout does `DELETE FROM refresh_tokens WHERE token = $1`, removing the single row **both** sessions relied on — one user signing out silently ended the other session.

The realistic trigger is two tills opened together on a shared account at shift start, which is a normal way a shop operates. It would be reported as "the till randomly logged itself out".

## The fix

Seven production lines: sign with `jwtid: randomUUID()`.

## Why no migration

With a per-token `jti` each login produces a distinct token string and therefore its own row, so `DELETE ... WHERE token = $1` already deletes exactly one session and `findValidRefreshToken` already matches exactly one. Adding a `jti` column and re-keying revocation on it would duplicate an identity the token string now carries uniquely, and would need a backfill for tokens issued before the change. The existing `UNIQUE` constraint becomes meaningful rather than hostile.

A `jti` column earns its place only when revocation must happen *without* the token in hand — revoke-all-sessions, an admin session list. That is the #44 redesign, not this fix.

## Testing

- `server/tests/concurrency/auth.concurrency.test.ts` (new, `describeWithPostgres`, ran for real against PostgreSQL — not skipped): two `Promise.all` logins yield distinct tokens and two rows; four simultaneous logins produce four rows with no `23505`; logging out of one leaves the other refreshable and its row the only survivor. The clock is pinned to a whole-second boundary in `beforeEach` so the collision condition (shared `iat`) is deterministic rather than left to scheduling luck.
- `server/tests/auth.test.ts` (pg-mem): two same-second logins share `iat` but differ in `jti`.
- Full server suite: 354 passed. `tsc --noEmit` clean, eslint 0 errors.

One pre-existing failure, `tests/exchanges.test.ts`, is unrelated and now filed as #69 — it fails identically on clean `main`.

## Out of scope

Hashing the stored token and rotation on refresh both belong to #44. Two findings for that issue: the refresh token is stored in plaintext, so a read of that table yields working 7-day sessions; and `refresh` re-issues an access token without rotating, so a captured refresh token stays valid its full 7 days regardless of use.

## Post-Deploy Monitoring & Validation

- **Watch:** 500s on `POST /api/v1/auth/login`, and any `23505` / `duplicate key value violates unique constraint "refresh_tokens_token_key"` in server logs. Both should go to zero.
- **Healthy signal:** `SELECT COUNT(*) FROM refresh_tokens WHERE user_id = <shared account>` grows by one per till at shift start rather than erroring on the second.
- **Failure signal / rollback trigger:** any new `23505` on `refresh_tokens`, or a rise in `UNAUTHORIZED` on `/auth/refresh` (would indicate tokens are not being found after issue). Revert is a single-commit revert with no schema to unwind.
- **Window:** first shift-start after deploy (the peak concurrent-login moment), then 24h.
- **Owner:** @zhamdy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN