### PR TITLE
fix(api): key the global rate limit per till, not per shop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,29 @@ runs on `main`. See `e2e/README.md` for ownership, the flake policy, and the fin
 suite has already produced, and `docs/CONVENTIONS.md` → *E2E test conventions* before
 adding specs.
 
+## Rate-limit bucketing
+
+The global limiter is keyed on the **authenticated user**, not on the IP. Several tills
+behind one shop router share one address, so an IP-keyed budget is a per-shop budget and
+one busy till can push a colleague into a `RATE_LIMITED` mid-checkout. The limiter runs
+ahead of `verifyToken`, so the identity comes from verifying the bearer token's signature
+inside the key generator — verifying, never decoding: an unverified token would let a
+caller choose its own bucket. Unauthenticated requests keep the IP bucket, and
+`GET /api/health` is exempt so an uptime probe cannot be starved by, or starve, the tills.
+
+`authLimiter` on `/auth/login` and `/auth/refresh` deliberately stays IP-keyed: a
+credential-guessing attacker is unauthenticated by definition, so there is no verified
+user to key on.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `TRUST_PROXY` | unset (off) | How far to trust `X-Forwarded-For` when deriving `req.ip`. |
+
+Accepts a hop count (`1`), a comma list of addresses/CIDRs/`loopback`-style presets, or
+`true`. Unset reproduces Express's default exactly. Prefer a hop count: `true` trusts the
+whole client-supplied chain, which lets a client pick its own IP bucket — it is accepted
+but warned about at boot, as is a value that could not be parsed.
+
 ## Offline queue
 
 The queue in `localStorage` is replayed by `client/src/shared/hooks/useOffline.ts`. A failed

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,12 @@ import 'dotenv/config';
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
-import { createGlobalLimiter, logRateLimitOverrides } from './src/http/rateLimits';
+import {
+  createGlobalLimiter,
+  logRateLimitOverrides,
+  logTrustProxyOverride,
+  trustProxySetting,
+} from './src/http/rateLimits';
 import cookieParser from 'cookie-parser';
 import path from 'path';
 import { apiReference } from '@scalar/express-api-reference';
