### PR TITLE
docs: restore the blank line before the refresh-token-rotation heading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ never read missing information as "unreferenced" — and it never touches an obj
 `MEDIA_ORPHAN_MIN_AGE_HOURS`. **A new table with an image URL column must be added to the
 reference query in `src/scheduler/mediaSweep.ts`** — the sweep deletes what that query does
 not return.
+
 ## Refresh token rotation
 
 Refresh tokens are stored as a SHA-256 digest, never in plaintext, and each login opens a


### PR DESCRIPTION
A one-line fix for damage I introduced while merging.

#74 and #75 both added a `CLAUDE.md` section at the same point in the file, so they conflicted. Keeping both sides meant stripping the conflict markers — and the `=======` marker had been standing in for the blank line between the two sections. Removing it left `## Refresh token rotation` sitting directly beneath the last paragraph of `## Media storage`, where a heading is not guaranteed to render as one.

No content changed; this restores the separating newline.

Worth noting as a general hazard: mechanically stripping conflict markers to keep both sides is only safe when the marker lines were not themselves carrying structure. In a Markdown file they usually are.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — documentation whitespace, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN