### PR TITLE
refactor(server): run cleanup once per fleet and put media behind a storage abstraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,14 @@ Jobs must be idempotent: a failed run is retried on the next interval, and both 
 keyed on the current state of the world rather than on a cursor, so a retry that finds
 nothing to do reports `0` rather than failing.
 
+**A claim is written before the work, so a process killed mid-run leaves the row in
+`running`.** Another instance takes that claim over once it is older than the job's
+`staleAfterMs` (default 10 min) — safe because the takeover is only ever reached with the
+advisory lock free, and a run that is genuinely in progress holds it. The lock, not the
+row, is the authority on "is someone running this"; the row only decides "has this been
+done recently enough". A takeover is logged, and means a previous run died without
+recording anything.
+
 Adding a job means adding a `ScheduledJob` to `src/scheduler/jobs.ts` with a **new, never
 reused** `lockId` — during a rolling deploy two ids for the same job means two concurrent
 runs.
@@ -251,7 +259,9 @@ before the row that references it, and the replaced object is released only afte
 stops pointing at it. Each step's failure mode is a temporary orphan, never a broken image.
 The daily `orphaned-media-cleanup` job is the backstop for orphans no request path could
 clean up; it reads every `image_url` in the database first and aborts rather than delete
-anything if that read fails, and it never touches an object younger than
+anything if that read fails **or if any URL that belongs to this store cannot be resolved
+to a key** — an unresolvable reference is missing information, and a deletion routine must
+never read missing information as "unreferenced" — and it never touches an object younger than
 `MEDIA_ORPHAN_MIN_AGE_HOURS`. **A new table with an image URL column must be added to the
 reference query in `src/scheduler/mediaSweep.ts`** — the sweep deletes what that query does
 not return.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,84 @@ till is confirmed to be sending the header. The observable is that
 matches the day's sale count. Flipping is a config change, not a deploy, so it is
 reversible in seconds.
 
+## Scheduled jobs
+
+Background maintenance runs through `server/src/scheduler`, not through a `setInterval`
+per process. Every instance still ticks on its own timer, but a tick only *offers* to run:
+`runScheduledJob` takes a session-level advisory lock (so two runs cannot overlap) and then
+claims the interval in the `scheduled_jobs` table with one conditional upsert (so a second
+instance waking a second later does not repeat the work). Horizontal scaling therefore does
+not multiply the work.
+
+There is deliberately no job framework and no Redis. PostgreSQL is already required and
+already provides both primitives; an external scheduler would be a component to run,
+monitor and fail over for what is a single `DELETE`.
+
+Every job reports an outcome, which is written to `scheduled_jobs.last_detail` and logged.
+To see what the fleet has been doing:
+
+```sql
+SELECT name, last_started_at, last_finished_at, last_status, last_detail,
+       run_count, failure_count
+  FROM scheduled_jobs;
+```
+
+| Job | Cadence | Outcome |
+| --- | --- | --- |
+| `reservation-cleanup` | 5 min | `{ deleted }` — expired stock reservations removed |
+| `orphaned-media-cleanup` | 24 h | `{ scanned, deleted, skippedRecent, failed }` |
+
+Jobs must be idempotent: a failed run is retried on the next interval, and both jobs are
+keyed on the current state of the world rather than on a cursor, so a retry that finds
+nothing to do reports `0` rather than failing.
+
+Adding a job means adding a `ScheduledJob` to `src/scheduler/jobs.ts` with a **new, never
+reused** `lockId` — during a rolling deploy two ids for the same job means two concurrent
+runs.
+
+## Media storage
+
+Uploaded images go through the `StorageDriver` abstraction in `server/src/storage`, never
+straight to disk. The controller mints a key, hands the driver a buffer, and stores the URL
+the driver returns; nothing above the interface knows where the bytes live.
+
+`local` (filesystem) is the only bundled driver and the default. Its defaults reproduce the
+previous behaviour exactly — objects under `server/uploads`, URLs of the form
+`/uploads/products/<name>` — so **every image URL already in the database keeps working
+untouched**. For a deployment it is durable only when `MEDIA_LOCAL_ROOT` points at storage
+that outlives the container and is shared by every instance (a mounted volume or NFS).
+Where that is not available, add a driver implementing `StorageDriver` and a case in
+`createStorageDriver`; no provider SDK or credential belongs in the callers, and none is
+hardcoded anywhere in this repo.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `MEDIA_STORAGE_DRIVER` | `local` | Which driver to resolve. |
+| `MEDIA_LOCAL_ROOT` | `server/uploads` | Root directory for the `local` driver. |
+| `MEDIA_PUBLIC_BASE_URL` | `/uploads` | Prefix `publicUrl` puts in front of a key. |
+| `MEDIA_ORPHAN_MIN_AGE_HOURS` | `24` | Grace period before the sweep may delete an unreferenced object. |
+
+**Local development:** nothing to configure. `npm run dev` with no media variables set
+writes to `server/uploads` and serves `/uploads` exactly as before.
+
+**Moving to a shared or remote store:** copy the existing `server/uploads` tree into the
+new store preserving keys, then point the config at it. Old rows hold relative
+`/uploads/...` URLs and keep resolving through the `/uploads` mount, so the copy can happen
+before or after the config change. Only set `MEDIA_PUBLIC_BASE_URL` to an absolute base
+once the objects are actually reachable there; new rows will then hold absolute URLs while
+old ones stay relative, and both remain valid.
+
+**Lifecycle.** Validation and authorization run before anything is written (Admin only,
+2 MB, JPEG/PNG/WebP, magic bytes must agree with the extension), the object is written
+before the row that references it, and the replaced object is released only after the row
+stops pointing at it. Each step's failure mode is a temporary orphan, never a broken image.
+The daily `orphaned-media-cleanup` job is the backstop for orphans no request path could
+clean up; it reads every `image_url` in the database first and aborts rather than delete
+anything if that read fails, and it never touches an object younger than
+`MEDIA_ORPHAN_MIN_AGE_HOURS`. **A new table with an image URL column must be added to the
+reference query in `src/scheduler/mediaSweep.ts`** — the sweep deletes what that query does
+not return.
+
 ## Git Workflow
 
 - **Always branch from `main`** before starting a feature (`feature/xxx`, `fix/xxx`)

--- a/server/.env.example
+++ b/server/.env.example
@@ -21,3 +21,19 @@ IDEMPOTENCY_REQUIRED=false
 # 10 within its first few logins. An override is warned about at boot.
 RATE_LIMIT_MAX=200
 AUTH_RATE_LIMIT_MAX=10
+
+# Media storage. Every value here is optional and the defaults reproduce the behaviour
+# that predates the storage abstraction exactly: images on the filesystem under
+# server/uploads, served at /uploads, which is the URL shape already in the database.
+#
+# local is the documented development option and the compatibility default. It is durable
+# in a deployment only when MEDIA_LOCAL_ROOT points at storage that outlives the container
+# and is shared by every instance (a mounted volume or a network filesystem). Where that is
+# not available, add a driver implementing StorageDriver (server/src/storage) rather than
+# changing the callers; no cloud credentials belong in this file.
+MEDIA_STORAGE_DRIVER=local
+# MEDIA_LOCAL_ROOT=/var/lib/moon/media
+# MEDIA_PUBLIC_BASE_URL=/uploads
+# Grace period before the daily sweep may delete an unreferenced object. It exists because
+# an upload writes the object before the row that references it.
+MEDIA_ORPHAN_MIN_AGE_HOURS=24

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,7 @@ import { openApiSpec } from './src/docs/openapi';
 
 import { routeTable } from './src/router';
 import { startScheduler } from './src/scheduler';
+import { getStorage, LocalStorageDriver } from './src/storage';
 
 // Validate required environment variables
 const requiredEnvVars = ['JWT_SECRET', 'JWT_REFRESH_SECRET'] as const;
@@ -92,8 +93,21 @@ app.use(sanitizeBody);
 // Request logging
 app.use(requestLogger);
 
-// Static files (product images)
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+/**
+ * Static files (product images).
+ *
+ * Only the filesystem driver needs a mount, and it serves the driver's own root rather
+ * than a path spelled out again here — so pointing `MEDIA_LOCAL_ROOT` at a mounted volume
+ * moves both the writes and the reads. A remote driver serves its own URLs and this mount
+ * stays in place only to keep already-stored `/uploads/...` rows resolvable.
+ */
+const storage = getStorage();
+app.use(
+  '/uploads',
+  express.static(
+    storage instanceof LocalStorageDriver ? storage.rootDir : path.join(__dirname, 'uploads')
+  )
+);
 
 // Routes
 for (const [routePath, router] of routeTable) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,8 @@ import db, { closePool } from './src/database/pool';
 import { errorResponse } from './src/http/errors';
 import { openApiSpec } from './src/docs/openapi';
 
-import { routeTable, cleanupExpiredReservations } from './src/router';
+import { routeTable } from './src/router';
+import { startScheduler } from './src/scheduler';
 
 // Validate required environment variables
 const requiredEnvVars = ['JWT_SECRET', 'JWT_REFRESH_SECRET'] as const;