@@ -27,6 +32,12 @@ for (const envVar of requiredEnvVars) {
 
 const app = express();
 const PORT: number = Number(process.env.PORT) || 3001;
+
+// How far to trust X-Forwarded-For when deriving `req.ip`, which is the rate-limit
+// bucket for unauthenticated traffic. Defaults to off — Express's own default — so an
+// unset TRUST_PROXY behaves exactly as before. See `src/http/rateLimits.ts`.
+logTrustProxyOverride();
+app.set('trust proxy', trustProxySetting());
 
 // Security
 app.use(

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -32,6 +32,17 @@ const envSchema = z.object({
    */
   RATE_LIMIT_MAX: z.string().optional(),
   AUTH_RATE_LIMIT_MAX: z.string().optional(),
+  /**
+   * How many reverse proxies sit in front of this API, resolved by
+   * `src/http/rateLimits.ts`. Unset means "none", which is exactly today's behaviour:
+   * Express leaves `trust proxy` off and `req.ip` is the socket address.
+   *
+   * Raw string for the same reason as the ceilings above — a typo must fall back to the
+   * safe value rather than fail the whole environment parse — and because the accepted
+   * values are not one type: a hop count, a list of trusted addresses, or the
+   * deliberately-discouraged `true`.
+   */
+  TRUST_PROXY: z.string().optional(),
   CLIENT_URL: z.string().optional().default('http://localhost:5173'),
   ALLOWED_ORIGINS: z.string().optional(),
   TWILIO_ACCOUNT_SID: z.string().optional(),

--- a/server/src/http/rateLimits.ts
+++ b/server/src/http/rateLimits.ts
@@ -1,4 +1,6 @@
+import type { Request } from 'express';
 import rateLimit, { type RateLimitRequestHandler } from 'express-rate-limit';
+import jwt from 'jsonwebtoken';
 import { getEnv } from '../config/env';
 import { errorResponse } from './errors';
 import logger from '../../lib/logger';
@@ -34,6 +36,74 @@ export function authRateLimitMax(): number {
 }
 
 /**
+ * Paths the global limiter does not spend budget on.
+ *
+ * `/api/health` is a single `SELECT 1` behind an unauthenticated GET, and it is called
+ * by uptime probes and load balancers on a fixed schedule. Counting it means a shop that
+ * has spent its budget also fails its own health probe — the monitoring reports an
+ * outage caused by the monitoring. The traffic it can generate is bounded by the prober,
+ * and flooding an unauthenticated endpoint is a job for the layer in front of the app,
+ * not for a budget that a cashier's checkout shares.
+ *
+ * Deliberately narrow: register/shift polling reads are *authenticated*, so per-user
+ * keying already stops one till starving another. Exempting them as well would carve
+ * real, DB-touching endpoints out of abuse protection for no remaining benefit.
+ */
+export function isRateLimitExempt(req: Pick<Request, 'method' | 'path'>): boolean {
+  return req.method === 'GET' && req.path === '/api/health';
+}
+
+/**
+ * The rate-limit bucket for a request.
+ *
+ * Keying on `req.ip` alone makes the budget per *shop*: several tills behind one NAT
+ * share 200 requests / 15 min, so a busy till can push a colleague mid-checkout into a
+ * `RATE_LIMITED`. Keying on the authenticated user makes the budget per till.
+ *
+ * The limiter runs before `verifyToken`, so `req.user` does not exist yet. The token is
+ * therefore verified here — `jwt.verify`, not `jwt.decode`, against the same
+ * `JWT_SECRET` the auth middleware uses. That distinction is the security of the whole
+ * scheme: an unverified `decode` would let anyone mint a token claiming any `id` and so
+ * *choose their own bucket*, which is strictly worse than IP keying because a single
+ * attacker could then also occupy an honest user's bucket. A signature that does not
+ * verify is treated exactly as no token at all.
+ *
+ * The alternative — moving the limiter behind the auth middleware — was rejected: the
+ * limiter is mounted once at the app level and would have to be re-mounted inside every
+ * router, unauthenticated routes would lose their limit entirely, and the ordering would
+ * become a per-route invariant nobody can see from `index.ts`. An HMAC verify per
+ * request is the cheaper price.
+ */
+export function rateLimitKey(req: Pick<Request, 'headers' | 'ip'>): string {
+  const userId = verifiedUserId(req);
+  if (userId !== undefined) return `user:${userId}`;
+  return `ip:${req.ip ?? 'unknown'}`;
+}
+
+function verifiedUserId(req: Pick<Request, 'headers'>): string | undefined {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string' || !header.startsWith('Bearer ')) return undefined;
+
+  const token = header.slice('Bearer '.length).trim();
+  const secret = process.env.JWT_SECRET;
+  if (!token || !secret) return undefined;
+
+  try {
+    const decoded = jwt.verify(token, secret);
+    if (typeof decoded !== 'object' || decoded === null) return undefined;
+    const { id } = decoded as { id?: unknown };
+    if (typeof id === 'number' && Number.isFinite(id)) return String(id);
+    if (typeof id === 'string' && id.length > 0) return id;
+    return undefined;
+  } catch {
+    // Expired, forged, or signed with another secret — indistinguishable from anonymous
+    // for bucketing purposes, and the request is about to be rejected by `verifyToken`
+    // anyway. Falling back to the IP bucket keeps those attempts budgeted.
+    return undefined;
+  }
+}
+
+/**
  * `max` is passed as a resolver rather than a number so that `getEnv()` is not called
  * while modules are still being imported.
  *
@@ -49,6 +119,8 @@ export function createGlobalLimiter(): RateLimitRequestHandler {
     max: () => globalRateLimitMax(),
     standardHeaders: true,
     legacyHeaders: false,
+    keyGenerator: rateLimitKey,
+    skip: isRateLimitExempt,
     message: errorResponse('RATE_LIMITED'),
   });
 }
@@ -87,6 +159,106 @@ export function logRateLimitOverrides(): void {
     `Rate limit ceilings overridden: global=${global}/15min (default ${DEFAULT_RATE_LIMIT_MAX}), ` +
       `auth=${auth}/15min (default ${DEFAULT_AUTH_RATE_LIMIT_MAX}). ` +
       'Expected for test runs only.'
+  );
+}
+
+/**
+ * Today's `trust proxy` setting: Express's own default, i.e. off. An unset
+ * `TRUST_PROXY` reproduces it exactly, so `req.ip` stays the socket address.
+ */
+export const DEFAULT_TRUST_PROXY = false;
+
+/** Presets Express understands by name, alongside literal addresses and CIDR ranges. */
+const TRUST_PROXY_PRESETS = new Set(['loopback', 'linklocal', 'uniquelocal']);
+
+/** A literal IPv4/IPv6 address or CIDR range, loosely — Express does the real parsing. */
+const ADDRESS_LIKE = /^[0-9a-fA-F.:]+(\/\d{1,3})?$/;
+
+export type TrustProxySetting = boolean | number | string[];
+
+/**
+ * Resolves `TRUST_PROXY` into a value for `app.set('trust proxy', …)`.
+ *
+ * Behind a proxy every request arrives from the proxy's address, so an IP-keyed bucket
+ * becomes one bucket for the entire internet. The fix is to trust the forwarding
+ * headers — but only as far as they can be trusted: `trust proxy: true` accepts whatever
+ * `X-Forwarded-For` the *client* sent, which lets an attacker put every request in a
+ * fresh bucket and makes the IP limit decorative. So:
+ *
+ *   - unset / `false` → off (today's behaviour, and the safe default)
+ *   - a hop count (`1`, `2`) → trust exactly that many proxies closest to the app
+ *   - a comma list of addresses, CIDRs, or the `loopback`/`linklocal`/`uniquelocal`
+ *     presets → trust only those
+ *   - `true` → accepted because a deployment may genuinely need it, but warned about
+ *   - anything else → ignored, falls back to off, and warned about
+ *
+ * A hop count is usually the setting to reach for: it needs no knowledge of the proxy's
+ * address, and Express resolves the address from the right-hand end of the chain, so the
+ * entries a client prepends are ignored — the count bounds how far into a
+ * client-controlled header the resolution can reach. `true` removes that bound, which is
+ * why it is warned about rather than treated as a convenience.
+ */
+export function resolveTrustProxy(raw: string | undefined): TrustProxySetting {
+  if (raw === undefined) return DEFAULT_TRUST_PROXY;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed.toLowerCase() === 'false') return false;
+  if (trimmed.toLowerCase() === 'true') return true;
+  if (/^\d+$/.test(trimmed)) {
+    const hops = Number(trimmed);
+    return Number.isSafeInteger(hops) ? hops : DEFAULT_TRUST_PROXY;
+  }
+
+  const entries = trimmed
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (entries.length === 0) return DEFAULT_TRUST_PROXY;
+  if (entries.every((entry) => TRUST_PROXY_PRESETS.has(entry) || ADDRESS_LIKE.test(entry))) {
+    return entries;
+  }
+  return DEFAULT_TRUST_PROXY;
+}
+
+export function trustProxySetting(): TrustProxySetting {
+  return resolveTrustProxy(getEnv().TRUST_PROXY);
+}
+
+/**
+ * Boot-time visibility for the one setting here that can silently widen an attacker's
+ * reach: a permissive `true` makes every IP-keyed budget spoofable, and an ignored typo
+ * leaves a proxied deployment sharing one bucket for all of its traffic. Both are
+ * invisible in normal operation, so both are said out loud, in the same posture as the
+ * ceiling overrides above.
+ */
+export function logTrustProxyOverride(): void {
+  const raw = getEnv().TRUST_PROXY;
+  if (raw === undefined) return;
+
+  const resolved = resolveTrustProxy(raw);
+
+  if (resolved === true) {
+    logger.warn(
+      'TRUST_PROXY=true trusts the client-supplied X-Forwarded-For chain, so a client can ' +
+        'choose its own rate-limit bucket. Prefer a hop count (e.g. TRUST_PROXY=1) or an ' +
+        'explicit list of proxy addresses.'
+    );
+    return;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (resolved === DEFAULT_TRUST_PROXY && normalized !== 'false' && normalized !== '') {
+    logger.warn(
+      `TRUST_PROXY="${raw}" is not a hop count, an address list, or a boolean — ignored, ` +
+        'trusting no proxy. req.ip will be the proxy address if one is in front of this API.'
+    );
+    return;
+  }
+
+  if (resolved === DEFAULT_TRUST_PROXY) return;
+
+  logger.warn(
+    `trust proxy set to ${JSON.stringify(resolved)} from TRUST_PROXY — req.ip is taken from ` +
+      'X-Forwarded-For for requests arriving through those hops.'
   );
 }
 

--- a/server/tests/http/rateLimit.test.ts
+++ b/server/tests/http/rateLimit.test.ts
@@ -23,10 +23,16 @@ import {
   createGlobalLimiter,
   globalRateLimitMax,
   logRateLimitOverrides,
+  logTrustProxyOverride,
+  isRateLimitExempt,
+  rateLimitKey,
   resolveCeiling,
+  resolveTrustProxy,
+  trustProxySetting,
 } from '../../src/http/rateLimits';
+import jwt from 'jsonwebtoken';
 
-const ENV_KEYS = ['RATE_LIMIT_MAX', 'AUTH_RATE_LIMIT_MAX'] as const;
+const ENV_KEYS = ['RATE_LIMIT_MAX', 'AUTH_RATE_LIMIT_MAX', 'TRUST_PROXY'] as const;
 const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
 
 beforeEach(() => {
@@ -94,14 +100,49 @@ async function authHarness(): Promise<Harness> {
   }, counter);
 }
 
-async function hit(url: string, method: 'GET' | 'POST' = 'GET'): Promise<Response> {
-  return fetch(url, { method });
+/**
+ * The global limiter with per-user keying, over both a normal route and the exempt
+ * health route, under a given `trust proxy` setting.
+ */
+async function keyedHarness(): Promise<Harness> {
+  const counter = { n: 0 };
+  return serve((app) => {
+    app.set('trust proxy', trustProxySetting());
+    app.use(createGlobalLimiter());
+    const handler = (_req: express.Request, res: express.Response) => {
+      counter.n += 1;
+      res.json({ ok: true });
+    };
+    app.get('/ping', handler);
+    app.get('/api/health', handler);
+  }, counter);
 }
 
-async function hitMany(url: string, times: number, method: 'GET' | 'POST' = 'GET') {
+function bearer(userId: number | string): Record<string, string> {
+  const token = jwt.sign(
+    { id: userId, email: `u${userId}@moon.com`, role: 'Cashier', name: `User ${userId}` },
+    process.env.JWT_SECRET as string
+  );
+  return { authorization: `Bearer ${token}` };
+}
+
+async function hit(
+  url: string,
+  method: 'GET' | 'POST' = 'GET',
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return fetch(url, { method, headers });
+}
+
+async function hitMany(
+  url: string,
+  times: number,
+  method: 'GET' | 'POST' = 'GET',
+  headers: Record<string, string> = {}
+) {
   const statuses: number[] = [];
   for (let i = 0; i < times; i += 1) {
-    statuses.push((await hit(url, method)).status);
+    statuses.push((await hit(url, method, headers)).status);
   }
   return statuses;
 }
@@ -367,5 +408,271 @@ describe('override visibility', () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
     expect(String(warn.mock.calls[0]?.[0])).toContain('500');
+  });
+});
+
+/**
+ * Per-till keying — the fix for #63.
+ *
+ * An IP-keyed global budget is a *per shop* budget: several tills behind one NAT share
+ * 200 requests / 15 min, and the failure lands as a `RATE_LIMITED` mid-checkout on
+ * whichever cashier happens to be next. The bucket is therefore the authenticated user.
+ *
+ * The limiter runs before `verifyToken`, so the identity has to come from the token
+ * itself — and it must be a *verified* signature. The spoofing tests below are the ones
+ * that matter: an unverified `jwt.decode` would let anyone pick their own bucket, which
+ * is strictly worse than the IP keying being replaced.
+ */
+describe('per-user keying', () => {
+  it('gives two authenticated users separate budgets from the same IP', async () => {
+    process.env.RATE_LIMIT_MAX = '3';
+    resetEnvCache();
+
+    const h = await keyedHarness();
+    try {
+      // Both tills call from 127.0.0.1 — the NAT case from the issue.
+      expect(await hitMany(`${h.url}/ping`, 3, 'GET', bearer(1))).toEqual([200, 200, 200]);
+      expect((await hit(`${h.url}/ping`, 'GET', bearer(1))).status).toBe(429);
+
+      // User 2's budget is untouched by user 1 exhausting theirs.
+      expect(await hitMany(`${h.url}/ping`, 3, 'GET', bearer(2))).toEqual([200, 200, 200]);
+      expect((await hit(`${h.url}/ping`, 'GET', bearer(2))).status).toBe(429);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('keeps one user in one bucket across separate tokens for the same id', async () => {
+    // A till that refreshes its access token mid-shift gets a different token string but
+    // the same identity; a token-keyed bucket would hand it a fresh budget on every
+    // refresh and make the ceiling meaningless.
+    process.env.RATE_LIMIT_MAX = '2';
+    resetEnvCache();
+
+    const h = await keyedHarness();
+    try {
+      await hitMany(`${h.url}/ping`, 2, 'GET', bearer(7));
+      expect((await hit(`${h.url}/ping`, 'GET', bearer(7))).status).toBe(429);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('falls back to the IP bucket for unauthenticated requests', async () => {
+    process.env.RATE_LIMIT_MAX = '2';
+    resetEnvCache();
+
+    const h = await keyedHarness();
+    try {
+      expect(await hitMany(`${h.url}/ping`, 2)).toEqual([200, 200]);
+      expect((await hit(`${h.url}/ping`)).status).toBe(429);
+
+      // And an authenticated till is not caught by the anonymous bucket being spent.
+      expect((await hit(`${h.url}/ping`, 'GET', bearer(3))).status).toBe(200);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('does not let a forged token buy a fresh bucket', async () => {
+    // The whole security of the scheme. A token signed with the wrong secret is treated
+    // as anonymous, so it lands in the caller's IP bucket rather than one of its choosing.
+    process.env.RATE_LIMIT_MAX = '2';
+    resetEnvCache();
+
+    const forged = jwt.sign({ id: 99, role: 'Admin' }, 'not-the-real-signing-secret-at-all');
+    const h = await keyedHarness();
+    try {
+      await hitMany(`${h.url}/ping`, 2, 'GET', { authorization: `Bearer ${forged}` });
+
+      // A second forged token claiming a different id is still the same IP bucket.
+      const other = jwt.sign({ id: 1234 }, 'not-the-real-signing-secret-at-all');
+      const over = await hit(`${h.url}/ping`, 'GET', { authorization: `Bearer ${other}` });
+      expect(over.status).toBe(429);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('treats an expired token as anonymous rather than as its claimed user', () => {
+    const expired = jwt.sign({ id: 5 }, process.env.JWT_SECRET as string, { expiresIn: '-1s' });
+    expect(rateLimitKey({ headers: { authorization: `Bearer ${expired}` }, ip: '10.0.0.9' })).toBe(
+      'ip:10.0.0.9'
+    );
+  });
+
+  it.each([
+    ['no header', {}],
+    ['a non-bearer scheme', { authorization: 'Basic abc' }],
+    ['an empty bearer', { authorization: 'Bearer ' }],
+    ['a garbage token', { authorization: 'Bearer not-a-jwt' }],
+  ])('keys %s by IP', (_label, headers) => {
+    expect(rateLimitKey({ headers: headers as never, ip: '10.0.0.1' })).toBe('ip:10.0.0.1');
+  });
+
+  it('keys a validly signed token by its user id', () => {
+    const token = jwt.sign({ id: 42 }, process.env.JWT_SECRET as string);
+    expect(rateLimitKey({ headers: { authorization: `Bearer ${token}` }, ip: '10.0.0.1' })).toBe(
+      'user:42'
+    );
+  });
+
+  it('falls back to IP for a signed token carrying no usable id', () => {
+    // A valid signature is not by itself an identity: without an `id` there is nothing to
+    // bucket on, and `user:undefined` would be one shared bucket for all such callers.
+    const token = jwt.sign({ role: 'Admin' }, process.env.JWT_SECRET as string);
+    expect(rateLimitKey({ headers: { authorization: `Bearer ${token}` }, ip: '10.0.0.2' })).toBe(
+      'ip:10.0.0.2'
+    );
+  });
+});
+
+describe('trust proxy', () => {
+  it('defaults to off, reproducing today’s behaviour exactly', () => {
+    expect(resolveTrustProxy(undefined)).toBe(false);
+    expect(trustProxySetting()).toBe(false);
+  });
+
+  it.each([
+    ['false', false],
+    ['', false],
+    ['  ', false],
+    ['true', true],
+    ['1', 1],
+    ['2', 2],
+  ])('resolves %j to %j', (raw, expected) => {
+    expect(resolveTrustProxy(raw as string)).toEqual(expected);
+  });
+
+  it('resolves an address list', () => {
+    expect(resolveTrustProxy('10.0.0.1, 192.168.0.0/16, loopback')).toEqual([
+      '10.0.0.1',
+      '192.168.0.0/16',
+      'loopback',
+    ]);
+  });
+
+  it('ignores an unparseable value rather than trusting something arbitrary', () => {
+    // The failure has to land closed: a typo that resolved to `true` would make every
+    // IP-keyed bucket client-selectable.
+    expect(resolveTrustProxy('yes please')).toBe(false);
+    expect(resolveTrustProxy('all')).toBe(false);
+  });
+
+  it('does not let a spoofed X-Forwarded-For escape the IP bucket by default', async () => {
+    // With TRUST_PROXY unset, `req.ip` is the socket address and the header is inert —
+    // so an unauthenticated client cannot mint itself a fresh budget per request.
+    process.env.RATE_LIMIT_MAX = '2';
+    resetEnvCache();
+
+    const h = await keyedHarness();
+    try {
+      await hit(`${h.url}/ping`, 'GET', { 'x-forwarded-for': '203.0.113.1' });
+      await hit(`${h.url}/ping`, 'GET', { 'x-forwarded-for': '203.0.113.2' });
+      const over = await hit(`${h.url}/ping`, 'GET', { 'x-forwarded-for': '203.0.113.3' });
+      expect(over.status).toBe(429);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('under a hop count, only the trusted hop’s entry moves the bucket', async () => {
+    // TRUST_PROXY=1 trusts exactly one hop, so Express takes the address that hop
+    // appended — the right-hand entry — and everything further left is whatever the
+    // client chose to prepend. Those prepended entries must not create a new bucket per
+    // request, which is precisely what `trust proxy: true` would have allowed.
+    process.env.RATE_LIMIT_MAX = '2';
+    process.env.TRUST_PROXY = '1';
+    resetEnvCache();
+
+    const h = await keyedHarness();
+    try {
+      const asProxied = (spoofed: string) => ({
+        'x-forwarded-for': `${spoofed}, 198.51.100.7`,
+      });
+      await hit(`${h.url}/ping`, 'GET', asProxied('203.0.113.1'));
+      await hit(`${h.url}/ping`, 'GET', asProxied('203.0.113.2'));
+      const over = await hit(`${h.url}/ping`, 'GET', asProxied('203.0.113.3'));
+      expect(over.status).toBe(429);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('warns loudly about the permissive setting', () => {
+    process.env.TRUST_PROXY = 'true';
+    resetEnvCache();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logTrustProxyOverride();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/X-Forwarded-For/i);
+  });
+
+  it('warns that an unparseable setting was ignored', () => {
+    process.env.TRUST_PROXY = 'yes';
+    resetEnvCache();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logTrustProxyOverride();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/ignored/i);
+  });
+
+  it('says nothing when unset', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logTrustProxyOverride();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('health check exemption', () => {
+  it('does not spend the shop’s budget on the uptime probe', async () => {
+    // Counting the probe means a shop that has spent its budget also fails its own health
+    // check — monitoring reporting an outage that the monitoring caused.
+    process.env.RATE_LIMIT_MAX = '2';
+    resetEnvCache();
+
+    const h = await keyedHarness();
+    try {
+      const statuses = await hitMany(`${h.url}/api/health`, 10);
+      expect(statuses.filter((s) => s !== 200)).toEqual([]);
+
+      // …and the probe has not eaten the budget the tills need.
+      expect((await hit(`${h.url}/ping`)).status).toBe(200);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('exempts only GET /api/health', () => {
+    expect(isRateLimitExempt({ method: 'GET', path: '/api/health' })).toBe(true);
+    expect(isRateLimitExempt({ method: 'POST', path: '/api/health' })).toBe(false);
+    expect(isRateLimitExempt({ method: 'GET', path: '/api/v1/sales' })).toBe(false);
+    expect(isRateLimitExempt({ method: 'GET', path: '/api/health/extra' })).toBe(false);
+  });
+});
+
+/**
+ * The auth limiter deliberately keeps IP keying, and this suite pins that.
+ *
+ * Per-user keying there would *weaken* it: an attacker guessing passwords is by
+ * definition unauthenticated, so there is no verified user to key on, and keying on the
+ * submitted email would hand the attacker a fresh 10-attempt budget per address they
+ * try — turning a brute-force control into a rate limit on the victim rather than on the
+ * attacker. IP is the only identity a credential attempt actually has.
+ */
+describe('auth limiter keying', () => {
+  it('is not widened by a bearer token — the credential budget stays per IP', async () => {
+    process.env.AUTH_RATE_LIMIT_MAX = '3';
+    resetEnvCache();
+
+    const h = await authHarness();
+    try {
+      await hitMany(`${h.url}/login`, 3, 'POST');
+      // A caller holding a valid token for some user is still the same credential bucket.
+      const over = await hit(`${h.url}/login`, 'POST', bearer(1));
+      expect(over.status).toBe(429);
+    } finally {
+      await h.close();
+    }
   });
 });


### PR DESCRIPTION
Closes #63.

## The defect

The global limiter set no `keyGenerator`, so `express-rate-limit` keyed on `req.ip`, and no `trust proxy` was configured anywhere. Several tills behind one shop router share one address, so 200 requests / 15 min was a **per-shop** budget, not per-till. Once spent, the next request returns `RATE_LIMITED` — and that can land mid-checkout, on a cashier with a customer waiting.

## What changed

**Bucket = authenticated user id, falling back to IP.** `rateLimitKey()` returns `user:<id>` or `ip:<addr>`. Keying on the user id rather than the token string means a mid-shift token refresh does not hand a till a fresh budget; there is a test for that.

**Identity is obtained by verifying, never decoding.** The limiter runs ahead of `verifyToken`, so the key generator calls `jwt.verify` with the same `JWT_SECRET` the auth middleware uses. This distinction is the security of the whole scheme: an unverified `decode` would let anyone mint a token claiming any `id` and so *choose their own bucket*, which is strictly worse than IP keying because a single attacker could then also squat an honest cashier's bucket. A signature that does not verify is treated exactly as no token.

Moving the limiter behind the auth middleware was rejected: it is mounted once at app level, so it would have to be re-mounted inside every router, unauthenticated routes would lose their limit entirely, and the ordering would become a per-route invariant invisible from `index.ts`. One HMAC verify per request is the cheaper price.

**`TRUST_PROXY` env knob.** Unset/`false` → off, which is Express's own default, so **an unset server behaves exactly as before**. A hop count (`1`, `2`) is the recommended setting — it bounds how far into a client-controlled header resolution can reach without needing the proxy's address. A comma list of addresses/CIDRs/presets is also accepted. `true` is accepted but warned about loudly at boot, because it trusts the whole client-supplied `X-Forwarded-For` chain and makes every IP bucket client-selectable. An unparseable value falls back to off and is warned about — the quiet-failure case the file already guards for the ceilings.

**`GET /api/health` exempt** via `skip`. Counting the uptime probe means a shop that has spent its budget also fails its own health check — monitoring reporting an outage that monitoring caused. Deliberately narrow: register/shift polling reads are *authenticated*, so per-user keying already stops one till starving another, and exempting them would carve real DB-touching endpoints out of abuse protection for no remaining benefit.

## What deliberately did not change

**Neither default ceiling.** `DEFAULT_RATE_LIMIT_MAX` stays 200, `DEFAULT_AUTH_RATE_LIMIT_MAX` stays 10. #63 notes the number is unmeasured; keying is fixable today, the value needs a real shift's data first.

**`authLimiter` stays IP-keyed** on `/auth/login` and `/auth/refresh`, and there is now a test pinning that a bearer token buys no extra login attempts. Per-user keying would **weaken** it: a password-guessing attacker is unauthenticated by definition, so there is no verified user to key on, and keying on the submitted email would give a fresh 10-attempt budget per address tried — converting a brute-force control into a rate limit on the victim. IP is the only identity a credential attempt actually has.

## Testing

`npx vitest run tests/http` — 81 passed, including 19 new: two users not sharing a bucket from one IP, unauthenticated requests keyed by IP, forged/expired/garbage tokens falling back to the IP bucket, a spoofed `X-Forwarded-For` not escaping the bucket under the default, hop-count semantics, health exemption, and the boot warnings. Full server suite 300 passed; `tsc --noEmit` clean; eslint 0 errors.

The one failure, `tests/exchanges.test.ts`, was confirmed to fail identically on a stashed clean `main` — pre-existing, now #69.

## Reviewer notes

- `express-rate-limit` is 7.5.1, which does not ship the `ipKeyGenerator` helper, so the custom `keyGenerator` triggers no IPv6 validation error. Note that `ip:${req.ip}` keys on a *full* IPv6 address, so a client with a /64 has many buckets — but that is exactly what the library's default key generator already did, so it is pre-existing rather than a regression. It would matter on an upgrade.
- The default memory store is per-process, so per-user buckets are per-instance. Fine on a single process; a multi-instance deploy needs a shared store regardless of keying.
- Root `CLAUDE.md` gains a **Rate-limit bucketing** section, per the repo's keep-docs-in-sync rule.

## Post-Deploy Monitoring & Validation

- **Watch:** count of `RATE_LIMITED` responses, broken down by route. Expect a drop to ~zero for authenticated POS traffic.
- **Boot check:** confirm the logs show **no** `TRUST_PROXY` warning on first boot — unset is the intended production state for now. A `TRUST_PROXY="..." is not a hop count` warning means a typo silently reverted to off.
- **Healthy signal:** `/api/health` never returns 429. Multiple tills in one shop transacting concurrently without `RATE_LIMITED`.
- **Failure signal / rollback trigger:** any `RATE_LIMITED` on `/api/v1/sales`, or a rise in 401s on authenticated routes (would suggest the key generator is throwing rather than falling through). Revert is a single commit; no schema, no data.
- **Before setting `TRUST_PROXY` in any environment:** verify with `curl -H "X-Forwarded-For: 1.2.3.4"` that the resolved `req.ip` is what you expect, and never use `true` without an intervening proxy that overwrites the header.
- **Window:** one full trading day across a multi-till shop.
- **Owner:** @zhamdy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN