### PR TITLE
feat(client): standardize mutation errors, recovery, and double-submit protection

### DIFF
--- a/client/src/app/__tests__/session.test.ts
+++ b/client/src/app/__tests__/session.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * The composition root's auth-failure path. Driven through the transport's
+ * auth port -- the same call `client.ts` makes when a token refresh fails --
+ * rather than by reaching into session.ts, so the wiring itself is what is
+ * under test.
+ */
+// Declared through vi.hoisted so the factory below -- which vitest hoists
+// above every import -- can see them.
+const { navigate, invalidate, location } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  invalidate: vi.fn(),
+  location: { href: '/inventory?page=2' },
+}));
+
+vi.mock('../router', () => ({
+  router: {
+    get state() {
+      return { location };
+    },
+    navigate,
+    invalidate,
+  },
+}));
+
+// Imported for its side effect: installing the auth port and the logout
+// teardown. Must come after the router mock.
+import '../session';
+import { onAuthFailure } from '../../shared/lib/transport/authPort';
+import { useAuthStore } from '../../features/auth';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  location.href = '/inventory?page=2';
+  useAuthStore.setState({
+    user: { id: 1, name: 'Sarah', email: 'sarah@moon.com', role: 'Cashier' },
+    accessToken: 'stale',
+    isAuthenticated: true,
+  });
+});
+
+describe('a refresh that could not be recovered', () => {
+  it('ends the session', () => {
+    onAuthFailure();
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().accessToken).toBeNull();
+  });
+
+  it('carries where the user was, so signing in returns them to it', () => {
+    onAuthFailure();
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/login',
+      search: { redirect: '/inventory?page=2' },
+    });
+  });
+
+  it('carries no redirect when the user was already on the login screen', () => {
+    location.href = '/login';
+
+    onAuthFailure();
+
+    expect(navigate).toHaveBeenCalledWith({ to: '/login', search: {} });
+  });
+
+  it('never carries a target pointing off this origin', () => {
+    location.href = '//evil.example/steal';
+
+    onAuthFailure();
+
+    expect(navigate).toHaveBeenCalledWith({ to: '/login', search: {} });
+  });
+});

--- a/client/src/app/session.ts
+++ b/client/src/app/session.ts
@@ -11,6 +11,7 @@
 import { queryClient } from '../shared/lib/queryClient';
 import { setAuthPort } from '../shared/lib/transport/index';
 import { onSessionEvent } from '../shared/lib/session';
+import { safeRedirectTarget } from '../shared/lib/authRedirect';
 import { useAuthStore } from '../features/auth';
 import { useOfflineStore } from '../shared/store/offlineStore';
 import { useCartStore } from '../features/pos';
@@ -20,8 +21,13 @@ setAuthPort({
   getAccessToken: () => useAuthStore.getState().accessToken,
   onTokenRefreshed: (user, accessToken) => useAuthStore.getState().login(user, accessToken),
   onAuthFailure: () => {
+    // Where the user was when the refresh failed, so signing in again returns
+    // them to it instead of dropping them on their role's home page. Read
+    // BEFORE logout(): the teardown below invalidates the router, and a
+    // guarded route may have moved us by the time we navigate.
+    const redirect = safeRedirectTarget(router.state.location.href);
     useAuthStore.getState().logout();
-    router.navigate({ to: '/login' });
+    router.navigate({ to: '/login', search: redirect ? { redirect } : {} });
     router.invalidate();
   },
 });

--- a/client/src/features/auth/pages/Login.test.tsx
+++ b/client/src/features/auth/pages/Login.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '../../../shared/lib/transport/index';
+import { ApiError } from '../../../shared/lib/transport/types';
+import type { Transport, TransportRequest, TransportResult } from '../../../shared/lib/transport/types';
+import { useSettingsStore } from '../../../shared/store/settingsStore';
+import { useAuthStore } from '../store/authStore';
+import Login from './Login';
+
+const { navigate, search } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  search: { redirect: undefined as string | undefined },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+  useSearch: () => search,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const CASHIER = { id: 2, name: 'Sarah', email: 'sarah@moon.com', role: 'Cashier' };
+
+function transportFor(reply: () => unknown): Transport {
+  return {
+    async request<T>(_req: TransportRequest): Promise<TransportResult<T>> {
+      const result = reply();
+      if (result instanceof Error) throw result;
+      return { data: result as T };
+    },
+  };
+}
+
+function renderLogin(transport: Transport) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+  return render(<Login />, { wrapper });
+}
+
+function signIn() {
+  fireEvent.change(screen.getByLabelText(/email/i), {
+    target: { value: 'sarah@moon.com' },
+  });
+  fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'cashier123' } });
+  fireEvent.click(screen.getByRole('button', { name: /sign in|login/i }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  search.redirect = undefined;
+  useSettingsStore.setState({ locale: 'en' });
+  useAuthStore.setState({ user: null, accessToken: null, isAuthenticated: false });
+});
+
+describe('signing in after a session expired mid-workflow', () => {
+  it('returns the user to where they were', async () => {
+    search.redirect = '/inventory?page=2';
+    renderLogin(transportFor(() => ({ accessToken: 'fresh', user: CASHIER })));
+
+    signIn();
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/inventory?page=2' }));
+  });
+
+  it('falls back to the role home when no target was carried', async () => {
+    renderLogin(transportFor(() => ({ accessToken: 'fresh', user: CASHIER })));
+
+    signIn();
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/pos' }));
+  });
+
+  it('refuses a target pointing off this origin even if one reaches the component', async () => {
+    // The route's validateSearch already filters this; the component filters
+    // again so it is safe to render outside that route.
+    search.redirect = 'https://evil.example/steal';
+    renderLogin(transportFor(() => ({ accessToken: 'fresh', user: CASHIER })));
+
+    signIn();
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/pos' }));
+  });
+
+  it('stays put and keeps what was typed when the credentials are rejected', async () => {
+    renderLogin(transportFor(() => new ApiError('Invalid email or password', 401, 'UNAUTHORIZED')));
+
+    signIn();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /sign in|login/i })).toBeEnabled()
+    );
+    expect(navigate).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(screen.getByLabelText(/email/i)).toHaveValue('sarah@moon.com');
+  });
+});

--- a/client/src/features/auth/pages/Login.tsx
+++ b/client/src/features/auth/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -7,6 +7,7 @@ import toast from 'react-hot-toast';
 import { Eye, EyeOff } from 'lucide-react';
 import { Card, CardBody, CardHeader, Button, Input, Checkbox } from '@heroui/react';
 import { useAuthStore } from '../store/authStore';
+import { getDefaultRoute, safeRedirectTarget } from '../../../shared/lib/authRedirect';
 import { useTransport } from '../../../shared/lib/transport/index';
 import moonLogo from '../../../shared/assets/moon-logo.svg';
 import { useTranslation, t as tStandalone } from '../../../shared/i18n/index';
