### PR TITLE
test: make the pg-mem suites hermetic and make the framer-motion mock actually apply

### DIFF
--- a/client/src/shared/tests/motionMock.test.tsx
+++ b/client/src/shared/tests/motionMock.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { Modal, ModalBody, ModalContent } from '@heroui/react';
+
+/**
+ * Guards the `framer-motion` mock in `./setup.ts` against silently going inert.
+ *
+ * That mock exists to flatten `LazyMotion`, whose async feature load calls `setState`
+ * after the test that mounted it has finished — a `window is not defined` unhandled
+ * rejection that fails the client job while every test passes (issue #77). But the
+ * component mounting `LazyMotion` is HeroUI, not our code, and a dependency vitest loads
+ * natively resolves its own imports through node, never seeing vitest's module registry.
+ * The mock therefore only reaches HeroUI while `server.deps.inline` in `vitest.config.ts`
+ * keeps `@heroui/*` on the transformed path.
+ *
+ * This test fails — rather than the suite going quietly back to flaking — if that config
+ * is removed: `renders` stays at 0 because HeroUI got the real `LazyMotion`.
+ */
+let renders = 0;
+
+vi.mock('framer-motion', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => {
+      renders += 1;
+      return children;
+    },
+    m: actual.motion,
+  };
+});
+
+describe('framer-motion test mock', () => {
+  it('replaces the LazyMotion that HeroUI itself renders', () => {
+    render(
+      <Modal isOpen>
+        <ModalContent>
+          <ModalBody>content</ModalBody>
+        </ModalContent>
+      </Modal>
+    );
+
+    expect(renders).toBeGreaterThan(0);
+  });
+});

--- a/client/src/shared/tests/setup.ts
+++ b/client/src/shared/tests/setup.ts
@@ -70,6 +70,13 @@ if (!window.scrollTo) {
  * Diagnosed from the CI stack (LazyMotion/index.mjs -> dispatchSetState ->
  * getCurrentEventPriority); it is deterministic there and has never reproduced locally,
  * which is the shape of a teardown race.
+ *
+ * The mock alone was NOT enough, which is why issue #77 recurred after #67: the component
+ * that mounts `LazyMotion` is HeroUI, and vitest loaded `@heroui/*` natively, so HeroUI
+ * resolved `framer-motion` through node and never saw this registry — every HeroUI button,
+ * modal, tooltip, tab and popover kept the real async load. `server.deps.inline` in
+ * `vitest.config.ts` is what puts HeroUI on the transformed path so this mock reaches it.
+ * The two are one fix; `./motionMock.test.tsx` fails if either half is removed.
  */
 vi.mock('framer-motion', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -12,6 +12,15 @@ export default defineConfig({
     // once several run concurrently, which showed up as flaky timeouts rather
     // than real failures.
     testTimeout: 20000,
+    server: {
+      deps: {
+        // HeroUI must be transformed by vite rather than loaded natively, or the
+        // framer-motion mock in src/shared/tests/setup.ts does not reach it: a
+        // natively-imported dependency resolves its own imports through node and
+        // never sees vitest's module registry. See the comment on that mock.
+        inline: [/@heroui\//],
+      },
+    },
   },
   resolve: {
     alias: {

--- a/docs/reports/api-verification-report.md
+++ b/docs/reports/api-verification-report.md
@@ -1,6 +1,6 @@
 # API Endpoint Health & Verification Diagnostic Report
 
-**Execution Date:** 2026-08-31T20:52:28.754Z
+**Execution Date:** 2026-09-02T16:07:50.147Z
 
 ## Summary
 
@@ -18,203 +18,203 @@
 
 | Method | Path | Role | Status | Duration | Result |
 |---|---|---|---|---|---|
-| `POST` | `/api/v1/auth/login` | `Public` | `200` | 184ms | ✅ |
-| `POST` | `/api/v1/auth/refresh` | `Public` | `401` | 7ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/auth/logout` | `Admin` | `204` | 7ms | ✅ |
-| `GET` | `/api/v1/auth/me` | `Admin` | `200` | 10ms | ✅ |
-| `GET` | `/api/v1/users` | `Admin` | `200` | 19ms | ✅ |
+| `POST` | `/api/v1/auth/login` | `Public` | `200` | 150ms | ✅ |
+| `POST` | `/api/v1/auth/refresh` | `Public` | `401` | 5ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/auth/logout` | `Admin` | `204` | 12ms | ✅ |
+| `GET` | `/api/v1/auth/me` | `Admin` | `200` | 7ms | ✅ |
+| `GET` | `/api/v1/users` | `Admin` | `200` | 13ms | ✅ |
 | `GET` | `/api/v1/users/delivery` | `Admin` | `200` | 6ms | ✅ |
-| `POST` | `/api/v1/users` | `Admin` | `201` | 163ms | ✅ |
-| `GET` | `/api/v1/users/me/favorites` | `Admin` | `200` | 7ms | ✅ |
-| `PUT` | `/api/v1/users/me/favorites` | `Admin` | `400` | 9ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/users/1` | `Admin` | `200` | 16ms | ✅ |
-| `DELETE` | `/api/v1/users/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/settings` | `Admin` | `200` | 7ms | ✅ |
-| `PUT` | `/api/v1/settings` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/audit-log` | `Admin` | `200` | 12ms | ✅ |
-| `GET` | `/api/v1/audit-log/actions` | `Admin` | `200` | 7ms | ✅ |
-| `GET` | `/api/v1/audit-log/entity-types` | `Admin` | `200` | 7ms | ✅ |
-| `GET` | `/api/v1/branches` | `Admin` | `200` | 39ms | ✅ |
-| `POST` | `/api/v1/branches` | `Admin` | `201` | 15ms | ✅ |
-| `GET` | `/api/v1/branches/consolidated` | `Admin` | `200` | 38ms | ✅ |
-| `GET` | `/api/v1/branches/transfers` | `Admin` | `200` | 32ms | ✅ |
-| `POST` | `/api/v1/branches/transfers` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/branches/transfers/1/status` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/branches/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/sales` | `Admin` | `200` | 37ms | ✅ |
-| `POST` | `/api/v1/sales` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/sales/1` | `Admin` | `404` | 16ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/sales/1/refund` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/register/current` | `Admin` | `200` | 32ms | ✅ |
-| `POST` | `/api/v1/register/open` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/users` | `Admin` | `201` | 120ms | ✅ |
+| `GET` | `/api/v1/users/me/favorites` | `Admin` | `200` | 4ms | ✅ |
+| `PUT` | `/api/v1/users/me/favorites` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/users/1` | `Admin` | `200` | 7ms | ✅ |
+| `DELETE` | `/api/v1/users/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/settings` | `Admin` | `200` | 3ms | ✅ |
+| `PUT` | `/api/v1/settings` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/audit-log` | `Admin` | `200` | 7ms | ✅ |
+| `GET` | `/api/v1/audit-log/actions` | `Admin` | `200` | 4ms | ✅ |
+| `GET` | `/api/v1/audit-log/entity-types` | `Admin` | `200` | 2ms | ✅ |
+| `GET` | `/api/v1/branches` | `Admin` | `200` | 19ms | ✅ |
+| `POST` | `/api/v1/branches` | `Admin` | `201` | 9ms | ✅ |
+| `GET` | `/api/v1/branches/consolidated` | `Admin` | `200` | 23ms | ✅ |
+| `GET` | `/api/v1/branches/transfers` | `Admin` | `200` | 15ms | ✅ |
+| `POST` | `/api/v1/branches/transfers` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/branches/transfers/1/status` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/branches/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/sales` | `Admin` | `200` | 21ms | ✅ |
+| `POST` | `/api/v1/sales` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/sales/1` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/sales/1/refund` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/register/current` | `Admin` | `200` | 25ms | ✅ |
+| `POST` | `/api/v1/register/open` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/register/movement` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/register/close` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/register/history` | `Admin` | `200` | 37ms | ✅ |
-| `GET` | `/api/v1/register/1/report` | `Admin` | `404` | 11ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/register/1/force-close` | `Admin` | `404` | 12ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/shifts/current` | `Admin` | `200` | 12ms | ✅ |
-| `POST` | `/api/v1/shifts/clock-in` | `Admin` | `201` | 18ms | ✅ |
-| `POST` | `/api/v1/shifts/clock-out` | `Admin` | `400` | 21ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/shifts/break/start` | `Admin` | `200` | 10ms | ✅ |
-| `POST` | `/api/v1/shifts/break/end` | `Admin` | `400` | 13ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/shifts` | `Admin` | `200` | 19ms | ✅ |
+| `GET` | `/api/v1/register/history` | `Admin` | `200` | 25ms | ✅ |
+| `GET` | `/api/v1/register/1/report` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/register/1/force-close` | `Admin` | `404` | 8ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/shifts/current` | `Admin` | `200` | 9ms | ✅ |
+| `POST` | `/api/v1/shifts/clock-in` | `Admin` | `201` | 15ms | ✅ |
+| `POST` | `/api/v1/shifts/clock-out` | `Admin` | `400` | 14ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/shifts/break/start` | `Admin` | `200` | 5ms | ✅ |
+| `POST` | `/api/v1/shifts/break/end` | `Admin` | `400` | 10ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/shifts` | `Admin` | `200` | 13ms | ✅ |
 | `POST` | `/api/v1/exchanges` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/exchanges` | `Admin` | `200` | 16ms | ✅ |
-| `GET` | `/api/v1/exchanges/1` | `Admin` | `404` | 13ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/exchanges` | `Admin` | `200` | 11ms | ✅ |
+| `GET` | `/api/v1/exchanges/1` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/layaway` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/layaway` | `Admin` | `200` | 21ms | ✅ |
-| `GET` | `/api/v1/layaway/1` | `Admin` | `404` | 13ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/layaway` | `Admin` | `200` | 16ms | ✅ |
+| `GET` | `/api/v1/layaway/1` | `Admin` | `404` | 8ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/layaway/1/pay` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/layaway/1/cancel` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/reservations` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/reservations/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/reservations/source/:sourceId` | `Admin` | `200` | 6ms | ✅ |
-| `GET` | `/api/v1/products` | `Admin` | `200` | 42ms | ✅ |
-| `GET` | `/api/v1/products/categories` | `Admin` | `200` | 6ms | ✅ |
-| `GET` | `/api/v1/products/lookup` | `Admin` | `400` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/generate-sku/1` | `Admin` | `200` | 13ms | ✅ |
-| `GET` | `/api/v1/products/generate-barcode` | `Admin` | `200` | 10ms | ✅ |
-| `GET` | `/api/v1/products/barcode/:barcode` | `Admin` | `404` | 19ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/products/batch-generate-barcodes` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/products/bulk-update` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/layaway/1/cancel` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/reservations` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/reservations/1` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/reservations/source/:sourceId` | `Admin` | `200` | 4ms | ✅ |
+| `GET` | `/api/v1/products` | `Admin` | `200` | 28ms | ✅ |
+| `GET` | `/api/v1/products/categories` | `Admin` | `200` | 5ms | ✅ |
+| `GET` | `/api/v1/products/lookup` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/generate-sku/1` | `Admin` | `200` | 9ms | ✅ |
+| `GET` | `/api/v1/products/generate-barcode` | `Admin` | `200` | 7ms | ✅ |
+| `GET` | `/api/v1/products/barcode/:barcode` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/products/batch-generate-barcodes` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/products/bulk-update` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/products/bulk-delete` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/products/import` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/1` | `Admin` | `200` | 12ms | ✅ |
-| `POST` | `/api/v1/products` | `Admin` | `201` | 12ms | ✅ |
-| `PUT` | `/api/v1/products/1` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/products/1/status` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/products/1` | `Admin` | `204` | 10ms | ✅ |
-| `POST` | `/api/v1/products/1/adjust-stock` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/1/stock-history` | `Admin` | `200` | 10ms | ✅ |
-| `POST` | `/api/v1/products/1/image` | `Admin` | `400` | 5ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/products/1/image` | `Admin` | `403` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/1/variants` | `Admin` | `200` | 5ms | ✅ |
-| `POST` | `/api/v1/products/1/variants` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/products/1/variants/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/products/1/variants/1` | `Admin` | `404` | 11ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/products/1/price-history` | `Admin` | `200` | 10ms | ✅ |
-| `GET` | `/api/v1/categories` | `Admin` | `200` | 24ms | ✅ |
-| `POST` | `/api/v1/categories` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/categories/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/categories/1` | `Admin` | `409` | 7ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/distributors` | `Admin` | `200` | 28ms | ✅ |
-| `POST` | `/api/v1/distributors` | `Admin` | `201` | 12ms | ✅ |
-| `PUT` | `/api/v1/distributors/1` | `Admin` | `200` | 5ms | ✅ |
-| `DELETE` | `/api/v1/distributors/1` | `Admin` | `409` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/stock-counts` | `Admin` | `200` | 31ms | ✅ |
-| `POST` | `/api/v1/stock-counts` | `Admin` | `201` | 138ms | ✅ |
-| `GET` | `/api/v1/stock-counts/1` | `Admin` | `200` | 23ms | ✅ |
-| `PUT` | `/api/v1/stock-counts/1/items/:itemId` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/stock-counts/1/complete` | `Admin` | `200` | 22ms | ✅ |
-| `POST` | `/api/v1/stock-counts/1/cancel` | `Admin` | `409` | 7ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/stock-adjustments` | `Admin` | `200` | 12ms | ✅ |
-| `GET` | `/api/v1/bundles` | `Admin` | `200` | 33ms | ✅ |
-| `GET` | `/api/v1/bundles/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/bundles` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/bundles/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/bundles/1` | `Admin` | `404` | 8ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/collections` | `Admin` | `200` | 26ms | ✅ |
+| `POST` | `/api/v1/products/import` | `Admin` | `400` | 1ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/1` | `Admin` | `200` | 6ms | ✅ |
+| `POST` | `/api/v1/products` | `Admin` | `201` | 8ms | ✅ |
+| `PUT` | `/api/v1/products/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/products/1/status` | `Admin` | `400` | 1ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/products/1` | `Admin` | `204` | 8ms | ✅ |
+| `POST` | `/api/v1/products/1/adjust-stock` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/1/stock-history` | `Admin` | `200` | 6ms | ✅ |
+| `POST` | `/api/v1/products/1/image` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/products/1/image` | `Admin` | `403` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/1/variants` | `Admin` | `200` | 4ms | ✅ |
+| `POST` | `/api/v1/products/1/variants` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/products/1/variants/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/products/1/variants/1` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/products/1/price-history` | `Admin` | `200` | 8ms | ✅ |
+| `GET` | `/api/v1/categories` | `Admin` | `200` | 15ms | ✅ |
+| `POST` | `/api/v1/categories` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/categories/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/categories/1` | `Admin` | `409` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/distributors` | `Admin` | `200` | 16ms | ✅ |
+| `POST` | `/api/v1/distributors` | `Admin` | `201` | 8ms | ✅ |
+| `PUT` | `/api/v1/distributors/1` | `Admin` | `200` | 6ms | ✅ |
+| `DELETE` | `/api/v1/distributors/1` | `Admin` | `409` | 5ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/stock-counts` | `Admin` | `200` | 24ms | ✅ |
+| `POST` | `/api/v1/stock-counts` | `Admin` | `201` | 85ms | ✅ |
+| `GET` | `/api/v1/stock-counts/1` | `Admin` | `200` | 21ms | ✅ |
+| `PUT` | `/api/v1/stock-counts/1/items/:itemId` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/stock-counts/1/complete` | `Admin` | `200` | 13ms | ✅ |
+| `POST` | `/api/v1/stock-counts/1/cancel` | `Admin` | `409` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/stock-adjustments` | `Admin` | `200` | 9ms | ✅ |
+| `GET` | `/api/v1/bundles` | `Admin` | `200` | 13ms | ✅ |
+| `GET` | `/api/v1/bundles/1` | `Admin` | `404` | 3ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/bundles` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/bundles/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/bundles/1` | `Admin` | `404` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/collections` | `Admin` | `200` | 20ms | ✅ |
 | `GET` | `/api/v1/collections/1` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/collections` | `Admin` | `201` | 10ms | ✅ |
-| `PUT` | `/api/v1/collections/1` | `Admin` | `200` | 15ms | ✅ |
-| `DELETE` | `/api/v1/collections/1` | `Admin` | `204` | 10ms | ✅ |
-| `GET` | `/api/v1/label-templates` | `Admin` | `200` | 4ms | ✅ |
-| `POST` | `/api/v1/label-templates` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/label-templates/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/label-templates/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/customers` | `Admin` | `200` | 9ms | ✅ |
-| `POST` | `/api/v1/customers` | `Admin` | `201` | 4ms | ✅ |
+| `POST` | `/api/v1/collections` | `Admin` | `201` | 5ms | ✅ |
+| `PUT` | `/api/v1/collections/1` | `Admin` | `200` | 7ms | ✅ |
+| `DELETE` | `/api/v1/collections/1` | `Admin` | `204` | 7ms | ✅ |
+| `GET` | `/api/v1/label-templates` | `Admin` | `200` | 3ms | ✅ |
+| `POST` | `/api/v1/label-templates` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/label-templates/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/label-templates/1` | `Admin` | `404` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/customers` | `Admin` | `200` | 5ms | ✅ |
+| `POST` | `/api/v1/customers` | `Admin` | `201` | 2ms | ✅ |
 | `GET` | `/api/v1/customers/1` | `Admin` | `404` | 1ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/customers/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/customers/1/stats` | `Admin` | `200` | 13ms | ✅ |
-| `GET` | `/api/v1/customers/1/sales` | `Admin` | `200` | 30ms | ✅ |
-| `GET` | `/api/v1/customers/1/loyalty` | `Admin` | `200` | 17ms | ✅ |
-| `POST` | `/api/v1/customers/1/loyalty/adjust` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/customers/1` | `Admin` | `204` | 12ms | ✅ |
-| `GET` | `/api/v1/coupons` | `Admin` | `200` | 17ms | ✅ |
-| `POST` | `/api/v1/coupons` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/coupons/validate` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/coupons/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/coupons/1` | `Admin` | `204` | 8ms | ✅ |
-| `GET` | `/api/v1/gift-cards` | `Admin` | `200` | 21ms | ✅ |
-| `POST` | `/api/v1/gift-cards` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/gift-cards/MOON10/balance` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/gift-cards/MOON10/redeem` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/gift-cards/1/transactions` | `Admin` | `200` | 17ms | ✅ |
+| `PUT` | `/api/v1/customers/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/customers/1/stats` | `Admin` | `200` | 8ms | ✅ |
+| `GET` | `/api/v1/customers/1/sales` | `Admin` | `200` | 19ms | ✅ |
+| `GET` | `/api/v1/customers/1/loyalty` | `Admin` | `200` | 5ms | ✅ |
+| `POST` | `/api/v1/customers/1/loyalty/adjust` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/customers/1` | `Admin` | `204` | 5ms | ✅ |
+| `GET` | `/api/v1/coupons` | `Admin` | `200` | 10ms | ✅ |
+| `POST` | `/api/v1/coupons` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/coupons/validate` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/coupons/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/coupons/1` | `Admin` | `204` | 10ms | ✅ |
+| `GET` | `/api/v1/gift-cards` | `Admin` | `200` | 9ms | ✅ |
+| `POST` | `/api/v1/gift-cards` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/gift-cards/MOON10/balance` | `Admin` | `404` | 3ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/gift-cards/MOON10/redeem` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/gift-cards/1/transactions` | `Admin` | `200` | 9ms | ✅ |
 | `PUT` | `/api/v1/gift-cards/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
-| `POST` | `/api/v1/feedback` | `Admin` | `201` | 3ms | ✅ |
-| `GET` | `/api/v1/feedback` | `Admin` | `200` | 22ms | ✅ |
-| `GET` | `/api/v1/segments` | `Admin` | `200` | 17ms | ✅ |
+| `POST` | `/api/v1/feedback` | `Admin` | `201` | 2ms | ✅ |
+| `GET` | `/api/v1/feedback` | `Admin` | `200` | 14ms | ✅ |
+| `GET` | `/api/v1/segments` | `Admin` | `200` | 14ms | ✅ |
 | `POST` | `/api/v1/segments` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/segments/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/segments/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/storefront/banners` | `Public` | `200` | 5ms | ✅ |
+| `PUT` | `/api/v1/segments/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `DELETE` | `/api/v1/segments/1` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/storefront/banners` | `Public` | `200` | 3ms | ✅ |
 | `GET` | `/api/v1/storefront/banners/all` | `Admin` | `200` | 4ms | ✅ |
-| `POST` | `/api/v1/storefront/banners` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/storefront/banners/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
+| `POST` | `/api/v1/storefront/banners` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/storefront/banners/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
 | `DELETE` | `/api/v1/storefront/banners/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/online-orders` | `Public` | `400` | 1ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/online-orders` | `Admin` | `200` | 40ms | ✅ |
-| `GET` | `/api/v1/online-orders/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/online-orders/1/status` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/vendors` | `Admin` | `200` | 28ms | ✅ |
-| `POST` | `/api/v1/vendors` | `Admin` | `201` | 12ms | ✅ |
-| `PUT` | `/api/v1/vendors/1` | `Admin` | `200` | 11ms | ✅ |
-| `GET` | `/api/v1/vendors/1/payouts` | `Admin` | `200` | 13ms | ✅ |
-| `POST` | `/api/v1/vendors/1/payouts` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/warranty` | `Admin` | `200` | 12ms | ✅ |
-| `POST` | `/api/v1/warranty` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/warranty/1` | `Admin` | `404` | 14ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/delivery` | `Admin` | `200` | 11ms | ✅ |
-| `GET` | `/api/v1/delivery/analytics/performance` | `Admin` | `200` | 35ms | ✅ |
-| `GET` | `/api/v1/delivery/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/online-orders` | `Admin` | `200` | 18ms | ✅ |
+| `GET` | `/api/v1/online-orders/1` | `Admin` | `404` | 3ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/online-orders/1/status` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/vendors` | `Admin` | `200` | 14ms | ✅ |
+| `POST` | `/api/v1/vendors` | `Admin` | `201` | 6ms | ✅ |
+| `PUT` | `/api/v1/vendors/1` | `Admin` | `200` | 8ms | ✅ |
+| `GET` | `/api/v1/vendors/1/payouts` | `Admin` | `200` | 10ms | ✅ |
+| `POST` | `/api/v1/vendors/1/payouts` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/warranty` | `Admin` | `200` | 10ms | ✅ |
+| `POST` | `/api/v1/warranty` | `Admin` | `400` | 1ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/warranty/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/delivery` | `Admin` | `200` | 7ms | ✅ |
+| `GET` | `/api/v1/delivery/analytics/performance` | `Admin` | `200` | 18ms | ✅ |
+| `GET` | `/api/v1/delivery/1` | `Admin` | `404` | 7ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/delivery` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/delivery/1` | `Admin` | `400` | 4ms | ⚠️ (4xx) |
-| `PUT` | `/api/v1/delivery/1/status` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/delivery/1/history` | `Admin` | `200` | 10ms | ✅ |
-| `GET` | `/api/v1/shipping-companies` | `Admin` | `200` | 20ms | ✅ |
-| `POST` | `/api/v1/shipping-companies` | `Admin` | `201` | 6ms | ✅ |
-| `PUT` | `/api/v1/shipping-companies/1` | `Admin` | `200` | 13ms | ✅ |
-| `DELETE` | `/api/v1/shipping-companies/1` | `Admin` | `204` | 8ms | ✅ |
-| `GET` | `/api/v1/purchase-orders` | `Admin` | `200` | 29ms | ✅ |
-| `GET` | `/api/v1/purchase-orders/1` | `Admin` | `404` | 10ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/delivery/1` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `PUT` | `/api/v1/delivery/1/status` | `Admin` | `400` | 1ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/delivery/1/history` | `Admin` | `200` | 7ms | ✅ |
+| `GET` | `/api/v1/shipping-companies` | `Admin` | `200` | 8ms | ✅ |
+| `POST` | `/api/v1/shipping-companies` | `Admin` | `201` | 5ms | ✅ |
+| `PUT` | `/api/v1/shipping-companies/1` | `Admin` | `200` | 8ms | ✅ |
+| `DELETE` | `/api/v1/shipping-companies/1` | `Admin` | `204` | 5ms | ✅ |
+| `GET` | `/api/v1/purchase-orders` | `Admin` | `200` | 13ms | ✅ |
+| `GET` | `/api/v1/purchase-orders/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/purchase-orders` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
 | `PUT` | `/api/v1/purchase-orders/1/status` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
 | `POST` | `/api/v1/purchase-orders/1/receive` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/purchase-orders/1` | `Admin` | `404` | 5ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/expenses` | `Admin` | `200` | 18ms | ✅ |
-| `POST` | `/api/v1/expenses` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/expenses/pnl` | `Admin` | `200` | 33ms | ✅ |
+| `DELETE` | `/api/v1/purchase-orders/1` | `Admin` | `404` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/expenses` | `Admin` | `200` | 12ms | ✅ |
+| `POST` | `/api/v1/expenses` | `Admin` | `400` | 2ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/expenses/pnl` | `Admin` | `200` | 28ms | ✅ |
 | `PUT` | `/api/v1/expenses/1` | `Admin` | `400` | 3ms | ⚠️ (4xx) |
-| `DELETE` | `/api/v1/expenses/1` | `Admin` | `404` | 6ms | ⚠️ (4xx) |
-| `GET` | `/api/v1/analytics/dashboard-all` | `Admin` | `200` | 164ms | ✅ |
-| `GET` | `/api/v1/analytics/dashboard` | `Admin` | `200` | 12ms | ✅ |
-| `GET` | `/api/v1/analytics/revenue` | `Admin` | `200` | 5ms | ✅ |
-| `GET` | `/api/v1/analytics/top-products` | `Admin` | `200` | 34ms | ✅ |
-| `GET` | `/api/v1/analytics/payment-methods` | `Admin` | `200` | 5ms | ✅ |
-| `GET` | `/api/v1/analytics/orders-per-day` | `Admin` | `200` | 4ms | ✅ |
-| `GET` | `/api/v1/analytics/cashier-performance` | `Admin` | `200` | 51ms | ✅ |
-| `GET` | `/api/v1/analytics/sales-by-category` | `Admin` | `200` | 46ms | ✅ |
-| `GET` | `/api/v1/analytics/sales-by-distributor` | `Admin` | `200` | 42ms | ✅ |
-| `GET` | `/api/v1/analytics/dead-stock` | `Admin` | `200` | 111ms | ✅ |
-| `GET` | `/api/v1/analytics/customer-ltv` | `Admin` | `200` | 98ms | ✅ |
-| `GET` | `/api/v1/analytics/hourly-heatmap` | `Admin` | `200` | 16ms | ✅ |
-| `GET` | `/api/v1/analytics/abc-classification` | `Admin` | `200` | 32ms | ✅ |
-| `GET` | `/api/v1/analytics/reorder-suggestions` | `Admin` | `200` | 57ms | ✅ |
-| `POST` | `/api/v1/analytics/inventory-snapshot` | `Admin` | `201` | 14ms | ✅ |
-| `GET` | `/api/v1/analytics/inventory-snapshots` | `Admin` | `200` | 13ms | ✅ |
-| `GET` | `/api/v1/reports/sales` | `Admin` | `200` | 51ms | ✅ |
+| `DELETE` | `/api/v1/expenses/1` | `Admin` | `404` | 4ms | ⚠️ (4xx) |
+| `GET` | `/api/v1/analytics/dashboard-all` | `Admin` | `200` | 116ms | ✅ |
+| `GET` | `/api/v1/analytics/dashboard` | `Admin` | `200` | 9ms | ✅ |
+| `GET` | `/api/v1/analytics/revenue` | `Admin` | `200` | 4ms | ✅ |
+| `GET` | `/api/v1/analytics/top-products` | `Admin` | `200` | 29ms | ✅ |
+| `GET` | `/api/v1/analytics/payment-methods` | `Admin` | `200` | 4ms | ✅ |
+| `GET` | `/api/v1/analytics/orders-per-day` | `Admin` | `200` | 3ms | ✅ |
+| `GET` | `/api/v1/analytics/cashier-performance` | `Admin` | `200` | 43ms | ✅ |
+| `GET` | `/api/v1/analytics/sales-by-category` | `Admin` | `200` | 25ms | ✅ |
+| `GET` | `/api/v1/analytics/sales-by-distributor` | `Admin` | `200` | 30ms | ✅ |
+| `GET` | `/api/v1/analytics/dead-stock` | `Admin` | `200` | 63ms | ✅ |
+| `GET` | `/api/v1/analytics/customer-ltv` | `Admin` | `200` | 65ms | ✅ |
+| `GET` | `/api/v1/analytics/hourly-heatmap` | `Admin` | `200` | 14ms | ✅ |
+| `GET` | `/api/v1/analytics/abc-classification` | `Admin` | `200` | 23ms | ✅ |
+| `GET` | `/api/v1/analytics/reorder-suggestions` | `Admin` | `200` | 37ms | ✅ |
+| `POST` | `/api/v1/analytics/inventory-snapshot` | `Admin` | `201` | 12ms | ✅ |
+| `GET` | `/api/v1/analytics/inventory-snapshots` | `Admin` | `200` | 8ms | ✅ |
+| `GET` | `/api/v1/reports/sales` | `Admin` | `200` | 57ms | ✅ |
 | `GET` | `/api/v1/reports/inventory` | `Admin` | `200` | 28ms | ✅ |
-| `GET` | `/api/v1/reports/profit-loss` | `Admin` | `200` | 39ms | ✅ |
-| `GET` | `/api/v1/exports/products` | `Admin` | `200` | 18ms | ✅ |
-| `GET` | `/api/v1/exports/sales` | `Admin` | `200` | 14ms | ✅ |
-| `GET` | `/api/v1/exports/customers` | `Admin` | `200` | 22ms | ✅ |
-| `GET` | `/api/v1/ai/forecast` | `Admin` | `200` | 42ms | ✅ |
-| `GET` | `/api/v1/ai/recommendations` | `Admin` | `200` | 52ms | ✅ |
-| `GET` | `/api/v1/ai/pricing-suggestions` | `Admin` | `200` | 116ms | ✅ |
-| `GET` | `/api/v1/ai/churn-risk` | `Admin` | `200` | 40ms | ✅ |
-| `GET` | `/api/v1/ai/anomalies` | `Admin` | `200` | 46ms | ✅ |
-| `GET` | `/api/v1/notifications` | `Admin` | `200` | 14ms | ✅ |
-| `GET` | `/api/v1/notifications/unread-count` | `Admin` | `200` | 4ms | ✅ |
-| `PUT` | `/api/v1/notifications/1/read` | `Admin` | `200` | 4ms | ✅ |
-| `PUT` | `/api/v1/notifications/read-all` | `Admin` | `200` | 6ms | ✅ |
+| `GET` | `/api/v1/reports/profit-loss` | `Admin` | `200` | 23ms | ✅ |
+| `GET` | `/api/v1/exports/products` | `Admin` | `200` | 10ms | ✅ |
+| `GET` | `/api/v1/exports/sales` | `Admin` | `200` | 8ms | ✅ |
+| `GET` | `/api/v1/exports/customers` | `Admin` | `200` | 14ms | ✅ |
+| `GET` | `/api/v1/ai/forecast` | `Admin` | `200` | 18ms | ✅ |
+| `GET` | `/api/v1/ai/recommendations` | `Admin` | `200` | 24ms | ✅ |
+| `GET` | `/api/v1/ai/pricing-suggestions` | `Admin` | `200` | 60ms | ✅ |
+| `GET` | `/api/v1/ai/churn-risk` | `Admin` | `200` | 21ms | ✅ |
+| `GET` | `/api/v1/ai/anomalies` | `Admin` | `200` | 25ms | ✅ |
+| `GET` | `/api/v1/notifications` | `Admin` | `200` | 9ms | ✅ |
+| `GET` | `/api/v1/notifications/unread-count` | `Admin` | `200` | 2ms | ✅ |
+| `PUT` | `/api/v1/notifications/1/read` | `Admin` | `200` | 3ms | ✅ |
+| `PUT` | `/api/v1/notifications/read-all` | `Admin` | `200` | 3ms | ✅ |

--- a/server/tests/exchanges.test.ts
+++ b/server/tests/exchanges.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Request, Response } from 'express';
+import type { Pool as PgPool } from 'pg';
+import path from 'path';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
 import { parseExchangeListQuery } from '../src/modules/pos/exchanges/types';
 import { ExchangesController } from '../src/modules/pos/exchanges/controller';
 import {
@@ -9,6 +14,24 @@ import {
 } from '../src/modules/pos/exchanges/service';
 import type { IExchangesRepository } from '../src/modules/pos/exchanges/repository';
 import type { Queryable } from '../src/database/transaction';
+
+/**
+ * The controller wraps its mutation in `withIdempotency`, which opens a transaction on
+ * the module pool before the (mocked) service ever runs. Without an injected pool that
+ * resolves to a real PostgreSQL connection, so this suite is only hermetic — and only
+ * runs on a checkout with no `server/.env` — because the pg-mem pool is installed here.
+ */
+let testPool: PgPool;
+
+beforeAll(async () => {
+  testPool = createPgMemPool();
+  setPool(testPool);
+  await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
+});
+
+afterAll(async () => {
+  await closePool();
+});
 
 describe('Exchanges list contract', () => {
   it('strictly parses canonical pagination, search, and sorting', () => {

--- a/server/tests/exchanges.test.ts
+++ b/server/tests/exchanges.test.ts
@@ -17,9 +17,9 @@ import type { Queryable } from '../src/database/transaction';
 
 /**
  * The controller wraps its mutation in `withIdempotency`, which opens a transaction on
- * the module pool before the (mocked) service ever runs. Without an injected pool that
- * resolves to a real PostgreSQL connection, so this suite is only hermetic — and only
- * runs on a checkout with no `server/.env` — because the pg-mem pool is installed here.
+ * the module pool before the (mocked) service ever runs. With no pool injected here that
+ * resolves to a real PostgreSQL connection, which is why this file used to pass only on a
+ * checkout that happened to have a working `server/.env` (issue #69).
  */
 let testPool: PgPool;
 

--- a/server/tests/inventory-bounded.test.ts
+++ b/server/tests/inventory-bounded.test.ts
@@ -25,6 +25,24 @@ function response() {
   return res;
 }
 
+/**
+ * File-scoped, not scoped to the stock-adjustment describe that needs the tables: the
+ * category-deletion contract above writes an audit row through the module pool, and a
+ * pool installed further down would still be uninstalled when that test runs — leaving
+ * it to open a real PostgreSQL connection whose failure the audit logger swallows.
+ */
+let testPool: PgPool;
+
+beforeAll(async () => {
+  testPool = createPgMemPool();
+  setPool(testPool);
+  await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
 describe('bounded inventory contracts', () => {
   afterEach(() => vi.restoreAllMocks());
 
@@ -112,19 +130,8 @@ describe('paginated inventory query contracts', () => {
 });
 
 describe('manual stock adjustment invariants', () => {
-  let testPool: PgPool;
   let userId: number;
   let productId: number;
-
-  beforeAll(async () => {
-    testPool = createPgMemPool();
-    setPool(testPool);
-    await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
-  });
-
-  afterAll(async () => {
-    await closePool();
-  });
 
   beforeEach(async () => {
     await testPool.query('DELETE FROM stock_adjustments');

--- a/server/tests/products.test.ts
+++ b/server/tests/products.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
 import { ProductsController } from '../src/modules/inventory/products/controller';
 import {
   parseProductListQuery,
@@ -7,6 +12,24 @@ import {
 import { productsRepository } from '../src/modules/inventory/products/repository';
 import { productsService } from '../src/modules/inventory/products/service';
 import productsRouter from '../src/modules/inventory/products/routes';
+
+/**
+ * `discontinue` writes an audit row through the module pool. The write is
+ * fire-and-forget and its failure is swallowed by the audit logger, so without an
+ * injected pool this file quietly opened a real PostgreSQL connection instead of
+ * failing — hermetic only by accident of that catch.
+ */
+let testPool: PgPool;
+
+beforeAll(async () => {
+  testPool = createPgMemPool();
+  setPool(testPool);
+  await runMigrationsUp(testPool, path.join(__dirname, '../src/database/migrations'));
+});
+
+afterAll(async () => {
+  await closePool();
+});
 
 function response() {
   const res: any = {};

--- a/server/tests/setup.ts
+++ b/server/tests/setup.ts
@@ -2,3 +2,36 @@
 process.env.JWT_SECRET = 'test-secret-key-for-vitest-at-least-32-chars';
 process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-key-for-vitest-32ch';
 process.env.NODE_ENV = 'test';
+
+import { setPool } from '../src/database/pool';
+
+/**
+ * A test that never injects a pool used to fall through to `getPool()`, which builds a
+ * real `pg.Pool` from `DATABASE_URL`. On a machine with `server/.env` (or any reachable
+ * local PostgreSQL) that silently *worked*; on a fresh checkout or worktree it failed
+ * with `28P01 password authentication failed`, in a test whose subject was nothing to do
+ * with the database. See issue #69 — it cost four agents an investigation each.
+ *
+ * Installing this trap as the default makes the fallthrough loud and self-describing at
+ * the first statement, everywhere, instead of dependent on the developer's environment.
+ * A suite that wants a database still calls `setPool(createPgMemPool())` (pg-mem) or goes
+ * through `describeWithPostgres` (real PostgreSQL); both replace this trap.
+ */
+const NO_POOL_INJECTED =
+  'This test reached the module PostgreSQL pool without injecting one. ' +
+  'pg-mem suites must call setPool(createPgMemPool()) — at file scope if any test in ' +
+  'the file touches the pool, including indirectly via audit logging. Suites that need ' +
+  'a real server use describeWithPostgres from tests/support/realPostgres.';
+
+const trapPool = {
+  connect: async () => {
+    throw new Error(NO_POOL_INJECTED);
+  },
+  query: async () => {
+    throw new Error(NO_POOL_INJECTED);
+  },
+  end: async () => {},
+  on: () => trapPool,
+};
+
+setPool(trapPool as never);

--- a/server/tests/support/pgMem.ts
+++ b/server/tests/support/pgMem.ts
@@ -58,10 +58,16 @@ function patchQueryable<T extends { query: (...args: never[]) => unknown }>(targ
 }
 
 /**
- * Wraps an existing pg-mem database in a pool that speaks the dialect the migrations are
- * written in. Migrations run through `pool.connect()`, so pooled clients are patched too.
+ * Registers the PostgreSQL functions pg-mem lacks but the production SQL uses.
+ *
+ * Exported separately because a suite that needs its own `newDb()` (the endpoint-health
+ * verification suite registers a further dozen shims of its own) would otherwise take
+ * `toPgMemCompatibleSql` alone and inherit none of this — which is how
+ * `POST /auth/logout` came to 500 on `clock_timestamp() does not exist` in a report
+ * everyone had learned to read past. Take this, or take `pgMemPoolFrom`; never the SQL
+ * rewriter by itself.
  */
-export function pgMemPoolFrom(memDb: IMemoryDb): PgPool {
+export function registerPgMemFunctions(memDb: IMemoryDb): void {
   memDb.public.registerFunction({
     name: 'clock_timestamp',
     args: [],
@@ -70,6 +76,14 @@ export function pgMemPoolFrom(memDb: IMemoryDb): PgPool {
     impure: true,
     implementation: () => new Date(),
   });
+}
+
+/**
+ * Wraps an existing pg-mem database in a pool that speaks the dialect the migrations are
+ * written in. Migrations run through `pool.connect()`, so pooled clients are patched too.
+ */
+export function pgMemPoolFrom(memDb: IMemoryDb): PgPool {
+  registerPgMemFunctions(memDb);
 
   const { Pool } = memDb.adapters.createPg();
   const pool = patchQueryable(new Pool() as unknown as PgPool);

--- a/server/tests/verification/endpointHealth.test.ts
+++ b/server/tests/verification/endpointHealth.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import path from 'path';
 import { newDb } from 'pg-mem';
-import { toPgMemCompatibleSql } from '../support/pgMem';
+import { registerPgMemFunctions, toPgMemCompatibleSql } from '../support/pgMem';
 import { Pool as PgPool } from 'pg';
 import { setPool, closePool } from '../../src/database/pool';
 import { runMigrationsUp } from '../../src/database/migrate';
@@ -20,6 +20,11 @@ const app = createTestApp();
 
 beforeAll(async () => {
   const memDb = newDb({ noAstCoverageCheck: true });
+
+  // The shared harness's shims first: this suite builds its own database, so without
+  // this it inherits the SQL rewriter and none of the function registrations, and
+  // `POST /auth/logout` 500s on `clock_timestamp() does not exist`.
+  registerPgMemFunctions(memDb);
 
   // Register missing PostgreSQL functions in pg-mem
   memDb.public.registerFunction({
@@ -274,8 +279,19 @@ afterAll(async () => {
   // Generate and save diagnostic report
   const diagnostics = diagnosticCollector.getDiagnostics();
   const reportMd = generateMarkdownReport(diagnostics);
-  const reportPath = path.join(__dirname, '../../../docs/reports/api-verification-report.md');
-  saveReportToFile(reportMd, reportPath);
+
+  /**
+   * Writing the tracked report on every run made `npm test` dirty the working tree with
+   * a fresh timestamp, and three agents in a row committed or reverted it as noise. The
+   * report is still worth having — it is a deliberate snapshot, regenerated when someone
+   * wants to look at it — so it is gated rather than deleted or gitignored: gitignoring
+   * would keep the write and hide the drift, which is the same problem one layer down.
+   * The console summary below is unaffected and still prints on every run.
+   */
+  if (process.env.WRITE_API_REPORT === '1') {
+    const reportPath = path.join(__dirname, '../../../docs/reports/api-verification-report.md');
+    saveReportToFile(reportMd, reportPath);
+  }
 
   await closePool();
 });


### PR DESCRIPTION
Closes #69 and #77. Both are CI-credibility defects: every test passes and the job exits 1, or a test passes only because of a file that is gitignored.

## #69 — pg-mem suites reaching a real database

**Root cause.** `ExchangesController.createExchange` wraps its mutation in `withIdempotency`, which calls `withTransaction(run, undefined, …)` → `getPool()` → a real `pg.Pool` built from `DATABASE_URL`. The pool is opened *before* the mocked service ever runs, so the test's mocks were irrelevant. It passed only where `server/.env` happened to supply working credentials.

**The census matters more than the fix.** Rather than grep by hand, this installs a trap pool in `server/tests/setup.ts` and runs the whole suite — a mechanical audit rather than a hopeful one. It found **two more**, both invisible because the audit logger swallows its own write failure:

- `products.test.ts` — no injection at all; `discontinue` writes an audit row.
- `inventory-bounded.test.ts` — injected inside the *last* `describe`, so the earlier category-deletion test ran with no pool.

> [!WARNING]
> On any machine with a reachable database, those two were **writing audit rows to a real database during `npm test`**. That is the more serious half of #69: the reported symptom was a failure on a clean checkout, but the unreported symptom was silent writes on a developer's machine.

The trap is now permanent. A future fallthrough fails at the first statement with an actionable message instead of `28P01`. Re-running the census after the fixes: zero hits.

**Also folded in — `endpointHealth.test.ts`.** Same shape one level up: it builds its own `newDb()` but imported only `toPgMemCompatibleSql`, inheriting the SQL rewriting and none of the harness's `registerFunction` calls. Hence `POST /api/v1/auth/logout` → 500 `clock_timestamp() does not exist`. `registerPgMemFunctions(memDb)` is now its own exported seam. **Server errors in the generated report: 1 → 0; successes 112 → 113** — `POST /auth/logout` now returns 204 on pg-mem, so the fast suite genuinely exercises it instead of reporting a permanent false 500.

Deliberately **not** done: forcing every pg-mem database through the shared harness. That suite legitimately needs its own `newDb()` (a dozen further shims and its own SQL sanitizer), and that would be a bigger change than #69 as filed. **Open question for review:** the exportable unit should probably be "the shims", not "the pool" — `pgMem.ts` now offers both, and the residual risk is that `toPgMemCompatibleSql` is still individually importable and still *looks* sufficient.

## #77 — the teardown race, and why #67 did not fix it

**The `vi.mock('framer-motion')` added in `9d67763` was inert.** The component mounting `LazyMotion` is HeroUI, not our code, and vitest loaded `@heroui/*` natively — a natively-imported dependency resolves its own imports through node and never sees vitest's module registry.

Proved directly rather than inferred: a HeroUI `Modal` rendered the mocked `LazyMotion` **0 times** before, **5 times** after adding `server.deps.inline: [/@heroui\//]`. Every HeroUI button (`@heroui/ripple`), modal, tooltip, tab, popover, navbar and accordion kept the real `features: () => import("@heroui/dom-animation")` lazy load — so the affected surface is essentially every suite, which is why the fix belongs in config and not in `POS.test.tsx`. `POS.test.tsx` is untouched.

`client/src/shared/tests/motionMock.test.tsx` pins the config and the mock together: it fails with `expected 0 to be greater than 0` under the pre-fix config.

No `dangerouslyIgnoreUnhandledErrors` — that would have silenced this and every genuine unhandled rejection.

**Flake rates, 10 full client runs per arm (~4 min each):**

| | runs | exit 1 | `window is not defined` |
|---|---|---|---|
| before | 10 | 1 | **0** |
| after | 10 | 0 | **0** |

Stated plainly: **the #77 signature did not reproduce locally in either arm**, consistent with it being CI-only. Confidence in this fix rests on the structural proof (0 → 5 mocked renders), *not* on the run counts. The single before-run failure is a **different** flake — `CartPanel.test.tsx > removes an applied coupon` hitting the 20s timeout on a run that took 1246s instead of ~240s under machine contention. Left alone; it deserves its own issue.

## Report artefact

`docs/reports/api-verification-report.md` is now written only when `WRITE_API_REPORT=1`. **Gated rather than gitignored**, because gitignoring keeps the write and hides the drift — the same problem one layer down. Three agents in a row left this file dirty. The console summary still prints every run and CI does not consume the file; the committed copy is updated to the zero-server-error state.

## Testing

- **server**, with no `server/.env` in the worktree: 31 files / 390 tests pass — which is the decisive check for #69. With `TEST_DATABASE_URL`: 45 files / 499 tests, all real-PG suites active. `tsc` 0 errors, `eslint` 0 errors.
- **client**: 49 files / 451 tests pass. Suite time **3m07 with inlining vs 4m09 without** — inlining is if anything cheaper here. lint 0 errors, madge clean, `tsc` delta 0.

## Proposed convention — not implemented, for you to decide

Three failures in two days, one signature: *every test passes, the job exits 1*. Causes were (a) a handler attached after the statement that rejected (`7c29625`), (b) async work outliving the jsdom environment (#77), (c) a non-hermetic pool surfacing asynchronously (#69).

A short **"Unhandled rejections in tests"** section in `docs/CONVENTIONS.md` would carry three rules — attach the handler in the statement that creates the promise; no async work may outlive the test that started it; a test never resolves a resource lazily — plus one piece of machinery worth more than the rules:

**A `process.on('unhandledRejection')` in each `setup.ts` that records `expect.getState().currentTestName`.** Vitest blames whichever *file* was running, which is exactly why #77 was chased in `POS.test.tsx` and why four separate agents chased #69 into their own branches. ~10 lines per side, silences nothing.

A lint rule would only catch (a), and only via type-aware `no-floating-promises` — which would *not* have flagged `7c29625`, since that promise was eventually awaited. This class needs attribution, not a rule.

## Post-Deploy Monitoring & Validation

No production runtime impact — test configuration and test files only. The observable is CI itself: the client job should stop failing with all tests passing, and the server job should stay green on a checkout with no `server/.env`. If the client flake recurs, the structural proof above means the cause is a *different* async source and the attribution hook is the next step, not another config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
