### PR TITLE
refactor(pos): decompose CartPanel around checkout responsibilities

### DIFF
--- a/client/src/features/pos/components/CartPanel.test.tsx
+++ b/client/src/features/pos/components/CartPanel.test.tsx
@@ -8,6 +8,7 @@ import type { TransportRequest, TransportResult } from '../../../shared/lib/tran
 import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
 import { useSettingsStore } from '../../../shared/store/settingsStore';
 import { useCartStore } from '../store/cartStore';
+import { useHeldCartsStore } from '../store/heldCartsStore';
 import { useOfflineStore } from '../../../shared/store/offlineStore';
 import CartPanel from './CartPanel';
 
@@ -733,5 +734,283 @@ describe('CartPanel amount-due parity across surfaces', () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+/**
+ * CHARACTERIZATION — the coupon, hold-cart and customer paths the checkout
+ * suite above never exercised. These lock in today's behaviour so the
+ * decomposition of this component (issue #51) cannot quietly change it.
+ */
+describe('CartPanel coupon, hold and customer characterization', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    useHeldCartsStore.setState({ carts: [] });
+    useCartStore.setState({
+      items: [SILK_DRESS],
+      discount: 0,
+      discountType: 'fixed',
+      notes: '',
+      tip: 0,
+      couponCode: '',
+      couponDiscount: 0,
+      needsReview: false,
+      checkoutAttempt: null,
+    });
+  });
+
+  /** The memory transport 404s an unknown sub-path, so coupon validation is answered here. */
+  function withCouponReply(memory: MemoryTransport, discount: number): MemoryTransport {
+    return {
+      ...memory,
+      async request<T>(req: TransportRequest): Promise<TransportResult<T>> {
+        if (req.method === 'POST' && req.path === 'coupons/validate') {
+          // Let the memory transport record the call (it has no coupon route,
+          // so it 404s) before answering it, so `calls()` still sees the body.
+          await memory.request<unknown>(req).catch(() => undefined);
+          const code = (req.body as { code: string }).code;
+          return { data: { code, discount } as T };
+        }
+        return memory.request<T>(req);
+      },
+    };
+  }
+
+  it('holds the cart with its notes, tip and coupon code — but no cached coupon amount', () => {
+    useCartStore.setState({
+      notes: 'call before delivery',
+      tip: 5,
+      couponCode: 'SUMMER20',
+      couponDiscount: 20,
+    });
+    const transport = makeTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hold' }));
+
+    const held = useHeldCartsStore.getState().carts;
+    expect(held).toHaveLength(1);
+    expect(held[0]).toMatchObject({
+      items: [expect.objectContaining({ product_id: 7 })],
+      discount: 0,
+      discountType: 'fixed',
+      notes: 'call before delivery',
+      tip: 5,
+      couponCode: 'SUMMER20',
+    });
+    // A held cart never carries a cached money amount forward.
+    expect(held[0]).not.toHaveProperty('couponDiscount');
+    expect(useCartStore.getState().items).toHaveLength(0);
+  });
+
+  it('does nothing when Hold is pressed on an empty cart', () => {
+    useCartStore.setState({ items: [] });
+    const transport = makeTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+
+    expect(screen.getByRole('button', { name: 'Hold' })).toBeDisabled();
+    expect(useHeldCartsStore.getState().carts).toHaveLength(0);
+  });
+
+  it('validates a coupon against the cart subtotal and its product ids, then stores the result', async () => {
+    const transport = withCouponReply(makeTransport(), 20);
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+
+    fireEvent.change(screen.getByPlaceholderText('Enter coupon code'), {
+      target: { value: 'summer20' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => expect(useCartStore.getState().couponCode).toBe('summer20'));
+    expect(useCartStore.getState().couponDiscount).toBe(20);
+
+    const validate = transport.calls().find((call) => call.path === 'coupons/validate');
+    expect(validate?.body).toEqual({
+      code: 'summer20',
+      subtotal: 500,
+      item_product_ids: [7],
+    });
+    // No customer is selected, so `customer_id` stays off the body entirely.
+    expect(validate?.body).not.toHaveProperty('customer_id');
+  });
+
+  it('surfaces a rejected coupon without touching the cart', async () => {
+    const transport = makeTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+
+    transport.failNext('Coupon expired', 400, undefined, undefined, 'coupons/validate');
+    fireEvent.change(screen.getByPlaceholderText('Enter coupon code'), {
+      target: { value: 'EXPIRED' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Coupon expired'));
+    expect(useCartStore.getState().couponCode).toBe('');
+    expect(useCartStore.getState().couponDiscount).toBe(0);
+  });
+
+  it('ignores Apply with an empty coupon field', async () => {
+    const transport = makeTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() =>
+      expect(transport.calls().some((call) => call.path === 'coupons/validate')).toBe(false)
+    );
+  });
+
+  it('removes an applied coupon and returns the input', async () => {
+    useCartStore.setState({ couponCode: 'SUMMER20', couponDiscount: 20 });
+    const transport = makeTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove coupon' }));
+
+    await waitFor(() => expect(useCartStore.getState().couponCode).toBe(''));
+    expect(useCartStore.getState().couponDiscount).toBe(0);
+    expect(screen.getByPlaceholderText('Enter coupon code')).toBeInTheDocument();
+  });
+
+  it('creates a customer, selects it, and attaches its id to the sale', async () => {
+    const transport = makeTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add New Customer' }));
+    fireEvent.change(screen.getByPlaceholderText('Customer name'), { target: { value: 'Amina' } });
+    fireEvent.change(screen.getByPlaceholderText('Phone number'), {
+      target: { value: '0100000000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // The created row comes back selected, replacing the create form.
+    await waitFor(() => expect(screen.getByText('Amina')).toBeInTheDocument());
+    expect(transport.peek('customers')).toEqual([{ id: 1, name: 'Amina', phone: '0100000000' }]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Sale' }));
+
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    const sale = transport.calls().find((call) => call.path === 'sales');
+    expect(sale?.body).toMatchObject({ customer_id: 1 });
+  });
+
+  it('cancels customer creation without selecting anyone', async () => {
+    const transport = makeTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add New Customer' }));
+    fireEvent.change(screen.getByPlaceholderText('Customer name'), { target: { value: 'Amina' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByPlaceholderText('Search customers...')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Sale' }));
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    expect(transport.calls().find((call) => call.path === 'sales')?.body).not.toHaveProperty(
+      'customer_id'
+    );
+  });
+});
+
+describe('CartPanel loyalty state ownership characterization', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    useCartStore.setState({
+      items: [SILK_DRESS],
+      discount: 0,
+      discountType: 'fixed',
+      notes: '',
+      tip: 0,
+      couponCode: '',
+      couponDiscount: 0,
+      needsReview: false,
+      checkoutAttempt: null,
+    });
+  });
+
+  function loyaltyTransport() {
+    return withSaleReply(
+      createMemoryTransport(
+        { customers: [{ id: 1, name: 'Amina', phone: '0100000000', loyalty_points: 200 }] },
+        {
+          reads: {
+            settings: {
+              tax_enabled: 'false',
+              loyalty_enabled: 'true',
+              loyalty_points_per_egp: '1',
+              loyalty_egp_per_point: '0.10',
+            },
+            'customers/1/loyalty': { points: 200 },
+          },
+        }
+      )
+    );
+  }
+
+  async function selectAminaAndRedeem() {
+    fireEvent.change(screen.getByPlaceholderText('Search customers...'), {
+      target: { value: 'Amina' },
+    });
+    fireEvent.click(await screen.findByRole('button', { name: /Amina/ }, { timeout: 5000 }));
+    fireEvent.click(await screen.findByLabelText('Use loyalty points', {}, { timeout: 5000 }));
+    fireEvent.change(screen.getByLabelText('Points to redeem'), { target: { value: '100' } });
+  }
+
+  it('drops the redemption entirely when the selected customer is removed', async () => {
+    const transport = loyaltyTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+    await selectAminaAndRedeem();
+
+    await waitFor(() => expect(screen.getAllByText('-10 EG').length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove selected customer' }));
+
+    // No customer, no loyalty section, and no lingering points discount line.
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Use loyalty points')).not.toBeInTheDocument()
+    );
+    expect(screen.queryByText('-10 EG')).not.toBeInTheDocument();
+  });
+
+  it('sends points_redeemed and clears the redemption once the sale lands', async () => {
+    const transport = loyaltyTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+    await selectAminaAndRedeem();
+
+    await waitFor(() => expect(screen.getAllByText('-10 EG').length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Sale' }));
+
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    const sale = transport.calls().find((call) => call.path === 'sales');
+    expect(sale?.body).toMatchObject({ customer_id: 1, points_redeemed: 100 });
+  });
+
+  it('unticking the redeem toggle zeroes the points, leaving the customer selected', async () => {
+    const transport = loyaltyTransport();
+    render(<CartPanel />, { wrapper: wrapperFor(transport) });
+    await openDrawer();
+    await selectAminaAndRedeem();
+
+    await waitFor(() => expect(screen.getAllByText('-10 EG').length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByLabelText('Use loyalty points'));
+
+    await waitFor(() => expect(screen.queryByText('-10 EG')).not.toBeInTheDocument());
+    expect(screen.getByText('Amina')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Sale' }));
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    expect(transport.calls().find((call) => call.path === 'sales')?.body).not.toHaveProperty(
+      'points_redeemed'
+    );
   });
 });

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -32,20 +32,15 @@ import { useCartStore } from '../store/cartStore';
 import { useHeldCartsStore } from '../store/heldCartsStore';
 import { formatCurrency } from '../../../shared/lib/utils';
 import { useTranslation } from '../../../shared/i18n/index';
-import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue';
 import ReceiptDialog from '../../../shared/components/ReceiptDialog';
 import HeldCartsDialog from './HeldCartsDialog';
-import { useApiQuery } from '../../../shared/lib/apiQuery';
-import { resource } from '../../../shared/lib/resource';
 import { useTransport } from '../../../shared/lib/transport/index';
 import { useCheckoutPricing } from '../hooks/useCheckoutPricing';
 import { useCustomerDisplayBroadcast } from '../hooks/useCustomerDisplayBroadcast';
 import { useCheckoutSubmission } from '../hooks/useCheckoutSubmission';
+import { useCustomerSelection } from '../hooks/useCustomerSelection';
 import type { SaleComposition } from '../lib/salePayload';
 import type { CouponValidation, PaymentEntry, PaymentMethod } from '../types';
-import type { Customer } from '../../../shared/types/index';
-
-const customers = resource<Customer>('customers');
 
 interface CartPanelProps {
   checkoutTriggerRef?: MutableRefObject<(() => void) | null>;
@@ -83,16 +78,12 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('Cash');
   const [splitPayment, setSplitPayment] = useState(false);
   const [payments, setPayments] = useState<PaymentEntry[]>([]);
-  const [customerSearch, setCustomerSearch] = useState('');
-  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
-  const [showCustomerDropdown, setShowCustomerDropdown] = useState(false);
   const [couponInput, setCouponInput] = useState('');
   const [editingMemo, setEditingMemo] = useState<string | null>(null);
-  const [showNewCustomer, setShowNewCustomer] = useState(false);
-  const [newCustomerName, setNewCustomerName] = useState('');
-  const [newCustomerPhone, setNewCustomerPhone] = useState('');
-
-  const debouncedCustomerSearch = useDebouncedValue(customerSearch, 300);
+  // Customer search/selection/creation -- UI state only; the sale carries the
+  // selected customer's id, and their loyalty balance is fetched by
+  // useCheckoutPricing below.
+  const customer = useCustomerSelection({ searchEnabled: checkoutOpen });
 
   // ONE authoritative owner of every checkout figure: totals, the split
   // allocation, the loyalty cap and the redemption state. Nothing below
@@ -108,7 +99,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     setRedeemPoints,
     setPointsToRedeem,
     resetRedemption,
-  } = useCheckoutPricing({ customerId: selectedCustomer?.id ?? null, payments });
+  } = useCheckoutPricing({ customerId: customer.selected?.id ?? null, payments });
 
   useCustomerDisplayBroadcast({ items, discount, discountType, couponCode, tax: taxInfo, totals });
 
@@ -120,35 +111,6 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
       if (checkoutTriggerRef) checkoutTriggerRef.current = null;
     };
   }, [checkoutTriggerRef]);
-
-  const { data: customerMatches } = useApiQuery<Customer[]>(
-    ['customers', { search: debouncedCustomerSearch }],
-    'customers',
-    { search: debouncedCustomerSearch || undefined },
-    {
-      enabled: checkoutOpen && debouncedCustomerSearch.length > 0,
-      staleTime: 30 * 1000,
-    }
-  );
-
-  const customerCreator = customers.useSave({
-    message: t('cart.customerCreated'),
-    fallbackMessage: t('cart.customerCreateError'),
-  });
-
-  const handleCreateCustomer = () => {
-    customerCreator.save(
-      { name: newCustomerName.trim(), phone: newCustomerPhone.trim() },
-      {
-        onSuccess: (result) => {
-          setSelectedCustomer(result.data as Customer);
-          setShowNewCustomer(false);
-          setNewCustomerName('');
-          setNewCustomerPhone('');
-        },
-      }
-    );
-  };
 
   /**
    * The single description of "what the cashier is about to sell", from which
@@ -165,7 +127,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     paymentMethod,
     splitPayment,
     payments,
-    customerId: selectedCustomer?.id ?? null,
+    customerId: customer.selected?.id ?? null,
     pointsToRedeem: redeemPoints ? pointsToRedeem : 0,
   };
 
@@ -174,11 +136,10 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   // sale is committed or queued -- never after a failure the cashier retries.
   const { submit, isPending, receiptOpen, setReceiptOpen, receiptData } = useCheckoutSubmission({
     tax: taxInfo,
-    customerName: selectedCustomer?.name,
+    customerName: customer.selected?.name,
     onCheckoutSettled: () => {
       setCheckoutOpen(false);
-      setSelectedCustomer(null);
-      setCustomerSearch('');
+      customer.reset();
       resetRedemption();
     },
   });
@@ -207,7 +168,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
           // derivation of the same figure; `totals.subtotal` is the minor-unit
           // one the server's own calculation agrees with.
           subtotal: totals.subtotal,
-          ...(selectedCustomer ? { customer_id: selectedCustomer.id } : {}),
+          ...(customer.selected ? { customer_id: customer.selected.id } : {}),
           item_product_ids: items.map((i) => i.product_id),
         },
       });
@@ -216,12 +177,6 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     } catch (err: unknown) {
       toast.error((err as Error).message || t('cart.couponInvalid'));
     }
-  };
-
-  const handleSelectCustomer = (customer: Customer) => {
-    setSelectedCustomer(customer);
-    setCustomerSearch('');
-    setShowCustomerDropdown(false);
   };
 
   const handleHoldCart = () => {
@@ -680,15 +635,15 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                   <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                     {t('cart.selectCustomer')}
                   </h3>
-                  {selectedCustomer ? (
+                  {customer.selected ? (
                     <div className="flex items-center gap-2 p-3 bg-muted/20 rounded-xl border border-border/50">
                       <UserRound className="h-4 w-4 text-primary shrink-0" />
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-medium text-foreground truncate">
-                          {selectedCustomer.name}
+                          {customer.selected.name}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          {selectedCustomer.phone}
+                          {customer.selected.phone}
                           {loyaltyInfo.enabled && (
                             <span className="ms-2 text-primary font-semibold">
                               <Star className="h-3 w-3 inline-block" />{' '}
@@ -705,7 +660,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                         size="sm"
                         className="h-7 w-7 shrink-0"
                         onClick={() => {
-                          setSelectedCustomer(null);
+                          customer.clear();
                           resetRedemption();
                         }}
                         aria-label="Remove selected customer"
@@ -713,21 +668,21 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                         <X className="h-3.5 w-3.5" />
                       </Button>
                     </div>
-                  ) : showNewCustomer ? (
+                  ) : customer.creating ? (
                     <div className="space-y-2.5 p-3 bg-muted/20 rounded-xl border border-border/50">
                       <Input
                         size="sm"
                         variant="bordered"
                         placeholder={t('cart.customerName')}
-                        value={newCustomerName}
-                        onValueChange={setNewCustomerName}
+                        value={customer.newName}
+                        onValueChange={customer.setNewName}
                       />
                       <Input
                         size="sm"
                         variant="bordered"
                         placeholder={t('cart.customerPhone')}
-                        value={newCustomerPhone}
-                        onValueChange={setNewCustomerPhone}
+                        value={customer.newPhone}
+                        onValueChange={customer.setNewPhone}
                       />
                       <div className="flex gap-2">
                         <Button
@@ -735,12 +690,12 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                           size="sm"
                           className="flex-1 text-xs"
                           isDisabled={
-                            !newCustomerName.trim() ||
-                            !newCustomerPhone.trim() ||
-                            customerCreator.isSaving
+                            !customer.newName.trim() ||
+                            !customer.newPhone.trim() ||
+                            customer.isSaving
                           }
-                          isLoading={customerCreator.isSaving}
-                          onClick={handleCreateCustomer}
+                          isLoading={customer.isSaving}
+                          onClick={customer.createAndSelect}
                         >
                           {t('cart.saveCustomer')}
                         </Button>
@@ -748,11 +703,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                           variant="flat"
                           size="sm"
                           className="text-xs"
-                          onClick={() => {
-                            setShowNewCustomer(false);
-                            setNewCustomerName('');
-                            setNewCustomerPhone('');
-                          }}
+                          onClick={customer.cancelCreating}
                         >
                           {t('common.cancel')}
                         </Button>
@@ -765,23 +716,23 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                           size="sm"
                           variant="bordered"
                           placeholder={t('cart.searchCustomer')}
-                          value={customerSearch}
+                          value={customer.search}
                           onValueChange={(val) => {
-                            setCustomerSearch(val);
-                            setShowCustomerDropdown(true);
+                            customer.setSearch(val);
+                            customer.setDropdownOpen(true);
                           }}
-                          onFocus={() => setShowCustomerDropdown(true)}
+                          onFocus={() => customer.setDropdownOpen(true)}
                           startContent={<Search className="h-3.5 w-3.5 text-muted-foreground" />}
                         />
-                        {showCustomerDropdown && customerSearch.length > 0 && (
+                        {customer.dropdownOpen && customer.search.length > 0 && (
                           <div className="absolute z-20 top-full mt-1 w-full bg-card border border-border rounded-xl shadow-lg max-h-40 overflow-y-auto divide-y divide-border/50">
-                            {customerMatches && customerMatches.length > 0 ? (
-                              customerMatches.map((c) => (
+                            {customer.matches && customer.matches.length > 0 ? (
+                              customer.matches.map((c) => (
                                 <button
                                   key={c.id}
                                   type="button"
                                   className="w-full text-start px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
-                                  onClick={() => handleSelectCustomer(c)}
+                                  onClick={() => customer.select(c)}
                                 >
                                   <span className="font-medium text-foreground">{c.name}</span>
                                   <span className="text-muted-foreground text-xs ms-2">
@@ -803,7 +754,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                         size="sm"
                         className="w-full text-xs"
                         startContent={<Plus className="h-3 w-3" />}
-                        onClick={() => setShowNewCustomer(true)}
+                        onClick={customer.startCreating}
                       >
                         {t('cart.addNewCustomer')}
                       </Button>
@@ -812,7 +763,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                 </div>
 
                 {/* Loyalty Points Redemption */}
-                {loyaltyInfo.enabled && selectedCustomer && (
+                {loyaltyInfo.enabled && customer.selected && (
                   <>
                     <Divider />
                     <div className="space-y-3">

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -1,46 +1,40 @@
+/**
+ * The cart panel: the cashier's view of what is being sold, and the entry
+ * point to checkout.
+ *
+ * This component coordinates focused units rather than containing their rules
+ * (issue #51). Specifically:
+ *
+ * - `useCheckoutPricing` is the ONE authority for every checkout figure —
+ *   totals, the split allocation, the loyalty cap and the redemption state.
+ *   Nothing here re-derives a money value.
+ * - `useCheckoutSubmission` owns keying, posting, the receipt and the offline
+ *   fallback.
+ * - `useCustomerSelection` and `useCouponApplication` own their own flows.
+ * - `useCustomerDisplayBroadcast` mirrors the same totals to the second screen.
+ * - The rendering lives in `components/checkout/*`, which is presentation only.
+ */
 import { useState, useEffect, type MutableRefObject } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
-import {
-  Minus,
-  Plus,
-  X,
-  ShoppingBag,
-  Search,
-  UserRound,
-  Tag,
-  Pause,
-  Archive,
-  Star,
-  StickyNote,
-  Pencil,
-  Ticket,
-  Percent,
-} from 'lucide-react';
+import { ShoppingBag, Pause, Archive } from 'lucide-react';
 import toast from 'react-hot-toast';
-import {
-  Button,
-  Input,
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerBody,
-  RadioGroup,
-  Radio,
-  Divider,
-} from '@heroui/react';
+import { Button } from '@heroui/react';
 import { useCartStore } from '../store/cartStore';
 import { useHeldCartsStore } from '../store/heldCartsStore';
-import { formatCurrency } from '../../../shared/lib/utils';
 import { useTranslation } from '../../../shared/i18n/index';
 import ReceiptDialog from '../../../shared/components/ReceiptDialog';
 import HeldCartsDialog from './HeldCartsDialog';
-import { useTransport } from '../../../shared/lib/transport/index';
+import CartFooter from './checkout/CartFooter';
+import CartLineItem from './checkout/CartLineItem';
+import CheckoutDrawer from './checkout/CheckoutDrawer';
 import { useCheckoutPricing } from '../hooks/useCheckoutPricing';
-import { useCustomerDisplayBroadcast } from '../hooks/useCustomerDisplayBroadcast';
 import { useCheckoutSubmission } from '../hooks/useCheckoutSubmission';
+import { useCouponApplication } from '../hooks/useCouponApplication';
+import { useCustomerDisplayBroadcast } from '../hooks/useCustomerDisplayBroadcast';
 import { useCustomerSelection } from '../hooks/useCustomerSelection';
+import { lineKey } from '../lib/cartLines';
 import type { SaleComposition } from '../lib/salePayload';
-import type { CouponValidation, PaymentEntry, PaymentMethod } from '../types';
+import type { PaymentEntry, PaymentMethod } from '../types';
 
 interface CartPanelProps {
   checkoutTriggerRef?: MutableRefObject<(() => void) | null>;
@@ -62,14 +56,11 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     setDiscountType,
     setNotes,
     setTip,
-    setCoupon,
-    clearCoupon,
     clearCart,
     needsReview,
     acknowledgeReview,
   } = useCartStore();
   const { carts: heldCarts, holdCart } = useHeldCartsStore();
-  const transport = useTransport();
   const { t, isRtl } = useTranslation();
   const [animateParent] = useAutoAnimate();
 
@@ -78,30 +69,24 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('Cash');
   const [splitPayment, setSplitPayment] = useState(false);
   const [payments, setPayments] = useState<PaymentEntry[]>([]);
-  const [couponInput, setCouponInput] = useState('');
   const [editingMemo, setEditingMemo] = useState<string | null>(null);
+
   // Customer search/selection/creation -- UI state only; the sale carries the
   // selected customer's id, and their loyalty balance is fetched by
   // useCheckoutPricing below.
   const customer = useCustomerSelection({ searchEnabled: checkoutOpen });
 
-  // ONE authoritative owner of every checkout figure: totals, the split
-  // allocation, the loyalty cap and the redemption state. Nothing below
-  // re-derives any of them.
-  const {
-    tax: taxInfo,
-    loyalty: loyaltyInfo,
-    totals,
-    split,
-    maxPoints,
-    redeemPoints,
-    pointsToRedeem,
-    setRedeemPoints,
-    setPointsToRedeem,
-    resetRedemption,
-  } = useCheckoutPricing({ customerId: customer.selected?.id ?? null, payments });
+  // ONE authoritative owner of every checkout figure.
+  const pricing = useCheckoutPricing({ customerId: customer.selected?.id ?? null, payments });
+  const { tax, totals, resetRedemption } = pricing;
 
-  useCustomerDisplayBroadcast({ items, discount, discountType, couponCode, tax: taxInfo, totals });
+  const coupon = useCouponApplication({
+    subtotal: totals.subtotal,
+    productIds: items.map((i) => i.product_id),
+    customerId: customer.selected?.id ?? null,
+  });
+
+  useCustomerDisplayBroadcast({ items, discount, discountType, couponCode, tax, totals });
 
   useEffect(() => {
     if (checkoutTriggerRef) {
@@ -128,14 +113,14 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     splitPayment,
     payments,
     customerId: customer.selected?.id ?? null,
-    pointsToRedeem: redeemPoints ? pointsToRedeem : 0,
+    pointsToRedeem: pricing.redeemPoints ? pricing.pointsToRedeem : 0,
   };
 
   // Submission lifecycle: keying, posting, the receipt, and the offline
   // fallback. `onCheckoutSettled` is the surrounding UI's reset, run once the
   // sale is committed or queued -- never after a failure the cashier retries.
   const { submit, isPending, receiptOpen, setReceiptOpen, receiptData } = useCheckoutSubmission({
-    tax: taxInfo,
+    tax,
     customerName: customer.selected?.name,
     onCheckoutSettled: () => {
       setCheckoutOpen(false);
@@ -155,30 +140,6 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     submit(composition);
   };
 
-  const handleApplyCoupon = async () => {
-    if (!couponInput.trim()) return;
-    try {
-      const { data } = await transport.request<CouponValidation>({
-        method: 'POST',
-        path: 'coupons/validate',
-        body: {
-          code: couponInput.trim(),
-          // The authoritative subtotal, same as every displayed line. This used
-          // to call `cartStore.getSubtotal()`, a second float-arithmetic
-          // derivation of the same figure; `totals.subtotal` is the minor-unit
-          // one the server's own calculation agrees with.
-          subtotal: totals.subtotal,
-          ...(customer.selected ? { customer_id: customer.selected.id } : {}),
-          item_product_ids: items.map((i) => i.product_id),
-        },
-      });
-      setCoupon(data.code, data.discount);
-      toast.success(t('cart.couponApplied'));
-    } catch (err: unknown) {
-      toast.error((err as Error).message || t('cart.couponInvalid'));
-    }
-  };
-
   const handleHoldCart = () => {
     if (items.length === 0) return;
     const name = `Cart #${heldCarts.length + 1}`;
@@ -188,13 +149,6 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     holdCart(name, items, discount, discountType, { notes, tip, couponCode });
     clearCart();
     toast.success(t('cart.holdSuccess'));
-  };
-
-  const paymentLabels: Record<PaymentMethod | 'Gift Card', string> = {
-    Cash: t('cart.cash'),
-    Card: t('cart.card'),
-    Other: t('cart.other'),
-    'Gift Card': t('cart.giftCard'),
   };
 
   return (
@@ -271,838 +225,70 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
           </div>
         ) : (
           items.map((item) => (
-            <div
-              key={`${item.product_id}-${item.variant_id || 0}`}
-              /* E2E: a cart line has no role and shows only the product name, so there is
-                 no accessible name to scope its per-line controls by. */
-              data-testid={`cart-line-${item.product_id}-${item.variant_id || 0}`}
-              className="flex items-center gap-3 p-3 bg-muted/20 hover:bg-muted/40 transition-colors rounded-lg border border-border/50"
-            >
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-1.5">
-                  <p className="text-sm font-medium text-foreground truncate">{item.name}</p>
-                  <button
-                    onClick={() => setEditingMemo(`${item.product_id}-${item.variant_id || 0}`)}
-                    className="p-0.5 rounded hover:bg-background transition-colors"
-                    title={t('cart.addMemo')}
-                  >
-                    <Pencil
-                      className={`h-3 w-3 ${item.memo ? 'text-primary' : 'text-muted-foreground'}`}
-                    />
-                  </button>
-                </div>
-                <p className="text-xs text-muted-foreground font-data">
-                  {formatCurrency(item.unit_price)}
-                </p>
-                {item.memo && <p className="text-xs text-primary/80 mt-0.5">{item.memo}</p>}
-                {editingMemo === `${item.product_id}-${item.variant_id || 0}` && (
-                  <Input
-                    autoFocus
-                    size="sm"
-                    variant="bordered"
-                    placeholder={t('cart.memoPlaceholder')}
-                    defaultValue={item.memo || ''}
-                    className="mt-1"
-                    onBlur={(e) => {
-                      setItemMemo(item.product_id, e.target.value, item.variant_id);
-                      setEditingMemo(null);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        setItemMemo(
-                          item.product_id,
-                          (e.target as HTMLInputElement).value,
-                          item.variant_id
-                        );
-                        setEditingMemo(null);
-                      }
-                    }}
-                  />
-                )}
-              </div>
-              <div className="flex items-center gap-1">
-                <Button
-                  isIconOnly
-                  variant="light"
-                  size="sm"
-                  className="h-7 w-7"
-                  onClick={() =>
-                    updateQuantity(item.product_id, item.quantity - 1, item.variant_id)
-                  }
-                  aria-label="Decrease quantity"
-                >
-                  <Minus className="h-3.5 w-3.5 text-primary" />
-                </Button>
-                {/* E2E: a bare number with no accessible name. The +/- buttons are
-                    reachable by aria-label; the value itself is not. */}
-                <span
-                  data-testid="cart-line-qty"
-                  className="w-7 text-center text-sm font-data font-medium text-foreground"
-                >
-                  {item.quantity}
-                </span>
-                <Button
-                  isIconOnly
-                  variant="light"
-                  size="sm"
-                  className="h-7 w-7"
-                  onClick={() =>
-                    updateQuantity(item.product_id, item.quantity + 1, item.variant_id)
-                  }
-                  isDisabled={item.quantity >= item.stock}
-                  aria-label="Increase quantity"
-                >
-                  <Plus className="h-3.5 w-3.5 text-primary" />
-                </Button>
-              </div>
-              <p className="text-sm font-semibold font-data w-20 text-end text-foreground">
-                {formatCurrency(item.unit_price * item.quantity)}
-              </p>
-              <Button
-                isIconOnly
-                variant="light"
-                color="danger"
-                size="sm"
-                className="h-7 w-7"
-                onClick={() => removeItem(item.product_id, item.variant_id)}
-                aria-label="Remove item"
-              >
-                <X className="h-3.5 w-3.5" />
-              </Button>
-            </div>
+            <CartLineItem
+              key={lineKey(item)}
+              item={item}
+              isEditingMemo={editingMemo === lineKey(item)}
+              onStartEditingMemo={() => setEditingMemo(lineKey(item))}
+              onCommitMemo={(memo) => {
+                setItemMemo(item.product_id, memo, item.variant_id);
+                setEditingMemo(null);
+              }}
+              onQuantityChange={(quantity) =>
+                updateQuantity(item.product_id, quantity, item.variant_id)
+              }
+              onRemove={() => removeItem(item.product_id, item.variant_id)}
+            />
           ))
         )}
       </div>
 
-      {/* Footer */}
-      <div className="border-t border-border/50 p-4 space-y-3">
-        {/* Discount */}
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
-              <Tag className="h-3 w-3" />
-              {t('cart.discount')}
-            </span>
-            {discount > 0 && (
-              <button
-                onClick={() => setDiscount(0)}
-                className="text-[10px] text-danger hover:underline transition-colors"
-              >
-                {t('cart.clearDiscount')}
-              </button>
-            )}
-          </div>
-
-          {/* Type toggle + input */}
-          <div className="flex items-center gap-2">
-            <div className="flex bg-muted/30 border border-border rounded-lg overflow-hidden p-0.5">
-              <button
-                className={`px-2.5 py-1 text-xs font-data font-medium rounded-md transition-colors ${
-                  discountType === 'percentage'
-                    ? 'bg-primary text-primary-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-                onClick={() => {
-                  if (discountType === 'fixed' && discount > 0) {
-                    const subtotal = totals.subtotal;
-                    setDiscount(
-                      subtotal > 0 ? Math.round((discount / subtotal) * 100 * 100) / 100 : 0
-                    );
-                  }
-                  setDiscountType('percentage');
-                }}
-              >
-                %
-              </button>
-              <button
-                className={`px-2.5 py-1 text-xs font-data font-medium rounded-md transition-colors ${
-                  discountType === 'fixed'
-                    ? 'bg-primary text-primary-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-                onClick={() => {
-                  if (discountType === 'percentage' && discount > 0) {
-                    const subtotal = totals.subtotal;
-                    setDiscount(Math.round(((subtotal * discount) / 100) * 100) / 100);
-                  }
-                  setDiscountType('fixed');
-                }}
-              >
-                $
-              </button>
-            </div>
-            <Input
-              type="number"
-              min="0"
-              size="sm"
-              variant="bordered"
-              max={discountType === 'percentage' ? 100 : undefined}
-              placeholder="0"
-              value={discount ? String(discount) : ''}
-              onValueChange={(val) => setDiscount(parseFloat(val) || 0)}
-              className="flex-1 font-data"
-            />
-          </div>
-
-          {/* Quick presets */}
-          <div className="flex gap-1.5">
-            {discountType === 'percentage'
-              ? [5, 10, 15, 20].map((pct) => (
-                  <Button
-                    key={pct}
-                    size="sm"
-                    variant={discount === pct ? 'solid' : 'bordered'}
-                    color={discount === pct ? 'primary' : 'default'}
-                    className="flex-1 h-7 min-w-0 px-1 text-[11px] font-data font-medium"
-                    onClick={() => setDiscount(pct)}
-                  >
-                    {pct}%
-                  </Button>
-                ))
-              : [5, 10, 25, 50].map((amt) => (
-                  <Button
-                    key={amt}
-                    size="sm"
-                    variant={discount === amt ? 'solid' : 'bordered'}
-                    color={discount === amt ? 'primary' : 'default'}
-                    className="flex-1 h-7 min-w-0 px-1 text-[11px] font-data font-medium"
-                    onClick={() => setDiscount(amt)}
-                  >
-                    ${amt}
-                  </Button>
-                ))}
-          </div>
-        </div>
-
-        <Divider />
-
-        <div className="space-y-1.5">
-          <div className="flex justify-between text-sm text-muted-foreground font-data">
-            <span>{t('cart.subtotal')}</span>
-            <span className="text-foreground">{formatCurrency(totals.subtotal)}</span>
-          </div>
-          {totals.discountAmount > 0 && (
-            <div className="flex justify-between text-sm text-danger font-data">
-              <span>
-                {t('cart.discount')}
-                <span className="text-xs ms-1 opacity-70">
-                  ({discountType === 'percentage' ? `${discount}%` : formatCurrency(discount)})
-                </span>
-              </span>
-              <span>-{formatCurrency(totals.discountAmount)}</span>
-            </div>
-          )}
-          {taxInfo.enabled && (
-            <div className="flex justify-between text-sm text-muted-foreground font-data">
-              <span>
-                {t('tax.vat')}
-                <span className="text-xs ms-1 opacity-70">({taxInfo.rate}%)</span>
-              </span>
-              <span className="text-foreground">{formatCurrency(totals.taxAmount)}</span>
-            </div>
-          )}
-          {totals.tip > 0 && (
-            <div className="flex justify-between text-sm text-primary font-data">
-              <span>{t('cart.tip')}</span>
-              <span>+{formatCurrency(totals.tip)}</span>
-            </div>
-          )}
-          {/* The SAME `amountDue` the checkout drawer and customer display
-              use -- never a separately-derived figure (Unit 5 parity). */}
-          <div className="flex justify-between text-lg font-semibold font-data text-foreground">
-            <span>{t('cart.total')}</span>
-            {/* E2E: the amount is a nameless sibling of its label, and "Total" renders
-                simultaneously here, in the checkout drawer and on the receipt. */}
-            <span data-testid="cart-total" className="text-primary font-bold">
-              {formatCurrency(totals.amountDue)}
-            </span>
-          </div>
-        </div>
-
-        <Button
-          color="primary"
-          size="md"
-          className="w-full font-semibold shadow-sm"
-          onClick={() => setCheckoutOpen(true)}
-          isDisabled={items.length === 0 || needsReview}
-        >
-          {t('cart.checkout')}
-        </Button>
-      </div>
+      <CartFooter
+        discount={discount}
+        discountType={discountType}
+        setDiscount={setDiscount}
+        setDiscountType={setDiscountType}
+        tax={tax}
+        totals={totals}
+        checkoutDisabled={items.length === 0 || needsReview}
+        onCheckout={() => setCheckoutOpen(true)}
+      />
 
       <ReceiptDialog open={receiptOpen} onOpenChange={setReceiptOpen} data={receiptData} />
       <HeldCartsDialog open={heldCartsOpen} onOpenChange={setHeldCartsOpen} />
 
-      {/* Checkout Drawer */}
-      <Drawer
+      <CheckoutDrawer
         isOpen={checkoutOpen}
         onOpenChange={setCheckoutOpen}
-        placement={isRtl ? 'left' : 'right'}
-        backdrop="blur"
-        size="md"
-        classNames={{
-          base: 'bg-card text-card-foreground border-s border-border shadow-2xl',
+        isRtl={isRtl}
+        items={items}
+        discount={discount}
+        discountType={discountType}
+        setDiscount={setDiscount}
+        setDiscountType={setDiscountType}
+        notes={notes}
+        setNotes={setNotes}
+        tip={tip}
+        setTip={setTip}
+        couponCode={couponCode}
+        couponDiscount={couponDiscount}
+        coupon={coupon}
+        pricing={pricing}
+        customer={customer}
+        onRemoveCustomer={() => {
+          customer.clear();
+          resetRedemption();
         }}
-      >
-        <DrawerContent>
-          {() => (
-            <>
-              <DrawerHeader className="border-b border-border/50">
-                <div>
-                  <h3 className="text-base font-semibold">{t('cart.completeSale')}</h3>
-                  <p className="text-xs text-muted-foreground font-normal mt-0.5">
-                    {t('cart.reviewSale')}
-                  </p>
-                </div>
-              </DrawerHeader>
-              <DrawerBody className="py-6 space-y-6 overflow-y-auto">
-                {/* Order summary */}
-                <div className="space-y-2">
-                  <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    {t('cart.orderSummary')}
-                  </h3>
-                  {items.map((item) => (
-                    <div key={item.product_id} className="flex justify-between text-sm font-data">
-                      <span className="text-foreground">
-                        {item.name} x{item.quantity}
-                      </span>
-                      <span className="text-foreground font-medium">
-                        {formatCurrency(item.unit_price * item.quantity)}
-                      </span>
-                    </div>
-                  ))}
-                  <Divider className="my-2" />
-                  <div className="flex justify-between text-sm text-muted-foreground font-data">
-                    <span>{t('cart.subtotal')}</span>
-                    <span className="text-foreground">{formatCurrency(totals.subtotal)}</span>
-                  </div>
-                  {totals.discountAmount > 0 && (
-                    <div className="flex justify-between text-sm text-danger font-data">
-                      <span>
-                        {t('cart.discount')}
-                        <span className="text-xs ms-1 opacity-70">
-                          (
-                          {discountType === 'percentage'
-                            ? `${discount}%`
-                            : formatCurrency(discount)}
-                          )
-                        </span>
-                      </span>
-                      <span>-{formatCurrency(totals.discountAmount)}</span>
-                    </div>
-                  )}
-                  {taxInfo.enabled && (
-                    <div className="flex justify-between text-sm text-muted-foreground font-data">
-                      <span>
-                        {t('tax.vat')} ({taxInfo.rate}%)
-                      </span>
-                      <span className="text-foreground">{formatCurrency(totals.taxAmount)}</span>
-                    </div>
-                  )}
-                  {totals.couponDiscount > 0 && (
-                    <div className="flex justify-between text-sm text-primary font-data">
-                      <span>
-                        {t('cart.coupon')} ({couponCode})
-                      </span>
-                      <span>-{formatCurrency(totals.couponDiscount)}</span>
-                    </div>
-                  )}
-                  {totals.pointsDiscount > 0 && (
-                    <div className="flex justify-between text-sm text-primary font-data">
-                      <span>{t('loyalty.pointsDiscount')}</span>
-                      <span>-{formatCurrency(totals.pointsDiscount)}</span>
-                    </div>
-                  )}
-                  {totals.tip > 0 && (
-                    <div className="flex justify-between text-sm text-primary font-data">
-                      <span>{t('cart.tip')}</span>
-                      <span>+{formatCurrency(totals.tip)}</span>
-                    </div>
-                  )}
-                  <div className="flex justify-between text-base font-bold font-data text-foreground">
-                    <span>{t('cart.total')}</span>
-                    {/* E2E: see cart-total — same nameless sibling, same label collision. */}
-                    <span data-testid="checkout-total" className="text-primary">
-                      {formatCurrency(totals.amountDue)}
-                    </span>
-                  </div>
-                </div>
-
-                <Divider />
-
-                {/* Customer selection */}
-                <div className="space-y-3">
-                  <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    {t('cart.selectCustomer')}
-                  </h3>
-                  {customer.selected ? (
-                    <div className="flex items-center gap-2 p-3 bg-muted/20 rounded-xl border border-border/50">
-                      <UserRound className="h-4 w-4 text-primary shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-foreground truncate">
-                          {customer.selected.name}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {customer.selected.phone}
-                          {loyaltyInfo.enabled && (
-                            <span className="ms-2 text-primary font-semibold">
-                              <Star className="h-3 w-3 inline-block" />{' '}
-                              {t('loyalty.pointsBalance', {
-                                points: String(loyaltyInfo.customerPoints),
-                              })}
-                            </span>
-                          )}
-                        </p>
-                      </div>
-                      <Button
-                        isIconOnly
-                        variant="light"
-                        size="sm"
-                        className="h-7 w-7 shrink-0"
-                        onClick={() => {
-                          customer.clear();
-                          resetRedemption();
-                        }}
-                        aria-label="Remove selected customer"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  ) : customer.creating ? (
-                    <div className="space-y-2.5 p-3 bg-muted/20 rounded-xl border border-border/50">
-                      <Input
-                        size="sm"
-                        variant="bordered"
-                        placeholder={t('cart.customerName')}
-                        value={customer.newName}
-                        onValueChange={customer.setNewName}
-                      />
-                      <Input
-                        size="sm"
-                        variant="bordered"
-                        placeholder={t('cart.customerPhone')}
-                        value={customer.newPhone}
-                        onValueChange={customer.setNewPhone}
-                      />
-                      <div className="flex gap-2">
-                        <Button
-                          color="primary"
-                          size="sm"
-                          className="flex-1 text-xs"
-                          isDisabled={
-                            !customer.newName.trim() ||
-                            !customer.newPhone.trim() ||
-                            customer.isSaving
-                          }
-                          isLoading={customer.isSaving}
-                          onClick={customer.createAndSelect}
-                        >
-                          {t('cart.saveCustomer')}
-                        </Button>
-                        <Button
-                          variant="flat"
-                          size="sm"
-                          className="text-xs"
-                          onClick={customer.cancelCreating}
-                        >
-                          {t('common.cancel')}
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="space-y-2">
-                      <div className="relative">
-                        <Input
-                          size="sm"
-                          variant="bordered"
-                          placeholder={t('cart.searchCustomer')}
-                          value={customer.search}
-                          onValueChange={(val) => {
-                            customer.setSearch(val);
-                            customer.setDropdownOpen(true);
-                          }}
-                          onFocus={() => customer.setDropdownOpen(true)}
-                          startContent={<Search className="h-3.5 w-3.5 text-muted-foreground" />}
-                        />
-                        {customer.dropdownOpen && customer.search.length > 0 && (
-                          <div className="absolute z-20 top-full mt-1 w-full bg-card border border-border rounded-xl shadow-lg max-h-40 overflow-y-auto divide-y divide-border/50">
-                            {customer.matches && customer.matches.length > 0 ? (
-                              customer.matches.map((c) => (
-                                <button
-                                  key={c.id}
-                                  type="button"
-                                  className="w-full text-start px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
-                                  onClick={() => customer.select(c)}
-                                >
-                                  <span className="font-medium text-foreground">{c.name}</span>
-                                  <span className="text-muted-foreground text-xs ms-2">
-                                    {c.phone}
-                                  </span>
-                                </button>
-                              ))
-                            ) : (
-                              <p className="px-3 py-2 text-xs text-muted-foreground">
-                                {t('cart.noCustomer')}
-                              </p>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                      <Button
-                        variant="light"
-                        color="primary"
-                        size="sm"
-                        className="w-full text-xs"
-                        startContent={<Plus className="h-3 w-3" />}
-                        onClick={customer.startCreating}
-                      >
-                        {t('cart.addNewCustomer')}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-
-                {/* Loyalty Points Redemption */}
-                {loyaltyInfo.enabled && customer.selected && (
-                  <>
-                    <Divider />
-                    <div className="space-y-3">
-                      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
-                        <Star className="h-3.5 w-3.5 text-primary" />
-                        {t('loyalty.redeemPoints')}
-                      </h3>
-                      <div className="flex items-center justify-between p-3 bg-muted/20 rounded-xl border border-border/50">
-                        <div>
-                          <p className="text-sm font-medium text-foreground">
-                            {t('loyalty.points')}
-                          </p>
-                          <p className="text-base font-bold text-primary font-data">
-                            {loyaltyInfo.customerPoints}
-                          </p>
-                        </div>
-                        {loyaltyInfo.customerPoints > 0 && (
-                          <div className="flex items-center gap-2">
-                            <label
-                              htmlFor="redeem-toggle"
-                              className="text-xs text-muted-foreground cursor-pointer"
-                            >
-                              {t('loyalty.redeemToggle')}
-                            </label>
-                            <input
-                              id="redeem-toggle"
-                              type="checkbox"
-                              checked={redeemPoints}
-                              onChange={(e) => {
-                                setRedeemPoints(e.target.checked);
-                                if (!e.target.checked) setPointsToRedeem(0);
-                              }}
-                              className="accent-primary h-4 w-4 rounded"
-                            />
-                          </div>
-                        )}
-                      </div>
-                      {redeemPoints && loyaltyInfo.customerPoints > 0 && (
-                        <div className="space-y-2">
-                          <Input
-                            type="number"
-                            label={t('loyalty.pointsToRedeem')}
-                            min="0"
-                            size="sm"
-                            variant="bordered"
-                            max={maxPoints}
-                            value={pointsToRedeem ? String(pointsToRedeem) : ''}
-                            onValueChange={(val) => {
-                              const v = Math.min(Math.max(0, parseInt(val) || 0), maxPoints);
-                              setPointsToRedeem(v);
-                            }}
-                            className="font-data w-36"
-                          />
-                          {totals.pointsDiscount > 0 && (
-                            <p className="text-xs text-primary font-data font-semibold">
-                              = -{formatCurrency(totals.pointsDiscount)}{' '}
-                              {t('loyalty.pointsDiscount')}
-                            </p>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  </>
-                )}
-
-                {/* Coupon */}
-                <Divider />
-                <div className="space-y-2">
-                  <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
-                    <Ticket className="h-3.5 w-3.5 text-primary" />
-                    {t('cart.coupon')}
-                  </h3>
-                  {couponCode ? (
-                    <div className="flex items-center justify-between p-3 bg-primary/10 rounded-xl border border-primary/30">
-                      <div>
-                        <p className="text-sm font-bold font-data text-foreground">{couponCode}</p>
-                        <p className="text-xs text-primary font-data">
-                          -{formatCurrency(couponDiscount)}
-                        </p>
-                      </div>
-                      <Button
-                        isIconOnly
-                        variant="light"
-                        size="sm"
-                        className="h-7 w-7"
-                        onClick={() => {
-                          clearCoupon();
-                          setCouponInput('');
-                        }}
-                        aria-label="Remove coupon"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <div className="flex gap-2 items-center">
-                      <Input
-                        size="sm"
-                        variant="bordered"
-                        placeholder={t('cart.couponPlaceholder')}
-                        value={couponInput}
-                        onValueChange={setCouponInput}
-                        className="flex-1"
-                      />
-                      <Button variant="bordered" size="sm" onClick={handleApplyCoupon}>
-                        {t('cart.applyCoupon')}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-
-                {/* Quick Discount -- writes ONLY into the manual discount/discount_type
-                    state, never `tip`. This is the fix for the historical bug
-                    where these buttons silently wrote a "discount" amount
-                    into the tip field (see Unit 3/5 of
-                    docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md). */}
-                <Divider />
-                <div className="space-y-2">
-                  <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
-                    <Percent className="h-3.5 w-3.5 text-primary" />
-                    {t('cart.quickDiscount')}
-                  </h3>
-                  <div className="flex gap-1.5 items-center">
-                    {[5, 10, 15].map((pct) => (
-                      <Button
-                        key={pct}
-                        size="sm"
-                        variant={
-                          discountType === 'percentage' && discount === pct ? 'solid' : 'bordered'
-                        }
-                        color={
-                          discountType === 'percentage' && discount === pct ? 'primary' : 'default'
-                        }
-                        className="flex-1 h-7 min-w-0 text-[11px] font-data font-medium"
-                        onClick={() => {
-                          setDiscountType('percentage');
-                          setDiscount(pct);
-                        }}
-                      >
-                        {pct}%
-                      </Button>
-                    ))}
-                    <Input
-                      type="number"
-                      min="0"
-                      max={discountType === 'percentage' ? 100 : undefined}
-                      step="0.01"
-                      size="sm"
-                      variant="bordered"
-                      placeholder={t('cart.customAmount')}
-                      aria-label={t('cart.quickDiscount')}
-                      value={discountType === 'percentage' && discount ? String(discount) : ''}
-                      onValueChange={(val) => {
-                        setDiscountType('percentage');
-                        setDiscount(parseFloat(val) || 0);
-                      }}
-                      className="flex-1 font-data"
-                    />
-                  </div>
-                </div>
-
-                {/* Tip -- its own, separately labeled, always-positive control.
-                    Never written to by Quick Discount above. Rendered as an
-                    added line (`+`) in the summary and in the receipt. */}
-                <Divider />
-                <div className="space-y-2">
-                  <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
-                    <StickyNote className="h-3.5 w-3.5 text-primary" />
-                    {t('cart.tip')}
-                  </h3>
-                  <Input
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    size="sm"
-                    variant="bordered"
-                    placeholder={t('cart.customTip')}
-                    aria-label={t('cart.tip')}
-                    value={tip ? String(tip) : ''}
-                    onValueChange={(val) => setTip(Math.max(0, parseFloat(val) || 0))}
-                    className="font-data"
-                  />
-                </div>
-
-                {/* Sale Notes */}
-                <Divider />
-                <div className="space-y-2">
-                  <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
-                    <StickyNote className="h-3.5 w-3.5 text-primary" />
-                    {t('cart.notes')}
-                  </h3>
-                  <textarea
-                    placeholder={t('cart.notesPlaceholder')}
-                    value={notes}
-                    onChange={(e) => setNotes(e.target.value)}
-                    rows={2}
-                    className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                    maxLength={500}
-                  />
-                </div>
-
-                <Divider />
-
-                {/* Payment method */}
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                      {t('cart.paymentMethod')}
-                    </h3>
-                    <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={splitPayment}
-                        onChange={(e) => {
-                          setSplitPayment(e.target.checked);
-                          if (e.target.checked) {
-                            setPayments([
-                              { method: 'Cash', amount: 0 },
-                              { method: 'Card', amount: 0 },
-                            ]);
-                          } else {
-                            setPayments([]);
-                          }
-                        }}
-                        className="accent-primary h-3.5 w-3.5 rounded"
-                      />
-                      {t('cart.splitPayment')}
-                    </label>
-                  </div>
-
-                  {!splitPayment ? (
-                    <RadioGroup
-                      value={paymentMethod}
-                      onValueChange={(val: string) => setPaymentMethod(val as PaymentMethod)}
-                      className="space-y-1.5"
-                    >
-                      {(['Cash', 'Card', 'Other'] as const).map((method) => (
-                        <Radio
-                          key={method}
-                          value={method}
-                          classNames={{
-                            base: `flex items-center gap-3 px-3 py-2 rounded-xl border transition-colors cursor-pointer max-w-full m-0 ${
-                              paymentMethod === method
-                                ? 'border-primary/50 bg-primary/5'
-                                : 'border-border hover:border-primary/30'
-                            }`,
-                            label: 'text-sm font-medium text-foreground cursor-pointer',
-                          }}
-                        >
-                          {paymentLabels[method]}
-                        </Radio>
-                      ))}
-                    </RadioGroup>
-                  ) : (
-                    <div className="space-y-2">
-                      {payments.map((p, idx) => (
-                        <div key={idx} className="flex gap-2 items-center">
-                          <select
-                            className="h-8 rounded-lg border border-border bg-card text-foreground px-2 text-xs"
-                            value={p.method}
-                            onChange={(e) => {
-                              const next = [...payments];
-                              next[idx] = { ...next[idx], method: e.target.value as PaymentMethod };
-                              setPayments(next);
-                            }}
-                          >
-                            <option value="Cash">{t('cart.cash')}</option>
-                            <option value="Card">{t('cart.card')}</option>
-                            <option value="Gift Card">{t('cart.giftCard')}</option>
-                            <option value="Other">{t('cart.other')}</option>
-                          </select>
-                          <Input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            size="sm"
-                            variant="bordered"
-                            aria-label={`${paymentLabels[p.method] ?? p.method} ${t('cart.splitPayment')} #${idx + 1}`}
-                            value={p.amount ? String(p.amount) : ''}
-                            onValueChange={(val) => {
-                              const next = [...payments];
-                              next[idx] = { ...next[idx], amount: parseFloat(val) || 0 };
-                              setPayments(next);
-                            }}
-                            className="flex-1 font-data"
-                          />
-                          {payments.length > 2 && (
-                            <Button
-                              isIconOnly
-                              variant="light"
-                              size="sm"
-                              className="h-7 w-7"
-                              onClick={() => setPayments(payments.filter((_, i) => i !== idx))}
-                              aria-label="Remove payment split"
-                            >
-                              <X className="h-3.5 w-3.5" />
-                            </Button>
-                          )}
-                        </div>
-                      ))}
-                      <div className="flex items-center justify-between text-xs pt-1">
-                        <Button
-                          variant="light"
-                          size="sm"
-                          startContent={<Plus className="h-3 w-3" />}
-                          onClick={() => setPayments([...payments, { method: 'Cash', amount: 0 }])}
-                        >
-                          {t('cart.addPayment')}
-                        </Button>
-                        <span
-                          className={`font-data font-semibold ${split.isBalanced ? 'text-success' : 'text-danger'}`}
-                        >
-                          {formatCurrency(split.allocated)} / {formatCurrency(totals.amountDue)}
-                        </span>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* `shrink-0` is load-bearing, not cosmetic. This button is the last child
-                    of a flex-column DrawerBody, and once the drawer's content is taller
-                    than the viewport the default `flex-shrink: 1` compresses it to zero
-                    height — leaving a cashier unable to complete a sale on any screen
-                    under roughly 1000px tall. Covered by checkout-cash.spec.ts. */}
-                <Button
-                  color="primary"
-                  size="md"
-                  className="w-full shrink-0 font-semibold shadow-sm"
-                  onClick={handleCheckout}
-                  isDisabled={isPending || needsReview || (splitPayment && !split.isBalanced)}
-                  isLoading={isPending}
-                >
-                  {isPending ? t('cart.processing') : t('cart.confirmSale')}
-                </Button>
-              </DrawerBody>
-            </>
-          )}
-        </DrawerContent>
-      </Drawer>
+        paymentMethod={paymentMethod}
+        setPaymentMethod={setPaymentMethod}
+        splitPayment={splitPayment}
+        setSplitPayment={setSplitPayment}
+        payments={payments}
+        setPayments={setPayments}
+        onConfirm={handleCheckout}
+        isPending={isPending}
+        needsReview={needsReview}
+      />
     </div>
   );
 }

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -43,112 +43,32 @@ import {
   allocateSplit,
   maxRedeemablePoints,
   SPLIT_PAYMENT_MISMATCH_CODE,
-  type TaxMode,
 } from '../../../shared/lib/checkout';
 import { resource } from '../../../shared/lib/resource';
 import { useTransport, createIdempotencyKey } from '../../../shared/lib/transport/index';
 import { ApiError } from '../../../shared/lib/transport/types';
-import type { ReceiptData, ReceiptItem, ReceiptPayment } from '../../../shared/components/Receipt';
+import { readTaxPolicy, readLoyaltyPolicy } from '../lib/checkoutSettings';
+import {
+  buildSalePayload,
+  buildOfflineSalePayload,
+  type SaleComposition,
+} from '../lib/salePayload';
+import { buildReceipt } from '../lib/saleReceipt';
+import type {
+  CheckoutAttempt,
+  CouponValidation,
+  PaymentEntry,
+  PaymentMethod,
+  SaleData,
+  SaleResponse,
+} from '../types';
+import type { ReceiptData } from '../../../shared/components/Receipt';
 import type { AppSettings, Customer } from '../../../shared/types/index';
 
 const customers = resource<Customer>('customers');
 
-type PaymentMethod = 'Cash' | 'Card' | 'Other';
-
-/** Write payload for POST /api/v1/sales — not the read shape returned by GET /api/sales/:id */
-interface SaleItemInput {
-  product_id: number;
-  variant_id?: number | null;
-  quantity: number;
-  unit_price: number;
-  memo?: string | null;
-}
-
-interface PaymentEntry {
-  method: PaymentMethod | 'Gift Card';
-  amount: number;
-}
-
-interface SaleData {
-  items: SaleItemInput[];
-  discount: number;
-  discount_type: string;
-  payment_method: PaymentMethod;
-  payments?: PaymentEntry[];
-  customer_id?: number;
-  tax_amount?: number;
-  points_redeemed?: number;
-  notes?: string;
-  tip?: number;
-  coupon_code?: string;
-}
-
-/** One checkout attempt: the composed body plus the key that dedupes its retries. */
-interface CheckoutAttempt {
-  saleData: SaleData;
-  idempotencyKey: string;
-}
-
 interface CustomerLoyalty {
   points: number;
-}
-
-/** A resolved sale line as the server actually persisted it (Unit 4's
- * `resolvedItems` -- authoritative product/variant identity, quantity and
- * price; no product name, which is why the receipt looks names up against
- * the cart the cashier just rang up, display-only, never for a monetary
- * figure). */
-interface ConfirmedSaleItem {
-  product_id: number;
-  variant_id?: number | null;
-  quantity: number;
-  unit_price: number;
-  memo?: string | null;
-}
-
-/** A validated payment entry exactly as persisted (`ConfirmedPayment` in
- * server/src/modules/pos/sales/types.ts). */
-interface ConfirmedSalePayment {
-  method: string;
-  amount: number;
-}
-
-/** Mirrors the server's immutable `SaleCalculationSnapshot` (Units 2/4) --
- * see client/src/shared/components/Receipt.tsx's `ReceiptCalculation`, which
- * this is mapped into 1:1. Every figure is the CONFIRMED, persisted amount
- * for this sale; the receipt renders these directly rather than the client's
- * own (possibly stale-by-then) preview. */
-interface ConfirmedSaleCalculation {
-  subtotal: number;
-  manualDiscount: number;
-  couponDiscount: number;
-  pointsDiscount: number;
-  taxAmount: number;
-  taxMode: 'inclusive' | 'exclusive';
-  taxRatePercent: number;
-  tipAmount: number;
-  amountDue: number;
-}
-
-/** What POST /api/v1/sales hands back, as far as the receipt needs it. */
-interface SaleResponse {
-  id: number;
-  discount?: number;
-  discount_type?: string;
-  total: number;
-  payment_method: string;
-  cashier_name?: string;
-  created_at: string;
-  /** Additive since Unit 4 -- present on every response from this branch's server. */
-  calculation?: ConfirmedSaleCalculation;
-  items?: ConfirmedSaleItem[];
-  payments?: ConfirmedSalePayment[];
-}
-
-/** What POST /api/v1/coupons/validate hands back, as far as the cart needs it. */
-interface CouponValidation {
-  code: string;
-  discount: number;
 }
 
 interface CartPanelProps {
@@ -222,23 +142,12 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     }
   );
 
-  const loyaltyInfo = useMemo(() => {
-    const enabled = appSettings?.loyalty_enabled === 'true';
-    // Canonical, direct-unit settings (Unit 1) -- never the legacy
-    // `loyalty_earn_rate`/`loyalty_redeem_value` aliases. Defaults match
-    // `server/src/database/seed.ts`.
-    const pointsPerEgp = parseFloat(appSettings?.loyalty_points_per_egp || '1');
-    const egpPerPoint = parseFloat(appSettings?.loyalty_egp_per_point || '0.1');
-    const customerPoints = customerLoyalty?.points || 0;
-    return { enabled, pointsPerEgp, egpPerPoint, customerPoints };
-  }, [appSettings, customerLoyalty]);
+  const loyaltyInfo = useMemo(
+    () => ({ ...readLoyaltyPolicy(appSettings), customerPoints: customerLoyalty?.points || 0 }),
+    [appSettings, customerLoyalty]
+  );
 
-  const taxInfo = useMemo(() => {
-    const enabled = appSettings?.tax_enabled === 'true';
-    const rate = parseFloat(appSettings?.tax_rate || '0');
-    const mode: TaxMode = appSettings?.tax_mode === 'inclusive' ? 'inclusive' : 'exclusive';
-    return { enabled: enabled && rate > 0, rate, mode };
-  }, [appSettings]);
+  const taxInfo = useMemo(() => readTaxPolicy(appSettings), [appSettings]);
 
   const totals = useMemo(
     () =>
@@ -369,6 +278,25 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   };
 
   /**
+   * The single description of "what the cashier is about to sell", from which
+   * BOTH the online body and the reduced offline-queue body are composed. One
+   * source, so the two can never drift apart the way two inline literals could.
+   */
+  const composition: SaleComposition = {
+    items,
+    discount,
+    discountType,
+    notes,
+    tip,
+    couponCode,
+    paymentMethod,
+    splitPayment,
+    payments,
+    customerId: selectedCustomer?.id ?? null,
+    pointsToRedeem: redeemPoints ? pointsToRedeem : 0,
+  };
+
+  /**
    * The idempotency key identifies one rung-up sale, not one HTTP request. It is keyed on
    * the composed payload so a cashier who hits Confirm again after a failure retries under
    * the SAME key (letting the server return the original outcome rather than committing a
@@ -401,55 +329,19 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     onSuccess: (response) => {
       setCheckoutAttempt(null);
       const sale = response.data;
-      const calc = sale.calculation;
 
-      // Display name only -- looked up against the cart the cashier just
-      // rang up (captured here, before `clearCart()` below empties it). Every
-      // MONETARY figure in the receipt (quantity, unit_price, every
-      // calculation line, total, payments) comes solely from `sale`/`calc`,
-      // the server's confirmed response -- never recomputed client-side. The
-      // server's resolved line items (Unit 4) carry product/variant identity
-      // and price but not the product name, so this lookup is purely
-      // cosmetic and never substitutes for a server-confirmed amount.
-      const nameByLine = new Map(
-        items.map((i) => [`${i.product_id}:${i.variant_id ?? 0}`, i.name])
-      );
-      const receiptItems: ReceiptItem[] = (sale.items ?? []).map((item) => ({
-        name: nameByLine.get(`${item.product_id}:${item.variant_id ?? 0}`) ?? item.memo ?? '',
-        quantity: item.quantity,
-        unit_price: item.unit_price,
-      }));
-
-      const receiptPayments: ReceiptPayment[] =
-        sale.payments && sale.payments.length > 0
-          ? sale.payments
-          : [{ method: sale.payment_method, amount: calc?.amountDue ?? sale.total }];
-
-      const newReceipt: ReceiptData = {
-        saleId: sale.id,
-        items: receiptItems,
-        discountType: sale.discount_type || discountType,
-        discountValue: sale.discount ?? discount,
-        couponCode: couponCode || undefined,
-        // `calc` is additive-but-guaranteed within this branch (Unit 4 ships
-        // alongside this unit); the fallback only guards a response shaped
-        // like the pre-Unit-4 contract so the receipt never crashes.
-        calculation: calc ?? {
-          subtotal: receiptItems.reduce((sum, i) => sum + i.unit_price * i.quantity, 0),
-          manualDiscount: 0,
-          couponDiscount: 0,
-          pointsDiscount: 0,
-          taxAmount: 0,
-          taxMode: taxInfo.mode,
-          taxRatePercent: taxInfo.rate,
-          tipAmount: 0,
-          amountDue: sale.total,
-        },
-        payments: receiptPayments,
-        cashierName: sale.cashier_name || '',
+      // Built from the cart as it stands right now -- captured before
+      // `clearCart()` below empties it. See saleReceipt.ts: every monetary
+      // figure comes from the server's confirmed response; the cart supplies
+      // display names only.
+      const newReceipt: ReceiptData = buildReceipt(sale, {
+        cartItems: items,
+        discount,
+        discountType,
+        couponCode,
+        tax: taxInfo,
         customerName: selectedCustomer?.name,
-        date: sale.created_at,
-      };
+      });
 
       toast.success(t('cart.saleSuccess'));
       clearCart();
@@ -467,18 +359,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     },
     onError: (error: Error, attempt: CheckoutAttempt) => {
       if (!navigator.onLine) {
-        const saleData: SaleData = {
-          items: items.map((i) => ({
-            product_id: i.product_id,
-            ...(i.variant_id ? { variant_id: i.variant_id } : {}),
-            quantity: i.quantity,
-            unit_price: i.unit_price,
-          })),
-          discount,
-          discount_type: discountType,
-          payment_method: paymentMethod,
-          ...(selectedCustomer ? { customer_id: selectedCustomer.id } : {}),
-        };
+        const saleData: SaleData = buildOfflineSalePayload(composition);
         addToQueue({
           type: 'sale',
           payload: saleData as unknown as Record<string, unknown>,
@@ -523,24 +404,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     // checkout drawer directly.
     if (items.length === 0 || needsReview) return;
 
-    const saleData: SaleData = {
-      items: items.map((i) => ({
-        product_id: i.product_id,
-        quantity: i.quantity,
-        unit_price: i.unit_price,
-        ...(i.variant_id ? { variant_id: i.variant_id } : {}),
-        ...(i.memo ? { memo: i.memo } : {}),
-      })),
-      discount,
-      discount_type: discountType,
-      payment_method: splitPayment ? 'Cash' : paymentMethod,
-      ...(splitPayment && payments.length > 0 ? { payments } : {}),
-      ...(selectedCustomer ? { customer_id: selectedCustomer.id } : {}),
-      ...(redeemPoints && pointsToRedeem > 0 ? { points_redeemed: pointsToRedeem } : {}),
-      ...(notes ? { notes } : {}),
-      ...(tip > 0 ? { tip } : {}),
-      ...(couponCode ? { coupon_code: couponCode } : {}),
-    };
+    const saleData: SaleData = buildSalePayload(composition);
 
     checkoutMutation.mutate({ saleData, idempotencyKey: idempotencyKeyFor(saleData) });
   };

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, type MutableRefObject } from 'react';
+import { useState, useEffect, type MutableRefObject } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -38,16 +38,12 @@ import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue';
 import ReceiptDialog from '../../../shared/components/ReceiptDialog';
 import HeldCartsDialog from './HeldCartsDialog';
 import { useApiQuery } from '../../../shared/lib/apiQuery';
-import {
-  calculateTotals,
-  allocateSplit,
-  maxRedeemablePoints,
-  SPLIT_PAYMENT_MISMATCH_CODE,
-} from '../../../shared/lib/checkout';
+import { SPLIT_PAYMENT_MISMATCH_CODE } from '../../../shared/lib/checkout';
 import { resource } from '../../../shared/lib/resource';
 import { useTransport, createIdempotencyKey } from '../../../shared/lib/transport/index';
 import { ApiError } from '../../../shared/lib/transport/types';
-import { readTaxPolicy, readLoyaltyPolicy } from '../lib/checkoutSettings';
+import { useCheckoutPricing } from '../hooks/useCheckoutPricing';
+import { useCustomerDisplayBroadcast } from '../hooks/useCustomerDisplayBroadcast';
 import {
   buildSalePayload,
   buildOfflineSalePayload,
@@ -63,13 +59,9 @@ import type {
   SaleResponse,
 } from '../types';
 import type { ReceiptData } from '../../../shared/components/Receipt';
-import type { AppSettings, Customer } from '../../../shared/types/index';
+import type { Customer } from '../../../shared/types/index';
 
 const customers = resource<Customer>('customers');
-
-interface CustomerLoyalty {
-  points: number;
-}
 
 interface CartPanelProps {
   checkoutTriggerRef?: MutableRefObject<(() => void) | null>;
@@ -93,7 +85,6 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     setTip,
     setCoupon,
     clearCoupon,
-    getSubtotal,
     clearCart,
     needsReview,
     acknowledgeReview,
@@ -125,119 +116,23 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
 
   const debouncedCustomerSearch = useDebouncedValue(customerSearch, 300);
 
-  const [redeemPoints, setRedeemPoints] = useState(false);
-  const [pointsToRedeem, setPointsToRedeem] = useState(0);
+  // ONE authoritative owner of every checkout figure: totals, the split
+  // allocation, the loyalty cap and the redemption state. Nothing below
+  // re-derives any of them.
+  const {
+    tax: taxInfo,
+    loyalty: loyaltyInfo,
+    totals,
+    split,
+    maxPoints,
+    redeemPoints,
+    pointsToRedeem,
+    setRedeemPoints,
+    setPointsToRedeem,
+    resetRedemption,
+  } = useCheckoutPricing({ customerId: selectedCustomer?.id ?? null, payments });
 
-  const { data: appSettings } = useApiQuery<AppSettings>(['settings'], 'settings', undefined, {
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const { data: customerLoyalty } = useApiQuery<CustomerLoyalty>(
-    ['customer-loyalty', selectedCustomer?.id],
-    `customers/${selectedCustomer?.id}/loyalty`,
-    undefined,
-    {
-      enabled: !!selectedCustomer && appSettings?.loyalty_enabled === 'true',
-      staleTime: 30 * 1000,
-    }
-  );
-
-  const loyaltyInfo = useMemo(
-    () => ({ ...readLoyaltyPolicy(appSettings), customerPoints: customerLoyalty?.points || 0 }),
-    [appSettings, customerLoyalty]
-  );
-
-  const taxInfo = useMemo(() => readTaxPolicy(appSettings), [appSettings]);
-
-  const totals = useMemo(
-    () =>
-      calculateTotals({
-        items,
-        discount,
-        discountType,
-        couponDiscount,
-        tax: taxInfo,
-        pointsToRedeem: redeemPoints && loyaltyInfo.enabled ? pointsToRedeem : 0,
-        redeemValue: loyaltyInfo.egpPerPoint,
-        pointsBalance: loyaltyInfo.customerPoints,
-        tip,
-        loyaltyEnabled: loyaltyInfo.enabled,
-        pointsPerEgp: loyaltyInfo.pointsPerEgp,
-      }),
-    [
-      items,
-      discount,
-      discountType,
-      couponDiscount,
-      taxInfo,
-      redeemPoints,
-      pointsToRedeem,
-      loyaltyInfo,
-      tip,
-    ]
-  );
-
-  // The most the selected customer may redeem on THIS sale: never more than
-  // their balance, and never more value than the sale (before loyalty) is
-  // worth. `netOfDiscounts + pointsDiscount` recovers the remaining value
-  // after manual discount/coupon but BEFORE loyalty, regardless of how many
-  // points are currently requested (see checkout.ts's calculation order).
-  const maxPoints = useMemo(
-    () =>
-      maxRedeemablePoints(
-        loyaltyInfo.customerPoints,
-        totals.netOfDiscounts + totals.pointsDiscount,
-        loyaltyInfo.egpPerPoint
-      ),
-    [loyaltyInfo, totals.netOfDiscounts, totals.pointsDiscount]
-  );
-
-  // A stale redeemed-points value must never silently outlive the subtotal,
-  // coupon, or tax change that shrank how much can actually be redeemed.
-  useEffect(() => {
-    if (pointsToRedeem > maxPoints) {
-      setPointsToRedeem(maxPoints);
-    }
-  }, [maxPoints, pointsToRedeem]);
-
-  const split = useMemo(() => allocateSplit(payments, totals.amountDue), [payments, totals]);
-
-  // Broadcast the SAME projected breakdown the cart footer/checkout drawer
-  // render -- never a separately-derived total -- so the customer display
-  // always agrees to the cent with what the cashier sees (Unit 5). This
-  // owns the channel entirely; POS.tsx no longer posts its own (partial,
-  // tax/loyalty-blind) projection.
-  useEffect(() => {
-    const channel = new BroadcastChannel('moon-customer-display');
-    if (items.length > 0) {
-      channel.postMessage({
-        type: 'cart-update',
-        cart: {
-          items: items.map((i) => ({
-            name: i.name,
-            quantity: i.quantity,
-            unit_price: i.unit_price,
-            memo: i.memo,
-          })),
-          subtotal: totals.subtotal,
-          discount,
-          discountType,
-          discountAmount: totals.discountAmount,
-          couponCode: couponCode || undefined,
-          couponDiscount: totals.couponDiscount,
-          taxEnabled: taxInfo.enabled,
-          taxRate: taxInfo.rate,
-          taxAmount: totals.taxAmount,
-          pointsDiscount: totals.pointsDiscount,
-          tip: totals.tip,
-          amountDue: totals.amountDue,
-        },
-      });
-    } else {
-      channel.postMessage({ type: 'cart-clear' });
-    }
-    channel.close();
-  }, [items, discount, discountType, couponCode, taxInfo, totals]);
+  useCustomerDisplayBroadcast({ items, discount, discountType, couponCode, tax: taxInfo, totals });
 
   useEffect(() => {
     if (checkoutTriggerRef) {
@@ -348,8 +243,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
       setCheckoutOpen(false);
       setSelectedCustomer(null);
       setCustomerSearch('');
-      setRedeemPoints(false);
-      setPointsToRedeem(0);
+      resetRedemption();
       queryClient.invalidateQueries({ queryKey: ['sales'] });
       queryClient.invalidateQueries({ queryKey: ['products'] });
       queryClient.invalidateQueries({ queryKey: ['customer-loyalty'] });
@@ -417,7 +311,11 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
         path: 'coupons/validate',
         body: {
           code: couponInput.trim(),
-          subtotal: getSubtotal(),
+          // The authoritative subtotal, same as every displayed line. This used
+          // to call `cartStore.getSubtotal()`, a second float-arithmetic
+          // derivation of the same figure; `totals.subtotal` is the minor-unit
+          // one the server's own calculation agrees with.
+          subtotal: totals.subtotal,
           ...(selectedCustomer ? { customer_id: selectedCustomer.id } : {}),
           item_product_ids: items.map((i) => i.product_id),
         },
@@ -660,7 +558,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                 }`}
                 onClick={() => {
                   if (discountType === 'fixed' && discount > 0) {
-                    const subtotal = getSubtotal();
+                    const subtotal = totals.subtotal;
                     setDiscount(
                       subtotal > 0 ? Math.round((discount / subtotal) * 100 * 100) / 100 : 0
                     );
@@ -678,7 +576,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                 }`}
                 onClick={() => {
                   if (discountType === 'percentage' && discount > 0) {
-                    const subtotal = getSubtotal();
+                    const subtotal = totals.subtotal;
                     setDiscount(Math.round(((subtotal * discount) / 100) * 100) / 100);
                   }
                   setDiscountType('fixed');
@@ -735,7 +633,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
         <div className="space-y-1.5">
           <div className="flex justify-between text-sm text-muted-foreground font-data">
             <span>{t('cart.subtotal')}</span>
-            <span className="text-foreground">{formatCurrency(getSubtotal())}</span>
+            <span className="text-foreground">{formatCurrency(totals.subtotal)}</span>
           </div>
           {totals.discountAmount > 0 && (
             <div className="flex justify-between text-sm text-danger font-data">
@@ -830,7 +728,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                   <Divider className="my-2" />
                   <div className="flex justify-between text-sm text-muted-foreground font-data">
                     <span>{t('cart.subtotal')}</span>
-                    <span className="text-foreground">{formatCurrency(getSubtotal())}</span>
+                    <span className="text-foreground">{formatCurrency(totals.subtotal)}</span>
                   </div>
                   {totals.discountAmount > 0 && (
                     <div className="flex justify-between text-sm text-danger font-data">
@@ -917,8 +815,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                         className="h-7 w-7 shrink-0"
                         onClick={() => {
                           setSelectedCustomer(null);
-                          setRedeemPoints(false);
-                          setPointsToRedeem(0);
+                          resetRedemption();
                         }}
                         aria-label="Remove selected customer"
                       >

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, type MutableRefObject } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Minus,
   Plus,
@@ -30,7 +29,6 @@ import {
   Divider,
 } from '@heroui/react';
 import { useCartStore } from '../store/cartStore';
-import { useOfflineStore, SALE_QUEUE_CONTRACT_VERSION } from '../../../shared/store/offlineStore';
 import { useHeldCartsStore } from '../store/heldCartsStore';
 import { formatCurrency } from '../../../shared/lib/utils';
 import { useTranslation } from '../../../shared/i18n/index';
@@ -38,27 +36,13 @@ import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue';
 import ReceiptDialog from '../../../shared/components/ReceiptDialog';
 import HeldCartsDialog from './HeldCartsDialog';
 import { useApiQuery } from '../../../shared/lib/apiQuery';
-import { SPLIT_PAYMENT_MISMATCH_CODE } from '../../../shared/lib/checkout';
 import { resource } from '../../../shared/lib/resource';
-import { useTransport, createIdempotencyKey } from '../../../shared/lib/transport/index';
-import { ApiError } from '../../../shared/lib/transport/types';
+import { useTransport } from '../../../shared/lib/transport/index';
 import { useCheckoutPricing } from '../hooks/useCheckoutPricing';
 import { useCustomerDisplayBroadcast } from '../hooks/useCustomerDisplayBroadcast';
-import {
-  buildSalePayload,
-  buildOfflineSalePayload,
-  type SaleComposition,
-} from '../lib/salePayload';
-import { buildReceipt } from '../lib/saleReceipt';
-import type {
-  CheckoutAttempt,
-  CouponValidation,
-  PaymentEntry,
-  PaymentMethod,
-  SaleData,
-  SaleResponse,
-} from '../types';
-import type { ReceiptData } from '../../../shared/components/Receipt';
+import { useCheckoutSubmission } from '../hooks/useCheckoutSubmission';
+import type { SaleComposition } from '../lib/salePayload';
+import type { CouponValidation, PaymentEntry, PaymentMethod } from '../types';
 import type { Customer } from '../../../shared/types/index';
 
 const customers = resource<Customer>('customers');
@@ -88,12 +72,8 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     clearCart,
     needsReview,
     acknowledgeReview,
-    checkoutAttempt,
-    setCheckoutAttempt,
   } = useCartStore();
-  const { addToQueue } = useOfflineStore();
   const { carts: heldCarts, holdCart } = useHeldCartsStore();
-  const queryClient = useQueryClient();
   const transport = useTransport();
   const { t, isRtl } = useTranslation();
   const [animateParent] = useAutoAnimate();
@@ -106,8 +86,6 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   const [customerSearch, setCustomerSearch] = useState('');
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
   const [showCustomerDropdown, setShowCustomerDropdown] = useState(false);
-  const [receiptOpen, setReceiptOpen] = useState(false);
-  const [receiptData, setReceiptData] = useState<ReceiptData | null>(null);
   const [couponInput, setCouponInput] = useState('');
   const [editingMemo, setEditingMemo] = useState<string | null>(null);
   const [showNewCustomer, setShowNewCustomer] = useState(false);
@@ -191,102 +169,17 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     pointsToRedeem: redeemPoints ? pointsToRedeem : 0,
   };
 
-  /**
-   * The idempotency key identifies one rung-up sale, not one HTTP request. It is keyed on
-   * the composed payload so a cashier who hits Confirm again after a failure retries under
-   * the SAME key (letting the server return the original outcome rather than committing a
-   * second sale), while a cart that has changed gets a fresh one. Cleared once a sale is
-   * committed or queued, so the next sale never inherits a key — even an identical repeat
-   * order.
-   *
-   * It lives in the persisted cart store rather than a ref: the cart survives a reload, so
-   * the key protecting it has to as well. A till that refreshes while a checkout is in
-   * flight would otherwise mint a new key and ring the same sale up twice.
-   */
-  const idempotencyKeyFor = (saleData: SaleData): string => {
-    const fingerprint = JSON.stringify(saleData);
-    if (checkoutAttempt?.fingerprint === fingerprint) {
-      return checkoutAttempt.key;
-    }
-    const attempt = { fingerprint, key: createIdempotencyKey() };
-    setCheckoutAttempt(attempt);
-    return attempt.key;
-  };
-
-  const checkoutMutation = useMutation({
-    mutationFn: ({ saleData, idempotencyKey }: CheckoutAttempt) =>
-      transport.request<SaleResponse>({
-        method: 'POST',
-        path: 'sales',
-        body: saleData,
-        idempotencyKey,
-      }),
-    onSuccess: (response) => {
-      setCheckoutAttempt(null);
-      const sale = response.data;
-
-      // Built from the cart as it stands right now -- captured before
-      // `clearCart()` below empties it. See saleReceipt.ts: every monetary
-      // figure comes from the server's confirmed response; the cart supplies
-      // display names only.
-      const newReceipt: ReceiptData = buildReceipt(sale, {
-        cartItems: items,
-        discount,
-        discountType,
-        couponCode,
-        tax: taxInfo,
-        customerName: selectedCustomer?.name,
-      });
-
-      toast.success(t('cart.saleSuccess'));
-      clearCart();
+  // Submission lifecycle: keying, posting, the receipt, and the offline
+  // fallback. `onCheckoutSettled` is the surrounding UI's reset, run once the
+  // sale is committed or queued -- never after a failure the cashier retries.
+  const { submit, isPending, receiptOpen, setReceiptOpen, receiptData } = useCheckoutSubmission({
+    tax: taxInfo,
+    customerName: selectedCustomer?.name,
+    onCheckoutSettled: () => {
       setCheckoutOpen(false);
       setSelectedCustomer(null);
       setCustomerSearch('');
       resetRedemption();
-      queryClient.invalidateQueries({ queryKey: ['sales'] });
-      queryClient.invalidateQueries({ queryKey: ['products'] });
-      queryClient.invalidateQueries({ queryKey: ['customer-loyalty'] });
-
-      setReceiptData(newReceipt);
-      setReceiptOpen(true);
-    },
-    onError: (error: Error, attempt: CheckoutAttempt) => {
-      if (!navigator.onLine) {
-        const saleData: SaleData = buildOfflineSalePayload(composition);
-        addToQueue({
-          type: 'sale',
-          payload: saleData as unknown as Record<string, unknown>,
-          // Stamps this entry as composed under the current (corrected)
-          // checkout contract, so useOffline.ts's replay never quarantines
-          // it. A legacy entry already sitting in a user's queue from before
-          // this deploy has no such field and is left for manual review.
-          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
-          // The same key the failed POST carried: if that request did reach
-          // the server after all, the replay is recognised as a duplicate
-          // instead of ringing the sale up twice.
-          idempotencyKey: attempt.idempotencyKey,
-        });
-        toast.success(t('cart.savedOffline'));
-        setCheckoutAttempt(null);
-        clearCart();
-        setCheckoutOpen(false);
-        setSelectedCustomer(null);
-        setCustomerSearch('');
-      } else {
-        // Authoritative data (catalog price, tax, coupon, or loyalty
-        // settings) changed between preview and submission and the split no
-        // longer balances against the server's recalculated total. The cart
-        // is intentionally left untouched (no clearCart/close above) so the
-        // cashier can review and rebalance rather than seeing a generic
-        // failure or a false success.
-        const isSplitMismatch =
-          error instanceof ApiError &&
-          error.details?.some((d) => d.code === SPLIT_PAYMENT_MISMATCH_CODE);
-        toast.error(
-          isSplitMismatch ? t('cart.splitMismatchError') : error.message || t('cart.saleFailed')
-        );
-      }
     },
   });
 
@@ -298,9 +191,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
     // checkout drawer directly.
     if (items.length === 0 || needsReview) return;
 
-    const saleData: SaleData = buildSalePayload(composition);
-
-    checkoutMutation.mutate({ saleData, idempotencyKey: idempotencyKeyFor(saleData) });
+    submit(composition);
   };
 
   const handleApplyCoupon = async () => {
@@ -1251,12 +1142,10 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
                   size="md"
                   className="w-full shrink-0 font-semibold shadow-sm"
                   onClick={handleCheckout}
-                  isDisabled={
-                    checkoutMutation.isPending || needsReview || (splitPayment && !split.isBalanced)
-                  }
-                  isLoading={checkoutMutation.isPending}
+                  isDisabled={isPending || needsReview || (splitPayment && !split.isBalanced)}
+                  isLoading={isPending}
                 >
-                  {checkoutMutation.isPending ? t('cart.processing') : t('cart.confirmSale')}
+                  {isPending ? t('cart.processing') : t('cart.confirmSale')}
                 </Button>
               </DrawerBody>
             </>

--- a/client/src/features/pos/components/checkout/CartFooter.tsx
+++ b/client/src/features/pos/components/checkout/CartFooter.tsx
@@ -1,0 +1,198 @@
+/**
+ * The cart footer: the manual discount controls, the running breakdown, and
+ * the button that opens the checkout drawer.
+ *
+ * Every figure it renders comes from the `totals` object it is handed — the
+ * SAME one the drawer and the customer display use. It derives nothing.
+ * Extracted from CartPanel (issue #51); markup unchanged.
+ */
+import { Button, Input, Divider } from '@heroui/react';
+import { Tag } from 'lucide-react';
+import { formatCurrency } from '../../../../shared/lib/utils';
+import { useTranslation } from '../../../../shared/i18n/index';
+import type { TaxSettings, Totals, DiscountType } from '../../../../shared/lib/checkout';
+
+const PERCENT_PRESETS = [5, 10, 15, 20];
+const FIXED_PRESETS = [5, 10, 25, 50];
+
+export default function CartFooter({
+  discount,
+  discountType,
+  setDiscount,
+  setDiscountType,
+  tax,
+  totals,
+  checkoutDisabled,
+  onCheckout,
+}: {
+  discount: number;
+  discountType: DiscountType;
+  setDiscount: (value: number) => void;
+  setDiscountType: (type: DiscountType) => void;
+  tax: TaxSettings;
+  totals: Totals;
+  checkoutDisabled: boolean;
+  onCheckout: () => void;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="border-t border-border/50 p-4 space-y-3">
+      {/* Discount */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+            <Tag className="h-3 w-3" />
+            {t('cart.discount')}
+          </span>
+          {discount > 0 && (
+            <button
+              onClick={() => setDiscount(0)}
+              className="text-[10px] text-danger hover:underline transition-colors"
+            >
+              {t('cart.clearDiscount')}
+            </button>
+          )}
+        </div>
+
+        {/* Type toggle + input */}
+        <div className="flex items-center gap-2">
+          <div className="flex bg-muted/30 border border-border rounded-lg overflow-hidden p-0.5">
+            <button
+              className={`px-2.5 py-1 text-xs font-data font-medium rounded-md transition-colors ${
+                discountType === 'percentage'
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              onClick={() => {
+                // Converting an entered amount between units keeps the money
+                // the same; the subtotal it converts against is the
+                // authoritative one, never a second derivation of it.
+                if (discountType === 'fixed' && discount > 0) {
+                  const subtotal = totals.subtotal;
+                  setDiscount(
+                    subtotal > 0 ? Math.round((discount / subtotal) * 100 * 100) / 100 : 0
+                  );
+                }
+                setDiscountType('percentage');
+              }}
+            >
+              %
+            </button>
+            <button
+              className={`px-2.5 py-1 text-xs font-data font-medium rounded-md transition-colors ${
+                discountType === 'fixed'
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              onClick={() => {
+                if (discountType === 'percentage' && discount > 0) {
+                  const subtotal = totals.subtotal;
+                  setDiscount(Math.round(((subtotal * discount) / 100) * 100) / 100);
+                }
+                setDiscountType('fixed');
+              }}
+            >
+              $
+            </button>
+          </div>
+          <Input
+            type="number"
+            min="0"
+            size="sm"
+            variant="bordered"
+            max={discountType === 'percentage' ? 100 : undefined}
+            placeholder="0"
+            value={discount ? String(discount) : ''}
+            onValueChange={(val) => setDiscount(parseFloat(val) || 0)}
+            className="flex-1 font-data"
+          />
+        </div>
+
+        {/* Quick presets */}
+        <div className="flex gap-1.5">
+          {discountType === 'percentage'
+            ? PERCENT_PRESETS.map((pct) => (
+                <Button
+                  key={pct}
+                  size="sm"
+                  variant={discount === pct ? 'solid' : 'bordered'}
+                  color={discount === pct ? 'primary' : 'default'}
+                  className="flex-1 h-7 min-w-0 px-1 text-[11px] font-data font-medium"
+                  onClick={() => setDiscount(pct)}
+                >
+                  {pct}%
+                </Button>
+              ))
+            : FIXED_PRESETS.map((amt) => (
+                <Button
+                  key={amt}
+                  size="sm"
+                  variant={discount === amt ? 'solid' : 'bordered'}
+                  color={discount === amt ? 'primary' : 'default'}
+                  className="flex-1 h-7 min-w-0 px-1 text-[11px] font-data font-medium"
+                  onClick={() => setDiscount(amt)}
+                >
+                  ${amt}
+                </Button>
+              ))}
+        </div>
+      </div>
+
+      <Divider />
+
+      <div className="space-y-1.5">
+        <div className="flex justify-between text-sm text-muted-foreground font-data">
+          <span>{t('cart.subtotal')}</span>
+          <span className="text-foreground">{formatCurrency(totals.subtotal)}</span>
+        </div>
+        {totals.discountAmount > 0 && (
+          <div className="flex justify-between text-sm text-danger font-data">
+            <span>
+              {t('cart.discount')}
+              <span className="text-xs ms-1 opacity-70">
+                ({discountType === 'percentage' ? `${discount}%` : formatCurrency(discount)})
+              </span>
+            </span>
+            <span>-{formatCurrency(totals.discountAmount)}</span>
+          </div>
+        )}
+        {tax.enabled && (
+          <div className="flex justify-between text-sm text-muted-foreground font-data">
+            <span>
+              {t('tax.vat')}
+              <span className="text-xs ms-1 opacity-70">({tax.rate}%)</span>
+            </span>
+            <span className="text-foreground">{formatCurrency(totals.taxAmount)}</span>
+          </div>
+        )}
+        {totals.tip > 0 && (
+          <div className="flex justify-between text-sm text-primary font-data">
+            <span>{t('cart.tip')}</span>
+            <span>+{formatCurrency(totals.tip)}</span>
+          </div>
+        )}
+        {/* The SAME `amountDue` the checkout drawer and customer display
+            use -- never a separately-derived figure (Unit 5 parity). */}
+        <div className="flex justify-between text-lg font-semibold font-data text-foreground">
+          <span>{t('cart.total')}</span>
+          {/* E2E: the amount is a nameless sibling of its label, and "Total" renders
+              simultaneously here, in the checkout drawer and on the receipt. */}
+          <span data-testid="cart-total" className="text-primary font-bold">
+            {formatCurrency(totals.amountDue)}
+          </span>
+        </div>
+      </div>
+
+      <Button
+        color="primary"
+        size="md"
+        className="w-full font-semibold shadow-sm"
+        onClick={onCheckout}
+        isDisabled={checkoutDisabled}
+      >
+        {t('cart.checkout')}
+      </Button>
+    </div>
+  );
+}

--- a/client/src/features/pos/components/checkout/CartLineItem.tsx
+++ b/client/src/features/pos/components/checkout/CartLineItem.tsx
@@ -1,0 +1,114 @@
+/**
+ * One line of the cart: name, per-unit price, optional memo, quantity stepper
+ * and line total. Presentation only — every mutation is a callback up to the
+ * cart store. Extracted from CartPanel (issue #51); markup unchanged.
+ */
+import { Button, Input } from '@heroui/react';
+import { Minus, Plus, X, Pencil } from 'lucide-react';
+import { formatCurrency } from '../../../../shared/lib/utils';
+import { useTranslation } from '../../../../shared/i18n/index';
+import { lineKey } from '../../lib/cartLines';
+import type { CartItem } from '../../store/cartStore';
+
+export default function CartLineItem({
+  item,
+  isEditingMemo,
+  onStartEditingMemo,
+  onCommitMemo,
+  onQuantityChange,
+  onRemove,
+}: {
+  item: CartItem;
+  isEditingMemo: boolean;
+  onStartEditingMemo: () => void;
+  onCommitMemo: (memo: string) => void;
+  onQuantityChange: (quantity: number) => void;
+  onRemove: () => void;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      /* E2E: a cart line has no role and shows only the product name, so there is
+         no accessible name to scope its per-line controls by. */
+      data-testid={`cart-line-${lineKey(item)}`}
+      className="flex items-center gap-3 p-3 bg-muted/20 hover:bg-muted/40 transition-colors rounded-lg border border-border/50"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <p className="text-sm font-medium text-foreground truncate">{item.name}</p>
+          <button
+            onClick={onStartEditingMemo}
+            className="p-0.5 rounded hover:bg-background transition-colors"
+            title={t('cart.addMemo')}
+          >
+            <Pencil className={`h-3 w-3 ${item.memo ? 'text-primary' : 'text-muted-foreground'}`} />
+          </button>
+        </div>
+        <p className="text-xs text-muted-foreground font-data">{formatCurrency(item.unit_price)}</p>
+        {item.memo && <p className="text-xs text-primary/80 mt-0.5">{item.memo}</p>}
+        {isEditingMemo && (
+          <Input
+            autoFocus
+            size="sm"
+            variant="bordered"
+            placeholder={t('cart.memoPlaceholder')}
+            defaultValue={item.memo || ''}
+            className="mt-1"
+            onBlur={(e) => onCommitMemo(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                onCommitMemo((e.target as HTMLInputElement).value);
+              }
+            }}
+          />
+        )}
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          isIconOnly
+          variant="light"
+          size="sm"
+          className="h-7 w-7"
+          onClick={() => onQuantityChange(item.quantity - 1)}
+          aria-label="Decrease quantity"
+        >
+          <Minus className="h-3.5 w-3.5 text-primary" />
+        </Button>
+        {/* E2E: a bare number with no accessible name. The +/- buttons are
+            reachable by aria-label; the value itself is not. */}
+        <span
+          data-testid="cart-line-qty"
+          className="w-7 text-center text-sm font-data font-medium text-foreground"
+        >
+          {item.quantity}
+        </span>
+        <Button
+          isIconOnly
+          variant="light"
+          size="sm"
+          className="h-7 w-7"
+          onClick={() => onQuantityChange(item.quantity + 1)}
+          isDisabled={item.quantity >= item.stock}
+          aria-label="Increase quantity"
+        >
+          <Plus className="h-3.5 w-3.5 text-primary" />
+        </Button>
+      </div>
+      <p className="text-sm font-semibold font-data w-20 text-end text-foreground">
+        {formatCurrency(item.unit_price * item.quantity)}
+      </p>
+      <Button
+        isIconOnly
+        variant="light"
+        color="danger"
+        size="sm"
+        className="h-7 w-7"
+        onClick={onRemove}
+        aria-label="Remove item"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/client/src/features/pos/components/checkout/CheckoutDrawer.tsx
+++ b/client/src/features/pos/components/checkout/CheckoutDrawer.tsx
@@ -1,0 +1,316 @@
+/**
+ * The checkout drawer: review the sale, attach a customer, redeem points,
+ * apply a coupon, adjust discount/tip/notes, choose how it is paid, confirm.
+ *
+ * It composes the focused sections around it and holds no financial state of
+ * its own — `pricing` is the single authority for every figure shown here.
+ * Extracted from CartPanel (issue #51); markup and ordering unchanged.
+ */
+import {
+  Button,
+  Input,
+  Divider,
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerBody,
+} from '@heroui/react';
+import { Percent, StickyNote, Ticket, X } from 'lucide-react';
+import { formatCurrency } from '../../../../shared/lib/utils';
+import { useTranslation } from '../../../../shared/i18n/index';
+import type { DiscountType } from '../../../../shared/lib/checkout';
+import type { CheckoutPricing } from '../../hooks/useCheckoutPricing';
+import type { CouponApplication } from '../../hooks/useCouponApplication';
+import type { CustomerSelection } from '../../hooks/useCustomerSelection';
+import type { CartItem } from '../../store/cartStore';
+import type { PaymentEntry, PaymentMethod } from '../../types';
+import CheckoutSummary from './CheckoutSummary';
+import CustomerSection from './CustomerSection';
+import LoyaltySection from './LoyaltySection';
+import PaymentSection from './PaymentSection';
+
+const QUICK_DISCOUNT_PRESETS = [5, 10, 15];
+
+export default function CheckoutDrawer({
+  isOpen,
+  onOpenChange,
+  isRtl,
+  items,
+  discount,
+  discountType,
+  setDiscount,
+  setDiscountType,
+  notes,
+  setNotes,
+  tip,
+  setTip,
+  couponCode,
+  couponDiscount,
+  coupon,
+  pricing,
+  customer,
+  onRemoveCustomer,
+  paymentMethod,
+  setPaymentMethod,
+  splitPayment,
+  setSplitPayment,
+  payments,
+  setPayments,
+  onConfirm,
+  isPending,
+  needsReview,
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  isRtl: boolean;
+  items: CartItem[];
+  discount: number;
+  discountType: DiscountType;
+  setDiscount: (value: number) => void;
+  setDiscountType: (type: DiscountType) => void;
+  notes: string;
+  setNotes: (notes: string) => void;
+  tip: number;
+  setTip: (tip: number) => void;
+  couponCode: string;
+  couponDiscount: number;
+  coupon: CouponApplication;
+  pricing: CheckoutPricing;
+  customer: CustomerSelection;
+  onRemoveCustomer: () => void;
+  paymentMethod: PaymentMethod;
+  setPaymentMethod: (method: PaymentMethod) => void;
+  splitPayment: boolean;
+  setSplitPayment: (on: boolean) => void;
+  payments: PaymentEntry[];
+  setPayments: (payments: PaymentEntry[]) => void;
+  onConfirm: () => void;
+  isPending: boolean;
+  needsReview: boolean;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+  const { tax, loyalty, totals, split, maxPoints } = pricing;
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      placement={isRtl ? 'left' : 'right'}
+      backdrop="blur"
+      size="md"
+      classNames={{
+        base: 'bg-card text-card-foreground border-s border-border shadow-2xl',
+      }}
+    >
+      <DrawerContent>
+        {() => (
+          <>
+            <DrawerHeader className="border-b border-border/50">
+              <div>
+                <h3 className="text-base font-semibold">{t('cart.completeSale')}</h3>
+                <p className="text-xs text-muted-foreground font-normal mt-0.5">
+                  {t('cart.reviewSale')}
+                </p>
+              </div>
+            </DrawerHeader>
+            <DrawerBody className="py-6 space-y-6 overflow-y-auto">
+              <CheckoutSummary
+                items={items}
+                discount={discount}
+                discountType={discountType}
+                couponCode={couponCode}
+                tax={tax}
+                totals={totals}
+              />
+
+              <Divider />
+
+              <CustomerSection
+                customer={customer}
+                loyalty={loyalty}
+                onRemoveSelected={onRemoveCustomer}
+              />
+
+              {loyalty.enabled && customer.selected && (
+                <>
+                  <Divider />
+                  <LoyaltySection
+                    loyalty={loyalty}
+                    totals={totals}
+                    maxPoints={maxPoints}
+                    redeemPoints={pricing.redeemPoints}
+                    pointsToRedeem={pricing.pointsToRedeem}
+                    setRedeemPoints={pricing.setRedeemPoints}
+                    setPointsToRedeem={pricing.setPointsToRedeem}
+                  />
+                </>
+              )}
+
+              {/* Coupon */}
+              <Divider />
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+                  <Ticket className="h-3.5 w-3.5 text-primary" />
+                  {t('cart.coupon')}
+                </h3>
+                {couponCode ? (
+                  <div className="flex items-center justify-between p-3 bg-primary/10 rounded-xl border border-primary/30">
+                    <div>
+                      <p className="text-sm font-bold font-data text-foreground">{couponCode}</p>
+                      <p className="text-xs text-primary font-data">
+                        -{formatCurrency(couponDiscount)}
+                      </p>
+                    </div>
+                    <Button
+                      isIconOnly
+                      variant="light"
+                      size="sm"
+                      className="h-7 w-7"
+                      onClick={coupon.remove}
+                      aria-label="Remove coupon"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex gap-2 items-center">
+                    <Input
+                      size="sm"
+                      variant="bordered"
+                      placeholder={t('cart.couponPlaceholder')}
+                      value={coupon.input}
+                      onValueChange={coupon.setInput}
+                      className="flex-1"
+                    />
+                    <Button variant="bordered" size="sm" onClick={coupon.apply}>
+                      {t('cart.applyCoupon')}
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {/* Quick Discount -- writes ONLY into the manual discount/discount_type
+                  state, never `tip`. This is the fix for the historical bug
+                  where these buttons silently wrote a "discount" amount
+                  into the tip field (see Unit 3/5 of
+                  docs/plans/2026-08-30-001-fix-pos-checkout-total-parity-plan.md). */}
+              <Divider />
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+                  <Percent className="h-3.5 w-3.5 text-primary" />
+                  {t('cart.quickDiscount')}
+                </h3>
+                <div className="flex gap-1.5 items-center">
+                  {QUICK_DISCOUNT_PRESETS.map((pct) => (
+                    <Button
+                      key={pct}
+                      size="sm"
+                      variant={
+                        discountType === 'percentage' && discount === pct ? 'solid' : 'bordered'
+                      }
+                      color={
+                        discountType === 'percentage' && discount === pct ? 'primary' : 'default'
+                      }
+                      className="flex-1 h-7 min-w-0 text-[11px] font-data font-medium"
+                      onClick={() => {
+                        setDiscountType('percentage');
+                        setDiscount(pct);
+                      }}
+                    >
+                      {pct}%
+                    </Button>
+                  ))}
+                  <Input
+                    type="number"
+                    min="0"
+                    max={discountType === 'percentage' ? 100 : undefined}
+                    step="0.01"
+                    size="sm"
+                    variant="bordered"
+                    placeholder={t('cart.customAmount')}
+                    aria-label={t('cart.quickDiscount')}
+                    value={discountType === 'percentage' && discount ? String(discount) : ''}
+                    onValueChange={(val) => {
+                      setDiscountType('percentage');
+                      setDiscount(parseFloat(val) || 0);
+                    }}
+                    className="flex-1 font-data"
+                  />
+                </div>
+              </div>
+
+              {/* Tip -- its own, separately labeled, always-positive control.
+                  Never written to by Quick Discount above. Rendered as an
+                  added line (`+`) in the summary and in the receipt. */}
+              <Divider />
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+                  <StickyNote className="h-3.5 w-3.5 text-primary" />
+                  {t('cart.tip')}
+                </h3>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  size="sm"
+                  variant="bordered"
+                  placeholder={t('cart.customTip')}
+                  aria-label={t('cart.tip')}
+                  value={tip ? String(tip) : ''}
+                  onValueChange={(val) => setTip(Math.max(0, parseFloat(val) || 0))}
+                  className="font-data"
+                />
+              </div>
+
+              {/* Sale Notes */}
+              <Divider />
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+                  <StickyNote className="h-3.5 w-3.5 text-primary" />
+                  {t('cart.notes')}
+                </h3>
+                <textarea
+                  placeholder={t('cart.notesPlaceholder')}
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  rows={2}
+                  className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                  maxLength={500}
+                />
+              </div>
+
+              <Divider />
+
+              <PaymentSection
+                paymentMethod={paymentMethod}
+                setPaymentMethod={setPaymentMethod}
+                splitPayment={splitPayment}
+                setSplitPayment={setSplitPayment}
+                payments={payments}
+                setPayments={setPayments}
+                split={split}
+                totals={totals}
+              />
+
+              {/* `shrink-0` is load-bearing, not cosmetic. This button is the last child
+                  of a flex-column DrawerBody, and once the drawer's content is taller
+                  than the viewport the default `flex-shrink: 1` compresses it to zero
+                  height — leaving a cashier unable to complete a sale on any screen
+                  under roughly 1000px tall. Covered by checkout-cash.spec.ts. */}
+              <Button
+                color="primary"
+                size="md"
+                className="w-full shrink-0 font-semibold shadow-sm"
+                onClick={onConfirm}
+                isDisabled={isPending || needsReview || (splitPayment && !split.isBalanced)}
+                isLoading={isPending}
+              >
+                {isPending ? t('cart.processing') : t('cart.confirmSale')}
+              </Button>
+            </DrawerBody>
+          </>
+        )}
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/client/src/features/pos/components/checkout/CheckoutSummary.test.tsx
+++ b/client/src/features/pos/components/checkout/CheckoutSummary.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useSettingsStore } from '../../../../shared/store/settingsStore';
+import type { CartItem } from '../../store/cartStore';
+import CheckoutSummary from './CheckoutSummary';
+
+/**
+ * REGRESSION (PR #76 review, finding 15): these rows used to be keyed on
+ * `item.product_id` alone, while the cart itself keys a line by
+ * (product_id, variant_id). A cart holding two variants of one product
+ * therefore emitted duplicate React keys, and React may then reconcile a row
+ * against the wrong element and show a stale quantity or price.
+ *
+ * Which assertion below actually catches it, verified by reverting the fix:
+ * only "gives each variant a distinct React key". The two content assertions
+ * pass either way -- with duplicate keys React still recovers for this shape
+ * of update, and whether it does depends on internals no test should depend
+ * on. They are kept as documentation of what the section must show, not as
+ * the guard. Do not delete the key assertion believing them to cover it.
+ */
+
+const SILK_DRESS_SMALL: CartItem = {
+  product_id: 7,
+  variant_id: 3,
+  name: 'Silk Dress',
+  unit_price: 250,
+  quantity: 2,
+  stock: 5,
+};
+
+const SILK_DRESS_LARGE: CartItem = {
+  product_id: 7,
+  variant_id: 9,
+  name: 'Silk Dress',
+  unit_price: 300,
+  quantity: 1,
+  stock: 5,
+};
+
+/** A breakdown is required but irrelevant here — the rows above it are what is under test. */
+function totalsFor(items: CartItem[]) {
+  const subtotal = items.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
+  return {
+    subtotal,
+    discountAmount: 0,
+    couponDiscount: 0,
+    netOfDiscounts: subtotal,
+    taxAmount: 0,
+    totalWithTax: subtotal,
+    pointsDiscount: 0,
+    tip: 0,
+    amountDue: subtotal,
+    earnedPoints: 0,
+  };
+}
+
+function renderSummary(items: CartItem[]) {
+  return render(
+    <CheckoutSummary
+      items={items}
+      discount={0}
+      discountType="fixed"
+      couponCode=""
+      tax={{ enabled: false, rate: 0, mode: 'exclusive' }}
+      totals={totalsFor(items)}
+    />
+  );
+}
+
+describe('CheckoutSummary line keys', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  // Documentation of intent -- passes with or without the fix (see file header).
+  it('renders two variants of the same product as two lines, each with its own values', () => {
+    renderSummary([SILK_DRESS_SMALL, SILK_DRESS_LARGE]);
+
+    expect(screen.getByText('Silk Dress x2')).toBeInTheDocument();
+    expect(screen.getByText('Silk Dress x1')).toBeInTheDocument();
+    // 2 x 250 and 1 x 300 -- neither line borrows the other's figure.
+    expect(screen.getByText('500 EG')).toBeInTheDocument();
+    expect(screen.getByText('300 EG')).toBeInTheDocument();
+  });
+
+  it('gives each variant a distinct React key', () => {
+    renderSummary([SILK_DRESS_SMALL, SILK_DRESS_LARGE]);
+
+    // THE guard for finding 15. React warns "Encountered two children with the
+    // same key" on a duplicate, which is the defect itself surfacing rather
+    // than a cosmetic complaint -- and it is the only assertion here that goes
+    // red if the key regresses to a bare `product_id`.
+    const warnings = (consoleError.mock.calls as unknown[][]).map((args) => String(args[0]));
+    expect(warnings.filter((message) => message.includes('same key'))).toEqual([]);
+  });
+
+  // Also documentation of intent -- see the file header on why this survives
+  // the bug. It pins the rendered behaviour, not the keying.
+  it('updates the right line when one variant changes, instead of reconciling against its sibling', () => {
+    const items = [SILK_DRESS_SMALL, SILK_DRESS_LARGE];
+    const { rerender } = renderSummary(items);
+
+    const updated = [SILK_DRESS_SMALL, { ...SILK_DRESS_LARGE, quantity: 4 }];
+    rerender(
+      <CheckoutSummary
+        items={updated}
+        discount={0}
+        discountType="fixed"
+        couponCode=""
+        tax={{ enabled: false, rate: 0, mode: 'exclusive' }}
+        totals={totalsFor(updated)}
+      />
+    );
+
+    // The changed variant, and only it, moved: 4 x 300 = 1200; the other line
+    // still reads 2 x 250 = 500.
+    expect(screen.getByText('Silk Dress x4')).toBeInTheDocument();
+    expect(screen.getByText('1,200 EG')).toBeInTheDocument();
+    expect(screen.getByText('Silk Dress x2')).toBeInTheDocument();
+    expect(screen.getByText('500 EG')).toBeInTheDocument();
+    expect(screen.queryByText('Silk Dress x1')).not.toBeInTheDocument();
+  });
+
+  it('still renders a plain single-variant cart', () => {
+    renderSummary([{ ...SILK_DRESS_SMALL, variant_id: null }]);
+
+    expect(screen.getByText('Silk Dress x2')).toBeInTheDocument();
+    expect(screen.getAllByText('500 EG').length).toBeGreaterThan(0);
+  });
+});

--- a/client/src/features/pos/components/checkout/CheckoutSummary.tsx
+++ b/client/src/features/pos/components/checkout/CheckoutSummary.tsx
@@ -1,0 +1,97 @@
+/**
+ * The drawer's order summary: the lines being sold and the full breakdown.
+ * Renders the same `totals` object the cart footer does — no figure here is
+ * derived locally. Extracted from CartPanel (issue #51); markup unchanged.
+ */
+import { Divider } from '@heroui/react';
+import { formatCurrency } from '../../../../shared/lib/utils';
+import { useTranslation } from '../../../../shared/i18n/index';
+import type { TaxSettings, Totals, DiscountType } from '../../../../shared/lib/checkout';
+import type { CartItem } from '../../store/cartStore';
+
+export default function CheckoutSummary({
+  items,
+  discount,
+  discountType,
+  couponCode,
+  tax,
+  totals,
+}: {
+  items: CartItem[];
+  discount: number;
+  discountType: DiscountType;
+  couponCode: string;
+  tax: TaxSettings;
+  totals: Totals;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {t('cart.orderSummary')}
+      </h3>
+      {items.map((item) => (
+        <div key={item.product_id} className="flex justify-between text-sm font-data">
+          <span className="text-foreground">
+            {item.name} x{item.quantity}
+          </span>
+          <span className="text-foreground font-medium">
+            {formatCurrency(item.unit_price * item.quantity)}
+          </span>
+        </div>
+      ))}
+      <Divider className="my-2" />
+      <div className="flex justify-between text-sm text-muted-foreground font-data">
+        <span>{t('cart.subtotal')}</span>
+        <span className="text-foreground">{formatCurrency(totals.subtotal)}</span>
+      </div>
+      {totals.discountAmount > 0 && (
+        <div className="flex justify-between text-sm text-danger font-data">
+          <span>
+            {t('cart.discount')}
+            <span className="text-xs ms-1 opacity-70">
+              ({discountType === 'percentage' ? `${discount}%` : formatCurrency(discount)})
+            </span>
+          </span>
+          <span>-{formatCurrency(totals.discountAmount)}</span>
+        </div>
+      )}
+      {tax.enabled && (
+        <div className="flex justify-between text-sm text-muted-foreground font-data">
+          <span>
+            {t('tax.vat')} ({tax.rate}%)
+          </span>
+          <span className="text-foreground">{formatCurrency(totals.taxAmount)}</span>
+        </div>
+      )}
+      {totals.couponDiscount > 0 && (
+        <div className="flex justify-between text-sm text-primary font-data">
+          <span>
+            {t('cart.coupon')} ({couponCode})
+          </span>
+          <span>-{formatCurrency(totals.couponDiscount)}</span>
+        </div>
+      )}
+      {totals.pointsDiscount > 0 && (
+        <div className="flex justify-between text-sm text-primary font-data">
+          <span>{t('loyalty.pointsDiscount')}</span>
+          <span>-{formatCurrency(totals.pointsDiscount)}</span>
+        </div>
+      )}
+      {totals.tip > 0 && (
+        <div className="flex justify-between text-sm text-primary font-data">
+          <span>{t('cart.tip')}</span>
+          <span>+{formatCurrency(totals.tip)}</span>
+        </div>
+      )}
+      <div className="flex justify-between text-base font-bold font-data text-foreground">
+        <span>{t('cart.total')}</span>
+        {/* E2E: see cart-total — same nameless sibling, same label collision. */}
+        <span data-testid="checkout-total" className="text-primary">
+          {formatCurrency(totals.amountDue)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/pos/components/checkout/CheckoutSummary.tsx
+++ b/client/src/features/pos/components/checkout/CheckoutSummary.tsx
@@ -7,6 +7,7 @@ import { Divider } from '@heroui/react';
 import { formatCurrency } from '../../../../shared/lib/utils';
 import { useTranslation } from '../../../../shared/i18n/index';
 import type { TaxSettings, Totals, DiscountType } from '../../../../shared/lib/checkout';
+import { lineKey } from '../../lib/cartLines';
 import type { CartItem } from '../../store/cartStore';
 
 export default function CheckoutSummary({
@@ -32,7 +33,11 @@ export default function CheckoutSummary({
         {t('cart.orderSummary')}
       </h3>
       {items.map((item) => (
-        <div key={item.product_id} className="flex justify-between text-sm font-data">
+        /* Keyed by product AND variant, like every other cart surface -- the
+           cart legitimately holds two variants of one product, and keying on
+           `product_id` alone gave them duplicate keys, letting React reconcile
+           a line against its sibling and show a stale quantity or price. */
+        <div key={lineKey(item)} className="flex justify-between text-sm font-data">
           <span className="text-foreground">
             {item.name} x{item.quantity}
           </span>

--- a/client/src/features/pos/components/checkout/CustomerSection.tsx
+++ b/client/src/features/pos/components/checkout/CustomerSection.tsx
@@ -1,0 +1,138 @@
+/**
+ * Attaching a customer to the sale: the selected card, the create-new form, or
+ * the search box with its dropdown. All state lives in `useCustomerSelection`;
+ * this renders it. Extracted from CartPanel (issue #51); markup unchanged.
+ */
+import { Button, Input } from '@heroui/react';
+import { Plus, Search, Star, UserRound, X } from 'lucide-react';
+import { useTranslation } from '../../../../shared/i18n/index';
+import type { CustomerSelection } from '../../hooks/useCustomerSelection';
+import type { LoyaltyState } from '../../hooks/useCheckoutPricing';
+
+export default function CustomerSection({
+  customer,
+  loyalty,
+  onRemoveSelected,
+}: {
+  customer: CustomerSelection;
+  loyalty: LoyaltyState;
+  /** Drops the customer AND any redemption that depended on them. */
+  onRemoveSelected: () => void;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {t('cart.selectCustomer')}
+      </h3>
+      {customer.selected ? (
+        <div className="flex items-center gap-2 p-3 bg-muted/20 rounded-xl border border-border/50">
+          <UserRound className="h-4 w-4 text-primary shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">{customer.selected.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {customer.selected.phone}
+              {loyalty.enabled && (
+                <span className="ms-2 text-primary font-semibold">
+                  <Star className="h-3 w-3 inline-block" />{' '}
+                  {t('loyalty.pointsBalance', { points: String(loyalty.customerPoints) })}
+                </span>
+              )}
+            </p>
+          </div>
+          <Button
+            isIconOnly
+            variant="light"
+            size="sm"
+            className="h-7 w-7 shrink-0"
+            onClick={onRemoveSelected}
+            aria-label="Remove selected customer"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : customer.creating ? (
+        <div className="space-y-2.5 p-3 bg-muted/20 rounded-xl border border-border/50">
+          <Input
+            size="sm"
+            variant="bordered"
+            placeholder={t('cart.customerName')}
+            value={customer.newName}
+            onValueChange={customer.setNewName}
+          />
+          <Input
+            size="sm"
+            variant="bordered"
+            placeholder={t('cart.customerPhone')}
+            value={customer.newPhone}
+            onValueChange={customer.setNewPhone}
+          />
+          <div className="flex gap-2">
+            <Button
+              color="primary"
+              size="sm"
+              className="flex-1 text-xs"
+              isDisabled={
+                !customer.newName.trim() || !customer.newPhone.trim() || customer.isSaving
+              }
+              isLoading={customer.isSaving}
+              onClick={customer.createAndSelect}
+            >
+              {t('cart.saveCustomer')}
+            </Button>
+            <Button variant="flat" size="sm" className="text-xs" onClick={customer.cancelCreating}>
+              {t('common.cancel')}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="relative">
+            <Input
+              size="sm"
+              variant="bordered"
+              placeholder={t('cart.searchCustomer')}
+              value={customer.search}
+              onValueChange={(val) => {
+                customer.setSearch(val);
+                customer.setDropdownOpen(true);
+              }}
+              onFocus={() => customer.setDropdownOpen(true)}
+              startContent={<Search className="h-3.5 w-3.5 text-muted-foreground" />}
+            />
+            {customer.dropdownOpen && customer.search.length > 0 && (
+              <div className="absolute z-20 top-full mt-1 w-full bg-card border border-border rounded-xl shadow-lg max-h-40 overflow-y-auto divide-y divide-border/50">
+                {customer.matches && customer.matches.length > 0 ? (
+                  customer.matches.map((c) => (
+                    <button
+                      key={c.id}
+                      type="button"
+                      className="w-full text-start px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
+                      onClick={() => customer.select(c)}
+                    >
+                      <span className="font-medium text-foreground">{c.name}</span>
+                      <span className="text-muted-foreground text-xs ms-2">{c.phone}</span>
+                    </button>
+                  ))
+                ) : (
+                  <p className="px-3 py-2 text-xs text-muted-foreground">{t('cart.noCustomer')}</p>
+                )}
+              </div>
+            )}
+          </div>
+          <Button
+            variant="light"
+            color="primary"
+            size="sm"
+            className="w-full text-xs"
+            startContent={<Plus className="h-3 w-3" />}
+            onClick={customer.startCreating}
+          >
+            {t('cart.addNewCustomer')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/pos/components/checkout/LoyaltySection.tsx
+++ b/client/src/features/pos/components/checkout/LoyaltySection.tsx
@@ -1,0 +1,88 @@
+/**
+ * Spending loyalty points on this sale.
+ *
+ * The cap (`maxPoints`) and the resulting discount are computed by
+ * `useCheckoutPricing`; this control only reads them and clamps the cashier's
+ * typing to the cap. Extracted from CartPanel (issue #51); markup unchanged.
+ */
+import { Input } from '@heroui/react';
+import { Star } from 'lucide-react';
+import { formatCurrency } from '../../../../shared/lib/utils';
+import { useTranslation } from '../../../../shared/i18n/index';
+import type { Totals } from '../../../../shared/lib/checkout';
+import type { LoyaltyState } from '../../hooks/useCheckoutPricing';
+
+export default function LoyaltySection({
+  loyalty,
+  totals,
+  maxPoints,
+  redeemPoints,
+  pointsToRedeem,
+  setRedeemPoints,
+  setPointsToRedeem,
+}: {
+  loyalty: LoyaltyState;
+  totals: Totals;
+  maxPoints: number;
+  redeemPoints: boolean;
+  pointsToRedeem: number;
+  setRedeemPoints: (on: boolean) => void;
+  setPointsToRedeem: (points: number) => void;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+        <Star className="h-3.5 w-3.5 text-primary" />
+        {t('loyalty.redeemPoints')}
+      </h3>
+      <div className="flex items-center justify-between p-3 bg-muted/20 rounded-xl border border-border/50">
+        <div>
+          <p className="text-sm font-medium text-foreground">{t('loyalty.points')}</p>
+          <p className="text-base font-bold text-primary font-data">{loyalty.customerPoints}</p>
+        </div>
+        {loyalty.customerPoints > 0 && (
+          <div className="flex items-center gap-2">
+            <label htmlFor="redeem-toggle" className="text-xs text-muted-foreground cursor-pointer">
+              {t('loyalty.redeemToggle')}
+            </label>
+            <input
+              id="redeem-toggle"
+              type="checkbox"
+              checked={redeemPoints}
+              onChange={(e) => {
+                setRedeemPoints(e.target.checked);
+                if (!e.target.checked) setPointsToRedeem(0);
+              }}
+              className="accent-primary h-4 w-4 rounded"
+            />
+          </div>
+        )}
+      </div>
+      {redeemPoints && loyalty.customerPoints > 0 && (
+        <div className="space-y-2">
+          <Input
+            type="number"
+            label={t('loyalty.pointsToRedeem')}
+            min="0"
+            size="sm"
+            variant="bordered"
+            max={maxPoints}
+            value={pointsToRedeem ? String(pointsToRedeem) : ''}
+            onValueChange={(val) => {
+              const v = Math.min(Math.max(0, parseInt(val) || 0), maxPoints);
+              setPointsToRedeem(v);
+            }}
+            className="font-data w-36"
+          />
+          {totals.pointsDiscount > 0 && (
+            <p className="text-xs text-primary font-data font-semibold">
+              = -{formatCurrency(totals.pointsDiscount)} {t('loyalty.pointsDiscount')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/pos/components/checkout/PaymentSection.tsx
+++ b/client/src/features/pos/components/checkout/PaymentSection.tsx
@@ -1,0 +1,159 @@
+/**
+ * How the sale is tendered: one method, or a split across several.
+ *
+ * The running "allocated / due" figure and whether the split balances are both
+ * decided by `useCheckoutPricing`'s `split`; this component never compares
+ * amounts itself. Extracted from CartPanel (issue #51); markup unchanged.
+ */
+import { Button, Input, RadioGroup, Radio } from '@heroui/react';
+import { Plus, X } from 'lucide-react';
+import { formatCurrency } from '../../../../shared/lib/utils';
+import { useTranslation } from '../../../../shared/i18n/index';
+import type { Allocation, Totals } from '../../../../shared/lib/checkout';
+import type { PaymentEntry, PaymentMethod } from '../../types';
+
+export default function PaymentSection({
+  paymentMethod,
+  setPaymentMethod,
+  splitPayment,
+  setSplitPayment,
+  payments,
+  setPayments,
+  split,
+  totals,
+}: {
+  paymentMethod: PaymentMethod;
+  setPaymentMethod: (method: PaymentMethod) => void;
+  splitPayment: boolean;
+  setSplitPayment: (on: boolean) => void;
+  payments: PaymentEntry[];
+  setPayments: (payments: PaymentEntry[]) => void;
+  split: Allocation;
+  totals: Totals;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+
+  const paymentLabels: Record<PaymentMethod | 'Gift Card', string> = {
+    Cash: t('cart.cash'),
+    Card: t('cart.card'),
+    Other: t('cart.other'),
+    'Gift Card': t('cart.giftCard'),
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          {t('cart.paymentMethod')}
+        </h3>
+        <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+          <input
+            type="checkbox"
+            checked={splitPayment}
+            onChange={(e) => {
+              setSplitPayment(e.target.checked);
+              if (e.target.checked) {
+                setPayments([
+                  { method: 'Cash', amount: 0 },
+                  { method: 'Card', amount: 0 },
+                ]);
+              } else {
+                setPayments([]);
+              }
+            }}
+            className="accent-primary h-3.5 w-3.5 rounded"
+          />
+          {t('cart.splitPayment')}
+        </label>
+      </div>
+
+      {!splitPayment ? (
+        <RadioGroup
+          value={paymentMethod}
+          onValueChange={(val: string) => setPaymentMethod(val as PaymentMethod)}
+          className="space-y-1.5"
+        >
+          {(['Cash', 'Card', 'Other'] as const).map((method) => (
+            <Radio
+              key={method}
+              value={method}
+              classNames={{
+                base: `flex items-center gap-3 px-3 py-2 rounded-xl border transition-colors cursor-pointer max-w-full m-0 ${
+                  paymentMethod === method
+                    ? 'border-primary/50 bg-primary/5'
+                    : 'border-border hover:border-primary/30'
+                }`,
+                label: 'text-sm font-medium text-foreground cursor-pointer',
+              }}
+            >
+              {paymentLabels[method]}
+            </Radio>
+          ))}
+        </RadioGroup>
+      ) : (
+        <div className="space-y-2">
+          {payments.map((p, idx) => (
+            <div key={idx} className="flex gap-2 items-center">
+              <select
+                className="h-8 rounded-lg border border-border bg-card text-foreground px-2 text-xs"
+                value={p.method}
+                onChange={(e) => {
+                  const next = [...payments];
+                  next[idx] = { ...next[idx], method: e.target.value as PaymentMethod };
+                  setPayments(next);
+                }}
+              >
+                <option value="Cash">{t('cart.cash')}</option>
+                <option value="Card">{t('cart.card')}</option>
+                <option value="Gift Card">{t('cart.giftCard')}</option>
+                <option value="Other">{t('cart.other')}</option>
+              </select>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                size="sm"
+                variant="bordered"
+                aria-label={`${paymentLabels[p.method] ?? p.method} ${t('cart.splitPayment')} #${idx + 1}`}
+                value={p.amount ? String(p.amount) : ''}
+                onValueChange={(val) => {
+                  const next = [...payments];
+                  next[idx] = { ...next[idx], amount: parseFloat(val) || 0 };
+                  setPayments(next);
+                }}
+                className="flex-1 font-data"
+              />
+              {payments.length > 2 && (
+                <Button
+                  isIconOnly
+                  variant="light"
+                  size="sm"
+                  className="h-7 w-7"
+                  onClick={() => setPayments(payments.filter((_, i) => i !== idx))}
+                  aria-label="Remove payment split"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+          ))}
+          <div className="flex items-center justify-between text-xs pt-1">
+            <Button
+              variant="light"
+              size="sm"
+              startContent={<Plus className="h-3 w-3" />}
+              onClick={() => setPayments([...payments, { method: 'Cash', amount: 0 }])}
+            >
+              {t('cart.addPayment')}
+            </Button>
+            <span
+              className={`font-data font-semibold ${split.isBalanced ? 'text-success' : 'text-danger'}`}
+            >
+              {formatCurrency(split.allocated)} / {formatCurrency(totals.amountDue)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/pos/hooks/useCheckoutPricing.test.tsx
+++ b/client/src/features/pos/hooks/useCheckoutPricing.test.tsx
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '../../../shared/lib/transport/index';
+import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
+import { useCartStore } from '../store/cartStore';
+import { useCheckoutPricing } from './useCheckoutPricing';
+import type { PaymentEntry } from '../types';
+
+/**
+ * The acceptance criterion for issue #51 is that checkout CALCULATION can be
+ * tested without rendering the POS screen. Everything below drives the hook
+ * directly — no CartPanel, no drawer, no POS page.
+ */
+
+const SILK_DRESS = {
+  product_id: 7,
+  name: 'Silk Dress',
+  unit_price: 250,
+  quantity: 2,
+  stock: 5,
+};
+
+function transportWith(settings: Record<string, string>, loyaltyPoints = 200): MemoryTransport {
+  return createMemoryTransport(
+    { customers: [{ id: 1, name: 'Amina', phone: '0100000000' }] },
+    { reads: { settings, 'customers/1/loyalty': { points: loyaltyPoints } } }
+  );
+}
+
+function wrapperFor(transport: MemoryTransport) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderPricing(
+  transport: MemoryTransport,
+  props: { customerId?: number | null; payments?: PaymentEntry[] } = {}
+) {
+  return renderHook(
+    (p: { customerId?: number | null; payments?: PaymentEntry[] }) =>
+      useCheckoutPricing({ customerId: p.customerId ?? null, payments: p.payments ?? [] }),
+    { wrapper: wrapperFor(transport), initialProps: props }
+  );
+}
+
+const NO_TAX_NO_LOYALTY = { tax_enabled: 'false', loyalty_enabled: 'false' };
+
+describe('useCheckoutPricing', () => {
+  beforeEach(() => {
+    useCartStore.setState({
+      items: [SILK_DRESS],
+      discount: 0,
+      discountType: 'fixed',
+      notes: '',
+      tip: 0,
+      couponCode: '',
+      couponDiscount: 0,
+      needsReview: false,
+      checkoutAttempt: null,
+    });
+  });
+
+  it('derives the amount due from the cart alone when tax and loyalty are off', async () => {
+    const { result } = renderPricing(transportWith(NO_TAX_NO_LOYALTY));
+
+    await waitFor(() => expect(result.current.tax.enabled).toBe(false));
+    expect(result.current.totals.subtotal).toBe(500);
+    expect(result.current.totals.amountDue).toBe(500);
+  });
+
+  it('applies manual discount, coupon, tax and tip in the canonical order', async () => {
+    useCartStore.setState({
+      discount: 10,
+      discountType: 'percentage',
+      couponCode: 'SUMMER20',
+      couponDiscount: 20,
+      tip: 5,
+    });
+    const { result } = renderPricing(
+      transportWith({ tax_enabled: 'true', tax_rate: '10', tax_mode: 'exclusive' })
+    );
+
+    await waitFor(() => expect(result.current.tax.enabled).toBe(true));
+    // 500 - 50 (10%) - 20 (coupon) = 430 taxable; +43 tax; +5 tip = 478.
+    expect(result.current.totals.discountAmount).toBe(50);
+    expect(result.current.totals.couponDiscount).toBe(20);
+    expect(result.current.totals.netOfDiscounts).toBe(430);
+    expect(result.current.totals.taxAmount).toBe(43);
+    expect(result.current.totals.tip).toBe(5);
+    expect(result.current.totals.amountDue).toBe(478);
+  });
+
+  it('names, but does not add, tax that is already inside the price', async () => {
+    const { result } = renderPricing(
+      transportWith({ tax_enabled: 'true', tax_rate: '10', tax_mode: 'inclusive' })
+    );
+
+    await waitFor(() => expect(result.current.tax.mode).toBe('inclusive'));
+    expect(result.current.totals.amountDue).toBe(500);
+    expect(result.current.totals.taxAmount).toBeCloseTo(45.45, 2);
+  });
+
+  it('ignores a redemption request while loyalty is disabled', async () => {
+    const { result } = renderPricing(transportWith(NO_TAX_NO_LOYALTY), { customerId: 1 });
+
+    await waitFor(() => expect(result.current.loyalty.enabled).toBe(false));
+    act(() => {
+      result.current.setRedeemPoints(true);
+      result.current.setPointsToRedeem(100);
+    });
+
+    expect(result.current.totals.pointsDiscount).toBe(0);
+    expect(result.current.totals.amountDue).toBe(500);
+    expect(result.current.maxPoints).toBe(0);
+  });
+
+  it('redeems at the direct EGP-per-point rate, before tax', async () => {
+    const { result } = renderPricing(
+      transportWith({
+        tax_enabled: 'true',
+        tax_rate: '10',
+        tax_mode: 'exclusive',
+        loyalty_enabled: 'true',
+        loyalty_points_per_egp: '1',
+        loyalty_egp_per_point: '0.10',
+      }),
+      { customerId: 1 }
+    );
+
+    await waitFor(() => expect(result.current.loyalty.customerPoints).toBe(200));
+    act(() => {
+      result.current.setRedeemPoints(true);
+      result.current.setPointsToRedeem(200);
+    });
+
+    // 200 pts * 0.10 = 20 EGP off the TAXABLE base, not off the taxed total.
+    await waitFor(() => expect(result.current.totals.pointsDiscount).toBe(20));
+    expect(result.current.totals.netOfDiscounts).toBe(480);
+    expect(result.current.totals.taxAmount).toBe(48);
+    expect(result.current.totals.amountDue).toBe(528);
+  });
+
+  it('caps redemption at the balance and re-clamps when the sale shrinks', async () => {
+    const { result } = renderPricing(
+      transportWith(
+        {
+          loyalty_enabled: 'true',
+          loyalty_points_per_egp: '1',
+          loyalty_egp_per_point: '1',
+          tax_enabled: 'false',
+        },
+        1000
+      ),
+      { customerId: 1 }
+    );
+
+    await waitFor(() => expect(result.current.loyalty.customerPoints).toBe(1000));
+    // 1000 points at 1 EGP each would cover twice the 500 EGP sale, so the cap
+    // is the sale's value, not the balance.
+    await waitFor(() => expect(result.current.maxPoints).toBe(500));
+
+    act(() => {
+      result.current.setRedeemPoints(true);
+      result.current.setPointsToRedeem(500);
+    });
+    await waitFor(() => expect(result.current.totals.pointsDiscount).toBe(500));
+
+    // The cart shrinks under the cashier: the stale 500 points must not survive.
+    act(() => {
+      useCartStore.setState({ items: [{ ...SILK_DRESS, quantity: 1 }] });
+    });
+
+    await waitFor(() => expect(result.current.maxPoints).toBe(250));
+    await waitFor(() => expect(result.current.pointsToRedeem).toBe(250));
+    expect(result.current.totals.amountDue).toBe(0);
+  });
+
+  it('forgets the redemption on reset', async () => {
+    const { result } = renderPricing(
+      transportWith({
+        loyalty_enabled: 'true',
+        loyalty_points_per_egp: '1',
+        loyalty_egp_per_point: '0.10',
+        tax_enabled: 'false',
+      }),
+      { customerId: 1 }
+    );
+
+    await waitFor(() => expect(result.current.loyalty.customerPoints).toBe(200));
+    act(() => {
+      result.current.setRedeemPoints(true);
+      result.current.setPointsToRedeem(100);
+    });
+    await waitFor(() => expect(result.current.totals.pointsDiscount).toBe(10));
+
+    act(() => result.current.resetRedemption());
+
+    expect(result.current.redeemPoints).toBe(false);
+    expect(result.current.pointsToRedeem).toBe(0);
+    expect(result.current.totals.pointsDiscount).toBe(0);
+  });
+
+  it('balances a split only when the tenders equal the amount due exactly', async () => {
+    const { result, rerender } = renderPricing(transportWith(NO_TAX_NO_LOYALTY), {
+      payments: [{ method: 'Cash', amount: 300 }],
+    });
+
+    await waitFor(() => expect(result.current.totals.amountDue).toBe(500));
+    expect(result.current.split).toMatchObject({
+      allocated: 300,
+      remaining: 200,
+      isBalanced: false,
+      isOverpaid: false,
+    });
+
+    rerender({
+      payments: [
+        { method: 'Cash', amount: 300 },
+        { method: 'Card', amount: 200 },
+      ],
+    });
+    expect(result.current.split.isBalanced).toBe(true);
+
+    rerender({
+      payments: [
+        { method: 'Cash', amount: 300 },
+        { method: 'Card', amount: 250 },
+      ],
+    });
+    expect(result.current.split).toMatchObject({ isBalanced: false, isOverpaid: true });
+  });
+
+  it('re-invalidates a balanced split when the amount due moves under it', async () => {
+    const { result } = renderPricing(transportWith(NO_TAX_NO_LOYALTY), {
+      payments: [{ method: 'Cash', amount: 500 }],
+    });
+
+    await waitFor(() => expect(result.current.split.isBalanced).toBe(true));
+
+    act(() => useCartStore.setState({ tip: 10 }));
+
+    await waitFor(() => expect(result.current.totals.amountDue).toBe(510));
+    expect(result.current.split.isBalanced).toBe(false);
+  });
+
+  it('does not fetch a loyalty balance for a walk-in', async () => {
+    const transport = transportWith({ loyalty_enabled: 'true', tax_enabled: 'false' });
+    const { result } = renderPricing(transport, { customerId: null });
+
+    await waitFor(() => expect(result.current.loyalty.enabled).toBe(true));
+    expect(result.current.loyalty.customerPoints).toBe(0);
+    expect(transport.calls().some((call) => call.path.includes('loyalty'))).toBe(false);
+  });
+});

--- a/client/src/features/pos/hooks/useCheckoutPricing.ts
+++ b/client/src/features/pos/hooks/useCheckoutPricing.ts
@@ -1,0 +1,164 @@
+/**
+ * The one place a checkout's money is decided.
+ *
+ * Everything the cashier sees — the cart footer's total, the checkout drawer's
+ * breakdown, the customer-facing display, the split-tender balance and the
+ * loyalty redemption cap — reads from this hook's single `totals` object, which
+ * is `shared/lib/checkout`'s `calculateTotals` applied once per render. Nothing
+ * else in the POS may derive a total of its own: that is exactly the class of
+ * bug the canonical calculation contract exists to prevent (the cart footer
+ * once added tax but ignored points and tip while the drawer subtracted both).
+ *
+ * It also owns the loyalty *redemption* state (the toggle and the point count)
+ * because that state is meaningless apart from the cap it is clamped to, and a
+ * second owner would let a stale point count outlive the change that shrank it.
+ *
+ * Extracted from CartPanel (issue #51) so checkout calculation can be tested
+ * without rendering the POS screen.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { useApiQuery } from '../../../shared/lib/apiQuery';
+import {
+  calculateTotals,
+  allocateSplit,
+  maxRedeemablePoints,
+  type Allocation,
+  type TaxSettings,
+  type Totals,
+} from '../../../shared/lib/checkout';
+import type { AppSettings } from '../../../shared/types/index';
+import { readTaxPolicy, readLoyaltyPolicy, type LoyaltyPolicy } from '../lib/checkoutSettings';
+import { useCartStore } from '../store/cartStore';
+import type { PaymentEntry } from '../types';
+
+interface CustomerLoyalty {
+  points: number;
+}
+
+export interface LoyaltyState extends LoyaltyPolicy {
+  /** The selected customer's current balance; 0 when nobody is selected. */
+  customerPoints: number;
+}
+
+export interface CheckoutPricing {
+  /** The settings row, exposed for callers that need more than tax/loyalty. */
+  appSettings?: AppSettings;
+  tax: TaxSettings;
+  loyalty: LoyaltyState;
+  /** The authoritative breakdown. Every displayed figure comes from here. */
+  totals: Totals;
+  /** Split-tender allocation against `totals.amountDue`. */
+  split: Allocation;
+  /** The most this customer may redeem on this sale. */
+  maxPoints: number;
+  redeemPoints: boolean;
+  pointsToRedeem: number;
+  setRedeemPoints: (on: boolean) => void;
+  setPointsToRedeem: (points: number) => void;
+  /** Forget the redemption entirely — used when the customer or the sale goes away. */
+  resetRedemption: () => void;
+}
+
+export function useCheckoutPricing(params: {
+  /** The selected customer, or null for a walk-in. */
+  customerId?: number | null;
+  /** The split tenders the cashier has entered, if any. */
+  payments: PaymentEntry[];
+}): CheckoutPricing {
+  const { customerId, payments } = params;
+
+  const items = useCartStore((s) => s.items);
+  const discount = useCartStore((s) => s.discount);
+  const discountType = useCartStore((s) => s.discountType);
+  const couponDiscount = useCartStore((s) => s.couponDiscount);
+  const tip = useCartStore((s) => s.tip);
+
+  const [redeemPoints, setRedeemPoints] = useState(false);
+  const [pointsToRedeem, setPointsToRedeem] = useState(0);
+
+  // Shared cache key: `features/admin/pages/Settings.tsx` and
+  // `features/customers/components/CustomerDetail.tsx` read and invalidate the
+  // same settings resource under this key. Intentional sharing, not a
+  // collision — see docs/CONVENTIONS.md, "Global string-coupling contract".
+  const { data: appSettings } = useApiQuery<AppSettings>(['settings'], 'settings', undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const loyaltyPolicy = useMemo(() => readLoyaltyPolicy(appSettings), [appSettings]);
+  const tax = useMemo(() => readTaxPolicy(appSettings), [appSettings]);
+
+  const { data: customerLoyalty } = useApiQuery<CustomerLoyalty>(
+    ['customer-loyalty', customerId],
+    `customers/${customerId}/loyalty`,
+    undefined,
+    {
+      enabled: !!customerId && loyaltyPolicy.enabled,
+      staleTime: 30 * 1000,
+    }
+  );
+
+  const loyalty = useMemo<LoyaltyState>(
+    () => ({ ...loyaltyPolicy, customerPoints: customerLoyalty?.points || 0 }),
+    [loyaltyPolicy, customerLoyalty]
+  );
+
+  const totals = useMemo(
+    () =>
+      calculateTotals({
+        items,
+        discount,
+        discountType,
+        couponDiscount,
+        tax,
+        pointsToRedeem: redeemPoints && loyalty.enabled ? pointsToRedeem : 0,
+        redeemValue: loyalty.egpPerPoint,
+        pointsBalance: loyalty.customerPoints,
+        tip,
+        loyaltyEnabled: loyalty.enabled,
+        pointsPerEgp: loyalty.pointsPerEgp,
+      }),
+    [items, discount, discountType, couponDiscount, tax, redeemPoints, pointsToRedeem, loyalty, tip]
+  );
+
+  // The most the selected customer may redeem on THIS sale: never more than
+  // their balance, and never more value than the sale (before loyalty) is
+  // worth. `netOfDiscounts + pointsDiscount` recovers the remaining value
+  // after manual discount/coupon but BEFORE loyalty, regardless of how many
+  // points are currently requested (see checkout.ts's calculation order).
+  const maxPoints = useMemo(
+    () =>
+      maxRedeemablePoints(
+        loyalty.customerPoints,
+        totals.netOfDiscounts + totals.pointsDiscount,
+        loyalty.egpPerPoint
+      ),
+    [loyalty, totals.netOfDiscounts, totals.pointsDiscount]
+  );
+
+  // A stale redeemed-points value must never silently outlive the subtotal,
+  // coupon, or tax change that shrank how much can actually be redeemed.
+  useEffect(() => {
+    if (pointsToRedeem > maxPoints) {
+      setPointsToRedeem(maxPoints);
+    }
+  }, [maxPoints, pointsToRedeem]);
+
+  const split = useMemo(() => allocateSplit(payments, totals.amountDue), [payments, totals]);
+
+  return {
+    appSettings,
+    tax,
+    loyalty,
+    totals,
+    split,
+    maxPoints,
+    redeemPoints,
+    pointsToRedeem,
+    setRedeemPoints,
+    setPointsToRedeem,
+    resetRedemption: () => {
+      setRedeemPoints(false);
+      setPointsToRedeem(0);
+    },
+  };
+}

--- a/client/src/features/pos/hooks/useCheckoutSubmission.test.tsx
+++ b/client/src/features/pos/hooks/useCheckoutSubmission.test.tsx
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import {
+  TransportProvider,
+  isValidIdempotencyKey,
+  type TransportRequest,
+  type TransportResult,
+} from '../../../shared/lib/transport/index';
+import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
+import { useOfflineStore } from '../../../shared/store/offlineStore';
+import { useSettingsStore } from '../../../shared/store/settingsStore';
+import { useCartStore } from '../store/cartStore';
+import { useCheckoutSubmission } from './useCheckoutSubmission';
+import type { SaleComposition } from '../lib/salePayload';
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+/**
+ * Submission behaviour, driven directly — no CartPanel, no drawer, no POS
+ * screen. This is the other half of issue #51's "testable independently"
+ * criterion (calculation is covered by useCheckoutPricing.test.tsx).
+ */
+
+const SILK_DRESS = {
+  product_id: 7,
+  name: 'Silk Dress',
+  unit_price: 250,
+  quantity: 2,
+  stock: 5,
+};
+
+const COMPOSITION: SaleComposition = {
+  items: [SILK_DRESS],
+  discount: 10,
+  discountType: 'percentage',
+  notes: 'call before delivery',
+  tip: 5,
+  couponCode: 'SUMMER20',
+  paymentMethod: 'Cash',
+  splitPayment: false,
+  payments: [],
+  customerId: null,
+  pointsToRedeem: 0,
+};
+
+function withSaleReply(memory: MemoryTransport): MemoryTransport {
+  return {
+    ...memory,
+    async request<T>(req: TransportRequest): Promise<TransportResult<T>> {
+      const result = await memory.request<T>(req);
+      if (req.method === 'POST' && req.path === 'sales') {
+        return {
+          data: {
+            ...(result.data as Record<string, unknown>),
+            id: 91,
+            total: 480,
+            payment_method: 'Cash',
+            cashier_name: 'Sarah',
+            created_at: '2026-02-01T10:00:00.000Z',
+            calculation: {
+              subtotal: 500,
+              manualDiscount: 50,
+              couponDiscount: 20,
+              pointsDiscount: 0,
+              taxAmount: 0,
+              taxMode: 'exclusive',
+              taxRatePercent: 0,
+              tipAmount: 5,
+              amountDue: 435,
+            },
+            items: [{ product_id: 7, variant_id: null, quantity: 2, unit_price: 250 }],
+            payments: [{ method: 'Cash', amount: 435 }],
+          } as T,
+        };
+      }
+      return result;
+    },
+  };
+}
+
+function wrapperFor(transport: MemoryTransport) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderSubmission(transport: MemoryTransport) {
+  const settled = vi.fn();
+  const rendered = renderHook(
+    () =>
+      useCheckoutSubmission({
+        tax: { enabled: false, rate: 0, mode: 'exclusive' },
+        customerName: 'Amina',
+        onCheckoutSettled: settled,
+      }),
+    { wrapper: wrapperFor(transport) }
+  );
+  return { ...rendered, settled };
+}
+
+/** Runs `body` with the browser reporting itself offline, then restores jsdom's getter. */
+async function whileOffline(body: () => Promise<void>) {
+  Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+  try {
+    await body();
+  } finally {
+    delete (navigator as { onLine?: boolean }).onLine;
+  }
+}
+
+describe('useCheckoutSubmission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.setState({ locale: 'en' });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    useCartStore.setState({
+      items: [SILK_DRESS],
+      discount: 10,
+      discountType: 'percentage',
+      notes: 'call before delivery',
+      tip: 5,
+      couponCode: 'SUMMER20',
+      couponDiscount: 20,
+      needsReview: false,
+      checkoutAttempt: null,
+    });
+  });
+
+  it('posts the composed body under a well-formed idempotency key', async () => {
+    const transport = withSaleReply(createMemoryTransport());
+    const { result } = renderSubmission(transport);
+
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(transport.idempotencyKeys()).toHaveLength(1));
+    expect(transport.calls().find((c) => c.path === 'sales')?.body).toEqual({
+      items: [{ product_id: 7, quantity: 2, unit_price: 250 }],
+      discount: 10,
+      discount_type: 'percentage',
+      payment_method: 'Cash',
+      notes: 'call before delivery',
+      tip: 5,
+      coupon_code: 'SUMMER20',
+    });
+    expect(isValidIdempotencyKey(transport.idempotencyKeys()[0])).toBe(true);
+  });
+
+  it('clears the cart, resets the surrounding UI and opens the confirmed receipt', async () => {
+    const transport = withSaleReply(createMemoryTransport());
+    const { result, settled } = renderSubmission(transport);
+
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(useCartStore.getState().checkoutAttempt).toBeNull();
+    expect(toast.success).toHaveBeenCalledWith('Sale completed successfully!');
+
+    await waitFor(() => expect(result.current.receiptOpen).toBe(true));
+    // Every figure on the receipt is the server's confirmed one.
+    expect(result.current.receiptData?.saleId).toBe(91);
+    expect(result.current.receiptData?.calculation.amountDue).toBe(435);
+    expect(result.current.receiptData?.items).toEqual([
+      { name: 'Silk Dress', quantity: 2, unit_price: 250 },
+    ]);
+    expect(result.current.receiptData?.customerName).toBe('Amina');
+  });
+
+  it('retries an unchanged cart under the SAME key, and leaves the cart alone to allow it', async () => {
+    const transport = withSaleReply(createMemoryTransport());
+    const { result, settled } = renderSubmission(transport);
+
+    transport.failNext('Gateway timeout', 502, undefined, undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Gateway timeout'));
+    // A failure the cashier can retry: nothing cleared, nothing closed.
+    expect(useCartStore.getState().items).toHaveLength(1);
+    expect(settled).not.toHaveBeenCalled();
+    expect(useOfflineStore.getState().queue).toHaveLength(0);
+
+    act(() => result.current.submit(COMPOSITION));
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+
+    const keys = transport.idempotencyKeys();
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toBe(keys[1]);
+  });
+
+  it('mints a fresh key for a genuinely different sale', async () => {
+    const transport = withSaleReply(createMemoryTransport());
+    const { result } = renderSubmission(transport);
+
+    transport.failNext('Gateway timeout', 502, undefined, undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    act(() => result.current.submit({ ...COMPOSITION, tip: 25 }));
+    await waitFor(() => expect(transport.idempotencyKeys()).toHaveLength(2));
+
+    const [first, second] = transport.idempotencyKeys();
+    expect(second).not.toBe(first);
+  });
+
+  it('names the stale-split failure specifically, and keeps the cart for rebalancing', async () => {
+    const transport = withSaleReply(createMemoryTransport());
+    const { result, settled } = renderSubmission(transport);
+
+    transport.failNext(
+      'Payments no longer balance',
+      400,
+      'VALIDATION_ERROR',
+      [{ field: 'payments', code: 'SPLIT_PAYMENT_MISMATCH', message: 'stale split' }],
+      'sales'
+    );
+    act(() =>
+      result.current.submit({
+        ...COMPOSITION,
+        splitPayment: true,
+        payments: [{ method: 'Cash', amount: 500 }],
+      })
+    );
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'The total or payments changed since checkout was opened. Review the amount due and rebalance payments before confirming.'
+      )
+    );
+    expect(useCartStore.getState().items).toHaveLength(1);
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The offline fallback is currently UNREACHABLE from the real checkout path
+   * (React Query pauses a mutation fired while offline rather than failing it
+   * — issue #53). These drive `onError` directly, which is exactly what the
+   * fix for #53 will make reachable, so the behaviour must not rot meanwhile.
+   */
+  it('queues the sale that was actually attempted, stamped and keyed, when the post fails offline', async () => {
+    await whileOffline(async () => {
+      const transport = withSaleReply(createMemoryTransport());
+      const { result, settled } = renderSubmission(transport);
+
+      transport.failNext('', 500, undefined, undefined, 'sales');
+      act(() => result.current.submit(COMPOSITION));
+
+      await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(1));
+      const [queued] = useOfflineStore.getState().queue;
+
+      // The reduced offline body: no notes, tip or coupon.
+      expect(queued).toMatchObject({
+        type: 'sale',
+        contractVersion: 'v1',
+        payload: {
+          items: [{ product_id: 7, quantity: 2, unit_price: 250 }],
+          discount: 10,
+          discount_type: 'percentage',
+          payment_method: 'Cash',
+        },
+      });
+      // Same key the failed POST carried, so a replay that already landed is deduped.
+      expect(queued.idempotencyKey).toBe(transport.idempotencyKeys()[0]);
+      expect(useCartStore.getState().items).toHaveLength(0);
+      expect(useCartStore.getState().checkoutAttempt).toBeNull();
+      expect(settled).toHaveBeenCalledTimes(1);
+      expect(toast.success).toHaveBeenCalledWith('Sale saved offline. Will sync when back online.');
+    });
+  });
+
+  it('queues the composition it was handed, not whatever the cart says afterwards', async () => {
+    await whileOffline(async () => {
+      const transport = withSaleReply(createMemoryTransport());
+      const { result } = renderSubmission(transport);
+
+      transport.failNext('', 500, undefined, undefined, 'sales');
+      act(() => {
+        result.current.submit({ ...COMPOSITION, paymentMethod: 'Card', customerId: 42 });
+        // The cart moves on while the request is in flight.
+        useCartStore.setState({ items: [{ ...SILK_DRESS, product_id: 99, quantity: 1 }] });
+      });
+
+      await waitFor(() => expect(useOfflineStore.getState().queue).toHaveLength(1));
+      expect(useOfflineStore.getState().queue[0].payload).toMatchObject({
+        items: [{ product_id: 7, quantity: 2, unit_price: 250 }],
+        payment_method: 'Card',
+        customer_id: 42,
+      });
+    });
+  });
+});

--- a/client/src/features/pos/hooks/useCheckoutSubmission.ts
+++ b/client/src/features/pos/hooks/useCheckoutSubmission.ts
@@ -1,0 +1,187 @@
+/**
+ * The submission half of a checkout: composing the request, keying it so a
+ * retry cannot double-charge, and deciding what happens to the cart, the
+ * receipt and the offline queue once the server answers (or doesn't).
+ *
+ * Extracted from CartPanel (issue #51) so the submission lifecycle can be
+ * exercised without rendering the POS screen. Behaviour is unchanged, including
+ * the offline fallback below — which is currently UNREACHABLE from the
+ * checkout path (React Query pauses rather than fails a mutation fired while
+ * `navigator.onLine` is false, so `onError` never runs). That is issue #53's
+ * territory; the fallback is preserved here exactly as it was, not deleted as
+ * dead code and not wired up.
+ */
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { useTranslation } from '../../../shared/i18n/index';
+import { SPLIT_PAYMENT_MISMATCH_CODE, type TaxSettings } from '../../../shared/lib/checkout';
+import { useTransport, createIdempotencyKey } from '../../../shared/lib/transport/index';
+import { ApiError } from '../../../shared/lib/transport/types';
+import { useOfflineStore, SALE_QUEUE_CONTRACT_VERSION } from '../../../shared/store/offlineStore';
+import type { ReceiptData } from '../../../shared/components/Receipt';
+import {
+  buildSalePayload,
+  buildOfflineSalePayload,
+  type SaleComposition,
+} from '../lib/salePayload';
+import { buildReceipt } from '../lib/saleReceipt';
+import { useCartStore } from '../store/cartStore';
+import type { CheckoutAttempt, SaleData, SaleResponse } from '../types';
+
+/**
+ * What one attempt carries: the composed body, its idempotency key, and the
+ * composition it came from. The composition rides along so the offline
+ * fallback queues the sale that was ACTUALLY attempted under that key, rather
+ * than re-reading a cart that may have moved on.
+ */
+type CheckoutMutationVariables = CheckoutAttempt & { composition: SaleComposition };
+
+export interface CheckoutSubmission {
+  /** Compose, key and post the sale the cashier just confirmed. */
+  submit: (composition: SaleComposition) => void;
+  isPending: boolean;
+  receiptOpen: boolean;
+  setReceiptOpen: (open: boolean) => void;
+  receiptData: ReceiptData | null;
+}
+
+export function useCheckoutSubmission(params: {
+  tax: TaxSettings;
+  /** Printed on the receipt; the cart supplies nothing monetary. */
+  customerName?: string;
+  /**
+   * Reset the surrounding checkout UI — close the drawer, drop the selected
+   * customer, forget the redemption. Called once a sale is COMMITTED or
+   * QUEUED, never after a failure the cashier is expected to retry.
+   */
+  onCheckoutSettled: () => void;
+}): CheckoutSubmission {
+  const { tax, customerName, onCheckoutSettled } = params;
+
+  const items = useCartStore((s) => s.items);
+  const discount = useCartStore((s) => s.discount);
+  const discountType = useCartStore((s) => s.discountType);
+  const couponCode = useCartStore((s) => s.couponCode);
+  const clearCart = useCartStore((s) => s.clearCart);
+  const checkoutAttempt = useCartStore((s) => s.checkoutAttempt);
+  const setCheckoutAttempt = useCartStore((s) => s.setCheckoutAttempt);
+  const addToQueue = useOfflineStore((s) => s.addToQueue);
+
+  const queryClient = useQueryClient();
+  const transport = useTransport();
+  const { t } = useTranslation();
+
+  const [receiptOpen, setReceiptOpen] = useState(false);
+  const [receiptData, setReceiptData] = useState<ReceiptData | null>(null);
+
+  /**
+   * The idempotency key identifies one rung-up sale, not one HTTP request. It is keyed on
+   * the composed payload so a cashier who hits Confirm again after a failure retries under
+   * the SAME key (letting the server return the original outcome rather than committing a
+   * second sale), while a cart that has changed gets a fresh one. Cleared once a sale is
+   * committed or queued, so the next sale never inherits a key — even an identical repeat
+   * order.
+   *
+   * It lives in the persisted cart store rather than a ref: the cart survives a reload, so
+   * the key protecting it has to as well. A till that refreshes while a checkout is in
+   * flight would otherwise mint a new key and ring the same sale up twice.
+   */
+  const idempotencyKeyFor = (saleData: SaleData): string => {
+    const fingerprint = JSON.stringify(saleData);
+    if (checkoutAttempt?.fingerprint === fingerprint) {
+      return checkoutAttempt.key;
+    }
+    const attempt = { fingerprint, key: createIdempotencyKey() };
+    setCheckoutAttempt(attempt);
+    return attempt.key;
+  };
+
+  const checkoutMutation = useMutation({
+    mutationFn: ({ saleData, idempotencyKey }: CheckoutMutationVariables) =>
+      transport.request<SaleResponse>({
+        method: 'POST',
+        path: 'sales',
+        body: saleData,
+        idempotencyKey,
+      }),
+    onSuccess: (response) => {
+      setCheckoutAttempt(null);
+
+      // Built from the cart as it stands right now -- captured before
+      // `clearCart()` below empties it. See saleReceipt.ts: every monetary
+      // figure comes from the server's confirmed response; the cart supplies
+      // display names only.
+      const newReceipt = buildReceipt(response.data, {
+        cartItems: items,
+        discount,
+        discountType,
+        couponCode,
+        tax,
+        customerName,
+      });
+
+      toast.success(t('cart.saleSuccess'));
+      clearCart();
+      onCheckoutSettled();
+      queryClient.invalidateQueries({ queryKey: ['sales'] });
+      queryClient.invalidateQueries({ queryKey: ['products'] });
+      queryClient.invalidateQueries({ queryKey: ['customer-loyalty'] });
+
+      setReceiptData(newReceipt);
+      setReceiptOpen(true);
+    },
+    onError: (error: Error, attempt: CheckoutMutationVariables) => {
+      if (!navigator.onLine) {
+        addToQueue({
+          type: 'sale',
+          payload: buildOfflineSalePayload(attempt.composition) as unknown as Record<
+            string,
+            unknown
+          >,
+          // Stamps this entry as composed under the current (corrected)
+          // checkout contract, so useOffline.ts's replay never quarantines
+          // it. A legacy entry already sitting in a user's queue from before
+          // this deploy has no such field and is left for manual review.
+          contractVersion: SALE_QUEUE_CONTRACT_VERSION,
+          // The same key the failed POST carried: if that request did reach
+          // the server after all, the replay is recognised as a duplicate
+          // instead of ringing the sale up twice.
+          idempotencyKey: attempt.idempotencyKey,
+        });
+        toast.success(t('cart.savedOffline'));
+        setCheckoutAttempt(null);
+        clearCart();
+        onCheckoutSettled();
+      } else {
+        // Authoritative data (catalog price, tax, coupon, or loyalty
+        // settings) changed between preview and submission and the split no
+        // longer balances against the server's recalculated total. The cart
+        // is intentionally left untouched (nothing cleared or closed above) so
+        // the cashier can review and rebalance rather than seeing a generic
+        // failure or a false success.
+        const isSplitMismatch =
+          error instanceof ApiError &&
+          error.details?.some((d) => d.code === SPLIT_PAYMENT_MISMATCH_CODE);
+        toast.error(
+          isSplitMismatch ? t('cart.splitMismatchError') : error.message || t('cart.saleFailed')
+        );
+      }
+    },
+  });
+
+  return {
+    submit: (composition: SaleComposition) => {
+      const saleData = buildSalePayload(composition);
+      checkoutMutation.mutate({
+        saleData,
+        idempotencyKey: idempotencyKeyFor(saleData),
+        composition,
+      });
+    },
+    isPending: checkoutMutation.isPending,
+    receiptOpen,
+    setReceiptOpen,
+    receiptData,
+  };
+}

--- a/client/src/features/pos/hooks/useCouponApplication.ts
+++ b/client/src/features/pos/hooks/useCouponApplication.ts
@@ -1,0 +1,67 @@
+/**
+ * Applying and removing a coupon.
+ *
+ * The discount is never computed here: the cashier's code is sent to
+ * `POST /api/v1/coupons/validate` and the server answers with the resolved
+ * amount, which is what lands in the cart store. Extracted from CartPanel
+ * (issue #51); behaviour unchanged.
+ */
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from '../../../shared/i18n/index';
+import { useTransport } from '../../../shared/lib/transport/index';
+import { useCartStore } from '../store/cartStore';
+import type { CouponValidation } from '../types';
+
+export interface CouponApplication {
+  input: string;
+  setInput: (value: string) => void;
+  apply: () => Promise<void>;
+  remove: () => void;
+}
+
+export function useCouponApplication(params: {
+  /** The authoritative subtotal the coupon is validated against. */
+  subtotal: number;
+  productIds: number[];
+  customerId?: number | null;
+}): CouponApplication {
+  const { subtotal, productIds, customerId } = params;
+  const setCoupon = useCartStore((s) => s.setCoupon);
+  const clearCoupon = useCartStore((s) => s.clearCoupon);
+  const transport = useTransport();
+  const { t } = useTranslation();
+
+  const [input, setInput] = useState('');
+
+  return {
+    input,
+    setInput,
+    apply: async () => {
+      if (!input.trim()) return;
+      try {
+        const { data } = await transport.request<CouponValidation>({
+          method: 'POST',
+          path: 'coupons/validate',
+          body: {
+            code: input.trim(),
+            // The authoritative subtotal, the same figure every displayed line
+            // uses. This used to be `cartStore.getSubtotal()`, a second
+            // float-arithmetic derivation of it.
+            subtotal,
+            ...(customerId ? { customer_id: customerId } : {}),
+            item_product_ids: productIds,
+          },
+        });
+        setCoupon(data.code, data.discount);
+        toast.success(t('cart.couponApplied'));
+      } catch (err: unknown) {
+        toast.error((err as Error).message || t('cart.couponInvalid'));
+      }
+    },
+    remove: () => {
+      clearCoupon();
+      setInput('');
+    },
+  };
+}

--- a/client/src/features/pos/hooks/useCustomerDisplayBroadcast.ts
+++ b/client/src/features/pos/hooks/useCustomerDisplayBroadcast.ts
@@ -1,0 +1,58 @@
+/**
+ * Mirrors the cart to the customer-facing display.
+ *
+ * The projection it posts is the SAME `totals` object the cart footer and the
+ * checkout drawer render — never a separately-derived one — so the customer's
+ * screen always agrees to the cent with the cashier's (Unit 5). This hook owns
+ * the channel entirely; POS.tsx deliberately posts nothing of its own.
+ *
+ * Extracted from CartPanel (issue #51); behaviour unchanged.
+ */
+import { useEffect } from 'react';
+import type { Totals, TaxSettings, DiscountType } from '../../../shared/lib/checkout';
+import type { CartItem } from '../store/cartStore';
+
+export const CUSTOMER_DISPLAY_CHANNEL = 'moon-customer-display';
+
+export function useCustomerDisplayBroadcast(input: {
+  items: CartItem[];
+  discount: number;
+  discountType: DiscountType;
+  couponCode: string;
+  tax: TaxSettings;
+  totals: Totals;
+}): void {
+  const { items, discount, discountType, couponCode, tax, totals } = input;
+
+  useEffect(() => {
+    const channel = new BroadcastChannel(CUSTOMER_DISPLAY_CHANNEL);
+    if (items.length > 0) {
+      channel.postMessage({
+        type: 'cart-update',
+        cart: {
+          items: items.map((i) => ({
+            name: i.name,
+            quantity: i.quantity,
+            unit_price: i.unit_price,
+            memo: i.memo,
+          })),
+          subtotal: totals.subtotal,
+          discount,
+          discountType,
+          discountAmount: totals.discountAmount,
+          couponCode: couponCode || undefined,
+          couponDiscount: totals.couponDiscount,
+          taxEnabled: tax.enabled,
+          taxRate: tax.rate,
+          taxAmount: totals.taxAmount,
+          pointsDiscount: totals.pointsDiscount,
+          tip: totals.tip,
+          amountDue: totals.amountDue,
+        },
+      });
+    } else {
+      channel.postMessage({ type: 'cart-clear' });
+    }
+    channel.close();
+  }, [items, discount, discountType, couponCode, tax, totals]);
+}

--- a/client/src/features/pos/hooks/useCustomerSelection.ts
+++ b/client/src/features/pos/hooks/useCustomerSelection.ts
@@ -1,0 +1,116 @@
+/**
+ * Attaching a customer to a checkout: searching for one, picking one, or
+ * creating one on the spot.
+ *
+ * All of it is UI state with no financial meaning of its own — the selected
+ * customer's *id* is what the sale carries, and their loyalty balance is
+ * fetched by `useCheckoutPricing`, not here. Extracted from CartPanel
+ * (issue #51) so the selection flow can be driven without the POS screen.
+ */
+import { useState } from 'react';
+import { useTranslation } from '../../../shared/i18n/index';
+import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue';
+import { useApiQuery } from '../../../shared/lib/apiQuery';
+import { resource } from '../../../shared/lib/resource';
+import type { Customer } from '../../../shared/types/index';
+
+const customers = resource<Customer>('customers');
+
+export interface CustomerSelection {
+  selected: Customer | null;
+  search: string;
+  setSearch: (value: string) => void;
+  dropdownOpen: boolean;
+  setDropdownOpen: (open: boolean) => void;
+  matches?: Customer[];
+  select: (customer: Customer) => void;
+  /** Drop the selection. Callers that also hold redemption state must reset it too. */
+  clear: () => void;
+  /** Reset selection AND the search box — what a completed checkout does. */
+  reset: () => void;
+  creating: boolean;
+  startCreating: () => void;
+  cancelCreating: () => void;
+  newName: string;
+  setNewName: (value: string) => void;
+  newPhone: string;
+  setNewPhone: (value: string) => void;
+  isSaving: boolean;
+  /** Create the customer from the entered name/phone and select the result. */
+  createAndSelect: () => void;
+}
+
+export function useCustomerSelection(params: {
+  /** Search only runs while the checkout drawer is open — it is a drawer control. */
+  searchEnabled: boolean;
+}): CustomerSelection {
+  const { t } = useTranslation();
+
+  const [selected, setSelected] = useState<Customer | null>(null);
+  const [search, setSearch] = useState('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newPhone, setNewPhone] = useState('');
+
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const { data: matches } = useApiQuery<Customer[]>(
+    ['customers', { search: debouncedSearch }],
+    'customers',
+    { search: debouncedSearch || undefined },
+    {
+      enabled: params.searchEnabled && debouncedSearch.length > 0,
+      staleTime: 30 * 1000,
+    }
+  );
+
+  const creator = customers.useSave({
+    message: t('cart.customerCreated'),
+    fallbackMessage: t('cart.customerCreateError'),
+  });
+
+  const clearNewCustomerForm = () => {
+    setCreating(false);
+    setNewName('');
+    setNewPhone('');
+  };
+
+  return {
+    selected,
+    search,
+    setSearch,
+    dropdownOpen,
+    setDropdownOpen,
+    matches,
+    select: (customer) => {
+      setSelected(customer);
+      setSearch('');
+      setDropdownOpen(false);
+    },
+    clear: () => setSelected(null),
+    reset: () => {
+      setSelected(null);
+      setSearch('');
+    },
+    creating,
+    startCreating: () => setCreating(true),
+    cancelCreating: clearNewCustomerForm,
+    newName,
+    setNewName,
+    newPhone,
+    setNewPhone,
+    isSaving: creator.isSaving,
+    createAndSelect: () => {
+      creator.save(
+        { name: newName.trim(), phone: newPhone.trim() },
+        {
+          onSuccess: (result) => {
+            setSelected(result.data as Customer);
+            clearNewCustomerForm();
+          },
+        }
+      );
+    },
+  };
+}

--- a/client/src/features/pos/lib/cartLines.ts
+++ b/client/src/features/pos/lib/cartLines.ts
@@ -1,0 +1,10 @@
+/**
+ * How a cart line is identified in the UI: by product AND variant, since the
+ * same product can appear twice under different variants. Shared by the cart
+ * list, its `data-testid`, and the memo-editing state that keys off it.
+ */
+import type { CartItem } from '../store/cartStore';
+
+export function lineKey(item: Pick<CartItem, 'product_id' | 'variant_id'>): string {
+  return `${item.product_id}-${item.variant_id || 0}`;
+}

--- a/client/src/features/pos/lib/checkoutSettings.test.ts
+++ b/client/src/features/pos/lib/checkoutSettings.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { readTaxPolicy, readLoyaltyPolicy } from './checkoutSettings';
+
+describe('readTaxPolicy', () => {
+  it('is off when the settings row has not loaded yet', () => {
+    expect(readTaxPolicy(undefined)).toEqual({ enabled: false, rate: 0, mode: 'exclusive' });
+  });
+
+  it('is off when the shop disabled tax, even with a rate still stored', () => {
+    expect(readTaxPolicy({ tax_enabled: 'false', tax_rate: '14' }).enabled).toBe(false);
+  });
+
+  it('is off when tax is enabled but the rate is zero — no VAT line for a 0% shop', () => {
+    expect(readTaxPolicy({ tax_enabled: 'true', tax_rate: '0' }).enabled).toBe(false);
+  });
+
+  it('reads an enabled exclusive rate', () => {
+    expect(readTaxPolicy({ tax_enabled: 'true', tax_rate: '14' })).toEqual({
+      enabled: true,
+      rate: 14,
+      mode: 'exclusive',
+    });
+  });
+
+  it('reads inclusive mode, and treats anything else as exclusive', () => {
+    expect(readTaxPolicy({ tax_enabled: 'true', tax_rate: '14', tax_mode: 'inclusive' }).mode).toBe(
+      'inclusive'
+    );
+    expect(readTaxPolicy({ tax_enabled: 'true', tax_rate: '14' }).mode).toBe('exclusive');
+  });
+
+  it('treats a blank or unparseable rate as zero, which disables tax', () => {
+    expect(readTaxPolicy({ tax_enabled: 'true', tax_rate: '' }).enabled).toBe(false);
+    expect(readTaxPolicy({ tax_enabled: 'true', tax_rate: 'abc' }).rate).toBeNaN();
+    expect(readTaxPolicy({ tax_enabled: 'true', tax_rate: 'abc' }).enabled).toBe(false);
+  });
+});
+
+describe('readLoyaltyPolicy', () => {
+  it('is off, but still carries seed defaults, when settings have not loaded', () => {
+    expect(readLoyaltyPolicy(undefined)).toEqual({
+      enabled: false,
+      pointsPerEgp: 1,
+      egpPerPoint: 0.1,
+    });
+  });
+
+  it('reads the canonical direct-unit settings', () => {
+    expect(
+      readLoyaltyPolicy({
+        loyalty_enabled: 'true',
+        loyalty_points_per_egp: '2',
+        loyalty_egp_per_point: '0.05',
+      })
+    ).toEqual({ enabled: true, pointsPerEgp: 2, egpPerPoint: 0.05 });
+  });
+
+  it('ignores the deprecated legacy aliases entirely', () => {
+    // A shop still carrying the old keys must fall back to the canonical
+    // defaults, not silently adopt reciprocal ("per 100") units.
+    expect(
+      readLoyaltyPolicy({
+        loyalty_enabled: 'true',
+        loyalty_earn_rate: '100',
+        loyalty_redeem_value: '10',
+      })
+    ).toEqual({ enabled: true, pointsPerEgp: 1, egpPerPoint: 0.1 });
+  });
+
+  it('treats any value other than the literal "true" as disabled', () => {
+    expect(readLoyaltyPolicy({ loyalty_enabled: 'false' }).enabled).toBe(false);
+    expect(readLoyaltyPolicy({}).enabled).toBe(false);
+  });
+});

--- a/client/src/features/pos/lib/checkoutSettings.ts
+++ b/client/src/features/pos/lib/checkoutSettings.ts
@@ -1,0 +1,45 @@
+/**
+ * How the POS reads the global settings row into the two financial policies a
+ * checkout depends on: tax and loyalty.
+ *
+ * Extracted from CartPanel so the parsing rules (which key is canonical, what
+ * a missing/blank value defaults to, when tax counts as "off") can be
+ * exercised without rendering the POS screen. Behaviour is unchanged from the
+ * inline `useMemo`s it replaces.
+ */
+import type { TaxSettings, TaxMode } from '../../../shared/lib/checkout';
+import type { AppSettings } from '../../../shared/types/index';
+
+export interface LoyaltyPolicy {
+  /** Gates BOTH earning and redemption, matching the server's single flag. */
+  enabled: boolean;
+  /** Points earned per 1 EGP of confirmed sale total. */
+  pointsPerEgp: number;
+  /** EGP value redeemed per ONE point (direct units, never a per-100 reciprocal). */
+  egpPerPoint: number;
+}
+
+/**
+ * Tax policy for this sale. `enabled` folds in the rate check deliberately: a
+ * shop with tax switched on but a 0% rate shows no VAT line, which is what the
+ * cart has always done.
+ */
+export function readTaxPolicy(appSettings?: AppSettings): TaxSettings {
+  const enabled = appSettings?.tax_enabled === 'true';
+  const rate = parseFloat(appSettings?.tax_rate || '0');
+  const mode: TaxMode = appSettings?.tax_mode === 'inclusive' ? 'inclusive' : 'exclusive';
+  return { enabled: enabled && rate > 0, rate, mode };
+}
+
+/**
+ * Loyalty policy for this sale. Reads the canonical, direct-unit settings
+ * (Unit 1) only -- never the legacy `loyalty_earn_rate`/`loyalty_redeem_value`
+ * aliases. Defaults match `server/src/database/seed.ts`.
+ */
+export function readLoyaltyPolicy(appSettings?: AppSettings): LoyaltyPolicy {
+  return {
+    enabled: appSettings?.loyalty_enabled === 'true',
+    pointsPerEgp: parseFloat(appSettings?.loyalty_points_per_egp || '1'),
+    egpPerPoint: parseFloat(appSettings?.loyalty_egp_per_point || '0.1'),
+  };
+}

--- a/client/src/features/pos/lib/salePayload.test.ts
+++ b/client/src/features/pos/lib/salePayload.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import { buildSalePayload, buildOfflineSalePayload, type SaleComposition } from './salePayload';
+
+const SILK_DRESS = {
+  product_id: 7,
+  name: 'Silk Dress',
+  unit_price: 250,
+  quantity: 2,
+  stock: 5,
+};
+
+function composition(overrides: Partial<SaleComposition> = {}): SaleComposition {
+  return {
+    items: [SILK_DRESS],
+    discount: 0,
+    discountType: 'fixed',
+    notes: '',
+    tip: 0,
+    couponCode: '',
+    paymentMethod: 'Cash',
+    splitPayment: false,
+    payments: [],
+    customerId: null,
+    pointsToRedeem: 0,
+    ...overrides,
+  };
+}
+
+describe('buildSalePayload', () => {
+  it('sends only the required fields for a bare walk-in sale', () => {
+    expect(buildSalePayload(composition())).toEqual({
+      items: [{ product_id: 7, quantity: 2, unit_price: 250 }],
+      discount: 0,
+      discount_type: 'fixed',
+      payment_method: 'Cash',
+    });
+  });
+
+  it('omits every unset optional field rather than sending it as null', () => {
+    const payload = buildSalePayload(composition());
+    for (const field of [
+      'payments',
+      'customer_id',
+      'points_redeemed',
+      'notes',
+      'tip',
+      'coupon_code',
+      'variant_id',
+    ]) {
+      expect(payload).not.toHaveProperty(field);
+    }
+    expect(payload.items[0]).not.toHaveProperty('variant_id');
+    expect(payload.items[0]).not.toHaveProperty('memo');
+  });
+
+  it('carries every configured extra through', () => {
+    const payload = buildSalePayload(
+      composition({
+        items: [{ ...SILK_DRESS, variant_id: 3, memo: 'gift wrap' }],
+        discount: 10,
+        discountType: 'percentage',
+        notes: 'call before delivery',
+        tip: 5,
+        couponCode: 'SUMMER20',
+        customerId: 42,
+        pointsToRedeem: 100,
+      })
+    );
+
+    expect(payload).toEqual({
+      items: [{ product_id: 7, quantity: 2, unit_price: 250, variant_id: 3, memo: 'gift wrap' }],
+      discount: 10,
+      discount_type: 'percentage',
+      payment_method: 'Cash',
+      customer_id: 42,
+      points_redeemed: 100,
+      notes: 'call before delivery',
+      tip: 5,
+      coupon_code: 'SUMMER20',
+    });
+  });
+
+  it('forces payment_method to Cash and attaches the tenders for a split', () => {
+    const payments = [
+      { method: 'Card' as const, amount: 300 },
+      { method: 'Gift Card' as const, amount: 200 },
+    ];
+    const payload = buildSalePayload(
+      composition({ paymentMethod: 'Card', splitPayment: true, payments })
+    );
+
+    expect(payload.payment_method).toBe('Cash');
+    expect(payload.payments).toEqual(payments);
+  });
+
+  it('does not attach an empty tender list even when split is toggled on', () => {
+    const payload = buildSalePayload(composition({ splitPayment: true, payments: [] }));
+    expect(payload).not.toHaveProperty('payments');
+    expect(payload.payment_method).toBe('Cash');
+  });
+
+  it('keeps a non-split sale on the chosen method', () => {
+    expect(buildSalePayload(composition({ paymentMethod: 'Other' })).payment_method).toBe('Other');
+  });
+
+  it('drops a zero or negative tip, points redemption and discount-free coupon', () => {
+    const payload = buildSalePayload(
+      composition({ tip: 0, pointsToRedeem: 0, couponCode: '', customerId: 0 })
+    );
+    expect(payload).not.toHaveProperty('tip');
+    expect(payload).not.toHaveProperty('points_redeemed');
+    expect(payload).not.toHaveProperty('coupon_code');
+    expect(payload).not.toHaveProperty('customer_id');
+  });
+
+  /**
+   * The idempotency key is derived from `JSON.stringify` of this object and a
+   * persisted mid-checkout attempt is matched by that exact string, so key
+   * ORDER is part of the contract, not a formatting detail.
+   */
+  it('emits its keys in a stable order, because the idempotency fingerprint is the stringified body', () => {
+    const payload = buildSalePayload(
+      composition({
+        discount: 10,
+        discountType: 'percentage',
+        notes: 'n',
+        tip: 5,
+        couponCode: 'C',
+        customerId: 42,
+        pointsToRedeem: 3,
+        splitPayment: true,
+        payments: [{ method: 'Cash', amount: 500 }],
+      })
+    );
+
+    expect(Object.keys(payload)).toEqual([
+      'items',
+      'discount',
+      'discount_type',
+      'payment_method',
+      'payments',
+      'customer_id',
+      'points_redeemed',
+      'notes',
+      'tip',
+      'coupon_code',
+    ]);
+  });
+});
+
+describe('buildOfflineSalePayload', () => {
+  it('stores a deliberately reduced body: no notes, tip, coupon, tenders or points', () => {
+    const payload = buildOfflineSalePayload(
+      composition({
+        discount: 10,
+        discountType: 'percentage',
+        notes: 'call before delivery',
+        tip: 5,
+        couponCode: 'SUMMER20',
+        pointsToRedeem: 100,
+        splitPayment: true,
+        payments: [{ method: 'Cash', amount: 500 }],
+        customerId: 42,
+      })
+    );
+
+    expect(payload).toEqual({
+      items: [{ product_id: 7, quantity: 2, unit_price: 250 }],
+      discount: 10,
+      discount_type: 'percentage',
+      payment_method: 'Cash',
+      customer_id: 42,
+    });
+  });
+
+  it('keeps the chosen payment method even when a split was configured', () => {
+    const payload = buildOfflineSalePayload(
+      composition({ paymentMethod: 'Card', splitPayment: true })
+    );
+    expect(payload.payment_method).toBe('Card');
+  });
+
+  it('carries variant identity but drops the line memo', () => {
+    const payload = buildOfflineSalePayload(
+      composition({ items: [{ ...SILK_DRESS, variant_id: 3, memo: 'gift wrap' }] })
+    );
+    expect(payload.items).toEqual([{ product_id: 7, variant_id: 3, quantity: 2, unit_price: 250 }]);
+  });
+});

--- a/client/src/features/pos/lib/salePayload.ts
+++ b/client/src/features/pos/lib/salePayload.ts
@@ -1,0 +1,99 @@
+/**
+ * Composing the body POST /api/v1/sales receives, and the reduced body the
+ * offline queue stores when that POST cannot go out.
+ *
+ * Both were inline object literals in CartPanel; extracted (issue #51) so the
+ * composition rules — which fields are omitted rather than sent as null, how a
+ * split tender overrides the single payment method, which fields the offline
+ * body deliberately drops — are testable without rendering the POS screen.
+ *
+ * Two rules that look incidental but are not, and must survive any edit here:
+ *
+ * 1. **Absent, never null.** Every optional field is spread in conditionally.
+ *    The server distinguishes "no customer" from `customer_id: null`.
+ * 2. **Key order is stable.** The idempotency key is derived from
+ *    `JSON.stringify(saleData)` (see CartPanel's `idempotencyKeyFor`), and a
+ *    persisted mid-checkout attempt is matched by that exact string. Reordering
+ *    the keys would make a till that reloads mid-checkout mint a fresh key and
+ *    ring the same sale up twice.
+ */
+import type { CartItem, DiscountType } from '../store/cartStore';
+import type { PaymentEntry, PaymentMethod, SaleData } from '../types';
+
+export interface SaleComposition {
+  items: CartItem[];
+  discount: number;
+  discountType: DiscountType;
+  notes: string;
+  tip: number;
+  couponCode: string;
+  paymentMethod: PaymentMethod;
+  splitPayment: boolean;
+  payments: PaymentEntry[];
+  /** The selected customer's id, or null/undefined for a walk-in. */
+  customerId?: number | null;
+  /** Points the cashier is actually spending — already gated by the redeem toggle. */
+  pointsToRedeem: number;
+}
+
+/** The full checkout body: everything the cashier configured in the drawer. */
+export function buildSalePayload(composition: SaleComposition): SaleData {
+  const {
+    items,
+    discount,
+    discountType,
+    notes,
+    tip,
+    couponCode,
+    paymentMethod,
+    splitPayment,
+    payments,
+    customerId,
+    pointsToRedeem,
+  } = composition;
+
+  return {
+    items: items.map((i) => ({
+      product_id: i.product_id,
+      quantity: i.quantity,
+      unit_price: i.unit_price,
+      ...(i.variant_id ? { variant_id: i.variant_id } : {}),
+      ...(i.memo ? { memo: i.memo } : {}),
+    })),
+    discount,
+    discount_type: discountType,
+    // A split tender still needs a single `payment_method` column on the sale
+    // row; the per-tender breakdown travels in `payments`.
+    payment_method: splitPayment ? 'Cash' : paymentMethod,
+    ...(splitPayment && payments.length > 0 ? { payments } : {}),
+    ...(customerId ? { customer_id: customerId } : {}),
+    ...(pointsToRedeem > 0 ? { points_redeemed: pointsToRedeem } : {}),
+    ...(notes ? { notes } : {}),
+    ...(tip > 0 ? { tip } : {}),
+    ...(couponCode ? { coupon_code: couponCode } : {}),
+  };
+}
+
+/**
+ * The reduced body the offline queue stores. Deliberately narrower than the
+ * full checkout body — no notes, tip, coupon, split tenders or loyalty
+ * redemption — and unchanged by this extraction. Its narrowness is
+ * characterized by CartPanel.test.tsx; widening it is a server-contract
+ * decision, not a refactor.
+ */
+export function buildOfflineSalePayload(composition: SaleComposition): SaleData {
+  const { items, discount, discountType, paymentMethod, customerId } = composition;
+
+  return {
+    items: items.map((i) => ({
+      product_id: i.product_id,
+      ...(i.variant_id ? { variant_id: i.variant_id } : {}),
+      quantity: i.quantity,
+      unit_price: i.unit_price,
+    })),
+    discount,
+    discount_type: discountType,
+    payment_method: paymentMethod,
+    ...(customerId ? { customer_id: customerId } : {}),
+  };
+}

--- a/client/src/features/pos/lib/saleReceipt.test.ts
+++ b/client/src/features/pos/lib/saleReceipt.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { buildReceipt, type ReceiptContext } from './saleReceipt';
+import type { SaleResponse } from '../types';
+
+const CART = [
+  { product_id: 7, variant_id: 3, name: 'Silk Dress', unit_price: 250, quantity: 2, stock: 5 },
+];
+
+function context(overrides: Partial<ReceiptContext> = {}): ReceiptContext {
+  return {
+    cartItems: CART,
+    discount: 10,
+    discountType: 'percentage',
+    couponCode: 'SUMMER20',
+    tax: { enabled: true, rate: 14, mode: 'exclusive' },
+    customerName: 'Amina',
+    ...overrides,
+  };
+}
+
+const CONFIRMED: SaleResponse = {
+  id: 91,
+  discount: 50,
+  discount_type: 'fixed',
+  total: 480,
+  payment_method: 'Cash',
+  cashier_name: 'Sarah',
+  created_at: '2026-02-01T10:00:00.000Z',
+  calculation: {
+    subtotal: 500,
+    manualDiscount: 50,
+    couponDiscount: 20,
+    pointsDiscount: 0,
+    taxAmount: 0,
+    taxMode: 'exclusive',
+    taxRatePercent: 0,
+    tipAmount: 5,
+    amountDue: 435,
+  },
+  items: [{ product_id: 7, variant_id: 3, quantity: 2, unit_price: 250 }],
+  payments: [{ method: 'Cash', amount: 435 }],
+};
+
+describe('buildReceipt', () => {
+  it('renders the confirmed calculation, never a client recomputation', () => {
+    const receipt = buildReceipt(CONFIRMED, context());
+
+    // 435, not the 425 a naive client recompute of 10% off 500 plus a 5 tip
+    // and a 20 coupon would have produced.
+    expect(receipt.calculation).toEqual(CONFIRMED.calculation);
+    expect(receipt.payments).toEqual([{ method: 'Cash', amount: 435 }]);
+    expect(receipt.saleId).toBe(91);
+    expect(receipt.cashierName).toBe('Sarah');
+    expect(receipt.date).toBe('2026-02-01T10:00:00.000Z');
+    expect(receipt.customerName).toBe('Amina');
+  });
+
+  it('prefers the server-confirmed discount over the cart it was rung up from', () => {
+    const receipt = buildReceipt(CONFIRMED, context());
+    expect(receipt.discountValue).toBe(50);
+    expect(receipt.discountType).toBe('fixed');
+  });
+
+  it('falls back to the cart discount only when the response omits one', () => {
+    const receipt = buildReceipt(
+      { ...CONFIRMED, discount: undefined, discount_type: undefined },
+      context()
+    );
+    expect(receipt.discountValue).toBe(10);
+    expect(receipt.discountType).toBe('percentage');
+  });
+
+  it('takes line quantities and prices from the server, and only the NAME from the cart', () => {
+    const receipt = buildReceipt(
+      {
+        ...CONFIRMED,
+        // The server re-priced this line; the receipt must show the server's figure.
+        items: [{ product_id: 7, variant_id: 3, quantity: 2, unit_price: 199 }],
+      },
+      context()
+    );
+    expect(receipt.items).toEqual([{ name: 'Silk Dress', quantity: 2, unit_price: 199 }]);
+  });
+
+  it('matches names by product AND variant, falling back to the line memo then empty', () => {
+    const receipt = buildReceipt(
+      {
+        ...CONFIRMED,
+        items: [
+          { product_id: 7, variant_id: 3, quantity: 1, unit_price: 250 },
+          // Same product, different variant: no name in the cart for it.
+          { product_id: 7, variant_id: 9, quantity: 1, unit_price: 250, memo: 'special order' },
+          { product_id: 99, variant_id: null, quantity: 1, unit_price: 10 },
+        ],
+      },
+      context()
+    );
+    expect(receipt.items.map((i) => i.name)).toEqual(['Silk Dress', 'special order', '']);
+  });
+
+  it('synthesizes a single payment from the confirmed amount due when none came back', () => {
+    const receipt = buildReceipt({ ...CONFIRMED, payments: [] }, context());
+    expect(receipt.payments).toEqual([{ method: 'Cash', amount: 435 }]);
+  });
+
+  it('reconstructs a minimal calculation for a pre-Unit-4 response, without crashing', () => {
+    const receipt = buildReceipt({ ...CONFIRMED, calculation: undefined }, context());
+
+    expect(receipt.calculation).toEqual({
+      subtotal: 500,
+      manualDiscount: 0,
+      couponDiscount: 0,
+      pointsDiscount: 0,
+      taxAmount: 0,
+      // Only the tax MODE/RATE come from local settings — never an amount.
+      taxMode: 'exclusive',
+      taxRatePercent: 14,
+      tipAmount: 0,
+      amountDue: 480,
+    });
+    // With no calculation and no payments, the sale total is the fallback.
+    expect(
+      buildReceipt({ ...CONFIRMED, calculation: undefined, payments: [] }, context()).payments
+    ).toEqual([{ method: 'Cash', amount: 480 }]);
+  });
+
+  it('leaves an unset coupon and cashier name undefined/empty rather than null', () => {
+    const receipt = buildReceipt(
+      { ...CONFIRMED, cashier_name: undefined },
+      context({ couponCode: '', customerName: undefined })
+    );
+    expect(receipt.couponCode).toBeUndefined();
+    expect(receipt.cashierName).toBe('');
+    expect(receipt.customerName).toBeUndefined();
+  });
+});

--- a/client/src/features/pos/lib/saleReceipt.ts
+++ b/client/src/features/pos/lib/saleReceipt.ts
@@ -1,0 +1,77 @@
+/**
+ * Turning the server's confirmed sale response into the receipt the cashier
+ * prints.
+ *
+ * The single rule this file exists to protect: **every monetary figure comes
+ * from the server's response, never from a client-side recomputation.** The
+ * cart is consulted for exactly one thing — the product *name* per line, which
+ * the server's resolved items do not carry. That lookup is cosmetic and never
+ * substitutes for a confirmed amount.
+ *
+ * Extracted from CartPanel's mutation `onSuccess` (issue #51) so the mapping
+ * can be tested without rendering the POS screen or completing a sale.
+ */
+import type { ReceiptData, ReceiptItem, ReceiptPayment } from '../../../shared/components/Receipt';
+import type { TaxSettings } from '../../../shared/lib/checkout';
+import type { CartItem, DiscountType } from '../store/cartStore';
+import type { SaleResponse } from '../types';
+
+export interface ReceiptContext {
+  /** The cart as it stood when the sale was confirmed — display names only. */
+  cartItems: CartItem[];
+  /** Fallbacks for a response shaped like the pre-Unit-4 contract. */
+  discount: number;
+  discountType: DiscountType;
+  couponCode: string;
+  tax: TaxSettings;
+  customerName?: string;
+}
+
+export function buildReceipt(sale: SaleResponse, context: ReceiptContext): ReceiptData {
+  const { cartItems, discount, discountType, couponCode, tax, customerName } = context;
+  const calc = sale.calculation;
+
+  // Display name only -- looked up against the cart the cashier just rang up.
+  // Every MONETARY figure below (quantity, unit_price, every calculation line,
+  // total, payments) comes solely from `sale`/`calc`, the server's confirmed
+  // response -- never recomputed client-side.
+  const nameByLine = new Map(
+    cartItems.map((i) => [`${i.product_id}:${i.variant_id ?? 0}`, i.name])
+  );
+  const receiptItems: ReceiptItem[] = (sale.items ?? []).map((item) => ({
+    name: nameByLine.get(`${item.product_id}:${item.variant_id ?? 0}`) ?? item.memo ?? '',
+    quantity: item.quantity,
+    unit_price: item.unit_price,
+  }));
+
+  const receiptPayments: ReceiptPayment[] =
+    sale.payments && sale.payments.length > 0
+      ? sale.payments
+      : [{ method: sale.payment_method, amount: calc?.amountDue ?? sale.total }];
+
+  return {
+    saleId: sale.id,
+    items: receiptItems,
+    discountType: sale.discount_type || discountType,
+    discountValue: sale.discount ?? discount,
+    couponCode: couponCode || undefined,
+    // `calc` is additive-but-guaranteed on this branch (Unit 4); the fallback
+    // only guards a response shaped like the pre-Unit-4 contract so the
+    // receipt never crashes.
+    calculation: calc ?? {
+      subtotal: receiptItems.reduce((sum, i) => sum + i.unit_price * i.quantity, 0),
+      manualDiscount: 0,
+      couponDiscount: 0,
+      pointsDiscount: 0,
+      taxAmount: 0,
+      taxMode: tax.mode,
+      taxRatePercent: tax.rate,
+      tipAmount: 0,
+      amountDue: sale.total,
+    },
+    payments: receiptPayments,
+    cashierName: sale.cashier_name || '',
+    customerName,
+    date: sale.created_at,
+  };
+}

--- a/client/src/features/pos/store/cartStore.test.ts
+++ b/client/src/features/pos/store/cartStore.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { calculateTotals } from '../../../shared/lib/checkout';
 import { useCartStore, sanitizeCartItem, type Product, type CartPersistedV0 } from './cartStore';
+
+/**
+ * What the current cart is worth, per the ONE authoritative calculation
+ * (`shared/lib/checkout`). The store used to expose its own `getTotal()` that
+ * derived this a second, tax/tip/loyalty-blind way; it was unused outside
+ * these assertions and was removed with issue #51's "one owner per checkout
+ * value" criterion. These cases still cover the same discount semantics --
+ * they just no longer require the store to own money.
+ */
+function amountDue(): number {
+  const { items, discount, discountType, couponDiscount } = useCartStore.getState();
+  return calculateTotals({
+    items,
+    discount,
+    discountType,
+    couponDiscount,
+    tax: { enabled: false, rate: 0, mode: 'exclusive' },
+    pointsToRedeem: 0,
+    redeemValue: 0,
+    tip: 0,
+  }).amountDue;
+}
 
 const mockProduct: Product = {
   id: 1,
@@ -121,7 +144,7 @@ describe('Cart - Subtotal & Total', () => {
 
   it('should return 0 for empty cart', () => {
     expect(useCartStore.getState().getSubtotal()).toBe(0);
-    expect(useCartStore.getState().getTotal()).toBe(0);
+    expect(amountDue()).toBe(0);
   });
 });
 
@@ -130,14 +153,14 @@ describe('Cart - Fixed Discount', () => {
     useCartStore.getState().addItem(mockProduct); // 500
     useCartStore.getState().setDiscount(100);
     useCartStore.getState().setDiscountType('fixed');
-    expect(useCartStore.getState().getTotal()).toBe(400);
+    expect(amountDue()).toBe(400);
   });
 
   it('should not go below zero with large discount', () => {
     useCartStore.getState().addItem(mockProduct2); // 200
     useCartStore.getState().setDiscount(500);
     useCartStore.getState().setDiscountType('fixed');
-    expect(useCartStore.getState().getTotal()).toBe(0);
+    expect(amountDue()).toBe(0);
   });
 });
 
@@ -146,14 +169,14 @@ describe('Cart - Percentage Discount', () => {
     useCartStore.getState().addItem(mockProduct); // 500
     useCartStore.getState().setDiscount(10);
     useCartStore.getState().setDiscountType('percentage');
-    expect(useCartStore.getState().getTotal()).toBe(450); // 500 - 10%
+    expect(amountDue()).toBe(450); // 500 - 10%
   });
 
   it('should apply 100% discount', () => {
     useCartStore.getState().addItem(mockProduct);
     useCartStore.getState().setDiscount(100);
     useCartStore.getState().setDiscountType('percentage');
-    expect(useCartStore.getState().getTotal()).toBe(0);
+    expect(amountDue()).toBe(0);
   });
 });
 
@@ -165,7 +188,7 @@ describe('Cart - Coupon Discount', () => {
     useCartStore.getState().setCoupon('SAVE20', 20);
 
     // 500 - 50 (fixed) - 20 (coupon) = 430
-    expect(useCartStore.getState().getTotal()).toBe(430);
+    expect(amountDue()).toBe(430);
   });
 
   it('should clear coupon', () => {
@@ -174,7 +197,7 @@ describe('Cart - Coupon Discount', () => {
     useCartStore.getState().clearCoupon();
     expect(useCartStore.getState().couponCode).toBe('');
     expect(useCartStore.getState().couponDiscount).toBe(0);
-    expect(useCartStore.getState().getTotal()).toBe(500);
+    expect(amountDue()).toBe(500);
   });
 });
 

--- a/client/src/features/pos/store/cartStore.test.ts
+++ b/client/src/features/pos/store/cartStore.test.ts
@@ -10,7 +10,7 @@ import { useCartStore, sanitizeCartItem, type Product, type CartPersistedV0 } fr
  * value" criterion. These cases still cover the same discount semantics --
  * they just no longer require the store to own money.
  */
-function amountDue(): number {
+function totals() {
   const { items, discount, discountType, couponDiscount } = useCartStore.getState();
   return calculateTotals({
     items,
@@ -21,8 +21,11 @@ function amountDue(): number {
     pointsToRedeem: 0,
     redeemValue: 0,
     tip: 0,
-  }).amountDue;
+  });
 }
+
+const amountDue = () => totals().amountDue;
+const subtotal = () => totals().subtotal;
 
 const mockProduct: Product = {
   id: 1,
@@ -133,17 +136,17 @@ describe('Cart - Subtotal & Total', () => {
   it('should calculate subtotal correctly', () => {
     useCartStore.getState().addItem(mockProduct); // 500
     useCartStore.getState().addItem(mockProduct2); // 200
-    expect(useCartStore.getState().getSubtotal()).toBe(700);
+    expect(subtotal()).toBe(700);
   });
 
   it('should calculate subtotal with quantity', () => {
     useCartStore.getState().addItem(mockProduct);
     useCartStore.getState().updateQuantity(1, 3);
-    expect(useCartStore.getState().getSubtotal()).toBe(1500); // 500 * 3
+    expect(subtotal()).toBe(1500); // 500 * 3
   });
 
   it('should return 0 for empty cart', () => {
-    expect(useCartStore.getState().getSubtotal()).toBe(0);
+    expect(subtotal()).toBe(0);
     expect(amountDue()).toBe(0);
   });
 });

--- a/client/src/features/pos/store/cartStore.ts
+++ b/client/src/features/pos/store/cartStore.ts
@@ -87,7 +87,6 @@ interface CartState {
   setTip: (tip: number) => void;
   setCoupon: (code: string, discount: number) => void;
   clearCoupon: () => void;
-  getSubtotal: () => number;
   clearCart: () => void;
   isRecoveredCart: () => boolean;
   /**
@@ -348,11 +347,6 @@ export const useCartStore = create<CartState>()(
       setTip: (tip) => set({ tip }),
       setCoupon: (code, discount) => set({ couponCode: code, couponDiscount: discount }),
       clearCoupon: () => set({ couponCode: '', couponDiscount: 0 }),
-
-      getSubtotal: () => {
-        const { items } = get();
-        return items.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
-      },
 
       clearCart: () =>
         set({

--- a/client/src/features/pos/store/cartStore.ts
+++ b/client/src/features/pos/store/cartStore.ts
@@ -88,7 +88,6 @@ interface CartState {
   setCoupon: (code: string, discount: number) => void;
   clearCoupon: () => void;
   getSubtotal: () => number;
-  getTotal: () => number;
   clearCart: () => void;
   isRecoveredCart: () => boolean;
   /**
@@ -353,14 +352,6 @@ export const useCartStore = create<CartState>()(
       getSubtotal: () => {
         const { items } = get();
         return items.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
-      },
-
-      getTotal: () => {
-        const { items, discount, discountType, couponDiscount } = get();
-        const subtotal = items.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
-        const discountAmount =
-          discountType === 'percentage' ? (subtotal * discount) / 100 : discount;
-        return Math.max(0, subtotal - discountAmount - couponDiscount);
       },
 
       clearCart: () =>

--- a/client/src/features/pos/types.ts
+++ b/client/src/features/pos/types.ts
@@ -57,3 +57,108 @@ export interface Shift {
   total_hours: number | null;
   break_minutes: number;
 }
+
+// --- Checkout wire types -------------------------------------------------
+// The shapes POST /api/v1/sales takes and gives back. Lifted verbatim out of
+// CartPanel.tsx when checkout composition was extracted (issue #51) so the
+// payload/receipt builders and the component can share one definition.
+
+export type PaymentMethod = 'Cash' | 'Card' | 'Other';
+
+/** Write payload for POST /api/v1/sales — not the read shape returned by GET /api/sales/:id */
+export interface SaleItemInput {
+  product_id: number;
+  variant_id?: number | null;
+  quantity: number;
+  unit_price: number;
+  memo?: string | null;
+}
+
+export interface PaymentEntry {
+  method: PaymentMethod | 'Gift Card';
+  amount: number;
+}
+
+export interface SaleData {
+  items: SaleItemInput[];
+  discount: number;
+  discount_type: string;
+  payment_method: PaymentMethod;
+  payments?: PaymentEntry[];
+  customer_id?: number;
+  tax_amount?: number;
+  points_redeemed?: number;
+  notes?: string;
+  tip?: number;
+  coupon_code?: string;
+}
+
+/** One checkout attempt: the composed body plus the key that dedupes its retries. */
+export interface CheckoutAttempt {
+  saleData: SaleData;
+  idempotencyKey: string;
+}
+
+/**
+ * A resolved sale line as the server actually persisted it (Unit 4's
+ * `resolvedItems` -- authoritative product/variant identity, quantity and
+ * price; no product name, which is why the receipt looks names up against
+ * the cart the cashier just rang up, display-only, never for a monetary
+ * figure).
+ */
+export interface ConfirmedSaleItem {
+  product_id: number;
+  variant_id?: number | null;
+  quantity: number;
+  unit_price: number;
+  memo?: string | null;
+}
+
+/**
+ * A validated payment entry exactly as persisted (`ConfirmedPayment` in
+ * server/src/modules/pos/sales/types.ts).
+ */
+export interface ConfirmedSalePayment {
+  method: string;
+  amount: number;
+}
+
+/**
+ * Mirrors the server's immutable `SaleCalculationSnapshot` (Units 2/4) --
+ * see client/src/shared/components/Receipt.tsx's `ReceiptCalculation`, which
+ * this is mapped into 1:1. Every figure is the CONFIRMED, persisted amount
+ * for this sale; the receipt renders these directly rather than the client's
+ * own (possibly stale-by-then) preview.
+ */
+export interface ConfirmedSaleCalculation {
+  subtotal: number;
+  manualDiscount: number;
+  couponDiscount: number;
+  pointsDiscount: number;
+  taxAmount: number;
+  taxMode: 'inclusive' | 'exclusive';
+  taxRatePercent: number;
+  tipAmount: number;
+  amountDue: number;
+}
+
+/** What POST /api/v1/sales hands back, as far as the receipt needs it. */
+export interface SaleResponse {
+  id: number;
+  discount?: number;
+  discount_type?: string;
+  total: number;
+  payment_method: string;
+  cashier_name?: string;
+  created_at: string;
+  /** Additive since Unit 4 -- present on every response from this branch's server. */
+  calculation?: ConfirmedSaleCalculation;
+  items?: ConfirmedSaleItem[];
+  payments?: ConfirmedSalePayment[];
+}
+
+/** What POST /api/v1/coupons/validate hands back, as far as the cart needs it. */
+export interface CouponValidation {
+  code: string;
+  discount: number;
+}

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -26,7 +26,10 @@ judgment — stop at the first question that matches.
 2. **Is it the app shell or the composition root** (renders/wires more than one feature, e.g. routing,
    the sidebar, session bootstrapping)? → `client/src/app/`.
 3. **Otherwise** → the one slice that uses it (`client/src/features/<slice>/`), in the folder matching
-   its kind (`pages/`, `components/`, `hooks/`, `store/`, or `types.ts`).
+   its kind (`pages/`, `components/`, `hooks/`, `lib/`, `store/`, or `types.ts`). `lib/` is for
+   slice-local **pure** logic — no React, no stores, no transport — the same role `shared/lib/`
+   plays one layer up (e.g. `features/pos/lib/salePayload.ts`). If it is pure *and* a second slice
+   needs it, it belongs in `shared/lib/` instead, by rule 1.
 4. **Does another slice need it?** → export it from that slice's `index.ts`. Never import a path inside
    another slice's internals (`@/features/other-slice/pages/...`) — that is an
    `eslint-plugin-boundaries` violation once the file leaves its own slice.
@@ -75,6 +78,36 @@ decision, not an oversight — do not "fix" it as a drive-by during unrelated wo
 Treat all four of the above as a deliberate, currently-flat global namespace. If you're adding to one of
 them, follow its existing shape; if you're tempted to namespace or split one of them "while you're in
 there," raise it as its own change instead.
+
+---
+
+## Checkout ownership contract
+
+Every value a checkout is made of has exactly **one** owner. This is not tidiness: the cart footer
+once added tax but ignored points and tip while the drawer subtracted both, so a cashier balanced
+split payments against a figure that was not what the customer owed.
+
+| Value | Owner |
+| --- | --- |
+| Every money figure (subtotal, discounts, tax, tip, amount due, earned points) | `shared/lib/checkout.ts`'s `calculateTotals`, called once per render by `features/pos/hooks/useCheckoutPricing.ts` |
+| Tax and loyalty policy (parsed from the settings row) | `features/pos/lib/checkoutSettings.ts` |
+| Loyalty redemption state (toggle + point count) and its cap | `useCheckoutPricing` — the count is meaningless apart from the cap that clamps it |
+| Split-tender allocation and whether it balances | `useCheckoutPricing`'s `split` |
+| The sale body and the reduced offline body | `features/pos/lib/salePayload.ts`, both from one `SaleComposition` |
+| The receipt | `features/pos/lib/saleReceipt.ts`, from the server's confirmed response only |
+| Submission, idempotency keying, receipt state, offline fallback | `features/pos/hooks/useCheckoutSubmission.ts` |
+
+Rules that follow from it:
+
+- **A component never derives money.** `CartPanel`, `CartFooter`, `CheckoutSummary`,
+  `PaymentSection` and the customer display all read the same `totals`/`split` objects. If you find
+  yourself writing arithmetic on prices in a component, the figure belongs in `calculateTotals`.
+- **The cart store holds inputs, not outcomes.** It owns items, discount, coupon code/amount, tip
+  and notes. It deliberately no longer exposes `getTotal()` or `getSubtotal()` — both were float
+  re-derivations of figures `calculateTotals` already produces in minor units. Read
+  `totals.subtotal` / `totals.amountDue` instead.
+- **The receipt never recomputes.** Only the product *name* is looked up against the cart; every
+  amount comes from the response.
 
 ---
 


### PR DESCRIPTION
Closes #51.

`CartPanel.tsx` **1507 → 294 lines**. Eight commits, one extraction each, every one with its own tests.

> [!NOTE]
> **This PR needs a visual check before merge.** It was verified by tests only — no browser, no dev server. A precise checklist is at the bottom.

## The decomposition

Cut on **ownership**, not on size — each unit is the sole owner of one checkout concern:

| Unit | Owns |
|---|---|
| `lib/checkoutSettings.ts` | Settings row → tax policy, loyalty policy (canonical keys only; 0% tax counts as off) |
| `lib/salePayload.ts` | One `SaleComposition` → both the online body and the reduced offline body |
| `lib/saleReceipt.ts` | Server response → receipt; the cart supplies names only |
| `hooks/useCheckoutPricing.ts` | **The single authority for money** — totals, split allocation, loyalty cap, redemption state |
| `hooks/useCheckoutSubmission.ts` | Idempotency keying, POST, receipt state, error branches, offline fallback |
| `hooks/useCustomerSelection.ts`, `useCouponApplication.ts`, `useCustomerDisplayBroadcast.ts` | Their own flows |
| `components/checkout/*` (7 files) | Presentation only — they render the `totals` / `split` they are handed |

The two units that decide money are **hooks precisely so they can be driven by `renderHook`** without the POS screen — which is the acceptance criterion "checkout calculation and submission behavior can be tested independently", and it is demonstrated rather than asserted: `useCheckoutPricing.test.tsx` (10 tests) and `useCheckoutSubmission.test.tsx` (7) render no component, and the three `lib/` units (29 tests) are pure.

## Three competing derivations of money, all consolidated

1. **`cartStore.getSubtotal()`** was a second, float-based derivation of `totals.subtotal`, used by the footer, the drawer summary, the %/EGP discount conversion **and the `coupons/validate` request body**. All now read `totals.subtotal`, which is computed in integer minor units and agrees with the server's own rounding. Store method removed.
2. **`cartStore.getTotal()`** — a third answer to "what does this cost?", blind to tax, tip and loyalty. No callers outside its own tests. Removed; its discount cases now assert through `calculateTotals`.
3. **The sale body and the offline body** were separate inline literals free to drift. Both now derive from one `SaleComposition`.

`cartStore` lives inside the pos slice, so both removals are contained; no reference survives outside comments.

## Two deliberate behaviour deltas — reported, not hidden

Each is called out in its own commit message:

- **The offline fallback now queues the composition that was actually submitted**, rather than re-reading the cart at failure time. The old code could queue a *changed* cart under the submitted sale's idempotency key. Latent, and in a path that is currently unreachable — but not worth re-introducing while moving the code.
- **The offline-queue reset now runs the same `onCheckoutSettled` as the success path**, which additionally clears the redemption. Previously incidental (dropping the customer clamps points to zero anyway); now explicit.

Nothing else looked like a live correctness bug.

## Deliberately not fixed

The offline fallback **remains unreachable** — `queryClient` sets no `networkMode`, so React Query pauses rather than fails a mutation fired while offline. Preserved verbatim with a comment pointing at #53, which owns it. Error-handling standardization (#52) untouched, as it is sequenced after this and would conflict.

## Testing

- `vitest run` in `client/`: **48 files, 447 tests passed**. The pos slice went from 69 tests at baseline to 126+.
- `npm run lint` (eslint + boundaries): **0 errors**. One pre-existing warning in `POS.tsx` (`isRecovered` dep), untouched.
- `lint:cycles` (madge): no circular dependency.
- `tsc --noEmit`: **39 errors at baseline → 33 now**, none in any file created or touched here.

> [!IMPORTANT]
> That last line is worth its own attention: **the repo's typecheck is not clean on `main`** — `HeldCartsDialog`, `Register`, `Deliveries`, `KpiCards` and others already fail. A "typecheck must pass" CI gate would red on `main` today. Worth its own issue; #43's scope touches it.

## What needs a visual check

Markup is preserved — same class names, same `data-testid`s, same section order — but jsdom does not prove pixels. On `/pos`, in **both** LTR (en) and RTL (ar), light and dark:

1. **Cart panel** — line rows (name, memo pencil, price, −/qty/+, line total, X) sit as before; the memo input opens inline and commits on blur and on Enter.
2. **Footer** — discount %/EGP toggle, numeric input, four preset buttons, then Subtotal / Discount / VAT / Tip / Total, then Checkout. Spacing and dividers unchanged.
3. **Checkout drawer** — opens from the correct side (right in en, left in ar); order is Summary → Customer → Loyalty (only with a customer and loyalty on) → Coupon → Quick Discount → Tip → Notes → Payment → Confirm.
4. **The Confirm button is still full-width and not compressed** on a short viewport (~900px tall). The `shrink-0` there is load-bearing and now lives in a different file — and a zero-height Confirm button is exactly the defect #65 found before.
5. **Split payment** — the "allocated / due" figure turns green exactly when the split balances, red otherwise; the remove-row X appears only with 3+ rows.
6. **Customer dropdown** overlays correctly (`z-20`, absolute under the search box) and does not clip inside the drawer.

## Post-Deploy Monitoring and Validation

- **Watch:** the error rate on `POST /api/v1/sales`, and the ratio of sales with a coupon or loyalty redemption to those without. A refactor of pricing that changed a total would show up as a shift in that ratio or in average sale value, not as an exception.
- **Healthy signal:** average sale total and average discount per sale unchanged versus the previous week. Coupon validation acceptance rate unchanged — the `coupons/validate` body now carries a minor-unit-rounded subtotal instead of a raw float sum, which agrees with the server but is the one wire value this PR alters.
- **Failure signals / rollback trigger:** any cashier report of a wrong total, a Confirm button that cannot be clicked, or a drawer section rendering out of order. Client-only change, so rollback is a revert and SPA redeploy with no data implications.
- **Window:** one full trading day, with the first hour watched actively since a pricing regression is worst at the till.
- **Owner:** @zhamdy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