@@ -132,8 +133,12 @@ app.use((_req: Request, res: Response) => {
 // Error handler
 app.use(errorHandler);
 
-// Cleanup expired reservations every 5 minutes
-const cleanupInterval = setInterval(cleanupExpiredReservations, 5 * 60 * 1000);
+/**
+ * Background maintenance. Every instance ticks, but each job runs at most once per
+ * interval across the whole fleet — the claim lives in `scheduled_jobs`, not in this
+ * process. See `src/scheduler/index.ts`.
+ */
+const scheduler = startScheduler();
 
 // Prevent crashes from unhandled errors
 process.on('uncaughtException', (err) => {
@@ -151,7 +156,7 @@ const server = app.listen(PORT, () => {
 // Graceful shutdown
 function shutdown(signal: string): void {
   logger.info(`${signal} received, shutting down gracefully`);
-  clearInterval(cleanupInterval);
+  scheduler.stop();
   server.close(async () => {
     logger.info('HTTP server closed');
     try {

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -43,6 +43,33 @@ const envSchema = z.object({
    * deliberately-discouraged `true`.
    */
   TRUST_PROXY: z.string().optional(),
+  /**
+   * Where uploaded media lives, resolved by `src/storage/index.ts`. Every default here
+   * reproduces the pre-abstraction behaviour exactly — the filesystem under
+   * `server/uploads`, served at `/uploads` — so an unconfigured deployment keeps serving
+   * the URLs already in the database.
+   *
+   * `local` is the documented development option and the compatibility default. It is
+   * durable in a deployment only when `MEDIA_LOCAL_ROOT` points at storage that outlives
+   * the container and is shared by every instance (a mounted volume or NFS). No cloud
+   * driver is bundled, and none of this file names a provider: a driver is a new file
+   * implementing `StorageDriver`, configured by adding a case to `createStorageDriver`.
+   */
+  MEDIA_STORAGE_DRIVER: z.enum(['local']).default('local'),
+  /** Root directory for the `local` driver. Defaults to `server/uploads`. */
+  MEDIA_LOCAL_ROOT: z.string().optional(),
+  /**
+   * URL prefix `publicUrl` puts in front of a key. Defaults to `/uploads`, the exact shape
+   * of every `image_url` already stored. Point it at a CDN once media is fronted by one;
+   * rows written before the change keep resolving through the `/uploads` mount.
+   */
+  MEDIA_PUBLIC_BASE_URL: z.string().optional(),
+  /**
+   * How long an unreferenced object must have sat in the store before the orphan sweep may
+   * delete it. The window exists because an upload is written before the row that
+   * references it: without it, a sweep landing between the two would delete a live image.
+   */
+  MEDIA_ORPHAN_MIN_AGE_HOURS: z.coerce.number().min(1).default(24),
   CLIENT_URL: z.string().optional().default('http://localhost:5173'),
   ALLOWED_ORIGINS: z.string().optional(),
   TWILIO_ACCOUNT_SID: z.string().optional(),

--- a/server/src/database/migrations/007_scheduled_jobs.down.sql
+++ b/server/src/database/migrations/007_scheduled_jobs.down.sql
@@ -1,0 +1,2 @@
+-- 007_scheduled_jobs.down.sql
+DROP TABLE IF EXISTS scheduled_jobs;

--- a/server/src/database/migrations/007_scheduled_jobs.sql
+++ b/server/src/database/migrations/007_scheduled_jobs.sql
@@ -1,0 +1,42 @@
+-- 007_scheduled_jobs.sql
+-- Single-execution semantics for background maintenance.
+--
+-- Until now the only scheduled work in this system -- expiring stock reservations --
+-- ran from a `setInterval` inside every API process. One process is fine; two are not.
+-- Every instance woke on its own timer and ran the same DELETE against the same rows,
+-- so the maintenance cost scaled with the number of web dynos rather than with the
+-- amount of work, and nothing recorded whether a run had happened or how it went.
+--
+-- This table is the claim ledger that fixes both. A run claims its slot with ONE
+-- conditional upsert:
+--
+--   INSERT INTO scheduled_jobs (name, last_started_at, ...)
+--   VALUES ($1, NOW(), ...)
+--   ON CONFLICT (name) DO UPDATE SET last_started_at = NOW(), ...
+--     WHERE scheduled_jobs.last_started_at <= NOW() - <interval>
+--   RETURNING name;
+--
+-- Under READ COMMITTED a second instance racing the same statement blocks on the row
+-- lock, then re-evaluates the DO UPDATE WHERE against the *updated* row -- which now
+-- carries the winner's `last_started_at` -- and matches nothing. It returns zero rows
+-- and skips. No extra table, no external scheduler, no Redis: the claim is the lock.
+--
+-- The runner ALSO takes a session-level advisory lock around the whole run. The claim
+-- row alone prevents duplicate work inside one interval; the advisory lock additionally
+-- prevents two runs *overlapping* when a job outlives its own interval. They guard
+-- different failures and are both cheap.
+--
+-- Columns other than the claim exist to make the job observable: `last_status` and
+-- `last_detail` are what a run reports, and `run_count` / `failure_count` are what an
+-- operator (or a health probe) reads without trawling logs. A failed run leaves
+-- `last_started_at` set, so the retry is the next interval -- deliberate: a job that
+-- fails fast in a tight loop is a worse outage than one that waits five minutes.
+CREATE TABLE IF NOT EXISTS scheduled_jobs (
+  name TEXT PRIMARY KEY,
+  last_started_at TIMESTAMPTZ,
+  last_finished_at TIMESTAMPTZ,
+  last_status TEXT,
+  last_detail TEXT,
+  run_count INTEGER NOT NULL DEFAULT 0,
+  failure_count INTEGER NOT NULL DEFAULT 0
+);

--- a/server/src/modules/commerce/storefront/controller.ts
+++ b/server/src/modules/commerce/storefront/controller.ts
@@ -3,11 +3,29 @@ import { z } from 'zod';
 import { storefrontService } from './service';
 import { success } from '../../../http/responses';
 import { PublicError } from '../../../http/errors';
+import { getStorage } from '../../../storage';
+
+/**
+ * A banner image is either somebody else's absolute URL or a path into this deployment's
+ * own media store. The store is asked rather than a `/uploads/` prefix being hard-coded,
+ * so a deployment that moves its media keeps accepting the URLs it now hands out.
+ */
+function isStoredOrAbsoluteUrl(value: string): boolean {
+  if (z.string().url().safeParse(value).success) return true;
+  return getStorage().keyFromUrl(value) !== null;
+}
 
 export const bannerSchema = z.object({
   title: z.string().min(1).max(100),
   subtitle: z.string().max(255).optional(),
-  image_url: z.string().url().or(z.string().startsWith('/uploads/')),
+  image_url: z
+    .string()
+    .min(1)
+    .max(1000)
+    .refine(
+      isStoredOrAbsoluteUrl,
+      'image_url must be an absolute URL or a path in the media store'
+    ),
   link_url: z.string().max(255).optional(),
   position: z.number().int().default(0),
   is_active: z.boolean().default(true),

--- a/server/src/modules/inventory/products/controller.ts
+++ b/server/src/modules/inventory/products/controller.ts
@@ -1,6 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import path from 'path';
-import fs from 'fs';
+import logger from '../../../../lib/logger';
 import { AuthRequest } from '../../../../middleware/auth';
 import { logAuditFromReq } from '../../../../middleware/auditLogger';
 import {
@@ -15,6 +14,7 @@ import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
 import { parseProductListQuery, parseProductLookupQuery } from './types';
+import { getStorage, productImageKey } from '../../../storage';
 
 const bulkUpdateSchema = z.object({
   ids: z.array(z.number().int().positive()).min(1),
@@ -321,6 +321,15 @@ export class ProductsController {
     }
   }
 
+  /**
+   * Replaces a product's image.
+   *
+   * Ordering is the whole design. The product is validated *before* anything is written,
+   * so a rejected upload leaves no object at all; the new object is written before the row
+   * so the row never points at something absent; and the previous object is deleted only
+   * after the row stops referencing it. Each step's failure mode is a temporary orphan the
+   * sweep collects, never a broken image or a lost upload.
+   */
   async uploadImage(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       if (!req.file) {
@@ -328,25 +337,44 @@ export class ProductsController {
       }
 
       const productId = Number(req.params.id);
-      const imageUrl = `/uploads/products/${req.file.filename}`;
+      const storage = getStorage();
 
       const existing = await productsRepository.findById(productId);
       if (!existing) {
-        fs.unlinkSync(req.file.path);
         throw new PublicError('NOT_FOUND', 'Product not found');
       }
       if (existing.status === 'discontinued') {
-        fs.unlinkSync(req.file.path);
         throw new PublicError('FORBIDDEN', 'Cannot modify a discontinued product');
       }
-      if (existing.image_url) {
-        const oldPath = path.join(__dirname, '../../../../..', existing.image_url);
-        if (fs.existsSync(oldPath)) {
-          fs.unlinkSync(oldPath);
-        }
+
+      const key = productImageKey(req.file.mimetype);
+      await storage.put(key, req.file.buffer, { contentType: req.file.mimetype });
+      const imageUrl = storage.publicUrl(key);
+
+      try {
+        await productsRepository.updateImage(productId, imageUrl);
+      } catch (err) {
+        // Nothing references the object yet, so it is an orphan the moment the write
+        // fails. Undo it here rather than leave it for the sweep.
+        await storage.delete(key).catch((cleanupErr: Error) =>
+          logger.error('Could not remove image after a failed product update', {
+            key,
+            error: cleanupErr.message,
+          })
+        );
+        throw err;
       }
 
-      await productsRepository.updateImage(productId, imageUrl);
+      const previousKey = existing.image_url ? storage.keyFromUrl(existing.image_url) : null;
+      if (previousKey && previousKey !== key) {
+        await storage.delete(previousKey).catch((err: Error) =>
+          logger.warn('Replaced product image could not be removed; left for the sweep', {
+            key: previousKey,
+            error: err.message,
+          })
+        );
+      }
+
       res.json(success({ image_url: imageUrl }));
     } catch (err) {
       next(err);
@@ -356,6 +384,8 @@ export class ProductsController {
   async deleteImage(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const productId = Number(req.params.id);
+      const storage = getStorage();
+
       const existing = await productsRepository.findById(productId);
       if (!existing) {
         throw new PublicError('NOT_FOUND', 'Product not found');
@@ -363,14 +393,21 @@ export class ProductsController {
       if (existing.status === 'discontinued') {
         throw new PublicError('FORBIDDEN', 'Cannot modify a discontinued product');
       }
-      if (existing.image_url) {
-        const oldPath = path.join(__dirname, '../../../../..', existing.image_url);
-        if (fs.existsSync(oldPath)) {
-          fs.unlinkSync(oldPath);
-        }
+
+      // The row is dropped first: an object that outlives its reference is collectable,
+      // while a reference that outlives its object is a broken image on the shop floor.
+      await productsRepository.updateImage(productId, null);
+
+      const key = existing.image_url ? storage.keyFromUrl(existing.image_url) : null;
+      if (key) {
+        await storage.delete(key).catch((err: Error) =>
+          logger.warn('Deleted product image could not be removed; left for the sweep', {
+            key,
+            error: err.message,
+          })
+        );
       }
 
-      await productsRepository.updateImage(productId, null);
       res.status(204).send();
     } catch (err) {
       next(err);

--- a/server/src/modules/inventory/products/routes.ts
+++ b/server/src/modules/inventory/products/routes.ts
@@ -1,10 +1,13 @@
 import { Router } from 'express';
 import { verifyToken, requireRole } from '../../../../middleware/auth';
-import { createUpload, validateMagic, uploadRateLimit } from '../../../../middleware/upload';
+import { uploadRateLimit } from '../../../../middleware/upload';
+import { createImageUpload, validateImageBytes } from '../../../storage/upload';
 import { cacheControl } from '../../../../middleware/cache';
 import { productsController } from './controller';
 
-const upload = createUpload({ maxSize: 2 * 1024 * 1024, destination: 'uploads/products' });
+// Memory-backed: the bytes go to the configured storage driver, not to this container's
+// disk. Size, extension and magic-byte checks are unchanged and still run before the write.
+const upload = createImageUpload({ maxSize: 2 * 1024 * 1024 });
 const router: Router = Router();
 
 router.get('/', verifyToken, (req, res, next) => productsController.getProducts(req, res, next));
@@ -59,7 +62,7 @@ router.post(
   requireRole('Admin'),
   uploadRateLimit,
   upload.single('image'),
-  validateMagic,
+  validateImageBytes,
   (req, res, next) => productsController.uploadImage(req, res, next)
 );
 router.delete('/:id/image', verifyToken, requireRole('Admin'), (req, res, next) =>

--- a/server/src/scheduler/index.ts
+++ b/server/src/scheduler/index.ts
@@ -20,7 +20,7 @@ import { runScheduledJob } from './runner';
 import type { ScheduledJob } from './types';
 
 export * from './types';
-export { runScheduledJob, ADVISORY_LOCK_NAMESPACE } from './runner';
+export { runScheduledJob, ADVISORY_LOCK_NAMESPACE, DEFAULT_STALE_CLAIM_MS } from './runner';
 export { reservationCleanupJob, orphanedMediaCleanupJob, JOB_LOCK_IDS } from './jobs';
 export { sweepOrphanedMedia, type SweepOutcome } from './mediaSweep';
 

--- a/server/src/scheduler/index.ts
+++ b/server/src/scheduler/index.ts
@@ -15,13 +15,14 @@
  */
 import type { Pool } from 'pg';
 import logger from '../../lib/logger';
-import { reservationCleanupJob } from './jobs';
+import { orphanedMediaCleanupJob, reservationCleanupJob } from './jobs';
 import { runScheduledJob } from './runner';
 import type { ScheduledJob } from './types';
 
 export * from './types';
 export { runScheduledJob, ADVISORY_LOCK_NAMESPACE } from './runner';
-export { reservationCleanupJob, JOB_LOCK_IDS } from './jobs';
+export { reservationCleanupJob, orphanedMediaCleanupJob, JOB_LOCK_IDS } from './jobs';
+export { sweepOrphanedMedia, type SweepOutcome } from './mediaSweep';
 
 /**
  * How often an instance offers to run due jobs. Shorter than the shortest job interval so
@@ -29,7 +30,10 @@ export { reservationCleanupJob, JOB_LOCK_IDS } from './jobs';
  */
 export const DEFAULT_TICK_MS = 60 * 1000;
 
-export const defaultJobs: ScheduledJob<unknown>[] = [reservationCleanupJob];
+export const defaultJobs: ScheduledJob<unknown>[] = [
+  reservationCleanupJob,
+  orphanedMediaCleanupJob,
+];
 
 export interface Scheduler {
   /** Runs one pass over the job list. Exposed for tests and for a manual trigger. */

--- a/server/src/scheduler/index.ts
+++ b/server/src/scheduler/index.ts
@@ -1,0 +1,76 @@
+/**
+ * In-process tick, fleet-wide single execution.
+ *
+ * Every API instance ticks on its own timer, exactly as the old `setInterval` did — what
+ * changed is that a tick no longer means "do the work". It means "offer to do the work":
+ * `runScheduledJob` claims the slot in `scheduled_jobs` and holds an advisory lock, so
+ * across N instances the work happens once per interval. See `runner.ts` and migration
+ * 007 for why the claim is a single conditional upsert.
+ *
+ * This is deliberately not a job framework. The whole requirement is "one instance does
+ * this every five minutes, and says what it did"; PostgreSQL is already a required
+ * dependency and already provides the two primitives that need. Adding Redis, a queue, or
+ * an external scheduler would add an operational component to run, monitor and fail over,
+ * for maintenance that is a single DELETE.
+ */
+import type { Pool } from 'pg';
+import logger from '../../lib/logger';
+import { reservationCleanupJob } from './jobs';
+import { runScheduledJob } from './runner';
+import type { ScheduledJob } from './types';
+
+export * from './types';
+export { runScheduledJob, ADVISORY_LOCK_NAMESPACE } from './runner';
+export { reservationCleanupJob, JOB_LOCK_IDS } from './jobs';
+
+/**
+ * How often an instance offers to run due jobs. Shorter than the shortest job interval so
+ * a job's real cadence is set by its own `intervalMs`, not by the tick.
+ */
+export const DEFAULT_TICK_MS = 60 * 1000;
+
+export const defaultJobs: ScheduledJob<unknown>[] = [reservationCleanupJob];
+
+export interface Scheduler {
+  /** Runs one pass over the job list. Exposed for tests and for a manual trigger. */
+  tick(): Promise<void>;
+  stop(): void;
+}
+
+export interface StartSchedulerOptions {
+  jobs?: ScheduledJob<unknown>[];
+  tickMs?: number;
+  /** Run a pass immediately on start, so a fresh deploy does not wait a full tick. */
+  runOnStart?: boolean;
+  /** Pool the jobs claim through. Defaults to the application pool. */
+  pool?: Pool;
+}
+
+export function startScheduler(options: StartSchedulerOptions = {}): Scheduler {
+  const jobs = options.jobs ?? defaultJobs;
+  const tickMs = options.tickMs ?? DEFAULT_TICK_MS;
+
+  async function tick(): Promise<void> {
+    for (const job of jobs) {
+      // runScheduledJob never throws; this catch is for the impossible case only.
+      await runScheduledJob(job, { pool: options.pool }).catch((err: Error) =>
+        logger.error('Scheduler tick failed', { job: job.name, error: err.message })
+      );
+    }
+  }
+
+  const handle = setInterval(() => void tick(), tickMs);
+
+  if (options.runOnStart !== false) {
+    void tick();
+  }
+
+  logger.info('Scheduler started', { jobs: jobs.map((j) => j.name), tickMs });
+
+  return {
+    tick,
+    stop() {
+      clearInterval(handle);
+    },
+  };
+}

--- a/server/src/scheduler/jobs.ts
+++ b/server/src/scheduler/jobs.ts
@@ -1,4 +1,5 @@
 import { reservationsRepository } from '../modules/pos/reservations/repository';
+import { sweepOrphanedMedia, type SweepOutcome } from './mediaSweep';
 import type { ScheduledJob } from './types';
 
 /**
@@ -26,5 +27,21 @@ export const reservationCleanupJob: ScheduledJob<{ deleted: number }> = {
   async run() {
     const deleted = await reservationsRepository.deleteExpired();
     return { deleted };
+  },
+};
+
+/**
+ * Collects stored images nothing references any more.
+ *
+ * Daily, and fleet-wide once per day: listing a bucket is the kind of work that has no
+ * business happening N times because N instances are deployed. See `mediaSweep.ts` for the
+ * two guards that keep it from deleting live media.
+ */
+export const orphanedMediaCleanupJob: ScheduledJob<SweepOutcome> = {
+  name: 'orphaned-media-cleanup',
+  intervalMs: 24 * 60 * 60 * 1000,
+  lockId: JOB_LOCK_IDS.orphanedMediaCleanup,
+  run() {
+    return sweepOrphanedMedia();
   },
 };

--- a/server/src/scheduler/jobs.ts
+++ b/server/src/scheduler/jobs.ts
@@ -1,0 +1,30 @@
+import { reservationsRepository } from '../modules/pos/reservations/repository';
+import type { ScheduledJob } from './types';
+
+/**
+ * Lock ids are identities, not indexes. Never renumber an existing one — during a rolling
+ * deploy the old and new code run side by side, and two ids for one job means two
+ * concurrent runs.
+ */
+export const JOB_LOCK_IDS = {
+  reservationCleanup: 1,
+  orphanedMediaCleanup: 2,
+} as const;
+
+/**
+ * Deletes stock reservations whose hold has expired.
+ *
+ * Idempotent by construction: the DELETE is keyed on `expires_at <= NOW()`, so a retry
+ * after a partial failure removes whatever is still expired and reports `{ deleted: 0 }`
+ * when there is nothing left. Reporting the count is the point — a silent `void` cleanup
+ * is indistinguishable from one that never ran.
+ */
+export const reservationCleanupJob: ScheduledJob<{ deleted: number }> = {
+  name: 'reservation-cleanup',
+  intervalMs: 5 * 60 * 1000,
+  lockId: JOB_LOCK_IDS.reservationCleanup,
+  async run() {
+    const deleted = await reservationsRepository.deleteExpired();
+    return { deleted };
+  },
+};

--- a/server/src/scheduler/mediaSweep.ts
+++ b/server/src/scheduler/mediaSweep.ts
@@ -60,10 +60,32 @@ export async function sweepOrphanedMedia(options: SweepOptions = {}): Promise<Sw
   // an empty reference set from a broken query would look exactly like "delete everything".
   const { rows } = await pool.query<{ image_url: string }>(REFERENCED_URLS_SQL);
 
+  /**
+   * A reference this store owns but cannot resolve to a key is missing information, not
+   * an absent reference. Treating the two alike is what makes a sweep dangerous: under a
+   * configuration change that stops a URL form resolving, every live image looks
+   * unreferenced at once. So an unresolved reference aborts the whole sweep before
+   * anything is deleted, and says which rows it could not read.
+   *
+   * A URL that does not address this store at all — a banner on somebody else's CDN — is
+   * not missing information; it is a complete answer, and is skipped.
+   */
   const referenced = new Set<string>();
+  const unresolved: string[] = [];
   for (const row of rows) {
     const key = storage.keyFromUrl(row.image_url);
-    if (key) referenced.add(key);
+    if (key) {
+      referenced.add(key);
+    } else if (storage.ownsUrl(row.image_url)) {
+      unresolved.push(row.image_url);
+    }
+  }
+
+  if (unresolved.length > 0) {
+    throw new Error(
+      `Refusing to sweep: ${unresolved.length} referenced URL(s) address this store but ` +
+        `could not be resolved to a key (e.g. ${unresolved.slice(0, 3).join(', ')})`
+    );
   }
 
   const objects = await storage.list(PRODUCT_IMAGE_PREFIX);

--- a/server/src/scheduler/mediaSweep.ts
+++ b/server/src/scheduler/mediaSweep.ts
@@ -1,0 +1,96 @@
+import type { Pool } from 'pg';
+import logger from '../../lib/logger';
+import { getEnv } from '../config/env';
+import { getPool } from '../database/pool';
+import { getStorage, PRODUCT_IMAGE_PREFIX, type StorageDriver } from '../storage';
+
+/**
+ * Every column that can reference a stored image.
+ *
+ * Deliberately one statement rather than three repository calls: the sweep deletes what
+ * this query does not return, so a reference it cannot see is a deleted image. Keeping the
+ * whole reference set visible in one place is what makes that reviewable.
+ *
+ * **Adding a table with an image URL means adding it here.**
+ */
+const REFERENCED_URLS_SQL = `
+  SELECT image_url FROM products WHERE image_url IS NOT NULL
+  UNION
+  SELECT image_url FROM storefront_banners WHERE image_url IS NOT NULL
+  UNION
+  SELECT image_url FROM collections WHERE image_url IS NOT NULL
+`;
+
+export interface SweepOutcome {
+  scanned: number;
+  deleted: number;
+  /** Unreferenced, but younger than the grace window — an upload in flight looks like this. */
+  skippedRecent: number;
+  failed: number;
+}
+
+export interface SweepOptions {
+  pool?: Pool;
+  storage?: StorageDriver;
+  /** Overrides `MEDIA_ORPHAN_MIN_AGE_HOURS`. */
+  minAgeMs?: number;
+  now?: Date;
+}
+
+/**
+ * Deletes stored product images that nothing references any more.
+ *
+ * The upload path already removes an image it replaces and the delete path removes the one
+ * it drops, so this is the backstop for the cases those cannot cover: a crash between the
+ * write and the row, a row deleted by a path that never saw the object, a restore from a
+ * backup. It is the reason "does not leave permanent orphaned objects" holds even when a
+ * best-effort delete fails.
+ *
+ * Two guards keep it from eating live media: it reads the reference set first and aborts
+ * the whole sweep if that read fails, and it never touches an object younger than the grace
+ * window, because an upload writes the object before the row that references it.
+ */
+export async function sweepOrphanedMedia(options: SweepOptions = {}): Promise<SweepOutcome> {
+  const pool = options.pool ?? getPool();
+  const storage = options.storage ?? getStorage();
+  const minAgeMs = options.minAgeMs ?? getEnv().MEDIA_ORPHAN_MIN_AGE_HOURS * 60 * 60 * 1000;
+  const cutoff = (options.now?.getTime() ?? Date.now()) - minAgeMs;
+
+  // Throws on failure, which fails the job before anything is deleted. That is the point:
+  // an empty reference set from a broken query would look exactly like "delete everything".
+  const { rows } = await pool.query<{ image_url: string }>(REFERENCED_URLS_SQL);
+
+  const referenced = new Set<string>();
+  for (const row of rows) {
+    const key = storage.keyFromUrl(row.image_url);
+    if (key) referenced.add(key);
+  }
+
+  const objects = await storage.list(PRODUCT_IMAGE_PREFIX);
+  const outcome: SweepOutcome = {
+    scanned: objects.length,
+    deleted: 0,
+    skippedRecent: 0,
+    failed: 0,
+  };
+
+  for (const object of objects) {
+    if (referenced.has(object.key)) continue;
+    if (object.lastModified.getTime() > cutoff) {
+      outcome.skippedRecent += 1;
+      continue;
+    }
+    try {
+      await storage.delete(object.key);
+      outcome.deleted += 1;
+    } catch (err) {
+      outcome.failed += 1;
+      logger.warn('Orphaned media could not be deleted', {
+        key: object.key,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  return outcome;
+}

--- a/server/src/scheduler/runner.ts
+++ b/server/src/scheduler/runner.ts
@@ -19,15 +19,23 @@ export const ADVISORY_LOCK_NAMESPACE = 0x4d4f4f4e;
  * depend on each instance's clock skew.
  */
 const CLAIM_SQL = `
-  INSERT INTO scheduled_jobs (name, last_started_at, last_status, run_count)
-  VALUES ($1, NOW(), 'running', 1)
-  ON CONFLICT (name) DO UPDATE
-    SET last_started_at = NOW(),
-        last_status = 'running',
-        run_count = scheduled_jobs.run_count + 1
-    WHERE scheduled_jobs.last_started_at IS NULL
-       OR scheduled_jobs.last_started_at <= NOW() - make_interval(secs => $2)
-  RETURNING name
+  WITH prior AS (
+    SELECT name, last_status FROM scheduled_jobs WHERE name = $1
+  ), claim AS (
+    INSERT INTO scheduled_jobs (name, last_started_at, last_status, run_count)
+    VALUES ($1, NOW(), 'running', 1)
+    ON CONFLICT (name) DO UPDATE
+      SET last_started_at = NOW(),
+          last_status = 'running',
+          run_count = scheduled_jobs.run_count + 1
+      WHERE scheduled_jobs.last_started_at IS NULL
+         OR scheduled_jobs.last_started_at <= NOW() - make_interval(secs => $2)
+         OR (scheduled_jobs.last_status = 'running'
+             AND scheduled_jobs.last_started_at <= NOW() - make_interval(secs => $3))
+    RETURNING name
+  )
+  SELECT claim.name, COALESCE(prior.last_status = 'running', false) AS took_over
+    FROM claim LEFT JOIN prior ON prior.name = claim.name
 `;
 
 const RECORD_SQL = `
@@ -49,6 +57,18 @@ function detailOf(value: unknown): string {
   }
   return (text ?? 'null').slice(0, 1000);
 }
+
+/**
+ * How long a claim may sit in `running` before another instance may take it over.
+ *
+ * Only consulted when the advisory lock is FREE, which is the whole safety argument: a run
+ * that is genuinely in progress holds the lock, so a takeover attempt never reaches the
+ * claim. A `running` row with no lock behind it therefore means the runner is gone — killed
+ * by a deploy, OOM, or the 10s force-exit in `index.ts` — and the row is stale by
+ * definition. The threshold only has to be long enough that a lock briefly unheld (the gap
+ * between claim and lock does not exist, but be generous) is not mistaken for a death.
+ */
+export const DEFAULT_STALE_CLAIM_MS = 10 * 60 * 1000;
 
 export interface RunScheduledJobOptions {
   /** Pool to claim through. Defaults to the application pool. */
@@ -89,6 +109,8 @@ export async function runScheduledJob<T>(
     return { job: job.name, status: 'failed', durationMs: since(), error: message };
   }
 
+  let unlockError: Error | undefined;
+
   try {
     const lock = await client.query<{ locked: boolean }>(
       'SELECT pg_try_advisory_lock($1, $2) AS locked',
@@ -100,47 +122,67 @@ export async function runScheduledJob<T>(
     }
 
     try {
-      if (!options.force) {
-        const claim = await client.query(CLAIM_SQL, [job.name, job.intervalMs / 1000]);
-        if ((claim.rowCount ?? 0) === 0) {
-          return { job: job.name, status: 'skipped-not-due', durationMs: since() };
-        }
-      } else {
-        await client.query(CLAIM_SQL, [job.name, 0]);
+      const staleAfterSecs = (job.staleAfterMs ?? DEFAULT_STALE_CLAIM_MS) / 1000;
+      const claim = await client.query<{ took_over: boolean }>(CLAIM_SQL, [
+        job.name,
+        options.force ? 0 : job.intervalMs / 1000,
+        options.force ? 0 : staleAfterSecs,
+      ]);
+      if ((claim.rowCount ?? 0) === 0) {
+        return { job: job.name, status: 'skipped-not-due', durationMs: since() };
+      }
+      if (claim.rows[0]?.took_over && !options.force) {
+        // Worth saying out loud: it means a previous run died without recording anything.
+        logger.warn('Scheduled job took over a stale claim', { job: job.name });
       }
 
+      let outcome: T;
       try {
-        const outcome = await job.run();
-        await client.query(RECORD_SQL, [job.name, 'success', detailOf(outcome), 0]);
-        logger.info('Scheduled job completed', {
-          job: job.name,
-          durationMs: since(),
-          outcome,
-        });
-        return { job: job.name, status: 'completed', durationMs: since(), outcome };
+        outcome = await job.run();
       } catch (err) {
         const message = (err as Error).message;
         await client.query(RECORD_SQL, [job.name, 'failed', detailOf(message), 1]).catch(() => {});
         logger.error('Scheduled job failed', { job: job.name, error: message });
         return { job: job.name, status: 'failed', durationMs: since(), error: message };
       }
+
+      // The work is done and committed. A ledger write that fails from here on is a
+      // bookkeeping problem, not a failed job, and reporting it as a failure would call
+      // for a retry of work that already succeeded.
+      try {
+        await client.query(RECORD_SQL, [job.name, 'success', detailOf(outcome), 0]);
+      } catch (err) {
+        logger.error('Scheduled job completed but its outcome could not be recorded', {
+          job: job.name,
+          error: (err as Error).message,
+          outcome,
+        });
+      }
+
+      logger.info('Scheduled job completed', { job: job.name, durationMs: since(), outcome });
+      return { job: job.name, status: 'completed', durationMs: since(), outcome };
     } finally {
       // Releasing on every path is what makes a failed run retryable rather than a
       // permanently wedged job.
       await client
         .query('SELECT pg_advisory_unlock($1, $2)', [ADVISORY_LOCK_NAMESPACE, job.lockId])
-        .catch((err: Error) =>
+        .catch((err: Error) => {
+          unlockError = err;
           logger.error('Scheduled job could not release its lock', {
             job: job.name,
             error: err.message,
-          })
-        );
+          });
+        });
     }
   } catch (err) {
     const message = (err as Error).message;
     logger.error('Scheduled job aborted', { job: job.name, error: message });
     return { job: job.name, status: 'failed', durationMs: since(), error: message };
   } finally {
-    client.release();
+    // A session whose advisory lock may still be held must not go back into the pool: the
+    // next borrower would inherit the lock, every instance would read `skipped-locked`
+    // fleet-wide, and a re-entrant re-acquisition would need more unlocks than anyone is
+    // going to issue. Passing the error destroys the connection instead.
+    client.release(unlockError);
   }
 }

--- a/server/src/scheduler/runner.ts
+++ b/server/src/scheduler/runner.ts
@@ -1,0 +1,146 @@
+import type { Pool, PoolClient } from 'pg';
+import logger from '../../lib/logger';
+import { getPool } from '../database/pool';
+import type { JobRunResult, ScheduledJob } from './types';
+
+/**
+ * First half of every advisory-lock pair this app takes ("MOON" as an int32). Keeps the
+ * scheduler's key space from colliding with any other advisory lock in the database.
+ */
+export const ADVISORY_LOCK_NAMESPACE = 0x4d4f4f4e;
+
+/**
+ * The claim. One statement decides whether this process runs the job, for the same
+ * reason a stock decrement is one statement: a read-then-write would let two instances
+ * both observe "due" and both run.
+ *
+ * `make_interval(secs => $2)` keeps the due-window arithmetic on the database clock.
+ * Comparing a stored timestamp against a locally computed instant would make the cadence
+ * depend on each instance's clock skew.
+ */
+const CLAIM_SQL = `
+  INSERT INTO scheduled_jobs (name, last_started_at, last_status, run_count)
+  VALUES ($1, NOW(), 'running', 1)
+  ON CONFLICT (name) DO UPDATE
+    SET last_started_at = NOW(),
+        last_status = 'running',
+        run_count = scheduled_jobs.run_count + 1
+    WHERE scheduled_jobs.last_started_at IS NULL
+       OR scheduled_jobs.last_started_at <= NOW() - make_interval(secs => $2)
+  RETURNING name
+`;
+
+const RECORD_SQL = `
+  UPDATE scheduled_jobs
+     SET last_finished_at = NOW(),
+         last_status = $2,
+         last_detail = $3,
+         failure_count = scheduled_jobs.failure_count + $4
+   WHERE name = $1
+`;
+
+/** Truncated so a pathological outcome cannot bloat the row. */
+function detailOf(value: unknown): string {
+  let text: string;
+  try {
+    text = typeof value === 'string' ? value : JSON.stringify(value ?? null);
+  } catch {
+    text = String(value);
+  }
+  return (text ?? 'null').slice(0, 1000);
+}
+
+export interface RunScheduledJobOptions {
+  /** Pool to claim through. Defaults to the application pool. */
+  pool?: Pool;
+  /**
+   * Ignore the due window and run as long as the advisory lock is free. For an operator
+   * triggering a run by hand; the scheduler never sets it.
+   */
+  force?: boolean;
+}
+
+/**
+ * Runs one job at most once across the whole fleet per interval.
+ *
+ * Two guards, in order:
+ *  1. a session-level advisory lock held for the duration of the run, so two runs cannot
+ *     overlap even if the handler outlives its own interval;
+ *  2. the conditional claim in `scheduled_jobs`, so a second instance waking a second
+ *     later inside the same window does not repeat work the first already did.
+ *
+ * Never throws: a maintenance failure must not take down the tick that schedules it. The
+ * outcome comes back as a value and is written to the ledger and the log.
+ */
+export async function runScheduledJob<T>(
+  job: ScheduledJob<T>,
+  options: RunScheduledJobOptions = {}
+): Promise<JobRunResult<T>> {
+  const pool = options.pool ?? getPool();
+  const startedAt = Date.now();
+  const since = () => Date.now() - startedAt;
+
+  let client: PoolClient;
+  try {
+    client = await pool.connect();
+  } catch (err) {
+    const message = (err as Error).message;
+    logger.error('Scheduled job could not reach the database', { job: job.name, error: message });
+    return { job: job.name, status: 'failed', durationMs: since(), error: message };
+  }
+
+  try {
+    const lock = await client.query<{ locked: boolean }>(
+      'SELECT pg_try_advisory_lock($1, $2) AS locked',
+      [ADVISORY_LOCK_NAMESPACE, job.lockId]
+    );
+    if (!lock.rows[0]?.locked) {
+      logger.debug('Scheduled job already running elsewhere', { job: job.name });
+      return { job: job.name, status: 'skipped-locked', durationMs: since() };
+    }
+
+    try {
+      if (!options.force) {
+        const claim = await client.query(CLAIM_SQL, [job.name, job.intervalMs / 1000]);
+        if ((claim.rowCount ?? 0) === 0) {
+          return { job: job.name, status: 'skipped-not-due', durationMs: since() };
+        }
+      } else {
+        await client.query(CLAIM_SQL, [job.name, 0]);
+      }
+
+      try {
+        const outcome = await job.run();
+        await client.query(RECORD_SQL, [job.name, 'success', detailOf(outcome), 0]);
+        logger.info('Scheduled job completed', {
+          job: job.name,
+          durationMs: since(),
+          outcome,
+        });
+        return { job: job.name, status: 'completed', durationMs: since(), outcome };
+      } catch (err) {
+        const message = (err as Error).message;
+        await client.query(RECORD_SQL, [job.name, 'failed', detailOf(message), 1]).catch(() => {});
+        logger.error('Scheduled job failed', { job: job.name, error: message });
+        return { job: job.name, status: 'failed', durationMs: since(), error: message };
+      }
+    } finally {
+      // Releasing on every path is what makes a failed run retryable rather than a
+      // permanently wedged job.
+      await client
+        .query('SELECT pg_advisory_unlock($1, $2)', [ADVISORY_LOCK_NAMESPACE, job.lockId])
+        .catch((err: Error) =>
+          logger.error('Scheduled job could not release its lock', {
+            job: job.name,
+            error: err.message,
+          })
+        );
+    }
+  } catch (err) {
+    const message = (err as Error).message;
+    logger.error('Scheduled job aborted', { job: job.name, error: message });
+    return { job: job.name, status: 'failed', durationMs: since(), error: message };
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/scheduler/types.ts
+++ b/server/src/scheduler/types.ts
@@ -15,6 +15,12 @@ export interface ScheduledJob<TOutcome = unknown> {
    * Must be unique per job and stable — it is an identity, not a counter.
    */
   readonly lockId: number;
+  /**
+   * How long this job's claim may sit in `running` before another instance takes it over,
+   * defaulting to `DEFAULT_STALE_CLAIM_MS`. Only ever consulted while the advisory lock is
+   * free, so it is a liveness knob, not a safety one.
+   */
+  readonly staleAfterMs?: number;
   /** Does the work. Throwing marks the run failed; the next interval retries it. */
   run(): Promise<TOutcome>;
 }

--- a/server/src/scheduler/types.ts
+++ b/server/src/scheduler/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Scheduled-job vocabulary.
+ *
+ * A job is a name, a cadence, an advisory-lock id and a handler that returns a small
+ * JSON-serializable outcome. The outcome is what gets written to `scheduled_jobs.last_detail`
+ * and logged, so it should say what the run actually did ("deleted 12 rows"), not that it ran.
+ */
+export interface ScheduledJob<TOutcome = unknown> {
+  /** Primary key in `scheduled_jobs`. Stable across deploys — renaming resets the cadence. */
+  readonly name: string;
+  /** Minimum spacing between two runs across the whole fleet, in milliseconds. */
+  readonly intervalMs: number;
+  /**
+   * Second half of the advisory-lock pair (the first half is a fixed namespace).
+   * Must be unique per job and stable — it is an identity, not a counter.
+   */
+  readonly lockId: number;
+  /** Does the work. Throwing marks the run failed; the next interval retries it. */
+  run(): Promise<TOutcome>;
+}
+
+export type JobRunStatus =
+  /** This process claimed the slot and the handler returned. */
+  | 'completed'
+  /** Another process is running this job right now. */
+  | 'skipped-locked'
+  /** The job already ran inside the current interval, here or on another instance. */
+  | 'skipped-not-due'
+  /** This process claimed the slot and the handler threw. */
+  | 'failed';
+
+export interface JobRunResult<TOutcome = unknown> {
+  readonly job: string;
+  readonly status: JobRunStatus;
+  readonly durationMs: number;
+  readonly outcome?: TOutcome;
+  readonly error?: string;
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Storage resolution.
+ *
+ * One driver per process, chosen by `MEDIA_STORAGE_DRIVER` through the validated env
+ * config. `local` is the only driver shipped today and is the documented development
+ * option; adding an object-store driver is a new file implementing `StorageDriver` plus a
+ * case here — deliberately not a provider SDK wired through the controllers, and
+ * deliberately no credentials anywhere in this repo.
+ */
+import path from 'path';
+import { getEnv } from '../config/env';
+import { LocalStorageDriver } from './localDriver';
+import type { StorageDriver } from './types';
+
+export * from './types';
+export { LocalStorageDriver } from './localDriver';
+export * from './keys';
+
+/** Where the filesystem driver defaults to: `server/uploads`, as before. */
+export const DEFAULT_LOCAL_ROOT = path.join(__dirname, '..', '..', 'uploads');
+
+let instance: StorageDriver | null = null;
+
+export function createStorageDriver(): StorageDriver {
+  const env = getEnv();
+
+  switch (env.MEDIA_STORAGE_DRIVER) {
+    case 'local':
+      return new LocalStorageDriver({
+        root: env.MEDIA_LOCAL_ROOT || DEFAULT_LOCAL_ROOT,
+        baseUrl: env.MEDIA_PUBLIC_BASE_URL,
+      });
+    default:
+      // Unreachable while the enum has one member; keeps the switch honest when it grows.
+      throw new Error(`Unsupported MEDIA_STORAGE_DRIVER: ${String(env.MEDIA_STORAGE_DRIVER)}`);
+  }
+}
+
+export function getStorage(): StorageDriver {
+  if (!instance) {
+    instance = createStorageDriver();
+  }
+  return instance;
+}
+
+/** Test seam, mirroring `setPool`. */
+export function setStorage(driver: StorageDriver): void {
+  instance = driver;
+}
+
+export function resetStorage(): void {
+  instance = null;
+}

--- a/server/src/storage/keys.ts
+++ b/server/src/storage/keys.ts
@@ -1,0 +1,30 @@
+import crypto from 'crypto';
+
+/** Prefix every product image lives under, in every driver. */
+export const PRODUCT_IMAGE_PREFIX = 'products';
+
+const EXTENSION_FOR_TYPE: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+};
+
+export function extensionForContentType(contentType: string): string | null {
+  return EXTENSION_FOR_TYPE[contentType] ?? null;
+}
+
+/**
+ * Mints a key for a new product image.
+ *
+ * Same shape the old disk filenames used (`<millis>-<random><ext>`), so the resulting
+ * public URL is indistinguishable from one written before this change. The name is derived
+ * from the *detected* content type, never from the client-supplied filename.
+ */
+export function productImageKey(contentType: string): string {
+  const ext = extensionForContentType(contentType);
+  if (!ext) {
+    throw new Error(`Unsupported image content type: ${contentType}`);
+  }
+  const suffix = crypto.randomBytes(4).toString('hex').slice(0, 6);
+  return `${PRODUCT_IMAGE_PREFIX}/${Date.now()}-${suffix}${ext}`;
+}

--- a/server/src/storage/localDriver.ts
+++ b/server/src/storage/localDriver.ts
@@ -2,6 +2,13 @@ import fs from 'fs/promises';
 import path from 'path';
 import { assertSafeKey, type PutOptions, type StorageDriver, type StoredObject } from './types';
 
+/**
+ * The path every image written before `MEDIA_PUBLIC_BASE_URL` existed was stored under,
+ * and the path `index.ts` mounts unconditionally. Owned forever: rows holding it are still
+ * live references no matter where new URLs point.
+ */
+export const LEGACY_PUBLIC_PATH = '/uploads';
+
 export interface LocalDriverOptions {
   /** Directory the objects live in. */
   root: string;
@@ -97,29 +104,80 @@ export class LocalStorageDriver implements StorageDriver {
     return `${this.baseUrl}/${assertSafeKey(key)}`;
   }
 
-  keyFromUrl(url: string): string | null {
-    if (!url) return null;
+  /**
+   * The URL forms this store answers for, longest first.
+   *
+   * More than one, because a store outlives its configuration. `MEDIA_PUBLIC_BASE_URL`
+   * says where *new* URLs are minted; it does not retract the ones already in the
+   * database, and the `/uploads` mount keeps serving them. A driver that only recognised
+   * its current base would classify every legacy row as somebody else's — which is
+   * exactly how a CDN cutover turned the orphan sweep into a delete-everything.
+   */
+  private ownedPrefixes(): string[] {
+    const prefixes = [this.baseUrl];
 
-    let candidate = url;
-    if (this.baseUrl.startsWith('/') && /^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
-      // A row may hold an absolute URL for an image this store still owns (an older
-      // deployment that wrote `${CLIENT_URL}/uploads/...`). Compare on the path.
+    if (!this.baseUrl.startsWith('/')) {
       try {
-        candidate = new URL(url).pathname;
+        const basePath = new URL(this.baseUrl).pathname.replace(/\/+$/, '');
+        if (basePath) prefixes.push(basePath);
       } catch {
-        return null;
+        // Not a parseable absolute base; the raw prefix above is all there is.
       }
     }
 
-    const prefix = `${this.baseUrl}/`;
-    if (!candidate.startsWith(prefix)) return null;
+    // The compatibility mount in `index.ts`, which is unconditional.
+    prefixes.push(LEGACY_PUBLIC_PATH);
 
-    const key = candidate.slice(prefix.length);
-    if (!key) return null;
-    try {
-      return assertSafeKey(key);
-    } catch {
-      return null;
+    return [...new Set(prefixes)].sort((a, b) => b.length - a.length);
+  }
+
+  /**
+   * Whether the URL addresses this store's URL space at all — regardless of whether a
+   * usable key comes out of it. `keyFromUrl` returning null is ambiguous between "not
+   * ours" and "ours but unreadable", and a deletion routine must not conflate those.
+   */
+  ownsUrl(url: string): boolean {
+    return this.candidatePaths(url).some((candidate) =>
+      this.ownedPrefixes().some((prefix) => candidate.startsWith(`${prefix}/`))
+    );
+  }
+
+  /**
+   * The forms of a stored URL worth comparing: the URL itself, plus its path when it is
+   * absolute. Path comparison is not a guess — an object of this store is reachable only
+   * under an owned path, on whatever host the API is being served as.
+   */
+  private candidatePaths(url: string): string[] {
+    if (!url) return [];
+    const candidates = [url];
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+      try {
+        candidates.push(new URL(url).pathname);
+      } catch {
+        // Unparseable; the raw form is all there is to compare.
+      }
     }
+    return candidates;
+  }
+
+  keyFromUrl(url: string): string | null {
+    const prefixes = this.ownedPrefixes();
+
+    for (const candidate of this.candidatePaths(url)) {
+      for (const prefix of prefixes) {
+        const withSlash = `${prefix}/`;
+        if (!candidate.startsWith(withSlash)) continue;
+
+        const key = candidate.slice(withSlash.length);
+        if (!key) continue;
+        try {
+          return assertSafeKey(key);
+        } catch {
+          return null;
+        }
+      }
+    }
+
+    return null;
   }
 }

--- a/server/src/storage/localDriver.ts
+++ b/server/src/storage/localDriver.ts
@@ -1,0 +1,125 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { assertSafeKey, type PutOptions, type StorageDriver, type StoredObject } from './types';
+
+export interface LocalDriverOptions {
+  /** Directory the objects live in. */
+  root: string;
+  /**
+   * Prefix `publicUrl` puts in front of a key. Defaults to `/uploads`, which is exactly
+   * the URL shape every existing `products.image_url` row already holds.
+   */
+  baseUrl?: string;
+}
+
+/**
+ * Filesystem driver.
+ *
+ * The default in development and the compatibility default in production: with `root`
+ * left alone it reads and writes the same `server/uploads` tree the old `multer.diskStorage`
+ * used, and produces byte-identical URLs, so no existing row has to change.
+ *
+ * For a deployment it is only durable if `root` points at storage that outlives the
+ * container and is shared by every instance — a mounted volume or network filesystem.
+ * Where that is not available, the answer is a driver for the object store, not a change
+ * here; everything above `StorageDriver` is already indifferent.
+ */
+export class LocalStorageDriver implements StorageDriver {
+  readonly name = 'local';
+  private readonly root: string;
+  private readonly baseUrl: string;
+
+  constructor(options: LocalDriverOptions) {
+    this.root = path.resolve(options.root);
+    this.baseUrl = (options.baseUrl ?? '/uploads').replace(/\/+$/, '');
+  }
+
+  /** Absolute path for a key. Exposed for the static file mount, not for callers. */
+  get rootDir(): string {
+    return this.root;
+  }
+
+  private pathFor(key: string): string {
+    return path.join(this.root, ...assertSafeKey(key).split('/'));
+  }
+
+  async put(key: string, body: Buffer, _options: PutOptions): Promise<void> {
+    const target = this.pathFor(key);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, body);
+  }
+
+  async delete(key: string): Promise<void> {
+    try {
+      await fs.unlink(this.pathFor(key));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await fs.stat(this.pathFor(key));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async list(prefix: string): Promise<StoredObject[]> {
+    const normalized = prefix.replace(/\/+$/, '');
+    const dir = normalized
+      ? path.join(this.root, ...assertSafeKey(normalized).split('/'))
+      : this.root;
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+
+    const objects: StoredObject[] = [];
+    for (const entry of entries) {
+      const stat = await fs.stat(path.join(dir, entry));
+      if (!stat.isFile()) continue;
+      objects.push({
+        key: normalized ? `${normalized}/${entry}` : entry,
+        size: stat.size,
+        lastModified: stat.mtime,
+      });
+    }
+    return objects;
+  }
+
+  publicUrl(key: string): string {
+    return `${this.baseUrl}/${assertSafeKey(key)}`;
+  }
+
+  keyFromUrl(url: string): string | null {
+    if (!url) return null;
+
+    let candidate = url;
+    if (this.baseUrl.startsWith('/') && /^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+      // A row may hold an absolute URL for an image this store still owns (an older
+      // deployment that wrote `${CLIENT_URL}/uploads/...`). Compare on the path.
+      try {
+        candidate = new URL(url).pathname;
+      } catch {
+        return null;
+      }
+    }
+
+    const prefix = `${this.baseUrl}/`;
+    if (!candidate.startsWith(prefix)) return null;
+
+    const key = candidate.slice(prefix.length);
+    if (!key) return null;
+    try {
+      return assertSafeKey(key);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/server/src/storage/types.ts
+++ b/server/src/storage/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Media storage abstraction.
+ *
+ * Uploaded product images used to be written straight to the API container's disk with
+ * `multer.diskStorage`, which makes them local to whichever instance answered the upload:
+ * a redeploy loses them, and a second instance serves 404s for images the first is happily
+ * serving. The fix is not "use S3" — it is that nothing above this interface knows where
+ * the bytes live. The controller puts a key and stores the URL the driver hands back; the
+ * driver decides whether that is a file, a bucket object, or anything else.
+ *
+ * A key is a POSIX-style relative path inside the store, e.g. `products/1771875072587-4wjwqx.webp`.
+ * It is never a filesystem path and never contains `..` — see `assertSafeKey`.
+ */
+export interface StoredObject {
+  readonly key: string;
+  readonly size: number;
+  readonly lastModified: Date;
+}
+
+export interface PutOptions {
+  readonly contentType: string;
+}
+
+export interface StorageDriver {
+  /** Driver id, for logs and diagnostics. */
+  readonly name: string;
+
+  /** Writes (or overwrites) an object. */
+  put(key: string, body: Buffer, options: PutOptions): Promise<void>;
+
+  /**
+   * Removes an object. Idempotent: deleting an absent key is a success, so a retry after
+   * a partial failure cannot turn into an error the caller has to special-case.
+   */
+  delete(key: string): Promise<void>;
+
+  exists(key: string): Promise<boolean>;
+
+  /** Lists objects under a key prefix. Used by the orphan sweep. */
+  list(prefix: string): Promise<StoredObject[]>;
+
+  /** The URL a client should fetch this object from. */
+  publicUrl(key: string): string;
+
+  /**
+   * Inverse of `publicUrl`: the key a stored URL refers to, or null when the URL does not
+   * belong to this store. Returning null is what stops a delete from acting on a banner
+   * that points at somebody else's CDN.
+   */
+  keyFromUrl(url: string): string | null;
+}
+
+/** Keys are ours to generate; this is a guard against a caller passing user input. */
+const SAFE_KEY = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+export function assertSafeKey(key: string): string {
+  if (!SAFE_KEY.test(key) || key.includes('..') || key.includes('//') || key.endsWith('/')) {
+    throw new Error(`Unsafe storage key: ${key}`);
+  }
+  return key;
+}

--- a/server/src/storage/types.ts
+++ b/server/src/storage/types.ts
@@ -48,6 +48,17 @@ export interface StorageDriver {
    * that points at somebody else's CDN.
    */
   keyFromUrl(url: string): string | null;
+
+  /**
+   * Whether the URL addresses this store's URL space, whether or not a usable key comes
+   * out of it.
+   *
+   * `keyFromUrl` returning null conflates two very different answers — "that is somebody
+   * else's image" and "that is one of mine and I could not read it" — and a routine that
+   * deletes what nothing references must not treat the second as the first. Callers that
+   * delete ask this question too; callers that only resolve a URL do not need it.
+   */
+  ownsUrl(url: string): boolean;
 }
 
 /** Keys are ours to generate; this is a guard against a caller passing user input. */

--- a/server/src/storage/upload.ts
+++ b/server/src/storage/upload.ts
@@ -1,0 +1,129 @@
+/**
+ * Upload intake for driver-backed media.
+ *
+ * The disk-backed intake in `middleware/upload.ts` writes the file, then validates it, then
+ * unlinks it if it was a lie — which only works because the destination is a local path. A
+ * driver may be a remote store, where "write then maybe delete" is a network round trip and
+ * a window in which a rejected file is publicly readable. So the buffer stays in memory and
+ * nothing reaches the store until it has passed every check.
+ *
+ * The checks themselves are the ones that were already enforced and must stay enforced: a
+ * size ceiling (multer's, before the buffer is complete), an extension allowlist, and magic
+ * bytes that must agree with the extension. Authorization is unchanged and still lives on
+ * the route.
+ */
+import { Request, Response, NextFunction } from 'express';
+import multer from 'multer';
+import path from 'path';
+import { errorResponse } from '../http/errors';
+
+export const DEFAULT_MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
+
+export const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+export type AllowedImageType = (typeof ALLOWED_IMAGE_TYPES)[number];
+
+const EXTENSIONS_FOR_TYPE: Record<AllowedImageType, string[]> = {
+  'image/jpeg': ['.jpg', '.jpeg'],
+  'image/png': ['.png'],
+  'image/webp': ['.webp'],
+};
+
+const MIME_FOR_EXTENSION: Record<string, AllowedImageType> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+};
+
+/** Content type implied by the first bytes of the file, or null if it is not an image we accept. */
+export function detectImageType(buffer: Buffer): AllowedImageType | null {
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (
+    buffer.length >= 4 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
+    return 'image/png';
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+  return null;
+}
+
+export interface ImageUploadOptions {
+  maxSize?: number;
+  allowedTypes?: readonly AllowedImageType[];
+}
+
+/** Multer instance that keeps the file in memory for the driver to write. */
+export function createImageUpload(options: ImageUploadOptions = {}) {
+  const { maxSize = DEFAULT_MAX_UPLOAD_BYTES, allowedTypes = ALLOWED_IMAGE_TYPES } = options;
+  const allowedExts = allowedTypes.flatMap((t) => EXTENSIONS_FOR_TYPE[t] ?? []);
+
+  return multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: maxSize, files: 1 },
+    fileFilter: (_req, file, cb) => {
+      const ext = path.extname(file.originalname).toLowerCase();
+      if (allowedExts.includes(ext)) {
+        cb(null, true);
+      } else {
+        cb(new Error('Only JPEG, PNG, and WebP images are allowed'));
+      }
+    },
+  });
+}
+
+/**
+ * Rejects a file whose bytes disagree with its name, and pins the *detected* type onto
+ * `req.file.mimetype` so everything downstream keys off the content rather than off
+ * anything the client said.
+ */
+export function validateImageBytes(req: Request, res: Response, next: NextFunction): void {
+  const file = req.file;
+  if (!file) {
+    next();
+    return;
+  }
+
+  if (!file.buffer || file.buffer.length === 0) {
+    res.status(400).json(errorResponse('VALIDATION_ERROR', 'Uploaded file is empty'));
+    return;
+  }
+
+  const detected = detectImageType(file.buffer);
+  if (!detected) {
+    res
+      .status(400)
+      .json(
+        errorResponse('VALIDATION_ERROR', 'File content does not match a supported image format')
+      );
+    return;
+  }
+
+  const ext = path.extname(file.originalname).toLowerCase();
+  const declared = MIME_FOR_EXTENSION[ext];
+  if (declared && declared !== detected) {
+    res
+      .status(400)
+      .json(
+        errorResponse(
+          'VALIDATION_ERROR',
+          `File extension (${ext}) does not match actual content (${detected})`
+        )
+      );
+    return;
+  }
+
+  file.mimetype = detected;
+  next();
+}

--- a/server/tests/concurrency/scheduler.concurrency.test.ts
+++ b/server/tests/concurrency/scheduler.concurrency.test.ts
@@ -12,7 +12,7 @@ import {
   setupRealPostgres,
   type RealPostgresHarness,
 } from '../support/realPostgres';
-import { runScheduledJob } from '../../src/scheduler/runner';
+import { ADVISORY_LOCK_NAMESPACE, runScheduledJob } from '../../src/scheduler/runner';
 import { reservationCleanupJob } from '../../src/scheduler/jobs';
 import type { ScheduledJob } from '../../src/scheduler/types';
 
@@ -143,6 +143,59 @@ describeWithPostgres('scheduled jobs against real PostgreSQL', () => {
       status: 'completed',
       outcome: 'recovered',
     });
+  });
+
+  it('takes over a claim left running by a process that died, once it is stale', async () => {
+    // What a SIGTERM mid-run leaves behind: the claim written, no outcome recorded, and
+    // no advisory lock because the connection died with the process.
+    const { job, calls } = countingJob({ name: 'stale-job', lockId: 4244, staleAfterMs: 60_000 });
+    await harness.pool.query(
+      `INSERT INTO scheduled_jobs (name, last_started_at, last_status, run_count)
+       VALUES ($1, NOW() - INTERVAL '30 seconds', 'running', 1)`,
+      [job.name]
+    );
+
+    // Still inside the takeover window: the ledger says running, so nothing runs.
+    expect((await runScheduledJob(job, { pool: harness.pool })).status).toBe('skipped-not-due');
+    expect(calls()).toBe(0);
+
+    await harness.pool.query(
+      `UPDATE scheduled_jobs SET last_started_at = NOW() - INTERVAL '10 minutes' WHERE name = $1`,
+      [job.name]
+    );
+
+    expect((await runScheduledJob(job, { pool: harness.pool })).status).toBe('completed');
+    expect(calls()).toBe(1);
+
+    const { rows } = await harness.pool.query<{ last_status: string; run_count: number }>(
+      'SELECT last_status, run_count FROM scheduled_jobs WHERE name = $1',
+      [job.name]
+    );
+    expect(rows[0].last_status).toBe('success');
+    expect(Number(rows[0].run_count)).toBe(2);
+  });
+
+  it('will not take over a claim whose runner is alive, however stale the row looks', async () => {
+    // The advisory lock, not the row, is the authority on "is someone running this".
+    const { job, calls } = countingJob({ name: 'held-job', lockId: 4245, staleAfterMs: 1 });
+    await harness.pool.query(
+      `INSERT INTO scheduled_jobs (name, last_started_at, last_status, run_count)
+       VALUES ($1, NOW() - INTERVAL '1 hour', 'running', 1)`,
+      [job.name]
+    );
+
+    const holder = await harness.pool.connect();
+    try {
+      await holder.query('SELECT pg_advisory_lock($1, $2)', [ADVISORY_LOCK_NAMESPACE, job.lockId]);
+      expect((await runScheduledJob(job, { pool: harness.pool })).status).toBe('skipped-locked');
+      expect(calls()).toBe(0);
+    } finally {
+      await holder.query('SELECT pg_advisory_unlock($1, $2)', [
+        ADVISORY_LOCK_NAMESPACE,
+        job.lockId,
+      ]);
+      holder.release();
+    }
   });
 
   it('deletes expired reservations exactly once across the fleet and reports the count', async () => {

--- a/server/tests/concurrency/scheduler.concurrency.test.ts
+++ b/server/tests/concurrency/scheduler.concurrency.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Scheduled jobs under horizontal scaling.
+ *
+ * The claim in `scheduled_jobs` is a conditional upsert whose correctness rests entirely
+ * on how READ COMMITTED re-evaluates an `ON CONFLICT DO UPDATE ... WHERE` after waiting on
+ * the row lock. pg-mem has no MVCC and no advisory locks, so this is the only place the
+ * "N instances, one execution" property can actually be proven.
+ */
+import { afterAll, beforeAll, beforeEach, expect, it } from 'vitest';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { runScheduledJob } from '../../src/scheduler/runner';
+import { reservationCleanupJob } from '../../src/scheduler/jobs';
+import type { ScheduledJob } from '../../src/scheduler/types';
+
+const INSTANCES = 8;
+
+describeWithPostgres('scheduled jobs against real PostgreSQL', () => {
+  let harness: RealPostgresHarness;
+  let productId: number;
+
+  beforeAll(async () => {
+    // Every simulated instance holds a connection for the length of its run.
+    harness = await setupRealPostgres('scheduler', { maxConnections: INSTANCES + 4 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    const { rows } = await harness.pool.query<{ id: number }>(
+      `INSERT INTO products (name, sku, price, stock)
+       VALUES ('Silk Scarf', 'SKU-SCHED-1', 100, 50) RETURNING id`
+    );
+    productId = rows[0].id;
+  });
+
+  async function seedExpiredReservations(count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      await harness.pool.query(
+        `INSERT INTO stock_reservations (product_id, quantity, source_type, expires_at)
+         VALUES ($1, 1, 'cart', NOW() - INTERVAL '1 minute')`,
+        [productId]
+      );
+    }
+  }
+
+  function countingJob(overrides: Partial<ScheduledJob<number>> = {}) {
+    let calls = 0;
+    const job: ScheduledJob<number> = {
+      name: 'race-job',
+      intervalMs: 300_000,
+      lockId: 4242,
+      async run() {
+        calls += 1;
+        // Long enough that every competing caller is inside the runner at once.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return calls;
+      },
+      ...overrides,
+    };
+    return { job, calls: () => calls };
+  }
+
+  it('runs once across simultaneous instances, and the losers say why they skipped', async () => {
+    const { job, calls } = countingJob();
+
+    const results = await Promise.all(
+      Array.from({ length: INSTANCES }, () => runScheduledJob(job, { pool: harness.pool }))
+    );
+
+    expect(results.filter((r) => r.status === 'completed')).toHaveLength(1);
+    expect(calls()).toBe(1);
+    for (const skipped of results.filter((r) => r.status !== 'completed')) {
+      expect(['skipped-locked', 'skipped-not-due']).toContain(skipped.status);
+    }
+
+    const { rows } = await harness.pool.query<{ run_count: number; last_status: string }>(
+      'SELECT run_count, last_status FROM scheduled_jobs WHERE name = $1',
+      [job.name]
+    );
+    expect(rows[0]).toMatchObject({ run_count: 1, last_status: 'success' });
+  });
+
+  it('does not repeat the work on a later tick inside the same interval', async () => {
+    const { job, calls } = countingJob();
+
+    expect((await runScheduledJob(job, { pool: harness.pool })).status).toBe('completed');
+    expect((await runScheduledJob(job, { pool: harness.pool })).status).toBe('skipped-not-due');
+    expect(calls()).toBe(1);
+  });
+
+  it('runs again once the interval has elapsed', async () => {
+    const { job, calls } = countingJob({ intervalMs: 50 });
+
+    expect((await runScheduledJob(job, { pool: harness.pool })).status).toBe('completed');
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect((await runScheduledJob(job, { pool: harness.pool })).status).toBe('completed');
+    expect(calls()).toBe(2);
+
+    const { rows } = await harness.pool.query<{ run_count: number }>(
+      'SELECT run_count FROM scheduled_jobs WHERE name = $1',
+      [job.name]
+    );
+    expect(Number(rows[0].run_count)).toBe(2);
+  });
+
+  it('records a failure and leaves the job runnable rather than wedged', async () => {
+    let attempt = 0;
+    const job: ScheduledJob<string> = {
+      name: 'flaky-job',
+      intervalMs: 1,
+      lockId: 4243,
+      async run() {
+        attempt += 1;
+        if (attempt === 1) throw new Error('transient outage');
+        return 'recovered';
+      },
+    };
+
+    const failed = await runScheduledJob(job, { pool: harness.pool });
+    expect(failed).toMatchObject({ status: 'failed', error: 'transient outage' });
+
+    const { rows } = await harness.pool.query<{
+      last_status: string;
+      last_detail: string;
+      failure_count: number;
+    }>('SELECT last_status, last_detail, failure_count FROM scheduled_jobs WHERE name = $1', [
+      job.name,
+    ]);
+    expect(rows[0].last_status).toBe('failed');
+    expect(rows[0].last_detail).toContain('transient outage');
+    expect(Number(rows[0].failure_count)).toBe(1);
+
+    // The advisory lock was released, so the retry is not blocked by the failed run.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(await runScheduledJob(job, { pool: harness.pool })).toMatchObject({
+      status: 'completed',
+      outcome: 'recovered',
+    });
+  });
+
+  it('deletes expired reservations exactly once across the fleet and reports the count', async () => {
+    await seedExpiredReservations(3);
+    await harness.pool.query(
+      `INSERT INTO stock_reservations (product_id, quantity, source_type, expires_at)
+       VALUES ($1, 2, 'cart', NOW() + INTERVAL '10 minutes')`,
+      [productId]
+    );
+
+    const results = await Promise.all(
+      Array.from({ length: INSTANCES }, () =>
+        runScheduledJob(reservationCleanupJob, { pool: harness.pool })
+      )
+    );
+
+    const completed = results.filter((r) => r.status === 'completed');
+    expect(completed).toHaveLength(1);
+    expect(completed[0].outcome).toEqual({ deleted: 3 });
+
+    const { rows } = await harness.pool.query<{ count: string }>(
+      'SELECT COUNT(*) AS count FROM stock_reservations'
+    );
+    expect(Number(rows[0].count)).toBe(1);
+  });
+
+  it('is safe to retry: a second forced run deletes nothing and still reports success', async () => {
+    await seedExpiredReservations(2);
+
+    const first = await runScheduledJob(reservationCleanupJob, { pool: harness.pool });
+    expect(first.outcome).toEqual({ deleted: 2 });
+
+    const second = await runScheduledJob(reservationCleanupJob, {
+      pool: harness.pool,
+      force: true,
+    });
+    expect(second).toMatchObject({ status: 'completed', outcome: { deleted: 0 } });
+
+    const { rows } = await harness.pool.query<{ last_detail: string }>(
+      'SELECT last_detail FROM scheduled_jobs WHERE name = $1',
+      [reservationCleanupJob.name]
+    );
+    expect(rows[0].last_detail).toBe('{"deleted":0}');
+  });
+});

--- a/server/tests/database/migrate.test.ts
+++ b/server/tests/database/migrate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Pool as PgPool } from 'pg';
+import fs from 'fs';
 import path from 'path';
 import { createPgMemPool } from '../support/pgMem';
 import {
@@ -9,9 +10,23 @@ import {
   ensureMigrationTable,
 } from '../../src/database/migrate';
 
+const migrationsDir = path.join(__dirname, '../../src/database/migrations');
+
+/**
+ * The expected sequence is read from the directory rather than hard-coded. A hard-coded
+ * list turns "someone added a migration" into a failure in this file, which says nothing
+ * about the runner — the runner's contract is "apply every un-applied file in name order,
+ * once", and that is what these assertions check.
+ */
+function allMigrations(): string[] {
+  return fs
+    .readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql') && !f.includes('.down.sql'))
+    .sort();
+}
+
 describe('PostgreSQL Migration Runner', () => {
   let memPool: PgPool;
-  const migrationsDir = path.join(__dirname, '../../src/database/migrations');
 
   beforeEach(() => {
     memPool = createPgMemPool();
@@ -43,12 +58,7 @@ describe('PostgreSQL Migration Runner', () => {
     expect(tableNames).toContain('customers');
 
     const records = await getAppliedMigrations(memPool);
-    expect(records).toEqual([
-      '001_initial_schema.sql',
-      '002_checkout_financial_contract.sql',
-      '003_sale_calculation_snapshot.sql',
-      '004_concurrency_and_idempotency.sql',
-    ]);
+    expect(records).toEqual(allMigrations());
   });
 
   it('should skip already applied migrations on subsequent run', async () => {
@@ -59,13 +69,9 @@ describe('PostgreSQL Migration Runner', () => {
 
   it('should rollback migrations with down runner', async () => {
     await runMigrationsUp(memPool, migrationsDir);
-    const rolledBack = await runMigrationsDown(4, memPool, migrationsDir);
-    expect(rolledBack).toEqual([
-      '004_concurrency_and_idempotency.sql',
-      '003_sale_calculation_snapshot.sql',
-      '002_checkout_financial_contract.sql',
-      '001_initial_schema.sql',
-    ]);
+    const expected = allMigrations();
+    const rolledBack = await runMigrationsDown(expected.length, memPool, migrationsDir);
+    expect(rolledBack).toEqual([...expected].reverse());
 
     const records = await getAppliedMigrations(memPool);
     expect(records).toHaveLength(0);
@@ -93,20 +99,10 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
 
   it('applies 002 on top of an already-applied 001 (upgrade path)', async () => {
     const firstRun = await runMigrationsUp(memPool, migrationsDir);
-    expect(firstRun).toEqual([
-      '001_initial_schema.sql',
-      '002_checkout_financial_contract.sql',
-      '003_sale_calculation_snapshot.sql',
-      '004_concurrency_and_idempotency.sql',
-    ]);
+    expect(firstRun).toEqual(allMigrations());
 
     const applied = await getAppliedMigrations(memPool);
-    expect(applied).toEqual([
-      '001_initial_schema.sql',
-      '002_checkout_financial_contract.sql',
-      '003_sale_calculation_snapshot.sql',
-      '004_concurrency_and_idempotency.sql',
-    ]);
+    expect(applied).toEqual(allMigrations());
   });
 
   it('fresh database: resolves canonical loyalty settings with documented safe defaults', async () => {
@@ -125,7 +121,6 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
 
     const upgradePool = createPgMemPool();
 
-    const fs = await import('fs');
     const sql001 = fs.readFileSync(path.join(migrationsDir, '001_initial_schema.sql'), 'utf8');
     await upgradePool.query(sql001);
     await ensureMigrationTable(upgradePool);
@@ -136,11 +131,7 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
     );
 
     const applied = await runMigrationsUp(upgradePool, migrationsDir);
-    expect(applied).toEqual([
-      '002_checkout_financial_contract.sql',
-      '003_sale_calculation_snapshot.sql',
-      '004_concurrency_and_idempotency.sql',
-    ]);
+    expect(applied).toEqual(allMigrations().slice(1));
 
     const settings = await settingsMap(upgradePool);
     expect(settings.loyalty_points_per_egp).toBe('3');
@@ -157,7 +148,6 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
 
     const upgradePool = createPgMemPool();
 
-    const fs = await import('fs');
     const sql001 = fs.readFileSync(path.join(migrationsDir, '001_initial_schema.sql'), 'utf8');
     await upgradePool.query(sql001);
     await ensureMigrationTable(upgradePool);
@@ -186,7 +176,6 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
 
     const upgradePool = createPgMemPool();
 
-    const fs = await import('fs');
     const sql001 = fs.readFileSync(path.join(migrationsDir, '001_initial_schema.sql'), 'utf8');
     await upgradePool.query(sql001);
     await ensureMigrationTable(upgradePool);
@@ -196,14 +185,11 @@ describe('002_checkout_financial_contract: canonical loyalty settings migration'
     );
 
     await runMigrationsUp(upgradePool, migrationsDir);
-    // Roll back 004 and 003 (both unrelated to loyalty settings) down to and
+    // Roll back everything above 002 (all unrelated to loyalty settings) down to and
     // including 002, to exercise 002's down migration specifically.
-    const rolledBack = await runMigrationsDown(3, upgradePool, migrationsDir);
-    expect(rolledBack).toEqual([
-      '004_concurrency_and_idempotency.sql',
-      '003_sale_calculation_snapshot.sql',
-      '002_checkout_financial_contract.sql',
-    ]);
+    const expected = allMigrations().slice(1);
+    const rolledBack = await runMigrationsDown(expected.length, upgradePool, migrationsDir);
+    expect(rolledBack).toEqual([...expected].reverse());
 
     const settings = await settingsMap(upgradePool);
     expect(settings.loyalty_points_per_egp).toBe('2');

--- a/server/tests/database/migration004.test.ts
+++ b/server/tests/database/migration004.test.ts
@@ -7,6 +7,7 @@
  * `tests/support/pgMem.ts` for the one clause they cannot parse.
  */
 import { afterAll, afterEach, beforeAll, expect, it } from 'vitest';
+import fs from 'fs';
 import path from 'path';
 import { Pool } from 'pg';
 import {
@@ -23,6 +24,24 @@ import {
 
 const MIGRATIONS_DIR = path.join(__dirname, '../../src/database/migrations');
 const MIGRATION = '004_concurrency_and_idempotency.sql';
+
+/**
+ * Read from the directory rather than hard-coded: this file is about what migration 004
+ * does, and a later migration existing is not a fact about 004. `fromMigration` is the
+ * tail of the sequence starting at 004, which is both the rollback depth and the list a
+ * re-apply must produce.
+ */
+function allMigrations(): string[] {
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql') && !f.includes('.down.sql'))
+    .sort();
+}
+
+function fromMigration(): string[] {
+  const all = allMigrations();
+  return all.slice(all.indexOf(MIGRATION));
+}
 
 const NON_NEGATIVE_CONSTRAINTS = [
   ['products', 'products_stock_non_negative'],
@@ -187,7 +206,8 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
     });
 
     try {
-      await runMigrationsDown(1, legacy.pool, MIGRATIONS_DIR);
+      const tail = fromMigration();
+      await runMigrationsDown(tail.length, legacy.pool, MIGRATIONS_DIR);
       expect(await getAppliedMigrations(legacy.pool)).not.toContain(MIGRATION);
 
       await legacy.pool.query(
@@ -195,7 +215,7 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
       );
 
       const applied = await runMigrationsUp(legacy.pool, MIGRATIONS_DIR);
-      expect(applied).toEqual([MIGRATION]);
+      expect(applied).toEqual(tail);
 
       // The legacy row survives untouched; only new writes are policed.
       const { rows } = await legacy.pool.query<{ stock: number }>(
@@ -218,8 +238,9 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
     });
 
     try {
-      const rolledBack = await runMigrationsDown(1, cycle.pool, MIGRATIONS_DIR);
-      expect(rolledBack).toEqual([MIGRATION]);
+      const tail = fromMigration();
+      const rolledBack = await runMigrationsDown(tail.length, cycle.pool, MIGRATIONS_DIR);
+      expect(rolledBack).toEqual([...tail].reverse());
 
       const gone = await cycle.pool.query<{ n: number }>(
         `SELECT COUNT(*)::int AS n FROM information_schema.tables
@@ -240,13 +261,8 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
         "INSERT INTO products (name, sku, price, stock) VALUES ('Rolled back', 'SKU-CYCLE', 10, -1)"
       );
 
-      expect(await runMigrationsUp(cycle.pool, MIGRATIONS_DIR)).toEqual([MIGRATION]);
-      expect(await getAppliedMigrations(cycle.pool)).toEqual([
-        '001_initial_schema.sql',
-        '002_checkout_financial_contract.sql',
-        '003_sale_calculation_snapshot.sql',
-        MIGRATION,
-      ]);
+      expect(await runMigrationsUp(cycle.pool, MIGRATIONS_DIR)).toEqual(tail);
+      expect(await getAppliedMigrations(cycle.pool)).toEqual(allMigrations());
     } finally {
       await cycle.teardown();
     }
@@ -264,12 +280,7 @@ describeWithPostgres('migration 004 — idempotency keys and non-negative invari
     });
 
     try {
-      expect(await runMigrationsUp(pool, MIGRATIONS_DIR)).toEqual([
-        '001_initial_schema.sql',
-        '002_checkout_financial_contract.sql',
-        '003_sale_calculation_snapshot.sql',
-        MIGRATION,
-      ]);
+      expect(await runMigrationsUp(pool, MIGRATIONS_DIR)).toEqual(allMigrations());
     } finally {
       await pool.end();
       await admin.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);

--- a/server/tests/scheduler.test.ts
+++ b/server/tests/scheduler.test.ts
@@ -72,7 +72,10 @@ afterEach(() => {
 describe('runScheduledJob', () => {
   it('claims the slot, runs once, and records the outcome it reports', async () => {
     const fake = fakePool();
-    const result = await runScheduledJob(job(async () => ({ deleted: 3 })), { pool: fake.pool });
+    const result = await runScheduledJob(
+      job(async () => ({ deleted: 3 })),
+      { pool: fake.pool }
+    );
 
     expect(result).toMatchObject({ job: 'test-job', status: 'completed', outcome: { deleted: 3 } });
 
@@ -151,7 +154,10 @@ describe('runScheduledJob', () => {
 
   it('bypasses the due window under force, but never the lock', async () => {
     const fake = fakePool();
-    await runScheduledJob(job(async () => null), { pool: fake.pool, force: true });
+    await runScheduledJob(
+      job(async () => null),
+      { pool: fake.pool, force: true }
+    );
     expect(fake.matched('INSERT INTO scheduled_jobs')[0].params).toEqual(['test-job', 0]);
 
     const locked = fakePool({ locked: false });

--- a/server/tests/scheduler.test.ts
+++ b/server/tests/scheduler.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Scheduler runner — the parts that do not need real MVCC.
+ *
+ * The fleet-wide single-execution guarantee is a property of two genuinely concurrent
+ * connections and lives in `tests/concurrency/scheduler.concurrency.test.ts`. What is
+ * provable here is the runner's contract around that: which statements it issues, that it
+ * always releases its lock, that a failure is reported rather than thrown, and that the
+ * cleanup job reports what it deleted.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { runScheduledJob, ADVISORY_LOCK_NAMESPACE } from '../src/scheduler/runner';
+import { reservationCleanupJob, JOB_LOCK_IDS } from '../src/scheduler/jobs';
+import { startScheduler } from '../src/scheduler';
+import { reservationsRepository } from '../src/modules/pos/reservations/repository';
+import type { ScheduledJob } from '../src/scheduler/types';
+
+interface FakeCall {
+  sql: string;
+  params: unknown[];
+}
+
+interface FakePoolOptions {
+  locked?: boolean;
+  claimed?: boolean;
+  failOn?: (sql: string) => boolean;
+}
+
+function fakePool(options: FakePoolOptions = {}) {
+  const { locked = true, claimed = true } = options;
+  const calls: FakeCall[] = [];
+  let released = 0;
+
+  const client = {
+    query: vi.fn(async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      if (options.failOn?.(sql)) {
+        throw new Error('query exploded');
+      }
+      if (sql.includes('pg_try_advisory_lock')) {
+        return { rows: [{ locked }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO scheduled_jobs')) {
+        return { rows: claimed ? [{ name: 'x' }] : [], rowCount: claimed ? 1 : 0 };
+      }
+      return { rows: [], rowCount: 1 };
+    }),
+    release: () => {
+      released += 1;
+    },
+  };
+
+  const pool = { connect: async () => client } as unknown as Pool;
+
+  return {
+    pool,
+    calls,
+    sqls: () => calls.map((c) => c.sql),
+    releasedCount: () => released,
+    matched: (needle: string) => calls.filter((c) => c.sql.includes(needle)),
+  };
+}
+
+function job(run: () => Promise<unknown>, overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+  return { name: 'test-job', intervalMs: 300_000, lockId: 99, run, ...overrides };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('runScheduledJob', () => {
+  it('claims the slot, runs once, and records the outcome it reports', async () => {
+    const fake = fakePool();
+    const result = await runScheduledJob(job(async () => ({ deleted: 3 })), { pool: fake.pool });
+
+    expect(result).toMatchObject({ job: 'test-job', status: 'completed', outcome: { deleted: 3 } });
+
+    const claim = fake.matched('INSERT INTO scheduled_jobs')[0];
+    expect(claim.params).toEqual(['test-job', 300]);
+
+    const record = fake.matched('UPDATE scheduled_jobs')[0];
+    expect(record.params).toEqual(['test-job', 'success', '{"deleted":3}', 0]);
+  });
+
+  it('does not run the handler when another instance holds the lock', async () => {
+    const fake = fakePool({ locked: false });
+    const run = vi.fn(async () => ({ deleted: 1 }));
+
+    const result = await runScheduledJob(job(run), { pool: fake.pool });
+
+    expect(result.status).toBe('skipped-locked');
+    expect(run).not.toHaveBeenCalled();
+    expect(fake.matched('INSERT INTO scheduled_jobs')).toHaveLength(0);
+    expect(fake.releasedCount()).toBe(1);
+  });
+
+  it('does not run the handler when the interval has not elapsed', async () => {
+    const fake = fakePool({ claimed: false });
+    const run = vi.fn(async () => ({ deleted: 1 }));
+
+    const result = await runScheduledJob(job(run), { pool: fake.pool });
+
+    expect(result.status).toBe('skipped-not-due');
+    expect(run).not.toHaveBeenCalled();
+    expect(fake.matched('pg_advisory_unlock')).toHaveLength(1);
+  });
+
+  it('reports a handler failure instead of throwing, and records it', async () => {
+    const fake = fakePool();
+    const result = await runScheduledJob(
+      job(async () => {
+        throw new Error('cleanup blew up');
+      }),
+      { pool: fake.pool }
+    );
+
+    expect(result).toMatchObject({ status: 'failed', error: 'cleanup blew up' });
+    const record = fake.matched('UPDATE scheduled_jobs')[0];
+    expect(record.params).toEqual(['test-job', 'failed', 'cleanup blew up', 1]);
+  });
+
+  it('releases the advisory lock on every path, so a failed run stays retryable', async () => {
+    for (const handler of [
+      async () => ({ ok: true }),
+      async () => {
+        throw new Error('boom');
+      },
+    ]) {
+      const fake = fakePool();
+      await runScheduledJob(job(handler), { pool: fake.pool });
+      const unlock = fake.matched('pg_advisory_unlock')[0];
+      expect(unlock.params).toEqual([ADVISORY_LOCK_NAMESPACE, 99]);
+      expect(fake.releasedCount()).toBe(1);
+    }
+  });
+
+  it('reports a failure rather than throwing when the database is unreachable', async () => {
+    const pool = {
+      connect: async () => {
+        throw new Error('connection refused');
+      },
+    } as unknown as Pool;
+
+    const run = vi.fn();
+    const result = await runScheduledJob(job(run as never), { pool });
+
+    expect(result).toMatchObject({ status: 'failed', error: 'connection refused' });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('bypasses the due window under force, but never the lock', async () => {
+    const fake = fakePool();
+    await runScheduledJob(job(async () => null), { pool: fake.pool, force: true });
+    expect(fake.matched('INSERT INTO scheduled_jobs')[0].params).toEqual(['test-job', 0]);
+
+    const locked = fakePool({ locked: false });
+    const run = vi.fn(async () => null);
+    const result = await runScheduledJob(job(run), { pool: locked.pool, force: true });
+    expect(result.status).toBe('skipped-locked');
+    expect(run).not.toHaveBeenCalled();
+  });
+});
+
+describe('reservation cleanup job', () => {
+  it('reports how many reservations it removed, and is safe to repeat', async () => {
+    const deleteExpired = vi
+      .spyOn(reservationsRepository, 'deleteExpired')
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(0);
+
+    const first = fakePool();
+    expect(await runScheduledJob(reservationCleanupJob, { pool: first.pool })).toMatchObject({
+      status: 'completed',
+      outcome: { deleted: 4 },
+    });
+
+    const second = fakePool();
+    expect(
+      await runScheduledJob(reservationCleanupJob, { pool: second.pool, force: true })
+    ).toMatchObject({ status: 'completed', outcome: { deleted: 0 } });
+
+    expect(deleteExpired).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a stable identity, because a rename or renumber would double-run it', () => {
+    expect(reservationCleanupJob.name).toBe('reservation-cleanup');
+    expect(reservationCleanupJob.lockId).toBe(JOB_LOCK_IDS.reservationCleanup);
+    expect(reservationCleanupJob.intervalMs).toBe(5 * 60 * 1000);
+  });
+
+  it('gives every registered job a distinct lock id', () => {
+    const ids = Object.values(JOB_LOCK_IDS);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('startScheduler', () => {
+  it('stops ticking after stop()', async () => {
+    vi.useFakeTimers();
+    try {
+      const run = vi.fn(async () => null);
+      const fake = fakePool();
+      const scheduler = startScheduler({
+        jobs: [job(run)],
+        tickMs: 1000,
+        runOnStart: false,
+        pool: fake.pool,
+      });
+
+      await vi.advanceTimersByTimeAsync(2500);
+      expect(run.mock.calls.length).toBeGreaterThan(0);
+
+      scheduler.stop();
+      const before = run.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(run.mock.calls.length).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/tests/scheduler.test.ts
+++ b/server/tests/scheduler.test.ts
@@ -29,7 +29,7 @@ interface FakePoolOptions {
 function fakePool(options: FakePoolOptions = {}) {
   const { locked = true, claimed = true } = options;
   const calls: FakeCall[] = [];
-  let released = 0;
+  const releases: Array<Error | undefined> = [];
 
   const client = {
     query: vi.fn(async (sql: string, params: unknown[] = []) => {
@@ -45,8 +45,8 @@ function fakePool(options: FakePoolOptions = {}) {
       }
       return { rows: [], rowCount: 1 };
     }),
-    release: () => {
-      released += 1;
+    release: (err?: Error) => {
+      releases.push(err);
     },
   };
 
@@ -56,7 +56,8 @@ function fakePool(options: FakePoolOptions = {}) {
     pool,
     calls,
     sqls: () => calls.map((c) => c.sql),
-    releasedCount: () => released,
+    releasedCount: () => releases.length,
+    releases: () => releases,
     matched: (needle: string) => calls.filter((c) => c.sql.includes(needle)),
   };
 }
@@ -80,7 +81,8 @@ describe('runScheduledJob', () => {
     expect(result).toMatchObject({ job: 'test-job', status: 'completed', outcome: { deleted: 3 } });
 
     const claim = fake.matched('INSERT INTO scheduled_jobs')[0];
-    expect(claim.params).toEqual(['test-job', 300]);
+    // name, due window (5 min), stale-claim takeover window (10 min default).
+    expect(claim.params).toEqual(['test-job', 300, 600]);
 
     const record = fake.matched('UPDATE scheduled_jobs')[0];
     expect(record.params).toEqual(['test-job', 'success', '{"deleted":3}', 0]);
@@ -152,13 +154,60 @@ describe('runScheduledJob', () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it('destroys a connection whose advisory lock could not be released', async () => {
+    // A session that may still hold the lock must not go back into the pool: the next
+    // borrower inherits it and the whole fleet reads `skipped-locked`.
+    const fake = fakePool({ failOn: (sql) => sql.includes('pg_advisory_unlock') });
+
+    const result = await runScheduledJob(
+      job(async () => ({ ok: true })),
+      { pool: fake.pool }
+    );
+
+    expect(result.status).toBe('completed');
+    expect(fake.releases()).toHaveLength(1);
+    expect(fake.releases()[0]).toBeInstanceOf(Error);
+  });
+
+  it('returns a healthy connection to the pool untouched', async () => {
+    const fake = fakePool();
+    await runScheduledJob(
+      job(async () => ({ ok: true })),
+      { pool: fake.pool }
+    );
+    expect(fake.releases()).toEqual([undefined]);
+  });
+
+  it('reports work that succeeded as completed even if the ledger write fails', async () => {
+    // The DELETE has already committed. Calling that a failure would ask for a retry of
+    // work that is already done, and would log an outage that did not happen.
+    const fake = fakePool({ failOn: (sql) => sql.includes('UPDATE scheduled_jobs') });
+
+    const result = await runScheduledJob(
+      job(async () => ({ deleted: 9 })),
+      { pool: fake.pool }
+    );
+
+    expect(result).toMatchObject({ status: 'completed', outcome: { deleted: 9 } });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('passes a per-job stale-claim window when one is set', async () => {
+    const fake = fakePool();
+    await runScheduledJob(
+      job(async () => null, { staleAfterMs: 90_000 }),
+      { pool: fake.pool }
+    );
+    expect(fake.matched('INSERT INTO scheduled_jobs')[0].params).toEqual(['test-job', 300, 90]);
+  });
+
   it('bypasses the due window under force, but never the lock', async () => {
     const fake = fakePool();
     await runScheduledJob(
       job(async () => null),
       { pool: fake.pool, force: true }
     );
-    expect(fake.matched('INSERT INTO scheduled_jobs')[0].params).toEqual(['test-job', 0]);
+    expect(fake.matched('INSERT INTO scheduled_jobs')[0].params).toEqual(['test-job', 0, 0]);
 
     const locked = fakePool({ locked: false });
     const run = vi.fn(async () => null);

--- a/server/tests/storage.test.ts
+++ b/server/tests/storage.test.ts
@@ -75,8 +75,16 @@ class FakeDriver implements StorageDriver {
     return `/uploads/${key}`;
   }
 
+  /** URLs in this store's space that deliberately fail to resolve to a key. */
+  unreadableUrls = new Set<string>();
+
   keyFromUrl(url: string): string | null {
+    if (this.unreadableUrls.has(url)) return null;
     return url.startsWith('/uploads/') ? url.slice('/uploads/'.length) : null;
+  }
+
+  ownsUrl(url: string): boolean {
+    return url.startsWith('/uploads/');
   }
 }
 
@@ -140,6 +148,7 @@ describe('LocalStorageDriver', () => {
       'uploads/products/a.png',
     ]) {
       expect(driver.keyFromUrl(url)).toBeNull();
+      expect(driver.ownsUrl(url)).toBe(false);
     }
   });
 
@@ -147,7 +156,28 @@ describe('LocalStorageDriver', () => {
     const cdn = new LocalStorageDriver({ root, baseUrl: 'https://cdn.example.com/media' });
     expect(cdn.publicUrl('products/a.png')).toBe('https://cdn.example.com/media/products/a.png');
     expect(cdn.keyFromUrl('https://cdn.example.com/media/products/a.png')).toBe('products/a.png');
-    expect(cdn.keyFromUrl('/uploads/products/a.png')).toBeNull();
+  });
+
+  it('still owns its legacy URLs after the base moves to a CDN', () => {
+    // The documented migration sets an absolute base while rows written before it stay
+    // relative and keep being served by the /uploads mount. A driver that disowned them
+    // would report every one of them as unreferenced.
+    const cdn = new LocalStorageDriver({ root, baseUrl: 'https://cdn.example.com/media' });
+
+    expect(cdn.keyFromUrl('/uploads/products/legacy.png')).toBe('products/legacy.png');
+    expect(cdn.ownsUrl('/uploads/products/legacy.png')).toBe(true);
+    // The base's own path is owned in relative form too, for a same-origin CDN.
+    expect(cdn.keyFromUrl('/media/products/a.png')).toBe('products/a.png');
+    // Someone else's image is still someone else's.
+    expect(cdn.keyFromUrl('https://other.example.com/hero.png')).toBeNull();
+    expect(cdn.ownsUrl('https://other.example.com/hero.png')).toBe(false);
+  });
+
+  it('separates "not mine" from "mine but unreadable"', () => {
+    // A key that cannot be parsed is missing information, not an absent reference — the
+    // sweep has to be able to tell the two apart.
+    expect(driver.keyFromUrl('/uploads/products/../../etc/passwd')).toBeNull();
+    expect(driver.ownsUrl('/uploads/products/../../etc/passwd')).toBe(true);
   });
 
   it('deleting an absent object succeeds, so a retry is not an error', async () => {
@@ -493,6 +523,54 @@ describe('orphaned media sweep', () => {
     await expect(
       sweepOrphanedMedia({ pool, storage: driver, minAgeMs: hours(24) })
     ).rejects.toThrow('connection reset');
+    expect(driver.objects.size).toBe(1);
+  });
+
+  it('deletes nothing after the documented CDN migration, when every row is legacy', async () => {
+    // Regression: `MEDIA_PUBLIC_BASE_URL` moves to an absolute base while every existing
+    // row still holds `/uploads/...`. A driver that stopped recognising those URLs would
+    // report the whole catalogue as unreferenced and delete it.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'moon-cdn-'));
+    try {
+      const cdn = new LocalStorageDriver({ root, baseUrl: 'https://cdn.example.com/media' });
+      await cdn.put('products/legacy-a.png', PNG, { contentType: 'image/png' });
+      await cdn.put('products/legacy-b.png', PNG, { contentType: 'image/png' });
+      await cdn.put('products/orphan.png', PNG, { contentType: 'image/png' });
+
+      const outcome = await sweepOrphanedMedia({
+        pool: poolReturning([
+          '/uploads/products/legacy-a.png',
+          'https://cdn.example.com/media/products/legacy-b.png',
+          'https://images.unsplash.com/photo-1.jpg',
+        ]),
+        storage: cdn,
+        // Everything was just written, so the sweep is aged past the grace window on
+        // purpose: age must not be the reason nothing was deleted, only the mapping.
+        minAgeMs: hours(1),
+        now: new Date(Date.now() + hours(2)),
+      });
+
+      expect(outcome).toMatchObject({ scanned: 3, deleted: 1 });
+      expect((await cdn.list('products')).map((o) => o.key).sort()).toEqual([
+        'products/legacy-a.png',
+        'products/legacy-b.png',
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to delete anything when a reference it owns cannot be resolved', async () => {
+    const driver = driverWith([['products/orphan.png', 48]]);
+    driver.unreadableUrls.add('/uploads/products/mangled');
+
+    await expect(
+      sweepOrphanedMedia({
+        pool: poolReturning(['/uploads/products/mangled']),
+        storage: driver,
+        minAgeMs: hours(24),
+      })
+    ).rejects.toThrow(/Refusing to sweep/);
     expect(driver.objects.size).toBe(1);
   });
 

--- a/server/tests/storage.test.ts
+++ b/server/tests/storage.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Media storage: the driver contract, the upload gate, and the image lifecycle.
+ *
+ * The controller tests run against an in-memory driver rather than a temp directory. What
+ * they are asserting is the *ordering* the lifecycle depends on — validate, write, commit,
+ * then release the old object — and the ordering is what has to hold on a driver that is a
+ * remote bucket, not a disk.
+ */
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import jwt from 'jsonwebtoken';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { LocalStorageDriver } from '../src/storage/localDriver';
+import {
+  assertSafeKey,
+  type PutOptions,
+  type StorageDriver,
+  type StoredObject,
+} from '../src/storage/types';
+import {
+  productImageKey,
+  extensionForContentType,
+  PRODUCT_IMAGE_PREFIX,
+} from '../src/storage/keys';
+import { detectImageType, validateImageBytes, createImageUpload } from '../src/storage/upload';
+import { setStorage, resetStorage } from '../src/storage';
+import { ProductsController } from '../src/modules/inventory/products/controller';
+import { productsRepository } from '../src/modules/inventory/products/repository';
+import productsRouter from '../src/modules/inventory/products/routes';
+import { sweepOrphanedMedia } from '../src/scheduler/mediaSweep';
+
+const PNG = Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47]), Buffer.alloc(20)]);
+const JPEG = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff]), Buffer.alloc(20)]);
+const WEBP = Buffer.concat([
+  Buffer.from('RIFF', 'ascii'),
+  Buffer.alloc(4),
+  Buffer.from('WEBP', 'ascii'),
+  Buffer.alloc(8),
+]);
+
+/** In-memory driver, so a controller test asserts behaviour rather than filesystem state. */
+class FakeDriver implements StorageDriver {
+  readonly name = 'fake';
+  readonly objects = new Map<string, { body: Buffer; contentType: string; lastModified: Date }>();
+  failPutKeys = new Set<string>();
+  failDeleteKeys = new Set<string>();
+
+  async put(key: string, body: Buffer, options: PutOptions): Promise<void> {
+    if (this.failPutKeys.has(key)) throw new Error('put failed');
+    this.objects.set(assertSafeKey(key), {
+      body,
+      contentType: options.contentType,
+      lastModified: new Date(),
+    });
+  }
+
+  async delete(key: string): Promise<void> {
+    if (this.failDeleteKeys.has(key)) throw new Error('delete failed');
+    this.objects.delete(key);
+  }
+
+  async exists(key: string): Promise<boolean> {
+    return this.objects.has(key);
+  }
+
+  async list(prefix: string): Promise<StoredObject[]> {
+    return [...this.objects.entries()]
+      .filter(([key]) => key.startsWith(`${prefix}/`))
+      .map(([key, value]) => ({ key, size: value.body.length, lastModified: value.lastModified }));
+  }
+
+  publicUrl(key: string): string {
+    return `/uploads/${key}`;
+  }
+
+  keyFromUrl(url: string): string | null {
+    return url.startsWith('/uploads/') ? url.slice('/uploads/'.length) : null;
+  }
+}
+
+function response() {
+  const res: Partial<Response> & { body?: unknown; statusCode?: number } = {};
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  }) as never;
+  res.json = vi.fn((body: unknown) => {
+    res.body = body;
+    return res as Response;
+  }) as never;
+  res.send = vi.fn(() => res as Response) as never;
+  return res as Response & { body?: unknown; statusCode?: number };
+}
+
+describe('LocalStorageDriver', () => {
+  let root: string;
+  let driver: LocalStorageDriver;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'moon-storage-'));
+    driver = new LocalStorageDriver({ root });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('round-trips an object and lists it under its prefix', async () => {
+    await driver.put('products/a.png', PNG, { contentType: 'image/png' });
+
+    expect(await driver.exists('products/a.png')).toBe(true);
+    const listed = await driver.list('products');
+    expect(listed.map((o) => o.key)).toEqual(['products/a.png']);
+    expect(listed[0].size).toBe(PNG.length);
+    expect(await fs.readFile(path.join(root, 'products', 'a.png'))).toEqual(PNG);
+  });
+
+  it('produces exactly the URL shape already stored in the database', () => {
+    expect(driver.publicUrl('products/1771875072587-4wjwqx.webp')).toBe(
+      '/uploads/products/1771875072587-4wjwqx.webp'
+    );
+    expect(driver.keyFromUrl('/uploads/products/1771875072587-4wjwqx.webp')).toBe(
+      'products/1771875072587-4wjwqx.webp'
+    );
+  });
+
+  it('recognises an absolute URL that points at its own base path', () => {
+    expect(driver.keyFromUrl('https://shop.example.com/uploads/products/a.png')).toBe(
+      'products/a.png'
+    );
+  });
+
+  it('returns null for a URL it does not own, so a foreign image is never deleted', () => {
+    for (const url of [
+      'https://cdn.example.com/banners/hero.jpg',
+      '/static/products/a.png',
+      '',
+      'uploads/products/a.png',
+    ]) {
+      expect(driver.keyFromUrl(url)).toBeNull();
+    }
+  });
+
+  it('serves a configured base URL while still resolving its own keys', () => {
+    const cdn = new LocalStorageDriver({ root, baseUrl: 'https://cdn.example.com/media' });
+    expect(cdn.publicUrl('products/a.png')).toBe('https://cdn.example.com/media/products/a.png');
+    expect(cdn.keyFromUrl('https://cdn.example.com/media/products/a.png')).toBe('products/a.png');
+    expect(cdn.keyFromUrl('/uploads/products/a.png')).toBeNull();
+  });
+
+  it('deleting an absent object succeeds, so a retry is not an error', async () => {
+    await driver.put('products/a.png', PNG, { contentType: 'image/png' });
+    await driver.delete('products/a.png');
+    await expect(driver.delete('products/a.png')).resolves.toBeUndefined();
+    expect(await driver.exists('products/a.png')).toBe(false);
+  });
+
+  it('lists nothing for a prefix that does not exist yet', async () => {
+    expect(await driver.list('products')).toEqual([]);
+  });
+
+  it('refuses a key that could escape the store', async () => {
+    for (const key of ['../secrets.env', 'products/../../etc/passwd', '/absolute/a.png', '']) {
+      await expect(driver.put(key, PNG, { contentType: 'image/png' })).rejects.toThrow(
+        /Unsafe storage key/
+      );
+    }
+  });
+});
+
+describe('image keys', () => {
+  it('names an object from the detected content type, never from the client filename', () => {
+    expect(productImageKey('image/webp')).toMatch(
+      new RegExp(`^${PRODUCT_IMAGE_PREFIX}/\\d+-[0-9a-f]{6}\\.webp$`)
+    );
+    expect(extensionForContentType('image/jpeg')).toBe('.jpg');
+    expect(extensionForContentType('image/gif')).toBeNull();
+    expect(() => productImageKey('image/svg+xml')).toThrow(/Unsupported image content type/);
+  });
+});
+
+describe('upload validation', () => {
+  it('identifies the formats it accepts and rejects everything else', () => {
+    expect(detectImageType(PNG)).toBe('image/png');
+    expect(detectImageType(JPEG)).toBe('image/jpeg');
+    expect(detectImageType(WEBP)).toBe('image/webp');
+    expect(detectImageType(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />'))).toBeNull();
+    expect(detectImageType(Buffer.from([0x47, 0x49, 0x46, 0x38]))).toBeNull();
+  });
+
+  it('rejects a file whose bytes disagree with its extension', () => {
+    const res = response();
+    const next = vi.fn();
+    validateImageBytes(
+      { file: { originalname: 'evil.png', buffer: JPEG } } as unknown as Request,
+      res,
+      next
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({
+      error: { code: 'VALIDATION_ERROR', message: expect.stringContaining('does not match') },
+    });
+  });
+
+  it('rejects a file that is not an image at all, and an empty one', () => {
+    for (const buffer of [Buffer.from('#!/bin/sh\nrm -rf /'), Buffer.alloc(0)]) {
+      const res = response();
+      const next = vi.fn();
+      validateImageBytes(
+        { file: { originalname: 'x.png', buffer } } as unknown as Request,
+        res,
+        next
+      );
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(400);
+    }
+  });
+
+  it('pins the detected type onto the file so nothing downstream trusts the client', () => {
+    const file = { originalname: 'photo.jpg', buffer: JPEG, mimetype: 'image/png' };
+    const next = vi.fn();
+    validateImageBytes({ file } as unknown as Request, response(), next);
+    expect(next).toHaveBeenCalled();
+    expect(file.mimetype).toBe('image/jpeg');
+  });
+
+  it('keeps the 2MB ceiling and the extension allowlist on the multer instance', () => {
+    const upload = createImageUpload() as unknown as {
+      limits: { fileSize: number; files: number };
+      fileFilter: (
+        req: unknown,
+        file: { originalname: string },
+        cb: (e: Error | null, ok?: boolean) => void
+      ) => void;
+    };
+    expect(upload.limits).toMatchObject({ fileSize: 2 * 1024 * 1024, files: 1 });
+
+    const rejected: string[] = [];
+    for (const name of ['x.svg', 'x.gif', 'x.php', 'x.png.exe', 'x']) {
+      upload.fileFilter({}, { originalname: name }, (err) => {
+        if (err) rejected.push(name);
+      });
+    }
+    expect(rejected).toEqual(['x.svg', 'x.gif', 'x.php', 'x.png.exe', 'x']);
+  });
+});
+
+describe('product image routes', () => {
+  function imageRouteHandlers(method: 'post' | 'delete') {
+    const layer = (
+      productsRouter as unknown as {
+        stack: Array<{
+          route?: {
+            path: string;
+            methods: Record<string, boolean>;
+            stack: Array<{ handle: (req: unknown, res: unknown, next: unknown) => void }>;
+          };
+        }>;
+      }
+    ).stack.find((l) => l.route?.path === '/:id/image' && l.route.methods[method]);
+    expect(layer).toBeDefined();
+    return layer!.route!.stack.map((s) => s.handle);
+  }
+
+  async function runChain(
+    handlers: Array<(req: unknown, res: unknown, next: unknown) => void>,
+    req: Partial<Request>
+  ) {
+    const res = response();
+    for (const handler of handlers) {
+      let advanced = false;
+      await new Promise<void>((resolve) => {
+        handler(req, res, () => {
+          advanced = true;
+          resolve();
+        });
+        if (!advanced) setImmediate(resolve);
+      });
+      if (!advanced) break;
+    }
+    return res;
+  }
+
+  it('rejects an unauthenticated upload before any storage work happens', async () => {
+    const driver = new FakeDriver();
+    setStorage(driver);
+    const res = await runChain(imageRouteHandlers('post'), { headers: {}, params: { id: '1' } });
+    expect(res.statusCode).toBe(401);
+    expect(driver.objects.size).toBe(0);
+  });
+
+  it('rejects a non-Admin upload and a non-Admin delete', async () => {
+    const token = jwt.sign(
+      { id: 2, role: 'Cashier', email: 'sarah@moon.com' },
+      process.env.JWT_SECRET as string
+    );
+    for (const method of ['post', 'delete'] as const) {
+      const res = await runChain(imageRouteHandlers(method), {
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: '1' },
+      });
+      expect(res.statusCode).toBe(403);
+    }
+  });
+});
+
+describe('product image lifecycle', () => {
+  let driver: FakeDriver;
+  const controller = new ProductsController();
+
+  beforeEach(() => {
+    driver = new FakeDriver();
+    setStorage(driver);
+  });
+
+  afterEach(() => {
+    resetStorage();
+    vi.restoreAllMocks();
+  });
+
+  function uploadRequest() {
+    return {
+      params: { id: '7' },
+      file: { originalname: 'photo.png', buffer: PNG, mimetype: 'image/png' },
+    } as unknown as Request;
+  }
+
+  it('stores the object, points the row at it, and releases the image it replaced', async () => {
+    driver.objects.set('products/old.png', {
+      body: PNG,
+      contentType: 'image/png',
+      lastModified: new Date(),
+    });
+    vi.spyOn(productsRepository, 'findById').mockResolvedValue({
+      id: 7,
+      status: 'active',
+      image_url: '/uploads/products/old.png',
+    } as never);
+    const updateImage = vi.spyOn(productsRepository, 'updateImage').mockResolvedValue(undefined);
+
+    const res = response();
+    await controller.uploadImage(uploadRequest(), res, vi.fn());
+
+    const body = res.body as { data: { image_url: string } };
+    expect(body.data.image_url).toMatch(/^\/uploads\/products\/\d+-[0-9a-f]{6}\.png$/);
+    expect(updateImage).toHaveBeenCalledWith(7, body.data.image_url);
+    expect([...driver.objects.keys()]).toEqual([body.data.image_url.replace('/uploads/', '')]);
+  });
+
+  it('writes nothing when the product does not exist or is discontinued', async () => {
+    const findById = vi.spyOn(productsRepository, 'findById');
+    const next = vi.fn();
+
+    findById.mockResolvedValueOnce(undefined as never);
+    await controller.uploadImage(uploadRequest(), response(), next);
+
+    findById.mockResolvedValueOnce({ id: 7, status: 'discontinued' } as never);
+    await controller.uploadImage(uploadRequest(), response(), next);
+
+    expect(next.mock.calls.map(([err]) => err.code)).toEqual(['NOT_FOUND', 'FORBIDDEN']);
+    expect(driver.objects.size).toBe(0);
+  });
+
+  it('removes the object it just wrote when the row cannot be updated', async () => {
+    vi.spyOn(productsRepository, 'findById').mockResolvedValue({
+      id: 7,
+      status: 'active',
+      image_url: null,
+    } as never);
+    vi.spyOn(productsRepository, 'updateImage').mockRejectedValue(new Error('deadlock detected'));
+
+    const next = vi.fn();
+    await controller.uploadImage(uploadRequest(), response(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'deadlock detected' }));
+    expect(driver.objects.size).toBe(0);
+  });
+
+  it('still succeeds when the replaced object cannot be deleted, leaving it to the sweep', async () => {
+    driver.objects.set('products/old.png', {
+      body: PNG,
+      contentType: 'image/png',
+      lastModified: new Date(),
+    });
+    driver.failDeleteKeys.add('products/old.png');
+    vi.spyOn(productsRepository, 'findById').mockResolvedValue({
+      id: 7,
+      status: 'active',
+      image_url: '/uploads/products/old.png',
+    } as never);
+    vi.spyOn(productsRepository, 'updateImage').mockResolvedValue(undefined);
+
+    const res = response();
+    await controller.uploadImage(uploadRequest(), res, vi.fn());
+
+    expect((res.body as { data: { image_url: string } }).data.image_url).toBeTruthy();
+    expect(driver.objects.has('products/old.png')).toBe(true);
+  });
+
+  it('clears the row and the object on delete, and never touches a foreign URL', async () => {
+    driver.objects.set('products/live.png', {
+      body: PNG,
+      contentType: 'image/png',
+      lastModified: new Date(),
+    });
+    const updateImage = vi.spyOn(productsRepository, 'updateImage').mockResolvedValue(undefined);
+    const findById = vi.spyOn(productsRepository, 'findById');
+
+    findById.mockResolvedValueOnce({
+      id: 7,
+      status: 'active',
+      image_url: '/uploads/products/live.png',
+    } as never);
+    await controller.deleteImage(
+      { params: { id: '7' } } as unknown as Request,
+      response(),
+      vi.fn()
+    );
+    expect(updateImage).toHaveBeenCalledWith(7, null);
+    expect(driver.objects.size).toBe(0);
+
+    driver.objects.set('products/live.png', {
+      body: PNG,
+      contentType: 'image/png',
+      lastModified: new Date(),
+    });
+    findById.mockResolvedValueOnce({
+      id: 8,
+      status: 'active',
+      image_url: 'https://cdn.example.com/hero.png',
+    } as never);
+    await controller.deleteImage(
+      { params: { id: '8' } } as unknown as Request,
+      response(),
+      vi.fn()
+    );
+    expect(driver.objects.has('products/live.png')).toBe(true);
+  });
+});
+
+describe('orphaned media sweep', () => {
+  const hours = (n: number) => n * 60 * 60 * 1000;
+
+  function driverWith(entries: Array<[string, number]>) {
+    const driver = new FakeDriver();
+    for (const [key, ageHours] of entries) {
+      driver.objects.set(key, {
+        body: PNG,
+        contentType: 'image/png',
+        lastModified: new Date(Date.now() - hours(ageHours)),
+      });
+    }
+    return driver;
+  }
+
+  function poolReturning(urls: string[]) {
+    return {
+      query: vi.fn(async () => ({ rows: urls.map((image_url) => ({ image_url })) })),
+    } as never;
+  }
+
+  it('deletes only what is unreferenced and old enough', async () => {
+    const driver = driverWith([
+      ['products/referenced.png', 48],
+      ['products/orphan.png', 48],
+      ['products/just-uploaded.png', 1],
+    ]);
+
+    const outcome = await sweepOrphanedMedia({
+      pool: poolReturning(['/uploads/products/referenced.png', 'https://cdn.example.com/x.png']),
+      storage: driver,
+      minAgeMs: hours(24),
+    });
+
+    expect(outcome).toEqual({ scanned: 3, deleted: 1, skippedRecent: 1, failed: 0 });
+    expect([...driver.objects.keys()].sort()).toEqual([
+      'products/just-uploaded.png',
+      'products/referenced.png',
+    ]);
+  });
+
+  it('deletes nothing when the reference query fails', async () => {
+    const driver = driverWith([['products/orphan.png', 48]]);
+    const pool = {
+      query: vi.fn(async () => {
+        throw new Error('connection reset');
+      }),
+    } as never;
+
+    await expect(
+      sweepOrphanedMedia({ pool, storage: driver, minAgeMs: hours(24) })
+    ).rejects.toThrow('connection reset');
+    expect(driver.objects.size).toBe(1);
+  });
+
+  it('counts a failed delete instead of aborting the sweep', async () => {
+    const driver = driverWith([
+      ['products/stuck.png', 48],
+      ['products/orphan.png', 48],
+    ]);
+    driver.failDeleteKeys.add('products/stuck.png');
+
+    const outcome = await sweepOrphanedMedia({
+      pool: poolReturning([]),
+      storage: driver,
+      minAgeMs: hours(24),
+    });
+
+    expect(outcome).toMatchObject({ scanned: 2, deleted: 1, failed: 1 });
+    expect(driver.objects.has('products/stuck.png')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #46 partially — see **Acceptance criteria** for the one item that is deliberately not fully met.

Two independent production-readiness problems, one per commit.

## 1. Reservation cleanup ran once per process (`980907e`)

`setInterval(cleanupExpiredReservations, 5 * 60 * 1000)` lived in `server/index.ts`, so horizontally scaling the API multiplied the same maintenance work, with every instance racing on the same rows.

**Chosen: a PostgreSQL claim row plus an advisory lock.** Every instance still ticks (60s), but a tick only *offers* to run. `runScheduledJob` takes a session-level `pg_try_advisory_lock` for the duration, then claims the interval with **one conditional upsert** into a new `scheduled_jobs` table:

```sql
INSERT INTO scheduled_jobs (name, last_started_at, last_status, run_count)
VALUES ($1, NOW(), 'running', 1)
ON CONFLICT (name) DO UPDATE SET ...
  WHERE scheduled_jobs.last_started_at IS NULL
     OR scheduled_jobs.last_started_at <= NOW() - make_interval(secs => $2)
RETURNING name
```

Under READ COMMITTED a racing instance blocks on the row lock, re-evaluates the `WHERE` against the winner's committed row, matches nothing, and returns `skipped-not-due`. **The claim is the lock**; the advisory lock additionally prevents two runs overlapping when a job outlives its own interval. Due-window arithmetic uses `make_interval` on the **database** clock, so cadence does not depend on per-instance clock skew.

**Rejected:** a job framework (BullMQ / Agenda / pg-boss) or Redis — a new operational component to run, monitor and fail over, for what is a single `DELETE`. An external cron or one-off dyno — Render's free tier has neither, and it splits the deploy. Leader election — strictly more machinery for the same guarantee.

Outcome is a value, not `void`: `{ deleted: n }` goes to `scheduled_jobs.last_detail` and the log, alongside `run_count` / `failure_count` / `last_status` for operators. A failed run releases its lock and retries next interval.

## 2. Product images lived on local disk (`c9bb409`)

`server/src/storage/`: a `StorageDriver` interface — `put / delete (idempotent) / exists / list / publicUrl / keyFromUrl` — with keys like `products/<millis>-<rand>.webp` guarded by `assertSafeKey`.

**One driver implemented: `local` (filesystem).** No S3 driver: no AWS SDK is installed and this branch was not permitted to add dependencies, and hand-rolling SigV4 would be untestable here. Adding one is a new file plus a case in `createStorageDriver`, configured through the validated env — no provider is named anywhere and no credential is committed.

Intake moved to a memory buffer (`src/storage/upload.ts`) so **nothing reaches the store until Admin auth, the 2MB ceiling, the extension allowlist and magic-byte agreement have all passed**; the *detected* type is pinned onto `req.file.mimetype` and names the key. Lifecycle order is validate product → write object → commit row → release the replaced object, and a failed row update deletes the object it just wrote. A daily `orphaned-media-cleanup` sweeps the rest, reading every `image_url` across products, storefront banners and collections in one statement, **aborting rather than deleting if that read fails**, and never touching objects younger than `MEDIA_ORPHAN_MIN_AGE_HOURS` (24).

## Existing image URLs are preserved byte-identically

Rows hold `/uploads/products/1771875072587-4wjwqx.webp`. `LocalStorageDriver` with default config produces exactly those URLs and reads and writes the same tree; `keyFromUrl` inverts them, also accepting an absolute URL whose path matches, and returning `null` for a foreign URL so a CDN-hosted banner can never be swept. The `/uploads` static mount now serves the **driver's** root, so `MEDIA_LOCAL_ROOT` moves reads and writes together.

Documented migration path to a remote store: copy the tree preserving keys, then set `MEDIA_PUBLIC_BASE_URL`. Old relative rows keep resolving through the mount, new rows are absolute, both valid.

## Acceptance criteria

Met: horizontal scaling does not multiply cleanup; cleanup is retry-safe and reports its outcome; replacing or deleting an image leaves no permanent orphan; upload validation and authorization remain enforced; local development storage option documented (nothing to configure).

> [!WARNING]
> **Partially met — "uploaded media survives API redeployment and is accessible from every instance."** True only when `MEDIA_LOCAL_ROOT` points at a shared, persistent volume. The abstraction that makes an object-store driver a drop-in landed; the driver did not. `render.yaml` configures no disk, so **on Render today this is unchanged behaviour**. This needs a follow-up issue for the S3-compatible driver plus the disk/bucket configuration before the criterion can be called met.

## Testing

- pg-mem: 423 passed, 1 failed — `exchanges.test.ts` / `28P01`, the pre-existing #69.
- With `TEST_DATABASE_URL`: same single pre-existing failure. New `tests/concurrency/scheduler.concurrency.test.ts` (6 tests) proves one execution across **8 simultaneous callers**, no repeat inside an interval, a run once it elapses, and that a failure is recorded, releases its lock, and retries successfully.
- New unit suites: `tests/scheduler.test.ts` (11), `tests/storage.test.ts` (24, including 401 unauthenticated and 403 non-Admin on both image routes with real signed tokens).
- `tsc --noEmit` clean; lint 0 errors; boot smoke on port 3999 — server starts, `/api/health` returns 200, scheduler logs its jobs, and against an un-migrated database the jobs log a contained error instead of crashing.

## Reviewer notes

- The health endpoint and its path are **untouched** — `rateLimits.ts` exempts `GET /api/health` by exact path match, and changing it here would silently un-exempt the uptime probe. #45 owns that split.
- `middleware/upload.ts` still exports the now-unused `createUpload` / `validateMagic` / `cleanupOrphanedFiles`; only `uploadRateLimit` is still imported. Outside this branch's permitted files, so left for a follow-up.
- `migration004.test.ts` and `migrate.test.ts` now derive the migration list from the directory rather than literals — the same edit two sibling PRs (#73, #74) make. Expect a small textual conflict, not a semantic one.
- Once #74 lands, its `purgeExpiredSessions(force)` should become a job here — it is piggy-backed on login today only because that branch had no scheduler.

## Post-Deploy Monitoring and Validation

- **Watch:** `SELECT name, last_status, last_detail, run_count, failure_count, last_finished_at FROM scheduled_jobs` — the operator's single view. `last_finished_at` advancing means the fleet is running maintenance; a stalled timestamp means no instance is claiming.
- **Healthy signal:** with N instances deployed, `run_count` increases by roughly one per interval, **not by N**. That is the whole point of the change and the first thing to verify after scaling past one instance.
- **Failure signals / rollback trigger:** `failure_count` climbing, or `last_status = 'failed'` persisting across intervals. For media: any 500 on image upload, or a `404` on a previously working `/uploads/...` URL — the latter would mean `MEDIA_LOCAL_ROOT` is pointed somewhere the old tree is not.
- **Before enabling the orphan sweep in production**, confirm `MEDIA_ORPHAN_MIN_AGE_HOURS` is at least as long as your longest upload-to-commit window, and check the sweep's first run reports a plausible count in `last_detail` rather than a large one.
- **Rollback:** the scheduler change is revertible with no data implication; `007_scheduled_jobs.down.sql` drops the table. Media is stored in the same tree with the same URLs as before, so reverting the code leaves existing images served by the old static mount.
- **Window:** 24h, extended to 48h if the daily media sweep has not yet run once.
- **Owner:** @zhamdy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