@@ -22,6 +23,11 @@ type LoginFormData = z.infer<ReturnType<typeof getLoginSchema>>;
 
 export default function Login() {
   const navigate = useNavigate();
+  // Set when the session expired mid-workflow (see app/session.ts) or when a
+  // guarded route bounced an unauthenticated visit. Already filtered by the
+  // route's validateSearch; re-filtered here so this component is safe to
+  // render outside that route, e.g. in a test.
+  const { redirect } = useSearch({ from: '/login' });
   const { login } = useAuthStore();
   const transport = useTransport();
   const [showPassword, setShowPassword] = useState(false);
@@ -49,14 +55,9 @@ export default function Login() {
       login(user, accessToken);
       toast.success(t('login.welcomeBack', { name: user.name }));
 
-      // Route based on role
-      if (user.role === 'Admin') {
-        navigate({ to: '/' });
-      } else if (user.role === 'Cashier') {
-        navigate({ to: '/pos' });
-      } else {
-        navigate({ to: '/deliveries' });
-      }
+      // Back to the screen the session expired on, if there was one and it is
+      // a place we are willing to bounce to; otherwise this role's home.
+      navigate({ to: safeRedirectTarget(redirect) ?? getDefaultRoute(user) });
     } catch (err) {
       toast.error((err instanceof Error && err.message) || t('login.failed'));
     } finally {

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -119,15 +119,16 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
   // Submission lifecycle: keying, posting, the receipt, and the offline
   // fallback. `onCheckoutSettled` is the surrounding UI's reset, run once the
   // sale is committed or queued -- never after a failure the cashier retries.
-  const { submit, isPending, receiptOpen, setReceiptOpen, receiptData } = useCheckoutSubmission({
-    tax,
-    customerName: customer.selected?.name,
-    onCheckoutSettled: () => {
-      setCheckoutOpen(false);
-      customer.reset();
-      resetRedemption();
-    },
-  });
+  const { submit, isPending, stockConflict, receiptOpen, setReceiptOpen, receiptData } =
+    useCheckoutSubmission({
+      tax,
+      customerName: customer.selected?.name,
+      onCheckoutSettled: () => {
+        setCheckoutOpen(false);
+        customer.reset();
+        resetRedemption();
+      },
+    });
 
   const handleCheckout = (): void => {
     // A recovered/restored cart is not fully trusted for checkout until the
@@ -288,6 +289,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
         onConfirm={handleCheckout}
         isPending={isPending}
         needsReview={needsReview}
+        stockConflict={stockConflict}
       />
     </div>
   );

--- a/client/src/features/pos/components/checkout/CheckoutDrawer.tsx
+++ b/client/src/features/pos/components/checkout/CheckoutDrawer.tsx
@@ -22,12 +22,14 @@ import type { DiscountType } from '../../../../shared/lib/checkout';
 import type { CheckoutPricing } from '../../hooks/useCheckoutPricing';
 import type { CouponApplication } from '../../hooks/useCouponApplication';
 import type { CustomerSelection } from '../../hooks/useCustomerSelection';
+import type { StockConflictRecovery } from '../../hooks/useStockConflictRecovery';
 import type { CartItem } from '../../store/cartStore';
 import type { PaymentEntry, PaymentMethod } from '../../types';
 import CheckoutSummary from './CheckoutSummary';
 import CustomerSection from './CustomerSection';
 import LoyaltySection from './LoyaltySection';
 import PaymentSection from './PaymentSection';
+import StockConflictNotice from './StockConflictNotice';
 
 const QUICK_DISCOUNT_PRESETS = [5, 10, 15];
 
@@ -59,6 +61,7 @@ export default function CheckoutDrawer({
   onConfirm,
   isPending,
   needsReview,
+  stockConflict,
 }: {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -87,6 +90,7 @@ export default function CheckoutDrawer({
   onConfirm: () => void;
   isPending: boolean;
   needsReview: boolean;
+  stockConflict: StockConflictRecovery;
 }): React.JSX.Element {
   const { t } = useTranslation();
   const { tax, loyalty, totals, split, maxPoints } = pricing;
@@ -291,6 +295,10 @@ export default function CheckoutDrawer({
                 split={split}
                 totals={totals}
               />
+
+              {/* Sits directly above Confirm so the numbers a cashier has to
+                  reconcile are next to the button they are blocking. */}
+              <StockConflictNotice conflict={stockConflict} />
 
               {/* `shrink-0` is load-bearing, not cosmetic. This button is the last child
                   of a flex-column DrawerBody, and once the drawer's content is taller

--- a/client/src/features/pos/components/checkout/StockConflictNotice.test.tsx
+++ b/client/src/features/pos/components/checkout/StockConflictNotice.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useSettingsStore } from '../../../../shared/store/settingsStore';
+import type { StockConflictRecovery } from '../../hooks/useStockConflictRecovery';
+import StockConflictNotice from './StockConflictNotice';
+
+function recovery(overrides: Partial<StockConflictRecovery> = {}): StockConflictRecovery {
+  return {
+    shortfalls: [],
+    isChecking: false,
+    check: vi.fn(),
+    resolve: vi.fn(),
+    clear: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useSettingsStore.setState({ locale: 'en' });
+});
+
+describe('StockConflictNotice', () => {
+  it('shows nothing at all when there is no conflict', () => {
+    const { container } = render(<StockConflictNotice conflict={recovery()} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('says it is checking while the stock re-read is in flight', () => {
+    render(<StockConflictNotice conflict={recovery({ isChecking: true })} />);
+
+    expect(screen.getByText('Checking current stock...')).toBeInTheDocument();
+  });
+
+  it('names each short line with what was asked for and what is left', () => {
+    render(
+      <StockConflictNotice
+        conflict={recovery({
+          shortfalls: [
+            { productId: 7, name: 'Silk Dress', requested: 4, available: 1 },
+            { productId: 9, name: 'Cashmere Scarf', requested: 2, available: 0 },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Silk Dress: 4 in cart, 1 left')).toBeInTheDocument();
+    expect(screen.getByText('Cashmere Scarf: 2 in cart, 0 left')).toBeInTheDocument();
+  });
+
+  it('offers the adjustment as an explicit action, never applying it on render', () => {
+    const resolve = vi.fn();
+    render(
+      <StockConflictNotice
+        conflict={recovery({
+          resolve,
+          shortfalls: [{ productId: 7, name: 'Silk Dress', requested: 4, available: 1 }],
+        })}
+      />
+    );
+
+    expect(resolve).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Adjust cart to available stock' }));
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/features/pos/components/checkout/StockConflictNotice.tsx
+++ b/client/src/features/pos/components/checkout/StockConflictNotice.tsx
@@ -1,0 +1,55 @@
+/**
+ * What the cashier sees after a checkout the server refused on stock: which
+ * line, how many were asked for, how many are left, and the one button that
+ * makes the cart sellable.
+ *
+ * Rendered inside the drawer rather than as a toast on purpose. The cashier has
+ * to read several numbers and then act on them, with a customer waiting; a
+ * notification that disappears on its own is the wrong shape for that.
+ */
+import { Button } from '@heroui/react';
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from '../../../../shared/i18n/index';
+import type { StockConflictRecovery } from '../../hooks/useStockConflictRecovery';
+
+export default function StockConflictNotice({
+  conflict,
+}: {
+  conflict: StockConflictRecovery;
+}): React.JSX.Element | null {
+  const { t } = useTranslation();
+
+  if (conflict.isChecking) {
+    return (
+      <p className="shrink-0 text-xs text-muted-foreground">{t('cart.stockConflictChecking')}</p>
+    );
+  }
+
+  if (conflict.shortfalls.length === 0) return null;
+
+  return (
+    <div
+      role="alert"
+      className="shrink-0 rounded-lg border border-warning/40 bg-warning/10 p-3 space-y-2"
+    >
+      <p className="flex items-center gap-2 text-xs font-semibold text-foreground">
+        <AlertTriangle className="h-4 w-4 text-warning" />
+        {t('cart.stockConflictTitle')}
+      </p>
+      <ul className="space-y-1">
+        {conflict.shortfalls.map((shortfall) => (
+          <li key={shortfall.productId} className="text-xs text-foreground">
+            {t('cart.stockConflictLine', {
+              name: shortfall.name,
+              requested: shortfall.requested,
+              available: shortfall.available,
+            })}
+          </li>
+        ))}
+      </ul>
+      <Button size="sm" variant="flat" color="warning" onClick={conflict.resolve}>
+        {t('cart.stockConflictAdjust')}
+      </Button>
+    </div>
+  );
+}

--- a/client/src/features/pos/hooks/useCheckoutSubmission.test.tsx
+++ b/client/src/features/pos/hooks/useCheckoutSubmission.test.tsx
@@ -183,7 +183,11 @@ describe('useCheckoutSubmission', () => {
     transport.failNext('Gateway timeout', 502, undefined, undefined, 'sales');
     act(() => result.current.submit(COMPOSITION));
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Gateway timeout'));
+    // The proxy's wording is deliberately NOT shown: a 5xx body is
+    // infrastructure talking, not a sentence for a cashier. See
+    // shared/lib/mutationError.ts -- server-authored wording is surfaced only
+    // for the kinds the server phrases for a user.
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Checkout failed'));
     // A failure the cashier can retry: nothing cleared, nothing closed.
     expect(useCartStore.getState().items).toHaveLength(1);
     expect(settled).not.toHaveBeenCalled();
@@ -296,5 +300,131 @@ describe('useCheckoutSubmission', () => {
         customer_id: 42,
       });
     });
+  });
+});
+
+describe('recovering from a rejected checkout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.setState({ locale: 'en' });
+    useOfflineStore.setState({ queue: [], isSyncing: false });
+    useCartStore.setState({
+      items: [SILK_DRESS],
+      discount: 0,
+      discountType: 'fixed',
+      notes: '',
+      tip: 0,
+      couponCode: '',
+      couponDiscount: 0,
+      needsReview: false,
+      checkoutAttempt: null,
+    });
+  });
+
+  /** The cart asks for 2; the server now has `available`. */
+  function transportWithStock(available: number): MemoryTransport {
+    return withSaleReply(
+      createMemoryTransport(
+        {},
+        { reads: { 'products/lookup': [{ id: 7, name: 'Silk Dress', stock: available }] } }
+      )
+    );
+  }
+
+  it('says which line is short and by how much, without parsing the server sentence', async () => {
+    const transport = transportWithStock(1);
+    const { result, settled } = renderSubmission(transport);
+
+    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(result.current.stockConflict.shortfalls).toHaveLength(1));
+    expect(result.current.stockConflict.shortfalls[0]).toEqual({
+      productId: 7,
+      name: 'Silk Dress',
+      requested: 2,
+      available: 1,
+    });
+    // A recoverable failure keeps the cart and the drawer exactly as they were.
+    expect(useCartStore.getState().items).toHaveLength(1);
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it('leaves the cart untouched until the cashier accepts the adjustment', async () => {
+    const transport = transportWithStock(1);
+    const { result } = renderSubmission(transport);
+
+    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+    await waitFor(() => expect(result.current.stockConflict.shortfalls).toHaveLength(1));
+    expect(useCartStore.getState().items[0].quantity).toBe(2);
+
+    act(() => result.current.stockConflict.resolve());
+
+    expect(useCartStore.getState().items[0].quantity).toBe(1);
+    expect(result.current.stockConflict.shortfalls).toEqual([]);
+  });
+
+  it('removes a line whose product is gone entirely', async () => {
+    const transport = withSaleReply(createMemoryTransport({}, { reads: { 'products/lookup': [] } }));
+    const { result } = renderSubmission(transport);
+
+    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+    await waitFor(() => expect(result.current.stockConflict.shortfalls).toHaveLength(1));
+
+    act(() => result.current.stockConflict.resolve());
+
+    expect(useCartStore.getState().items).toHaveLength(0);
+  });
+
+  it('proposes nothing when stock turns out to be fine -- the cause was elsewhere', async () => {
+    const transport = transportWithStock(50);
+    const { result } = renderSubmission(transport);
+
+    transport.failNext('Coupon has expired', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Coupon has expired'));
+    await waitFor(() => expect(result.current.stockConflict.isChecking).toBe(false));
+    expect(result.current.stockConflict.shortfalls).toEqual([]);
+  });
+
+  it('does not go looking at stock for a failure that is not about the world changing', async () => {
+    const transport = transportWithStock(0);
+    const { result } = renderSubmission(transport);
+
+    transport.failNext('', 500, undefined, undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Checkout failed'));
+    expect(transport.calls().some((call) => call.path === 'products/lookup')).toBe(false);
+    expect(result.current.stockConflict.shortfalls).toEqual([]);
+  });
+
+  it('stays quiet when the stock re-read itself fails, rather than burying the first error', async () => {
+    const transport = withSaleReply(createMemoryTransport());
+    const { result } = renderSubmission(transport);
+
+    // No `reads` entry for products/lookup, so the memory transport rejects it.
+    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.stockConflict.isChecking).toBe(false));
+    expect(result.current.stockConflict.shortfalls).toEqual([]);
+  });
+
+  it('drops a second Confirm pressed before the first has answered', async () => {
+    const transport = transportWithStock(50);
+    const { result } = renderSubmission(transport);
+
+    act(() => {
+      result.current.submit(COMPOSITION);
+      result.current.submit(COMPOSITION);
+    });
+
+    await waitFor(() => expect(useCartStore.getState().items).toHaveLength(0));
+    expect(transport.calls().filter((call) => call.path === 'sales')).toHaveLength(1);
   });
 });

--- a/client/src/features/pos/hooks/useCheckoutSubmission.ts
+++ b/client/src/features/pos/hooks/useCheckoutSubmission.ts
@@ -12,12 +12,13 @@
  * dead code and not wired up.
  */
 import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { useTranslation } from '../../../shared/i18n/index';
 import { SPLIT_PAYMENT_MISMATCH_CODE, type TaxSettings } from '../../../shared/lib/checkout';
 import { useTransport, createIdempotencyKey } from '../../../shared/lib/transport/index';
-import { ApiError } from '../../../shared/lib/transport/types';
+import { hasDetailCode } from '../../../shared/lib/mutationError';
+import { useGuardedMutation } from '../../../shared/lib/useGuardedMutation';
 import { useOfflineStore, SALE_QUEUE_CONTRACT_VERSION } from '../../../shared/store/offlineStore';
 import type { ReceiptData } from '../../../shared/components/Receipt';
 import {
@@ -27,6 +28,7 @@ import {
 } from '../lib/salePayload';
 import { buildReceipt } from '../lib/saleReceipt';
 import { useCartStore } from '../store/cartStore';
+import { useStockConflictRecovery, type StockConflictRecovery } from './useStockConflictRecovery';
 import type { CheckoutAttempt, SaleData, SaleResponse } from '../types';
 
 /**
@@ -38,9 +40,22 @@ import type { CheckoutAttempt, SaleData, SaleResponse } from '../types';
 type CheckoutMutationVariables = CheckoutAttempt & { composition: SaleComposition };
 
 export interface CheckoutSubmission {
-  /** Compose, key and post the sale the cashier just confirmed. */
+  /**
+   * Compose, key and post the sale the cashier just confirmed.
+   *
+   * A second call while one is in flight is dropped by `useGuardedMutation`,
+   * so a double-pressed Confirm (or a held keyboard shortcut) cannot open two
+   * concurrent checkouts. That is separate from, and in front of, the
+   * idempotency key below: the key makes a duplicate that DOES reach the
+   * server harmless, this stops it being sent at all.
+   */
   submit: (composition: SaleComposition) => void;
   isPending: boolean;
+  /**
+   * What the cart would have to become for the sale to go through, after a
+   * rejection whose cause was stock. Empty at every other time.
+   */
+  stockConflict: StockConflictRecovery;
   receiptOpen: boolean;
   setReceiptOpen: (open: boolean) => void;
   receiptData: ReceiptData | null;
@@ -97,7 +112,9 @@ export function useCheckoutSubmission(params: {
     return attempt.key;
   };
 
-  const checkoutMutation = useMutation({
+  const stockConflict = useStockConflictRecovery();
+
+  const checkoutMutation = useGuardedMutation<CheckoutMutationVariables, { data: SaleResponse }>({
     mutationFn: ({ saleData, idempotencyKey }: CheckoutMutationVariables) =>
       transport.request<SaleResponse>({
         method: 'POST',
@@ -131,7 +148,7 @@ export function useCheckoutSubmission(params: {
       setReceiptData(newReceipt);
       setReceiptOpen(true);
     },
-    onError: (error: Error, attempt: CheckoutMutationVariables) => {
+    onFailure: (failure, attempt: CheckoutMutationVariables) => {
       if (!navigator.onLine) {
         addToQueue({
           type: 'sale',
@@ -153,33 +170,52 @@ export function useCheckoutSubmission(params: {
         setCheckoutAttempt(null);
         clearCart();
         onCheckoutSettled();
-      } else {
-        // Authoritative data (catalog price, tax, coupon, or loyalty
-        // settings) changed between preview and submission and the split no
-        // longer balances against the server's recalculated total. The cart
-        // is intentionally left untouched (nothing cleared or closed above) so
-        // the cashier can review and rebalance rather than seeing a generic
-        // failure or a false success.
-        const isSplitMismatch =
-          error instanceof ApiError &&
-          error.details?.some((d) => d.code === SPLIT_PAYMENT_MISMATCH_CODE);
-        toast.error(
-          isSplitMismatch ? t('cart.splitMismatchError') : error.message || t('cart.saleFailed')
-        );
+        // The queue entry IS the outcome the cashier was told about; the
+        // failure that produced it is not theirs to act on.
+        return true;
       }
+
+      // Authoritative data (catalog price, tax, coupon, or loyalty
+      // settings) changed between preview and submission and the split no
+      // longer balances against the server's recalculated total. The cart
+      // is intentionally left untouched (nothing cleared or closed above) so
+      // the cashier can review and rebalance rather than seeing a generic
+      // failure or a false success.
+      if (hasDetailCode(failure, SPLIT_PAYMENT_MISMATCH_CODE)) {
+        toast.error(t('cart.splitMismatchError'));
+        return true;
+      }
+
+      // Anything the server rejected on the state of the world -- stock,
+      // coupon, loyalty, a bundle -- arrives as a bare validation or conflict
+      // failure. Re-read stock to find out whether the cart is the reason and,
+      // if so, say which line and by how much. The toast still fires: this
+      // check is asynchronous and additive, not a replacement for telling the
+      // cashier immediately that the sale did not go through.
+      if (failure.recovery === 'fix' || failure.recovery === 'review') {
+        stockConflict.check();
+      }
+      // `saleFailed` only stands in when the server said nothing of its own;
+      // the classifier already prefers the server's wording where there is any.
+      if (!failure.serverMessage) {
+        toast.error(t('cart.saleFailed'));
+        return true;
+      }
+      return false;
     },
   });
 
   return {
     submit: (composition: SaleComposition) => {
       const saleData = buildSalePayload(composition);
-      checkoutMutation.mutate({
+      checkoutMutation.submit({
         saleData,
         idempotencyKey: idempotencyKeyFor(saleData),
         composition,
       });
     },
     isPending: checkoutMutation.isPending,
+    stockConflict,
     receiptOpen,
     setReceiptOpen,
     receiptData,

--- a/client/src/features/pos/hooks/useStockConflictRecovery.ts
+++ b/client/src/features/pos/hooks/useStockConflictRecovery.ts
@@ -1,0 +1,85 @@
+/**
+ * The recovery half of a rejected checkout: re-read stock for what is in the
+ * cart, say what changed, and offer the one action that makes the cart
+ * sellable again.
+ *
+ * Deliberately explicit rather than automatic. The cart is money the cashier
+ * has already agreed with a customer standing in front of them; silently
+ * dropping a line would be worse than the generic failure it replaces. So this
+ * hook only ever *proposes* — `resolve()` runs when the cashier presses the
+ * button, never on its own.
+ */
+import { useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTransport } from '../../../shared/lib/transport/index';
+import type { Product } from '../../../shared/types/index';
+import {
+  checkableProductIds,
+  findStockShortfalls,
+  planCartAdjustment,
+  type StockShortfall,
+} from '../lib/stockConflict';
+import { useCartStore } from '../store/cartStore';
+
+export interface StockConflictRecovery {
+  shortfalls: StockShortfall[];
+  isChecking: boolean;
+  /** Re-read stock for the cart and work out what no longer fits. */
+  check: () => void;
+  /** Apply the proposal: trim oversold lines, drop the ones with nothing left. */
+  resolve: () => void;
+  /** Forget the proposal, e.g. once the cashier has edited the cart by hand. */
+  clear: () => void;
+}
+
+export function useStockConflictRecovery(): StockConflictRecovery {
+  const transport = useTransport();
+  const queryClient = useQueryClient();
+  const items = useCartStore((s) => s.items);
+  const updateQuantity = useCartStore((s) => s.updateQuantity);
+  const removeItem = useCartStore((s) => s.removeItem);
+
+  const [shortfalls, setShortfalls] = useState<StockShortfall[]>([]);
+  const [isChecking, setIsChecking] = useState(false);
+
+  const check = useCallback(() => {
+    const ids = checkableProductIds(useCartStore.getState().items);
+    if (ids.length === 0) {
+      setShortfalls([]);
+      return;
+    }
+
+    setIsChecking(true);
+    void transport
+      .request<Product[]>({
+        method: 'GET',
+        path: 'products/lookup',
+        params: { ids: ids.join(',') },
+      })
+      .then(({ data }) => {
+        const fresh = new Map(data.map((product) => [product.id, Number(product.stock)]));
+        setShortfalls(findStockShortfalls(useCartStore.getState().items, fresh));
+        // The POS grid is showing the same numbers this call just corrected.
+        queryClient.invalidateQueries({ queryKey: ['products'] });
+      })
+      .catch(() => {
+        // The check is a courtesy on top of a failure the cashier has already
+        // been told about. If it cannot run there is nothing further to say --
+        // surfacing a second error here would only bury the first.
+        setShortfalls([]);
+      })
+      .finally(() => setIsChecking(false));
+  }, [transport, queryClient]);
+
+  const resolve = useCallback(() => {
+    for (const adjustment of planCartAdjustment(items, shortfalls)) {
+      if (adjustment.quantity === 0) removeItem(adjustment.productId, adjustment.variantId);
+      else updateQuantity(adjustment.productId, adjustment.quantity, adjustment.variantId);
+    }
+    setShortfalls([]);
+  }, [items, shortfalls, removeItem, updateQuantity]);
+
+  const clear = useCallback(() => setShortfalls([]), []);
+
+  return { shortfalls, isChecking, check, resolve, clear };
+}

--- a/client/src/features/pos/lib/stockConflict.test.ts
+++ b/client/src/features/pos/lib/stockConflict.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkableProductIds,
+  findStockShortfalls,
+  planCartAdjustment,
+  type StockShortfall,
+} from './stockConflict';
+import type { CartItem } from '../store/cartStore';
+
+function line(overrides: Partial<CartItem> & { product_id: number }): CartItem {
+  return {
+    name: `Product ${overrides.product_id}`,
+    unit_price: 100,
+    quantity: 1,
+    stock: 10,
+    ...overrides,
+  };
+}
+
+describe('checkableProductIds', () => {
+  it('lists each product once', () => {
+    expect(checkableProductIds([line({ product_id: 7 }), line({ product_id: 7 })])).toEqual([7]);
+  });
+
+  it('leaves out variant lines, whose stock this endpoint does not carry', () => {
+    const items = [line({ product_id: 7 }), line({ product_id: 8, variant_id: 3 })];
+
+    expect(checkableProductIds(items)).toEqual([7]);
+  });
+
+  it('is empty for a cart that is entirely variant lines', () => {
+    expect(checkableProductIds([line({ product_id: 8, variant_id: 3 })])).toEqual([]);
+  });
+});
+
+describe('findStockShortfalls', () => {
+  it('reports nothing when every line still fits', () => {
+    const items = [line({ product_id: 7, quantity: 2 })];
+
+    expect(findStockShortfalls(items, new Map([[7, 5]]))).toEqual([]);
+  });
+
+  it('reports what was asked for against what is left', () => {
+    const items = [line({ product_id: 7, name: 'Silk Dress', quantity: 4 })];
+
+    expect(findStockShortfalls(items, new Map([[7, 1]]))).toEqual<StockShortfall[]>([
+      { productId: 7, name: 'Silk Dress', requested: 4, available: 1 },
+    ]);
+  });
+
+  it('sums the same product across lines, which alone would each look affordable', () => {
+    const items = [
+      line({ product_id: 7, name: 'Silk Dress', quantity: 1, memo: 'gift wrap' }),
+      line({ product_id: 7, name: 'Silk Dress', quantity: 1 }),
+    ];
+
+    expect(findStockShortfalls(items, new Map([[7, 1]]))).toEqual<StockShortfall[]>([
+      { productId: 7, name: 'Silk Dress', requested: 2, available: 1 },
+    ]);
+  });
+
+  it('treats a product missing from the fresh read as no longer sellable', () => {
+    // `products/lookup` hides anything not active from a cashier.
+    const items = [line({ product_id: 7, name: 'Silk Dress', quantity: 2 })];
+
+    expect(findStockShortfalls(items, new Map())).toEqual<StockShortfall[]>([
+      { productId: 7, name: 'Silk Dress', requested: 2, available: 0 },
+    ]);
+  });
+
+  it('never reports a negative availability', () => {
+    const items = [line({ product_id: 7, quantity: 2 })];
+
+    expect(findStockShortfalls(items, new Map([[7, -3]]))[0].available).toBe(0);
+  });
+
+  it('ignores variant lines rather than judging them by product stock', () => {
+    const items = [line({ product_id: 7, variant_id: 3, quantity: 99 })];
+
+    expect(findStockShortfalls(items, new Map([[7, 1]]))).toEqual([]);
+  });
+});
+
+describe('planCartAdjustment', () => {
+  it('trims an oversold line to what is left', () => {
+    const items = [line({ product_id: 7, quantity: 4 })];
+    const shortfalls = [{ productId: 7, name: 'Silk Dress', requested: 4, available: 1 }];
+
+    expect(planCartAdjustment(items, shortfalls)).toEqual([
+      { productId: 7, variantId: null, quantity: 1 },
+    ]);
+  });
+
+  it('removes a line whose product has nothing left', () => {
+    const items = [line({ product_id: 7, quantity: 2 })];
+    const shortfalls = [{ productId: 7, name: 'Silk Dress', requested: 2, available: 0 }];
+
+    expect(planCartAdjustment(items, shortfalls)).toEqual([
+      { productId: 7, variantId: null, quantity: 0 },
+    ]);
+  });
+
+  it('spreads what is left across lines in cart order rather than losing both', () => {
+    const items = [
+      line({ product_id: 7, quantity: 1, memo: 'first' }),
+      line({ product_id: 7, quantity: 1, memo: 'second' }),
+    ];
+    const shortfalls = [{ productId: 7, name: 'Silk Dress', requested: 2, available: 1 }];
+
+    // The first line keeps its single unit and is therefore not adjusted at
+    // all; only the second is emptied.
+    expect(planCartAdjustment(items, shortfalls)).toEqual([
+      { productId: 7, variantId: null, quantity: 0 },
+    ]);
+  });
+
+  it('leaves lines of products that are not short alone', () => {
+    const items = [line({ product_id: 7, quantity: 1 }), line({ product_id: 9, quantity: 3 })];
+    const shortfalls = [{ productId: 9, name: 'Scarf', requested: 3, available: 2 }];
+
+    expect(planCartAdjustment(items, shortfalls)).toEqual([
+      { productId: 9, variantId: null, quantity: 2 },
+    ]);
+  });
+});

--- a/client/src/features/pos/lib/stockConflict.ts
+++ b/client/src/features/pos/lib/stockConflict.ts
@@ -1,0 +1,117 @@
+/**
+ * What a rejected checkout means for the cart, worked out from stock rather
+ * than from the rejection's wording.
+ *
+ * The server refuses an oversold line with `Insufficient stock for product ID
+ * 7` under a bare VALIDATION_ERROR — the typed `INSUFFICIENT_STOCK` code
+ * exists in `server/src/modules/pos/sales/types.ts` but the controller drops
+ * it before the response is built. So the client has no reliable code to
+ * branch on, and the message is an English sentence naming a database id: not
+ * translatable, and not something a cashier can act on.
+ *
+ * Rather than parse that sentence, this module re-reads the stock for what is
+ * in the cart and reports the difference. That says *which product*, *how many
+ * were asked for* and *how many are left*, in the cashier's own language, and
+ * it keeps working if the server's wording ever changes.
+ *
+ * ## Variant lines are not checked
+ *
+ * `GET /api/v1/products/lookup` returns product-level stock only, and variant
+ * stock is a separate column decremented by a separate statement
+ * (`decrementVariantStock`). There is no bulk endpoint for it, so a variant
+ * line is left out entirely rather than compared against a number that is not
+ * its own. A checkout that failed purely on a variant line therefore falls
+ * back to the plain classified message — which is the behaviour that existed
+ * before this module, not a regression.
+ */
+import type { CartItem } from '../store/cartStore';
+
+export interface StockShortfall {
+  productId: number;
+  name: string;
+  /** Total quantity the cart asks for across every non-variant line. */
+  requested: number;
+  /** What the server says is left. Zero for a product that has disappeared. */
+  available: number;
+}
+
+/** Lines this module can speak for: product-level, with a usable id. */
+function checkableLines(items: readonly CartItem[]): CartItem[] {
+  return items.filter((item) => !item.variant_id && Number.isSafeInteger(item.product_id));
+}
+
+/** The product ids to re-read. Empty when the cart is all variant lines. */
+export function checkableProductIds(items: readonly CartItem[]): number[] {
+  return [...new Set(checkableLines(items).map((item) => item.product_id))];
+}
+
+/**
+ * Compares the cart against freshly-read stock.
+ *
+ * A product absent from `freshStock` is treated as zero available: for a
+ * cashier, `products/lookup` hides anything not `active`, so a product that
+ * vanished between add and checkout is one they can no longer sell — which is
+ * exactly what the notice should say.
+ */
+export function findStockShortfalls(
+  items: readonly CartItem[],
+  freshStock: ReadonlyMap<number, number>
+): StockShortfall[] {
+  const requested = new Map<number, { name: string; quantity: number }>();
+  for (const item of checkableLines(items)) {
+    const entry = requested.get(item.product_id);
+    // Quantities are summed per product: the same product can sit on more than
+    // one line (different memos), and each line alone may look affordable
+    // while together they are not.
+    if (entry) entry.quantity += item.quantity;
+    else requested.set(item.product_id, { name: item.name, quantity: item.quantity });
+  }
+
+  const shortfalls: StockShortfall[] = [];
+  for (const [productId, { name, quantity }] of requested) {
+    const available = freshStock.get(productId) ?? 0;
+    if (quantity > available) {
+      shortfalls.push({ productId, name, requested: quantity, available: Math.max(0, available) });
+    }
+  }
+  return shortfalls;
+}
+
+/**
+ * How to change the cart so it can be sold: the new quantity for each line of
+ * an oversold product, zero meaning "remove this line".
+ *
+ * Available stock is spread across that product's lines in cart order, so a
+ * cashier with two lines of the same shirt and one left in stock keeps the
+ * first line rather than losing both.
+ */
+export interface LineAdjustment {
+  productId: number;
+  variantId: number | null;
+  quantity: number;
+}
+
+export function planCartAdjustment(
+  items: readonly CartItem[],
+  shortfalls: readonly StockShortfall[]
+): LineAdjustment[] {
+  const remaining = new Map(shortfalls.map((s) => [s.productId, s.available]));
+  const adjustments: LineAdjustment[] = [];
+
+  for (const item of items) {
+    if (item.variant_id) continue;
+    const left = remaining.get(item.product_id);
+    if (left === undefined) continue;
+    const quantity = Math.min(item.quantity, left);
+    remaining.set(item.product_id, left - quantity);
+    if (quantity !== item.quantity) {
+      adjustments.push({
+        productId: item.product_id,
+        variantId: item.variant_id ?? null,
+        quantity,
+      });
+    }
+  }
+
+  return adjustments;
+}

--- a/client/src/routes/login.tsx
+++ b/client/src/routes/login.tsx
@@ -1,14 +1,17 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { Login } from '@/features/auth';
-import { getDefaultRoute } from '@/shared/lib/authRedirect';
+import { getDefaultRoute, safeRedirectTarget } from '@/shared/lib/authRedirect';
 
 interface LoginSearchParams {
   redirect?: string;
 }
 
 export const Route = createFileRoute('/login')({
+  // Filtered here rather than where it is read: this is the one door the
+  // param comes in through, and an open redirect is only open if it survives
+  // parsing. See safeRedirectTarget for what is rejected.
   validateSearch: (search: Record<string, unknown>): LoginSearchParams => ({
-    redirect: typeof search.redirect === 'string' ? search.redirect : undefined,
+    redirect: safeRedirectTarget(search.redirect),
   }),
   beforeLoad: ({ context, search }) => {
     if (context.auth.isAuthenticated) {

--- a/client/src/shared/i18n/ar.json
+++ b/client/src/shared/i18n/ar.json
@@ -1495,5 +1495,22 @@
   "startup.openingFloat": "الرصيد الافتتاحي",
   "startup.skip": "لاحقاً",
   "startup.shiftStarted": "بدأت الوردية!",
-  "startup.registerOpened": "تم فتح الصندوق!"
+  "startup.registerOpened": "تم فتح الصندوق!",
+
+  "mutationError.validation": "بعض البيانات تحتاج إلى تصحيح قبل الحفظ.",
+  "mutationError.conflict": "تغيّر هذا السجل منذ فتحه. راجعه ثم حاول مرة أخرى.",
+  "mutationError.unauthorized": "انتهت جلستك. سجّل الدخول مرة أخرى للمتابعة.",
+  "mutationError.forbidden": "صلاحيتك لا تسمح بهذا الإجراء.",
+  "mutationError.notFound": "لم يعد هذا السجل موجوداً. حدّث الصفحة ثم حاول مرة أخرى.",
+  "mutationError.rateLimited": "طلبات كثيرة جداً. انتظر لحظة ثم حاول مرة أخرى.",
+  "mutationError.offline": "أنت غير متصل بالإنترنت. أعد الاتصال ثم حاول مرة أخرى.",
+  "mutationError.network": "تعذّر الوصول إلى الخادم. حاول مرة أخرى.",
+  "mutationError.server": "تعذّر على الخادم إتمام العملية. حاول مرة أخرى.",
+  "mutationError.unknown": "حدث خطأ ما. حاول مرة أخرى.",
+  "mutationError.retry": "حاول مرة أخرى",
+  "mutationError.dismiss": "إغلاق",
+  "cart.stockConflictTitle": "تغيّر المخزون أثناء إتمام الدفع",
+  "cart.stockConflictLine": "{name}: {requested} في السلة، المتبقي {available}",
+  "cart.stockConflictAdjust": "تعديل السلة حسب المخزون المتاح",
+  "cart.stockConflictChecking": "جارٍ التحقق من المخزون الحالي..."
 }

--- a/client/src/shared/i18n/en.json
+++ b/client/src/shared/i18n/en.json
@@ -1496,5 +1496,22 @@
   "startup.openingFloat": "Opening Float",
   "startup.skip": "Later",
   "startup.shiftStarted": "Shift started!",
-  "startup.registerOpened": "Register opened!"
+  "startup.registerOpened": "Register opened!",
+
+  "mutationError.validation": "Some details need fixing before this can be saved.",
+  "mutationError.conflict": "This changed since you opened it. Review it and try again.",
+  "mutationError.unauthorized": "Your session expired. Sign in again to continue.",
+  "mutationError.forbidden": "Your role does not allow this action.",
+  "mutationError.notFound": "This record no longer exists. Refresh and try again.",
+  "mutationError.rateLimited": "Too many requests. Wait a moment, then try again.",
+  "mutationError.offline": "You are offline. Reconnect and try again.",
+  "mutationError.network": "Could not reach the server. Try again.",
+  "mutationError.server": "The server could not complete this. Try again.",
+  "mutationError.unknown": "Something went wrong. Try again.",
+  "mutationError.retry": "Try again",
+  "mutationError.dismiss": "Dismiss",
+  "cart.stockConflictTitle": "Stock changed while you were checking out",
+  "cart.stockConflictLine": "{name}: {requested} in cart, {available} left",
+  "cart.stockConflictAdjust": "Adjust cart to available stock",
+  "cart.stockConflictChecking": "Checking current stock..."
 }

--- a/client/src/shared/lib/authRedirect.test.ts
+++ b/client/src/shared/lib/authRedirect.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { getDefaultRoute, safeRedirectTarget } from './authRedirect';
+
+describe('getDefaultRoute', () => {
+  it.each([
+    ['Admin', '/'],
+    ['Cashier', '/pos'],
+    ['Delivery', '/deliveries'],
+  ])('sends a %s to %s', (role, route) => {
+    expect(getDefaultRoute({ role })).toBe(route);
+  });
+
+  it('sends an unknown or absent user back to login', () => {
+    expect(getDefaultRoute(null)).toBe('/login');
+    expect(getDefaultRoute({ role: 'Auditor' })).toBe('/login');
+  });
+});
+
+describe('safeRedirectTarget', () => {
+  it('keeps an in-app path, including its search and hash', () => {
+    expect(safeRedirectTarget('/inventory')).toBe('/inventory');
+    expect(safeRedirectTarget('/sales?page=3')).toBe('/sales?page=3');
+    expect(safeRedirectTarget('/pos#cart')).toBe('/pos#cart');
+  });
+
+  it('rejects an absolute URL to another origin', () => {
+    expect(safeRedirectTarget('https://evil.example/steal')).toBeUndefined();
+    expect(safeRedirectTarget('http://evil.example')).toBeUndefined();
+    expect(safeRedirectTarget('javascript:alert(1)')).toBeUndefined();
+  });
+
+  it('rejects a protocol-relative path that only looks internal', () => {
+    expect(safeRedirectTarget('//evil.example/steal')).toBeUndefined();
+    // Browsers normalise the backslash form the same way.
+    expect(safeRedirectTarget('/\\evil.example')).toBeUndefined();
+  });
+
+  it('rejects login itself, which would loop', () => {
+    expect(safeRedirectTarget('/login')).toBeUndefined();
+    expect(safeRedirectTarget('/login?redirect=/pos')).toBeUndefined();
+    expect(safeRedirectTarget('/login#x')).toBeUndefined();
+  });
+
+  it('rejects anything that is not a string', () => {
+    expect(safeRedirectTarget(undefined)).toBeUndefined();
+    expect(safeRedirectTarget(null)).toBeUndefined();
+    expect(safeRedirectTarget(['/pos'])).toBeUndefined();
+    expect(safeRedirectTarget(7)).toBeUndefined();
+  });
+
+  it('does not treat a path that merely starts with the word login as the login page', () => {
+    expect(safeRedirectTarget('/login-history')).toBe('/login-history');
+  });
+});

--- a/client/src/shared/lib/authRedirect.ts
+++ b/client/src/shared/lib/authRedirect.ts
@@ -8,3 +8,33 @@ export function getDefaultRoute(
   if (user?.role === 'Delivery') return '/deliveries';
   return '/login';
 }
+
+/**
+ * The `redirect` search param is the only thing that gets a user back to the
+ * screen their session expired on, and it is also the only thing on the login
+ * route an attacker can choose. So it is filtered here, once, rather than
+ * trusted at either end.
+ *
+ * Returns the target to send the user to after signing in, or `undefined` when
+ * the value is not a place we are willing to bounce to:
+ *
+ * - anything that is not an in-app absolute path (`/inventory`), which rules
+ *   out `https://evil.example` outright;
+ * - a protocol-relative path (`//evil.example`, and its `/\` variant, which
+ *   several browsers normalise the same way) — these look internal and are not;
+ * - `/login` itself, which would loop.
+ *
+ * Route-level authorisation is NOT this function's job: `_authenticated` and
+ * `_admin` still guard their subtrees, so a stale link to an admin page is
+ * bounced by the router, not silently honoured here.
+ */
+export function safeRedirectTarget(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const target = value.trim();
+  if (!target.startsWith('/')) return undefined;
+  if (target.startsWith('//') || target.startsWith('/\\')) return undefined;
+  if (target === '/login' || target.startsWith('/login?') || target.startsWith('/login#')) {
+    return undefined;
+  }
+  return target;
+}

--- a/client/src/shared/lib/mutationError.test.ts
+++ b/client/src/shared/lib/mutationError.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ApiError } from './transport/types';
+import {
+  classifyMutationError,
+  hasDetailCode,
+  messageKeyFor,
+  type MutationErrorKind,
+} from './mutationError';
+import { useSettingsStore } from '../store/settingsStore';
+import en from '../i18n/en.json';
+import ar from '../i18n/ar.json';
+
+const ALL_KINDS: MutationErrorKind[] = [
+  'validation',
+  'conflict',
+  'unauthorized',
+  'forbidden',
+  'notFound',
+  'rateLimited',
+  'offline',
+  'network',
+  'server',
+  'unknown',
+];
+
+const messages = en as Record<string, string>;
+
+// The app defaults to Arabic; pin a locale so the assertions below read as
+// English rather than as whatever the last test left behind.
+beforeEach(() => {
+  useSettingsStore.setState({ locale: 'en' });
+});
+
+describe('classifyMutationError', () => {
+  it.each([
+    ['VALIDATION_ERROR', 400, 'validation', 'fix'],
+    ['CONFLICT', 409, 'conflict', 'review'],
+    ['UNAUTHORIZED', 401, 'unauthorized', 'signIn'],
+    ['FORBIDDEN', 403, 'forbidden', 'none'],
+    ['NOT_FOUND', 404, 'notFound', 'review'],
+    ['RATE_LIMITED', 429, 'rateLimited', 'wait'],
+  ] as const)('maps %s to the %s kind with a %s recovery', (code, status, kind, recovery) => {
+    const failure = classifyMutationError(new ApiError('boom', status, code), true);
+
+    expect(failure.kind).toBe(kind);
+    expect(failure.recovery).toBe(recovery);
+  });
+
+  it('treats a 5xx as a retryable server failure whatever code rides on it', () => {
+    const failure = classifyMutationError(new ApiError('Internal server error', 500), true);
+
+    expect(failure.kind).toBe('server');
+    expect(failure.retryable).toBe(true);
+  });
+
+  it('separates a request that never reached the server into offline vs network', () => {
+    expect(classifyMutationError(new ApiError('', null), false).kind).toBe('offline');
+    expect(classifyMutationError(new ApiError('', null), true).kind).toBe('network');
+  });
+
+  it('falls back to the HTTP status when the body carries no code', () => {
+    expect(classifyMutationError(new ApiError('', 409), true).kind).toBe('conflict');
+    expect(classifyMutationError(new ApiError('', 408), true).kind).toBe('network');
+    expect(classifyMutationError(new ApiError('', 418), true).kind).toBe('unknown');
+  });
+
+  it('shows the server wording for a rejection the server phrased for a user', () => {
+    const failure = classifyMutationError(
+      new ApiError('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR'),
+      true
+    );
+
+    expect(failure.message).toBe('Insufficient stock for product ID 7');
+  });
+
+  it('never shows the server wording for an authentication, rate-limit or 5xx failure', () => {
+    const cases: [ApiError, MutationErrorKind][] = [
+      [new ApiError('Invalid refresh token', 401, 'UNAUTHORIZED'), 'unauthorized'],
+      [new ApiError('Too many requests', 429, 'RATE_LIMITED'), 'rateLimited'],
+      [new ApiError('pg: relation "sales" does not exist', 500), 'server'],
+    ];
+
+    for (const [error, kind] of cases) {
+      const failure = classifyMutationError(error, true);
+      expect(failure.message).toBe(messages[messageKeyFor(kind)]);
+      expect(failure.message).not.toBe(error.message);
+    }
+  });
+
+  it('falls back to its own wording when the transport blanked the message', () => {
+    // transport/http.ts deliberately drops axios's "Network Error".
+    const failure = classifyMutationError(new ApiError('', null), true);
+
+    expect(failure.message).toBe(messages['mutationError.network']);
+  });
+
+  it('pins validation details to the fields that caused them', () => {
+    const failure = classifyMutationError(
+      new ApiError('Request validation failed', 400, 'VALIDATION_ERROR', [
+        { field: 'price', code: 'too_small', message: 'Value is too small' },
+        { field: 'sku', code: 'invalid_type', message: 'Expected string' },
+      ]),
+      true
+    );
+
+    expect(failure.fieldErrors).toEqual({
+      price: 'Value is too small',
+      sku: 'Expected string',
+    });
+  });
+
+  it('keeps the first message for a field reported twice', () => {
+    const failure = classifyMutationError(
+      new ApiError('nope', 400, 'VALIDATION_ERROR', [
+        { field: 'price', code: 'too_small', message: 'outermost' },
+        { field: 'price', code: 'invalid_type', message: 'innermost' },
+      ]),
+      true
+    );
+
+    expect(failure.fieldErrors.price).toBe('outermost');
+  });
+
+  it('leaves a detail with no field out of fieldErrors so it stays in the headline', () => {
+    const failure = classifyMutationError(
+      new ApiError('Payments do not balance', 400, 'VALIDATION_ERROR', [
+        { field: '', code: 'SPLIT_PAYMENT_MISMATCH', message: 'Payments do not balance' },
+      ]),
+      true
+    );
+
+    expect(failure.fieldErrors).toEqual({});
+    expect(failure.message).toBe('Payments do not balance');
+    expect(hasDetailCode(failure, 'SPLIT_PAYMENT_MISMATCH')).toBe(true);
+  });
+
+  it('never attaches field errors to a non-validation failure', () => {
+    const failure = classifyMutationError(
+      new ApiError('conflict', 409, 'CONFLICT', [
+        { field: 'code', code: 'IDEMPOTENCY_KEY_REUSED', message: 'reused' },
+      ]),
+      true
+    );
+
+    expect(failure.fieldErrors).toEqual({});
+    // ...but the detail is still readable by a caller that knows the code.
+    expect(hasDetailCode(failure, 'IDEMPOTENCY_KEY_REUSED')).toBe(true);
+  });
+
+  it('never leaks the message of a throw that did not come from the server', () => {
+    const failure = classifyMutationError(new TypeError('cannot read property of undefined'));
+
+    expect(failure.kind).toBe('unknown');
+    expect(failure.message).toBe(messages['mutationError.unknown']);
+    expect(failure.message).not.toContain('undefined');
+  });
+
+  it('classifies a non-Error throw rather than crashing on it', () => {
+    expect(classifyMutationError('nope').kind).toBe('unknown');
+    expect(classifyMutationError(null).kind).toBe('unknown');
+  });
+});
+
+describe('the message for every kind', () => {
+  it.each(ALL_KINDS)('is translated in both locales for %s', (kind) => {
+    const key = messageKeyFor(kind);
+    expect((en as Record<string, string>)[key]).toBeTruthy();
+    expect((ar as Record<string, string>)[key]).toBeTruthy();
+  });
+});

--- a/client/src/shared/lib/mutationError.ts
+++ b/client/src/shared/lib/mutationError.ts
@@ -1,0 +1,255 @@
+/**
+ * The client-side mutation error contract: one classification of "the write
+ * failed", derived only from signals the server actually sends.
+ *
+ * Why this exists: every page phrased its own failure handling, so the same
+ * 401 was a red toast on one screen and a silent no-op on another, and a
+ * validation rejection that names a field was flattened to a sentence the
+ * cashier could not act on. This module is the single place that turns an
+ * unknown thrown value into (a) what class of failure it was and (b) what the
+ * user can DO about it.
+ *
+ * ## What the server actually sends
+ *
+ * `server/src/http/errors.ts` is the whole surface. Seven codes, and nothing
+ * else ever reaches the wire:
+ *
+ *   VALIDATION_ERROR (400) · UNAUTHORIZED (401) · FORBIDDEN (403)
+ *   NOT_FOUND (404) · CONFLICT (409) · RATE_LIMITED (429) · INTERNAL_ERROR (500)
+ *
+ * `details[]` carries `{ field, code, message }` triples — Zod issues for a
+ * validation rejection, and a handful of hand-written domain codes riding
+ * under a generic parent (`IDEMPOTENCY_KEY_REUSED` and `IDEMPOTENCY_UNRESOLVED`
+ * under CONFLICT, `SPLIT_PAYMENT_MISMATCH` under VALIDATION_ERROR).
+ *
+ * Deliberately NOT invented here: codes the server does not send. Notably
+ * `INSUFFICIENT_STOCK` exists in `server/src/modules/pos/sales/types.ts` but
+ * the controller drops it, re-wrapping the error as a bare VALIDATION_ERROR
+ * with an English sentence. So this module cannot classify a stock conflict,
+ * and does not pretend to: POS recovers from one by comparing the cart against
+ * freshly-fetched stock (`features/pos/lib/stockConflict.ts`) rather than by
+ * parsing a message. The constant below is honoured if the server ever starts
+ * sending it, and costs nothing until then.
+ *
+ * ## Message safety
+ *
+ * A server message is shown ONLY where the server authored it for a user:
+ * VALIDATION_ERROR, CONFLICT, NOT_FOUND and FORBIDDEN. For 401, 429 and 5xx
+ * the client's own translated wording is used instead — those messages are
+ * either uninformative ("Internal server error") or carry authentication
+ * detail that is not worth surfacing. Transport-level failures never have a
+ * message at all: `transport/http.ts` deliberately blanks axios's wording, so
+ * the fallback below is what the user sees.
+ */
+import { t } from '../i18n/index';
+import { ApiError, type ValidationDetail } from './transport/types';
+
+/**
+ * The classes a mutation failure can land in. Chosen so that each one implies
+ * exactly one recovery — if two kinds would offer the user the same action and
+ * the same explanation, they should not be two kinds.
+ */
+export type MutationErrorKind =
+  | 'validation'
+  | 'conflict'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'notFound'
+  | 'rateLimited'
+  | 'offline'
+  | 'network'
+  | 'server'
+  | 'unknown';
+
+/**
+ * What the user can do next. This is the point of the whole module: a class of
+ * error with no recovery is just a colour of toast.
+ *
+ * - `fix`    — the input is wrong and is fixable in place. Keep the form open,
+ *              keep every value, attach `fieldErrors` to the fields.
+ * - `review` — the world moved under the request. Refresh what it depended on
+ *              and let the user look before resubmitting. Never auto-retry.
+ * - `retry`  — the request never got a verdict. The same submission again is
+ *              safe (writes that matter carry an `Idempotency-Key`).
+ * - `wait`   — a rate limit. Retrying now makes it worse.
+ * - `signIn` — the session is gone. Re-authenticate and come back here.
+ * - `none`   — nothing the user can do from this screen.
+ */
+export type MutationRecovery = 'fix' | 'review' | 'retry' | 'wait' | 'signIn' | 'none';
+
+export interface MutationFailure {
+  kind: MutationErrorKind;
+  recovery: MutationRecovery;
+  /** Safe, user-facing, translated where the client owns the wording. */
+  message: string;
+  /**
+   * Field path -> message, for a `fix`. Empty for every other kind. Pages hand
+   * this to React Hook Form's `setError` so the failure lands on the input
+   * that caused it instead of in a toast that closes the dialog.
+   */
+  fieldErrors: Record<string, string>;
+  /** The server's structured code, when it sent one. */
+  code?: string;
+  /** The server's `details[]`, verbatim, for callers that read domain codes. */
+  details: ValidationDetail[];
+  status: number | null;
+  /**
+   * Whether resubmitting the identical request could succeed. Note this is
+   * about the request, not about whether the UI should retry automatically —
+   * nothing here retries on its own.
+   */
+  retryable: boolean;
+}
+
+/**
+ * Recognised if the server ever forwards it (see the header note); today the
+ * sales controller drops the code, so nothing matches this in practice.
+ */
+export const INSUFFICIENT_STOCK_CODE = 'INSUFFICIENT_STOCK';
+
+const RECOVERY: Record<MutationErrorKind, MutationRecovery> = {
+  validation: 'fix',
+  conflict: 'review',
+  unauthorized: 'signIn',
+  forbidden: 'none',
+  notFound: 'review',
+  rateLimited: 'wait',
+  offline: 'retry',
+  network: 'retry',
+  server: 'retry',
+  unknown: 'retry',
+};
+
+const RETRYABLE: Record<MutationErrorKind, boolean> = {
+  validation: false,
+  conflict: false,
+  unauthorized: false,
+  forbidden: false,
+  notFound: false,
+  rateLimited: true,
+  offline: true,
+  network: true,
+  server: true,
+  unknown: true,
+};
+
+/** Kinds whose message the server authored for a human to read. */
+const SERVER_MESSAGE_KINDS: ReadonlySet<MutationErrorKind> = new Set<MutationErrorKind>([
+  'validation',
+  'conflict',
+  'notFound',
+  'forbidden',
+]);
+
+/** Translation key carrying the client's own wording for each kind. */
+export function messageKeyFor(kind: MutationErrorKind): string {
+  return `mutationError.${kind}`;
+}
+
+function kindFor(error: ApiError, online: boolean): MutationErrorKind {
+  // `http.ts` leaves the status null when the request never reached the
+  // server. Offline and network are the same HTTP fact and different user
+  // facts: one is "your shop's link is down", the other "something ate that
+  // request". Both retry, but the wording has to differ or the cashier is
+  // told to check a connection that is fine.
+  if (error.status === null) return online ? 'network' : 'offline';
+  if (error.status >= 500) return 'server';
+
+  switch (error.code) {
+    case 'VALIDATION_ERROR':
+      return 'validation';
+    case 'CONFLICT':
+      return 'conflict';
+    case 'UNAUTHORIZED':
+      return 'unauthorized';
+    case 'FORBIDDEN':
+      return 'forbidden';
+    case 'NOT_FOUND':
+      return 'notFound';
+    case 'RATE_LIMITED':
+      return 'rateLimited';
+    default:
+      break;
+  }
+
+  // No code on the body — an older deploy, or a proxy that answered instead of
+  // the app. Status is still trustworthy, so fall back to it rather than
+  // calling a plain 404 "unknown".
+  switch (error.status) {
+    case 400:
+      return 'validation';
+    case 401:
+      return 'unauthorized';
+    case 403:
+      return 'forbidden';
+    case 404:
+      return 'notFound';
+    case 408:
+      return 'network';
+    case 409:
+      return 'conflict';
+    case 429:
+      return 'rateLimited';
+    default:
+      return 'unknown';
+  }
+}
+
+function fieldErrorsFrom(details: ValidationDetail[]): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const detail of details) {
+    // A detail with no field is a whole-request complaint (the split-payment
+    // mismatch is one). It belongs in the headline, not pinned to an input.
+    if (!detail.field) continue;
+    // First one wins: Zod reports the outermost failure first, which is the
+    // one whose wording matches what the user typed.
+    if (!(detail.field in fields)) fields[detail.field] = detail.message;
+  }
+  return fields;
+}
+
+/**
+ * Turns anything a mutation can throw into the one shape the UI reasons about.
+ *
+ * `online` is injected rather than read inline so a test can drive the offline
+ * branch without stubbing a global.
+ */
+export function classifyMutationError(
+  error: unknown,
+  online: boolean = typeof navigator === 'undefined' ? true : navigator.onLine
+): MutationFailure {
+  if (!(error instanceof ApiError)) {
+    // Not an ApiError means the throw came from our own code, not the server —
+    // a bug in a mutationFn, a serialisation failure. Never show its message:
+    // it is a developer string and may name internals.
+    return {
+      kind: 'unknown',
+      recovery: RECOVERY.unknown,
+      message: t(messageKeyFor('unknown')),
+      fieldErrors: {},
+      details: [],
+      status: null,
+      retryable: RETRYABLE.unknown,
+    };
+  }
+
+  const kind = kindFor(error, online);
+  const details = error.details ?? [];
+  const serverMessage = SERVER_MESSAGE_KINDS.has(kind) ? error.message.trim() : '';
+
+  return {
+    kind,
+    recovery: RECOVERY[kind],
+    message: serverMessage || t(messageKeyFor(kind)),
+    fieldErrors: kind === 'validation' ? fieldErrorsFrom(details) : {},
+    code: error.code,
+    details,
+    status: error.status,
+    retryable: RETRYABLE[kind],
+  };
+}
+
+/** True when `failure` carries the given domain code in its `details[]`. */
+export function hasDetailCode(failure: MutationFailure, code: string): boolean {
+  return failure.details.some((detail) => detail.code === code);
+}

--- a/client/src/shared/lib/mutationError.ts
+++ b/client/src/shared/lib/mutationError.ts
@@ -83,6 +83,14 @@ export interface MutationFailure {
   /** Safe, user-facing, translated where the client owns the wording. */
   message: string;
   /**
+   * The server's own wording, present only for the kinds it phrases for a user
+   * and only when non-empty. Callers use it to decide whether to prefer their
+   * own domain sentence ("Failed to create customer") over the generic one:
+   * the server's specific wording beats both, but a generic fallback should
+   * not beat the caller's.
+   */
+  serverMessage?: string;
+  /**
    * Field path -> message, for a `fix`. Empty for every other kind. Pages hand
    * this to React Hook Form's `setError` so the failure lands on the input
    * that caused it instead of in a toast that closes the dialog.
@@ -241,6 +249,7 @@ export function classifyMutationError(
     kind,
     recovery: RECOVERY[kind],
     message: serverMessage || t(messageKeyFor(kind)),
+    ...(serverMessage ? { serverMessage } : {}),
     fieldErrors: kind === 'validation' ? fieldErrorsFrom(details) : {},
     code: error.code,
     details,

--- a/client/src/shared/lib/resource.test.tsx
+++ b/client/src/shared/lib/resource.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ApiError, TransportProvider } from './transport/index';
+import { TransportProvider } from './transport/index';
 import { createMemoryTransport, type MemoryTransport } from './transport/memory';
 import { resource } from './resource';
 
@@ -306,10 +306,38 @@ describe('resource', () => {
 
     result.current.save({ category: 'rent', amount: -5 });
 
-    await waitFor(() => expect(result.current.error).toBeInstanceOf(ApiError));
-    expect(result.current.error).toMatchObject({
+    await waitFor(() => expect(result.current.failure).not.toBeNull());
+    expect(result.current.failure).toMatchObject({
+      kind: 'validation',
+      recovery: 'fix',
       message: 'Amount must be positive',
       status: 400,
     });
+  });
+
+  it('drops a second write fired before the first has settled', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT] });
+    const requests: string[] = [];
+    const counting: MemoryTransport = {
+      ...transport,
+      request(req) {
+        requests.push(`${req.method} ${req.path}`);
+        return transport.request(req);
+      },
+    };
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => expenses.useSave(), {
+      wrapper: wrapperFor(counting),
+    });
+
+    // One tick, two clicks: the page never disabled anything, and the guard
+    // in useGuardedMutation is what stops the second POST.
+    result.current.save({ category: 'utilities', amount: 300 });
+    result.current.save({ category: 'utilities', amount: 300 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(requests.filter((r) => r === 'POST expenses')).toHaveLength(1);
+    expect(transport.peek('expenses')).toHaveLength(2);
   });
 });

--- a/client/src/shared/lib/resource.ts
+++ b/client/src/shared/lib/resource.ts
@@ -1,7 +1,12 @@
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
-import { t } from '../i18n/index';
-import { useTransport, type TransportMethod, type TransportRequest } from './transport/index';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useTransport,
+  type TransportMethod,
+  type TransportRequest,
+  type TransportResult,
+} from './transport/index';
+import type { MutationFailure } from './mutationError';
+import { useGuardedMutation } from './useGuardedMutation';
 import { normalizeQueryParams } from './queryClient';
 
 /** A record being saved. An `id` means update; its absence means create. */
@@ -14,6 +19,12 @@ export interface WriteOptions {
   message?: string;
   /** Toasted on failure when the server offers no message of its own. */
   fallbackMessage?: string;
+  /**
+   * Sees the classified failure before the toast. Return `true` when the page
+   * has presented it another way (field errors on the form, an inline notice)
+   * and the toast should be suppressed.
+   */
+  onFailure?: (failure: MutationFailure) => boolean | void;
 }
 
 export interface ActionOptions extends WriteOptions {
@@ -24,27 +35,31 @@ export interface ActionOptions extends WriteOptions {
 /**
  * What every write does once it settles: refresh this resource's reads, tell
  * the caller, and say something. Pages get all three without wiring any of it.
+ *
+ * Every write also inherits the app's mutation contract from
+ * `useGuardedMutation`: a second submit while one is in flight is dropped, and
+ * the failure is classified into a kind and a recovery rather than being
+ * flattened to whatever string the throw happened to carry. That is why this
+ * indirection exists rather than each page wiring `useMutation` itself — a
+ * page that forgets to disable its button no longer double-writes.
  */
 function useWrite<Args>(
   key: readonly unknown[],
   toRequest: (args: Args) => TransportRequest,
-  { onDone, message, fallbackMessage }: WriteOptions
+  { onDone, message, fallbackMessage, onFailure }: WriteOptions
 ) {
   const transport = useTransport();
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useGuardedMutation<Args, TransportResult<unknown>>({
     mutationFn: (args: Args) => transport.request(toRequest(args)),
+    successMessage: message,
+    fallbackMessage,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: key });
-      if (message) toast.success(message);
       onDone?.();
     },
-    onError: (error: Error) => {
-      // Empty when the failure was the transport's own (a dropped connection,
-      // a timeout). Callers get to phrase those; axios's wording never shows.
-      toast.error(error.message || fallbackMessage || t('common.error'));
-    },
+    onFailure,
   });
 }
 
@@ -131,7 +146,7 @@ export function resource<Row, Meta = Record<string, unknown>>(name: string) {
         options
       );
 
-      return { ...mutation, save: mutation.mutate, isSaving: mutation.isPending };
+      return { ...mutation, save: mutation.submit, isSaving: mutation.isPending };
     },
 
     useRemove(options: WriteOptions = {}) {
@@ -141,7 +156,7 @@ export function resource<Row, Meta = Record<string, unknown>>(name: string) {
         options
       );
 
-      return { ...mutation, remove: mutation.mutate, isRemoving: mutation.isPending };
+      return { ...mutation, remove: mutation.submit, isRemoving: mutation.isPending };
     },
 
     /**
@@ -159,7 +174,7 @@ export function resource<Row, Meta = Record<string, unknown>>(name: string) {
         options
       );
 
-      return { ...mutation, run: mutation.mutate, isRunning: mutation.isPending };
+      return { ...mutation, run: mutation.submit, isRunning: mutation.isPending };
     },
   };
 }

--- a/client/src/shared/lib/useGuardedMutation.test.tsx
+++ b/client/src/shared/lib/useGuardedMutation.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { ApiError } from './transport/types';
+import { useSettingsStore } from '../store/settingsStore';
+import { useGuardedMutation } from './useGuardedMutation';
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+/** A mutationFn whose promise the test settles by hand. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  // A rejection settled later still needs a handler attached now, or Node
+  // reports an unhandled rejection before React Query subscribes.
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useSettingsStore.setState({ locale: 'en' });
+});
+
+describe('double-submit protection', () => {
+  it('drops a second submit fired while the first is still in flight', async () => {
+    const pending = deferred<string>();
+    const mutationFn = vi.fn((_args: string) => pending.promise);
+
+    const { result } = renderHook(() => useGuardedMutation({ mutationFn }), { wrapper });
+
+    // Both calls inside ONE act(), i.e. inside one tick with no render
+    // between them -- exactly the window `isPending` cannot close.
+    act(() => {
+      result.current.submit('once');
+      result.current.submit('twice');
+    });
+
+    // React Query dispatches the mutationFn on a microtask, so flush before
+    // counting -- the guard's work was already done, synchronously, above.
+    await waitFor(() => expect(mutationFn).toHaveBeenCalledTimes(1));
+    expect(mutationFn.mock.calls[0][0]).toBe('once');
+
+    await act(async () => {
+      pending.resolve('ok');
+    });
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the next submit once the first has settled', async () => {
+    const first = deferred<string>();
+    const mutationFn = vi.fn(() => first.promise);
+
+    const { result } = renderHook(() => useGuardedMutation({ mutationFn }), { wrapper });
+
+    act(() => result.current.submit('a'));
+    await act(async () => {
+      first.resolve('ok');
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    act(() => result.current.submit('b'));
+    await waitFor(() => expect(mutationFn).toHaveBeenCalledTimes(2));
+  });
+
+  it('releases the guard after a failure, so the user can retry', async () => {
+    const first = deferred<string>();
+    const mutationFn = vi.fn(() => first.promise);
+
+    const { result } = renderHook(() => useGuardedMutation({ mutationFn }), { wrapper });
+
+    act(() => result.current.submit('a'));
+    await act(async () => {
+      first.reject(new ApiError('', null));
+    });
+    await waitFor(() => expect(result.current.failure).not.toBeNull());
+
+    act(() => result.current.submit('a'));
+    await waitFor(() => expect(mutationFn).toHaveBeenCalledTimes(2));
+  });
+
+  it('exposes a pending state for the whole flight and a terminal state after it', async () => {
+    const pending = deferred<string>();
+    const { result } = renderHook(() => useGuardedMutation({ mutationFn: () => pending.promise }), {
+      wrapper,
+    });
+
+    expect(result.current.isPending).toBe(false);
+    act(() => result.current.submit('a'));
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    await act(async () => {
+      pending.resolve('ok');
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.failure).toBeNull();
+  });
+});
+
+describe('failure presentation', () => {
+  async function failWith(error: unknown, options: Record<string, unknown> = {}) {
+    const pending = deferred<string>();
+    const { result } = renderHook(
+      () => useGuardedMutation({ mutationFn: () => pending.promise, ...options }),
+      { wrapper }
+    );
+    act(() => result.current.submit('a'));
+    await act(async () => {
+      pending.reject(error);
+    });
+    await waitFor(() => expect(result.current.failure).not.toBeNull());
+    return result;
+  }
+
+  it('classifies the failure and keeps it as terminal state', async () => {
+    const result = await failWith(
+      new ApiError('Request validation failed', 400, 'VALIDATION_ERROR', [
+        { field: 'price', code: 'too_small', message: 'Value is too small' },
+      ])
+    );
+
+    expect(result.current.failure?.kind).toBe('validation');
+    expect(result.current.failure?.recovery).toBe('fix');
+    expect(result.current.failure?.fieldErrors).toEqual({ price: 'Value is too small' });
+  });
+
+  it('toasts the server wording ahead of the caller fallback', async () => {
+    await failWith(new ApiError('Email already exists', 409, 'CONFLICT'), {
+      fallbackMessage: 'Could not save user',
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Email already exists');
+  });
+
+  it('toasts the caller fallback when the server offered no wording of its own', async () => {
+    await failWith(new ApiError('', null), { fallbackMessage: 'Could not save user' });
+
+    expect(toast.error).toHaveBeenCalledWith('Could not save user');
+  });
+
+  it('toasts the classified message when there is no fallback either', async () => {
+    await failWith(new ApiError('', 429, 'RATE_LIMITED'));
+
+    expect(toast.error).toHaveBeenCalledWith('Too many requests. Wait a moment, then try again.');
+  });
+
+  it('suppresses the toast when the caller says it presented the failure itself', async () => {
+    const onFailure = vi.fn(() => true);
+    const result = await failWith(new ApiError('nope', 400, 'VALIDATION_ERROR'), { onFailure });
+
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+    // Suppressing the toast must not suppress the terminal state -- the whole
+    // point is that the caller renders it somewhere durable.
+    expect(result.current.failure?.kind).toBe('validation');
+  });
+
+  it('still toasts when onFailure inspects the failure but does not claim it', async () => {
+    const onFailure = vi.fn(() => undefined);
+    await failWith(new ApiError('Branch code already exists', 409, 'CONFLICT'), { onFailure });
+
+    expect(toast.error).toHaveBeenCalledWith('Branch code already exists');
+  });
+
+  it('clears the previous failure when a new attempt starts', async () => {
+    const result = await failWith(new ApiError('nope', 400, 'VALIDATION_ERROR'));
+
+    act(() => result.current.submit('a'));
+    expect(result.current.failure).toBeNull();
+  });
+
+  it('clears the failure on request', async () => {
+    const result = await failWith(new ApiError('nope', 400, 'VALIDATION_ERROR'));
+
+    act(() => result.current.clearFailure());
+    expect(result.current.failure).toBeNull();
+  });
+});
+
+describe('success', () => {
+  it('toasts the success message and calls back with the result', async () => {
+    const pending = deferred<string>();
+    const onSuccess = vi.fn();
+    const { result } = renderHook(
+      () =>
+        useGuardedMutation({
+          mutationFn: () => pending.promise,
+          successMessage: 'Saved',
+          onSuccess,
+        }),
+      { wrapper }
+    );
+
+    act(() => result.current.submit('a'));
+    await act(async () => {
+      pending.resolve('row');
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('row', 'a'));
+    expect(toast.success).toHaveBeenCalledWith('Saved');
+  });
+
+  it('says nothing when no success message was given', async () => {
+    const pending = deferred<string>();
+    const { result } = renderHook(() => useGuardedMutation({ mutationFn: () => pending.promise }), {
+      wrapper,
+    });
+
+    act(() => result.current.submit('a'));
+    await act(async () => {
+      pending.resolve('row');
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/shared/lib/useGuardedMutation.ts
+++ b/client/src/shared/lib/useGuardedMutation.ts
@@ -1,0 +1,131 @@
+/**
+ * One mutation lifecycle for the whole app: a pending state that cannot be
+ * double-submitted, and a terminal state that says what failed and what the
+ * user can do about it.
+ *
+ * ## Why a ref and not `isPending`
+ *
+ * `isPending` is React state. Between `mutate()` and the re-render that flips
+ * it, the button is still enabled and a second click still fires. HeroUI's
+ * `isLoading` does disable the button (`isDisabled = isDisabledProp ||
+ * isLoading`), so the window is narrow — but it is a *render* wide, and a
+ * double-click, a wireless barcode gun's repeat, or a shortcut key held down
+ * all fit inside it. The ref below is set synchronously inside `submit`, so
+ * the second call is dropped before React is involved at all.
+ *
+ * This is the CLIENT half of double-submit protection. The server half is
+ * already solved for the writes that matter: `POST /api/v1/sales` and the
+ * other retry-prone endpoints are idempotency-keyed, so a duplicate that does
+ * escape returns the original outcome instead of charging twice. What was
+ * missing is that a duplicate escaped at all — the two concurrent requests,
+ * the second toast, and, for the endpoints with no key, the second row.
+ *
+ * ## Terminal state
+ *
+ * `failure` holds the classified last failure until the next submit, so a
+ * caller can render recovery inline (field errors on a form, a review notice
+ * on a cart) instead of losing it to a toast that vanishes in four seconds.
+ */
+import { useCallback, useRef, useState } from 'react';
+import { useMutation, type MutateOptions } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { classifyMutationError, type MutationFailure } from './mutationError';
+
+export interface GuardedMutationOptions<Args, Result> {
+  mutationFn: (args: Args) => Promise<Result>;
+  onSuccess?: (result: Result, args: Args) => void;
+  /**
+   * Runs before the default toast. Return `true` to say the failure has been
+   * presented some other way (an inline notice, a field error) and suppress
+   * it. Returning nothing keeps the toast.
+   */
+  onFailure?: (failure: MutationFailure, args: Args) => boolean | void;
+  /** Toasted on success. Omit for a silent write. */
+  successMessage?: string;
+  /**
+   * Toasted instead of the classified message when the classifier had nothing
+   * better — i.e. when the server sent no user-facing wording of its own.
+   */
+  fallbackMessage?: string;
+}
+
+export interface GuardedMutation<Args, Result> {
+  /**
+   * Fires the write. A no-op while one is already in flight.
+   *
+   * `options` are React Query's per-call callbacks, forwarded untouched — a
+   * caller that needs the created row (to select the customer it just made,
+   * say) passes `onSuccess` here rather than at hook level, where it would
+   * close over stale state.
+   */
+  submit: (
+    args: Args,
+    options?: MutateOptions<Result, Error, Args, unknown>
+  ) => void;
+  isPending: boolean;
+  /** The other terminal state. Reset when a new attempt starts. */
+  isSuccess: boolean;
+  /** The last failure, or null. Cleared when a new submit starts. */
+  failure: MutationFailure | null;
+  clearFailure: () => void;
+  /** Escape hatch for callers that need the raw React Query mutation. */
+  mutation: ReturnType<typeof useMutation<Result, Error, Args>>;
+}
+
+export function useGuardedMutation<Args, Result>({
+  mutationFn,
+  onSuccess,
+  onFailure,
+  successMessage,
+  fallbackMessage,
+}: GuardedMutationOptions<Args, Result>): GuardedMutation<Args, Result> {
+  const [failure, setFailure] = useState<MutationFailure | null>(null);
+  const inFlight = useRef(false);
+
+  const mutation = useMutation<Result, Error, Args>({
+    mutationFn,
+    onSuccess: (result, args) => {
+      setFailure(null);
+      if (successMessage) toast.success(successMessage);
+      onSuccess?.(result, args);
+    },
+    onError: (error, args) => {
+      const classified = classifyMutationError(error);
+      setFailure(classified);
+      const handled = onFailure?.(classified, args) === true;
+      // The server's own wording is the most specific thing anyone has; the
+      // caller's domain sentence beats the generic per-kind one.
+      if (!handled) toast.error(classified.serverMessage || fallbackMessage || classified.message);
+    },
+    // Released here rather than in onSuccess/onError so a callback that throws
+    // cannot strand the guard and freeze the button for the life of the tab.
+    onSettled: () => {
+      inFlight.current = false;
+    },
+  });
+
+  // `mutate` is referentially stable across renders in React Query v5, so
+  // `submit` is too — safe to pass to a memoised child or an effect.
+  const { mutate } = mutation;
+
+  const submit = useCallback(
+    (args: Args, options?: MutateOptions<Result, Error, Args, unknown>) => {
+      if (inFlight.current) return;
+      inFlight.current = true;
+      setFailure(null);
+      mutate(args, options);
+    },
+    [mutate]
+  );
+
+  const clearFailure = useCallback(() => setFailure(null), []);
+
+  return {
+    submit,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    failure,
+    clearFailure,
+    mutation,
+  };
+}


### PR DESCRIPTION
Closes #52. Builds on #76, which decomposed `CartPanel` and gave checkout a submission hook to attach this to.

Four commits, bottom-up: classify → guard → recover → explain.

## 1. One classification with recovery attached (`99531fc`)

Every page phrased its own failure handling, so the same rejection was a red toast on one screen and a silent no-op on another, and a validation error naming a field was flattened into a sentence nobody could act on.

`classifyMutationError` turns anything a mutation can throw into a **kind plus the recovery that kind implies** — `fix` / `review` / `retry` / `wait` / `signIn` / `none`. The recovery is the point: a validation error is fixable in place, a rate limit is a wait, a network failure is a retry, a stock conflict needs the cart changed. A toast that says "something went wrong" tells a cashier none of that.

Codes come from what the server actually sends (`server/src/http/errors.ts`), not from an invented taxonomy.

## 2. A guarded pending/terminal lifecycle (`476174e`)

`useGuardedMutation` drops a submit fired while one is already in flight.

**The guard is a ref set synchronously inside `submit`, not `isPending`.** `isPending` is React state: between `mutate()` and the re-render that flips it, the button is still live. HeroUI does disable on `isLoading`, so the window is one render wide — wide enough for a double-click or a held shortcut key.

This is the **client half only, deliberately.** The server half is already solved for the writes that matter: sales and the other retry-prone endpoints are idempotency-keyed, so a duplicate that escapes returns the original outcome byte-identically. What was missing was that a duplicate escaped at all — two concurrent requests, two toasts, and a second row on the endpoints that carry no key.

`resource()`'s `useSave` / `useRemove` / `useAction` now go through it, **so every CRUD page inherits both the guard and the classified failure without changing a line** — that is how the "adopted first by POS and inventory" criterion is met, structurally rather than by editing five inventory pages. Failure survives as terminal state rather than only as a toast, and `onFailure` lets a page claim it and render recovery inline.

## 3. Session expiry returns you to your workflow (`5019ee8`)

An unrecoverable refresh dropped the user on `/login` with no memory of where they were, so a cashier mid-inventory-edit came back to their role's home page and navigated back by hand. The location now rides the login route's existing `redirect` param — read *before* `logout()`, since teardown invalidates the router underneath.

`safeRedirectTarget` is the single filter, applied both where the param enters (`validateSearch`) and where it is consumed: in-app absolute paths only, never protocol-relative (`//evil.example`, and the `/\` variant browsers normalise identically), never `/login` itself. Route-level authorization stays the router's job — a stale link to an admin page is bounced by `_admin`, not silently honoured here.

## 4. A stock conflict explained in stock, not in the server's sentence (`36713ae`)

The server refuses an oversold checkout with `Insufficient stock for product ID 7` under a bare `VALIDATION_ERROR`. The cashier got an English sentence naming a database id and no way to know which line to change.

Rather than parse that sentence, a `fix`/`review` rejection now re-reads stock for the cart's product lines and reports the difference: **which product, how many the cart wants, how many remain**, in the cashier's language. Adjusting the cart is an explicit button, never automatic — this is money already agreed with a customer standing at the till.

Variant lines are deliberately excluded: `products/lookup` carries product-level stock only, and variant stock is a separate column with no bulk endpoint, so a variant line falls back to the classified message rather than being judged against a number that is not its own.

> [!NOTE]
> **A server-side defect this exposed, reported not fixed:** the sales module *has* a typed `INSUFFICIENT_STOCK` code, but the controller drops it before the response is built. The client re-reads stock only because the server discards its own typed code. Filed separately — fixing it would let the client skip the extra round-trip entirely.

## Deliberate behaviour changes

- A 5xx body's wording (`Gateway timeout`) is no longer shown to the cashier. That is infrastructure talking, not a sentence for someone at a till; `cart.saleFailed` stands in. Covered by an updated characterization test.
- `useCheckoutSubmission` moves onto `useGuardedMutation`, so a double-pressed Confirm cannot open two concurrent checkouts — **in front of, not instead of, the idempotency key.**

## Non-goals honoured

The offline fallback is **preserved verbatim**, including its `!navigator.onLine` condition and its comment marking it unreachable. `queryClient` still sets no `networkMode`, so React Query pauses rather than fails a mutation fired offline — that is #53's territory and is untouched here.

## Testing

- `vitest run` in `client/`: **56 files, 536 tests passed**.
- `npm run lint` + `lint:cycles`: 0 errors, 19 pre-existing warnings, no cycles.
- `tsc --noEmit`: **33 errors, against a 35 baseline on `main`** — two fewer, none added. (The client typecheck is not gated in CI; see #80.)

Every error branch added here has a test that drives it. Error handling is exactly the code that gets written and never exercised.

## Post-Deploy Monitoring & Validation

- **Watch:** duplicate sale rows created within a second of each other for one cashier — this PR's guard should take that to zero. `SELECT cashier_id, COUNT(*) FROM sales WHERE created_at > NOW() - INTERVAL '1 hour' GROUP BY cashier_id, date_trunc('second', created_at) HAVING COUNT(*) > 1`.
- **Healthy signals:** `Idempotent-Replay: true` responses should become *rarer*, not commoner — the guard stops the duplicate before it reaches the server. A rise would mean the guard is not holding and idempotency is catching what it should have.
- **Failure signals / rollback trigger:** cashiers reporting a Confirm button that does nothing (guard stuck set — it releases on terminal state, so a missed release would wedge checkout), or a rise in abandoned carts after a stock conflict, which would suggest the recovery UI is unclear rather than helpful.
- **Watch the login redirect specifically:** any `/login?redirect=` value that is not an in-app path reaching the logs would mean `safeRedirectTarget` has a hole. It is filtered at both ends, so this is a belt-and-braces check.
- Client-only change: rollback is a revert and SPA redeploy, no data implications.
- **Window:** one full trading day, first hour watched actively.
- **Owner:** @zhamdy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
