### PR TITLE
feat(server): correlation IDs, structured request logs, and liveness/readiness probes

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -12,10 +12,17 @@ import cookieParser from 'cookie-parser';
 import path from 'path';
 import { apiReference } from '@scalar/express-api-reference';
 import errorHandler from './middleware/errorHandler';
-import { requestLogger } from './middleware/requestLogger';
+import { errorClassifier, observabilityMiddleware } from './src/observability/requestLogging';
+import {
+  beginShutdown,
+  legacyHealthHandler,
+  livenessHandler,
+  readinessHandler,
+} from './src/observability/health';
+import { resolveMetricsInterval, startMetricsReporter } from './src/observability/metrics';
 import { sanitizeBody } from './middleware/sanitize';
 import logger from './lib/logger';
-import db, { closePool } from './src/database/pool';
+import { closePool } from './src/database/pool';
 import { errorResponse } from './src/http/errors';
 import { openApiSpec } from './src/docs/openapi';
 
@@ -79,6 +86,15 @@ app.use(
   })
 );
 
+/**
+ * Correlation id, request log line, metrics.
+ *
+ * Ahead of the rate limiter on purpose: a `429` is exactly the response a shop calls
+ * support about, and without an id and a log line it is unattributable. Ahead of the body
+ * parser too, so a request rejected for an oversized body still produces one.
+ */
+app.use(observabilityMiddleware);
+
 // Rate limiting
 logRateLimitOverrides();
 app.use(createGlobalLimiter());
@@ -89,9 +105,6 @@ app.use(cookieParser());
 
 // Input sanitization (strip HTML/XSS vectors from request body strings)
 app.use(sanitizeBody);
-
-// Request logging
-app.use(requestLogger);
 
 /**
  * Static files (product images).
@@ -130,21 +143,25 @@ app.use(
   })
 );
 
-// Health check (includes DB connectivity test)
-app.get('/api/health', async (_req: Request, res: Response) => {
-  try {
-    await db.query('SELECT 1');
-    res.json({ success: true, data: { status: 'ok', timestamp: new Date().toISOString() } });
-  } catch {
-    res.status(503).json({ success: false, error: 'Database unreachable' });
-  }
-});
+/**
+ * Health probes. Liveness answers from the event loop and touches no dependency, so a
+ * database blip cannot get a healthy process killed; readiness checks the database and
+ * fails while shutting down, so a load balancer drains before the socket closes. The
+ * original `/api/health` keeps its exact legacy shape for the E2E harness and the deploy
+ * health check. All three are rate-limit exempt via `observability/probePaths.ts`.
+ * See `src/docs/OBSERVABILITY.md`.
+ */
+app.get('/api/health/live', livenessHandler);
+app.get('/api/health/ready', readinessHandler);
+app.get('/api/health', legacyHealthHandler);
 
 app.use((_req: Request, res: Response) => {
   res.status(404).json(errorResponse('NOT_FOUND'));
 });
 
-// Error handler
+// Error handler. `errorClassifier` only records the public error code on the request
+// context — so the request log line can carry it — and hands the error straight on.
+app.use(errorClassifier);
 app.use(errorHandler);
 
 /**
@@ -153,6 +170,15 @@ app.use(errorHandler);
  * process. See `src/scheduler/index.ts`.
  */
 const scheduler = startScheduler();
+
+/**
+ * Periodic `service_metrics` line: pool saturation and business-failure counts, the two
+ * signals no per-request line can carry. The log stream is this service's metrics
+ * transport — see `src/observability/metrics.ts` for why there is no `/metrics` endpoint.
+ */
+const metricsReporter = startMetricsReporter(
+  resolveMetricsInterval(process.env.METRICS_LOG_INTERVAL_MS)
+);
 
 // Prevent crashes from unhandled errors
 process.on('uncaughtException', (err) => {
@@ -170,7 +196,17 @@ const server = app.listen(PORT, () => {
 // Graceful shutdown
 function shutdown(signal: string): void {
   logger.info(`${signal} received, shutting down gracefully`);
+  /*
+   * Readiness goes false first, before anything stops. The window between "this instance
+   * stops advertising itself" and "this instance stops listening" is the drain: without
+   * it the load balancer is still routing new checkouts at a socket that is closing, and
+   * a cashier sees a connection reset instead of a retry against another instance.
+   * Liveness deliberately keeps passing — the process is winding down on purpose, and a
+   * failing liveness probe here would have the orchestrator SIGKILL the drain.
+   */
+  beginShutdown();
   scheduler.stop();
+  metricsReporter.stop();
   server.close(async () => {
     logger.info('HTTP server closed');
     try {

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -1,3 +1,22 @@
+/**
+ * The process logger.
+ *
+ * Two things happen to every line that passes through here, and both are deliberately
+ * unavoidable by call sites:
+ *
+ *   - **Correlation.** If the line is emitted while a request is in flight, it is stamped
+ *     with that request's `request_id` from `AsyncLocalStorage`. No call site threads a
+ *     context argument, which is what makes "trace a request through the logs by one id"
+ *     true for repository and service lines and not only for the HTTP boundary.
+ *
+ *   - **Redaction.** Metadata and message both pass through `redactMeta`/`scrubString`.
+ *     This is the second layer — the first is that nothing logs bodies, headers or query
+ *     values in the first place — and it exists for the day a future caller passes
+ *     `{ user }` or an `Authorization` header into a log line by accident.
+ */
+import { currentRequestId } from '../src/observability/correlation';
+import { redactMeta, scrubString } from '../src/observability/redaction';
+
 const isProduction = process.env.NODE_ENV === 'production';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -14,9 +33,20 @@ function formatMessage(level: LogLevel, message: string, meta?: Record<string, u
   return `${prefix} ${message}${metaStr}`;
 }
 
+/**
+ * An explicit `request_id` in the metadata wins: a line about *another* request — the
+ * shutdown sweep reporting which request it abandoned, say — must be able to name it.
+ */
+function withCorrelation(meta: Record<string, unknown> | undefined): Record<string, unknown> {
+  const requestId = currentRequestId();
+  if (!requestId) return meta ?? {};
+  return { request_id: requestId, ...(meta ?? {}) };
+}
+
 function log(level: LogLevel, message: string, meta?: Record<string, unknown>): void {
   if (LEVELS[level] < minLevel) return;
-  const formatted = formatMessage(level, message, meta);
+  const safeMeta = redactMeta(withCorrelation(meta));
+  const formatted = formatMessage(level, scrubString(message), safeMeta);
   if (level === 'error') {
     console.error(formatted);
   } else if (level === 'warn') {

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -80,6 +80,16 @@ const envSchema = z.object({
    */
   TRUST_PROXY: z.string().optional(),
   /**
+   * How often the `service_metrics` snapshot line is emitted, in milliseconds, resolved
+   * by `src/observability/metrics.ts`. `0` disables it. Values under a second are raised
+   * to a second — a sub-second snapshot is a log flood, not a metric.
+   *
+   * There is no `/metrics` endpoint to configure: the log stream is the metrics
+   * transport, so that an operator needs nothing beyond the aggregator they already run.
+   * See the module comment for the reasoning and for what was rejected.
+   */
+  METRICS_LOG_INTERVAL_MS: z.string().optional(),
+  /**
    * Where uploaded media lives, resolved by `src/storage/index.ts`. Every default here
    * reproduces the pre-abstraction behaviour exactly — the filesystem under
    * `server/uploads`, served at `/uploads` — so an unconfigured deployment keeps serving

--- a/server/src/database/pool.ts
+++ b/server/src/database/pool.ts
@@ -47,6 +47,25 @@ export function setPool(pool: Pool): void {
   poolInstance = pool;
 }
 
+/**
+ * Pool saturation gauges, or `null` when no pool has been created yet.
+ *
+ * Deliberately does *not* call `getPool()`: this is read by the metrics reporter and by
+ * the readiness probe, and a monitoring read that lazily opens a connection pool would be
+ * observation changing the thing observed. `waiting > 0` sustained is the signal that
+ * matters — every checkout is then queueing behind a connection rather than a query.
+ */
+export function poolStats(): { total: number; idle: number; waiting: number } | null {
+  if (!poolInstance) return null;
+  // Coerced because a test double standing in for `Pool` need not carry the gauges, and
+  // a missing gauge should read as zero rather than as `null` in a log line.
+  return {
+    total: Number(poolInstance.totalCount) || 0,
+    idle: Number(poolInstance.idleCount) || 0,
+    waiting: Number(poolInstance.waitingCount) || 0,
+  };
+}
+
 export async function closePool(): Promise<void> {
   if (poolInstance) {
     await poolInstance.end();

--- a/server/src/docs/OBSERVABILITY.md
+++ b/server/src/docs/OBSERVABILITY.md
@@ -1,0 +1,165 @@
+# Backend observability & health semantics
+
+What this service emits, what an operator can probe, and what is worth waking someone for.
+Implementation lives in `server/src/observability/`.
+
+## Health endpoints
+
+| Endpoint | Touches the database? | Meaning of a failure | What an orchestrator should do |
+| --- | --- | --- | --- |
+| `GET /api/health/live` | No | The process cannot serve at all | Restart the process |
+| `GET /api/health/ready` | Yes, under a 2s timeout | This instance cannot safely serve *right now* | Stop routing to it; do **not** restart |
+| `GET /api/health` | Yes | Legacy alias for readiness | Kept for the E2E harness and the deploy health check |
+
+The split is the whole point. A failing liveness probe gets the process killed, so a
+liveness check that touches the database turns a thirty-second database blip into a
+rolling restart of every healthy instance — each dropping in-flight requests and a warm
+pool, all reconnecting at once into the database that was already struggling. Liveness
+therefore answers from the event loop and touches nothing.
+
+Readiness is the one that checks dependencies, because a failed readiness probe means
+"route elsewhere" and clears with no intervention when the dependency returns. Its
+database check runs under a hard 2s timeout: a dependency that stops answering *without*
+refusing connections would otherwise hang the probe until the prober's own timeout, so
+the instance would neither pass nor fail — it would simply stop reporting.
+
+Liveness keeps returning `200` during graceful shutdown (`shutting_down: true` in the
+body). The process is winding down deliberately; a failing liveness probe there would
+have the orchestrator `SIGKILL` the drain it is waiting for.
+
+All three paths are exempt from the global rate limiter. The list is
+`src/observability/probePaths.ts`, read by both the route registration and
+`isRateLimitExempt` — **any new probe path must be added there**, or the probes start
+spending the shop's request budget and monitoring reports an outage that monitoring
+caused (see *Rate-limit bucketing* in `CLAUDE.md`, and #71).
+
+### Shutdown behaviour
+
+On `SIGTERM`/`SIGINT`, in order:
+
+1. Readiness flips to `503 not_ready` (`reason: shutting_down`) — the load balancer stops
+   sending new work while the socket is still open. This gap is the drain.
+2. The scheduler stops claiming jobs; the metrics reporter emits one final snapshot.
+3. `server.close()` waits for in-flight requests, then the pool is closed.
+4. A 10s watchdog forces `exit(1)` if connections do not close.
+
+Liveness stays green throughout.
+
+## Correlation IDs
+
+Every request is assigned a UUID and it is returned on the `X-Request-Id` response
+header. Every log line the request produces carries it as `request_id`, including lines
+emitted deep inside a service or repository — propagation is via `AsyncLocalStorage`, so
+no call site threads a context argument.
+
+**An inbound ID is recorded, never adopted.** This API is reached directly by tills and by
+a public storefront, so a caller-chosen ID is an attacker-chosen primary key for the log
+store: it can collide with another request's ID, be reused across thousands of requests to
+make that traffic unsearchable, or carry newlines and kilobytes into every line. A
+well-formed inbound `X-Request-Id` / `X-Correlation-Id` (8–128 chars of
+`[A-Za-z0-9_.:-]`) is logged as `client_request_id`, so a join with an upstream trace is
+still possible — but the field operators search by is one this process minted.
+
+## Log lines
+
+Production logs are one JSON object per line. Two events matter to monitoring:
+
+### `http_request` — one per finished request
+
+| Field | Notes |
+| --- | --- |
+| `request_id`, `client_request_id` | Correlation, as above |
+| `method`, `path` | `path` is normalized: numeric, UUID and barcode-shaped segments become `:id` |
+| `status`, `outcome`, `error_code` | See the outcome classes below |
+| `duration_ms` | Server-side handling time |
+| `user_id`, `user_role` | Actor, when authenticated |
+| `query_keys` | Allow-listed query key *names* only — never values |
+
+Health probes log at `debug` unless they fail; they are still counted in the metrics.
+
+### `service_metrics` — a periodic snapshot
+
+Emitted every `METRICS_LOG_INTERVAL_MS` (default 60000; `0` disables). Carries
+`uptime_s`, `requests_total`, `requests_by_outcome`, a latency histogram
+(`latency_ms.buckets.le_*`, `over_5000`, `avg`, `max`), `db_pool`
+(`total`/`idle`/`waiting`) and `business_failures`. Counters are cumulative since process
+start, which is what an aggregator's `rate()` expects; `uptime_s` in the same line is how
+a reader tells a restart from a gap.
+
+### Outcome classes
+
+`outcome` is what makes HTTP failures and business validation failures distinguishable:
+
+| Class | Statuses | Reading |
+| --- | --- | --- |
+| `success` | 2xx/3xx | — |
+| `business_rule` | 400, 409, 422 | The domain said no. **Normal traffic** — a shop scanning an out-of-stock item produces these all day. Alerting on them as errors trains operators to ignore the alert. |
+| `client_error` | 401, 403, 404, 405, 415, 429 | The caller was wrong or refused. A spike is an auth or client-version problem. |
+| `server_error` | 5xx | The server's fault. The class worth paging on. |
+
+## Metrics transport
+
+**The log stream is the metrics transport. There is no `/metrics` endpoint.**
+
+A Prometheus-style scrape endpoint (`prom-client` + `GET /metrics`) was considered and
+rejected. It is not the metric shape that costs, it is the component: a scrape endpoint is
+only a metrics system once somebody runs a Prometheus or an agent, keeps it reachable from
+the API's network, and maintains a second retention and alerting stack beside the log
+pipeline that already exists — and nobody has agreed to run that. Meanwhile the endpoint
+is not free while it waits for one: it is a new unauthenticated surface whose body
+enumerates every route and internal failure mode of the system. Same reasoning as #46
+using a PostgreSQL claim row rather than introducing Redis.
+
+Every signal #45 names is derivable from the two log events above. If a scrape endpoint is
+later agreed to, `metrics.snapshot()` is already the registry — exposing one is a
+formatter, not a redesign.
+
+## Redaction
+
+Two layers, and the first is the structural one:
+
+1. **Nothing logs a request body, a header, a cookie, or a query value.** The request line
+   logs allow-listed query *key names*; the auth module logs a 12-character digest prefix
+   and never token material (#74); actor metadata is the user's id and role, never their
+   email or name. An allow-list cannot leak a field nobody anticipated.
+2. **Everything reaching `logger` is scrubbed** (`src/observability/redaction.ts`), in both
+   directions: a *key* naming a secret is replaced whatever it holds, and a *value* shaped
+   like a credential is replaced whatever it is called — JWTs, `Bearer`/`Basic` headers,
+   connection strings with credentials, email addresses, E.164 phone numbers, full
+   SHA-256 digests. Depth, array length and string length are bounded so one bad call
+   cannot flood the aggregator.
+
+Never logged: passwords and hashes, access/refresh tokens and any JWT, `Authorization`
+headers, cookies, session identifiers, API keys, connection strings, card/PIN/OTP
+material, and customer personal data (phone, email, address, name).
+
+Key matching is on tokenized words rather than substrings, so `company` does not become
+sensitive because it contains `pan`. Pinned by `tests/observability/redaction.test.ts`,
+including the negative cases — a scrubber that eats stack traces is one people work around
+by not logging.
+
+## Alertable conditions
+
+| Condition | Signal | Severity | Why |
+| --- | --- | --- | --- |
+| Readiness failing on all instances > 1 min | `GET /api/health/ready` 503 | Page | No instance can serve; the shop is down |
+| Readiness failing on one instance > 5 min | Same, per instance | Ticket | Capacity loss; the LB has already routed around it |
+| Liveness failing | `GET /api/health/live` non-200 | Page | The process cannot serve at all — a restart is the fix |
+| `uptime_s` repeatedly resetting | `service_metrics` | Page | Crash loop; liveness alone will look healthy between restarts |
+| `server_error` rate > 1% of requests over 5 min | `http_request` `outcome` | Page | Genuine server faults, distinct from a shop hitting business rules |
+| `client_error` spike, mostly 401 | `http_request` `outcome`, `status` | Ticket | Token/refresh regression or a stale client build |
+| Sustained 429s | `http_request` `status=429` | Ticket | A ceiling is too low for a busy shop, or one till is looping |
+| `db_pool.waiting > 0` sustained > 1 min | `service_metrics` | Page | Every checkout is queueing for a connection, not for a query |
+| `latency_ms.over_5000` rising | `service_metrics` | Ticket | Cashiers are waiting; usually the leading indicator of pool exhaustion |
+| A `business_failures` label jumping order of magnitude | `service_metrics` | Ticket | A domain rule started rejecting traffic it used to accept — usually a bad config or price/promotion change |
+| `Refresh token reuse detected` | log message (auth) | Page | Possible session theft; the family is already revoked |
+| No `service_metrics` line for 3 intervals | Absence of the event | Ticket | The instance is wedged or its logs are not shipping |
+
+Deliberately **not** alertable: `business_rule` outcomes on their own. They are the sound
+of a shop working.
+
+## Environment
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `METRICS_LOG_INTERVAL_MS` | `60000` | Snapshot cadence. `0` disables; sub-second values are raised to 1s. Invalid values fall back to the default. |

--- a/server/src/docs/openapi.ts
+++ b/server/src/docs/openapi.ts
@@ -346,6 +346,77 @@ export const openApiSpec = {
         },
       },
     },
+    '/api/health/live': {
+      get: {
+        tags: ['Health'],
+        summary: 'Liveness Probe',
+        description:
+          'Is this process alive? Answers from the event loop and touches no dependency, ' +
+          'so a temporarily unavailable database never fails it. A failure here means the ' +
+          'process cannot serve at all and should be restarted. Keeps returning 200 during ' +
+          'graceful shutdown so the drain is not cut short.',
+        security: [],
+        responses: {
+          '200': {
+            description: 'Process is alive',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    status: { type: 'string', example: 'alive' },
+                    uptime_s: { type: 'integer', example: 3600 },
+                    shutting_down: { type: 'boolean', example: false },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/health/ready': {
+      get: {
+        tags: ['Health'],
+        summary: 'Readiness Probe',
+        description:
+          'Can this instance safely serve traffic right now? Checks the database under a ' +
+          '2s timeout and fails while the process is shutting down. A failure means "stop ' +
+          'routing traffic here", not "restart this process"; it clears without ' +
+          'intervention when the dependency returns.',
+        security: [],
+        responses: {
+          '200': {
+            description: 'Ready to serve traffic',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    status: { type: 'string', example: 'ready' },
+                    checks: {
+                      type: 'object',
+                      properties: {
+                        database: {
+                          type: 'object',
+                          properties: {
+                            status: { type: 'string', example: 'ok' },
+                            latency_ms: { type: 'integer', example: 3 },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '503': {
+            description: 'Not ready — dependency unavailable or shutting down',
+          },
+        },
+      },
+    },
     '/api/v1/auth/login': {
       post: {
         tags: ['Auth'],

--- a/server/src/http/rateLimits.ts
+++ b/server/src/http/rateLimits.ts
@@ -4,6 +4,7 @@ import jwt from 'jsonwebtoken';
 import { getEnv } from '../config/env';
 import { errorResponse } from './errors';
 import logger from '../../lib/logger';
+import { isHealthPath } from '../observability/probePaths';
 
 export const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
@@ -38,19 +39,24 @@ export function authRateLimitMax(): number {
 /**
  * Paths the global limiter does not spend budget on.
  *
- * `/api/health` is a single `SELECT 1` behind an unauthenticated GET, and it is called
- * by uptime probes and load balancers on a fixed schedule. Counting it means a shop that
- * has spent its budget also fails its own health probe — the monitoring reports an
- * outage caused by the monitoring. The traffic it can generate is bounded by the prober,
- * and flooding an unauthenticated endpoint is a job for the layer in front of the app,
- * not for a budget that a cashier's checkout shares.
+ * The health probes are unauthenticated GETs called by uptime probes, load balancers and
+ * orchestrators on a fixed schedule. Counting them means a shop that has spent its budget
+ * also fails its own health probe — the monitoring reports an outage caused by the
+ * monitoring. The traffic they can generate is bounded by the prober, and flooding an
+ * unauthenticated endpoint is a job for the layer in front of the app, not for a budget
+ * that a cashier's checkout shares.
+ *
+ * The list comes from `observability/probePaths.ts` rather than being spelled out here,
+ * because the failure mode of the two drifting apart is invisible: splitting `/api/health`
+ * into `/live` and `/ready` while this predicate still matched one exact string would put
+ * the probes back on the budget and break no test.
  *
  * Deliberately narrow: register/shift polling reads are *authenticated*, so per-user
  * keying already stops one till starving another. Exempting them as well would carve
  * real, DB-touching endpoints out of abuse protection for no remaining benefit.
  */
 export function isRateLimitExempt(req: Pick<Request, 'method' | 'path'>): boolean {
-  return req.method === 'GET' && req.path === '/api/health';
+  return req.method === 'GET' && isHealthPath(req.path);
 }
 
 /**

--- a/server/src/observability/correlation.ts
+++ b/server/src/observability/correlation.ts
@@ -1,0 +1,92 @@
+/**
+ * Correlation IDs.
+ *
+ * Every request gets exactly one id, and it is *generated here* — never adopted from the
+ * caller.
+ *
+ * The trust argument: this API is reached directly by tills, by a public storefront, and
+ * by anything else that can open a socket. An adopted `X-Request-Id` is an
+ * attacker-chosen primary key for the log store. It lets a caller (a) collide with
+ * another request's id, so a support investigation reads two unrelated requests as one
+ * causal chain, (b) reuse one id across thousands of requests to make its own traffic
+ * unsearchable, and (c) inject newlines or several kilobytes into every log line the
+ * request produces. None of those need any privilege. The upstream benefit — a shared id
+ * across a service boundary — does not apply: nothing in this deployment sits in front of
+ * the API generating ids, and if something does later, its id can be *recorded* without
+ * being *trusted*.
+ *
+ * So: the server's own id is authoritative and is what the response header carries; an
+ * inbound id, if it passes a strict format check, is logged alongside it as
+ * `client_request_id`. Both halves of the join are then available, and the field an
+ * operator searches by is one this process minted.
+ *
+ * Propagation is via `AsyncLocalStorage`, so `logger` can stamp the id onto *every* line
+ * a request produces — including deep inside a repository — without any call site
+ * threading a context argument. That is what makes "trace a request through the logs by
+ * one id" true rather than aspirational.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+import type { NextFunction, Request, Response } from 'express';
+
+/** Header the id is returned on, and the one an upstream id is read from. */
+export const REQUEST_ID_HEADER = 'X-Request-Id';
+
+/** Also accepted as an inbound hint; many proxies emit this spelling instead. */
+export const CORRELATION_ID_HEADER = 'X-Correlation-Id';
+
+export interface RequestContext {
+  /** This server's id for the request. Authoritative; always present. */
+  requestId: string;
+  /** A well-formed id the caller sent, recorded but never trusted. */
+  clientRequestId?: string;
+  /** Public error code, when the request failed through the error boundary. */
+  errorCode?: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * A caller-supplied id is accepted into the logs only if it is short, single-line, and
+ * made of characters that cannot break a JSON log line or a log query: this is the
+ * bound on (c) above. Anything else is dropped silently — a malformed hint is not worth
+ * a log line of its own, which would itself be caller-triggered noise.
+ */
+const INBOUND_ID = /^[A-Za-z0-9_.:-]{8,128}$/;
+
+export function sanitizeInboundRequestId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return INBOUND_ID.test(trimmed) ? trimmed : undefined;
+}
+
+export function currentContext(): RequestContext | undefined {
+  return storage.getStore();
+}
+
+export function currentRequestId(): string | undefined {
+  return storage.getStore()?.requestId;
+}
+
+/** Runs `fn` inside a fresh context. Used by the middleware and by tests. */
+export function runWithContext<T>(context: RequestContext, fn: () => T): T {
+  return storage.run(context, fn);
+}
+
+/**
+ * Assigns the request its id, echoes it to the client, and runs the rest of the chain
+ * inside the context so every downstream log line carries it.
+ *
+ * Mounted before the rate limiter in `server/index.ts`: a `429` is precisely the response
+ * a shop will call support about, and it is worthless without an id to look up.
+ */
+export function correlationMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const context: RequestContext = {
+    requestId: randomUUID(),
+    clientRequestId:
+      sanitizeInboundRequestId(req.headers[REQUEST_ID_HEADER.toLowerCase()]) ??
+      sanitizeInboundRequestId(req.headers[CORRELATION_ID_HEADER.toLowerCase()]),
+  };
+  res.setHeader(REQUEST_ID_HEADER, context.requestId);
+  runWithContext(context, next);
+}

--- a/server/src/observability/health.ts
+++ b/server/src/observability/health.ts
@@ -1,0 +1,173 @@
+/**
+ * Liveness and readiness.
+ *
+ * Today's single `GET /api/health` runs `SELECT 1`. That is a *readiness* check wearing a
+ * liveness name, and the difference is not cosmetic: an orchestrator responds to a failed
+ * liveness probe by killing the process and to a failed readiness probe by taking the
+ * instance out of rotation. Wire a database round-trip to liveness and a thirty-second
+ * database blip becomes a rolling restart of every healthy API instance — each one
+ * dropping its in-flight requests and its warm pool, all of them reconnecting at once
+ * into the database that was already struggling. The outage is then caused by the
+ * monitoring, which is the same failure mode the rate-limit exemption in #71 exists to
+ * prevent.
+ *
+ * So:
+ *
+ *   `GET /api/health/live`  — is this process still a working Node process? It answers
+ *                             from the event loop and touches nothing else. It fails only
+ *                             when the process cannot serve at all (event loop wedged,
+ *                             heap exhausted, port not accepting), which is exactly the
+ *                             condition a restart fixes. It does *not* fail during
+ *                             shutdown: the process is deliberately winding down, and
+ *                             killing it harder cuts the drain short.
+ *
+ *   `GET /api/health/ready` — can this instance safely serve traffic *right now*? It
+ *                             checks the database, because every non-trivial route needs
+ *                             one, and it fails while shutting down so a load balancer
+ *                             stops sending new work before the socket closes. Recovery
+ *                             needs no intervention: the next probe passes when the
+ *                             dependency returns.
+ *
+ *   `GET /api/health`       — unchanged, byte-for-byte, including its legacy
+ *                             `{ success, data }` envelope. The E2E harness and the
+ *                             Playwright `webServer` gate both wait on it, and Render's
+ *                             health check points at it. It behaves as a readiness check,
+ *                             which is what it always was.
+ *
+ * All three are exempt from the global rate limiter — see `isRateLimitExempt` in
+ * `src/http/rateLimits.ts`, which must list every probe path here. A probe that spends
+ * the shop's request budget is a monitoring-caused outage.
+ */
+import type { Request, Response } from 'express';
+import db from '../database/pool';
+import logger from '../../lib/logger';
+
+/** How long a readiness database check may take before it is treated as a failure. */
+export const READINESS_TIMEOUT_MS = 2000;
+
+let shuttingDown = false;
+
+/**
+ * Flips readiness to failing. Called at the *top* of the shutdown handler, before the
+ * server stops accepting: the gap between "stop being advertised" and "stop listening" is
+ * the drain, and without it a load balancer keeps routing to a closing socket.
+ */
+export function beginShutdown(): void {
+  shuttingDown = true;
+}
+
+export function isShuttingDown(): boolean {
+  return shuttingDown;
+}
+
+/** Test seam — a module-level flag would otherwise leak between suites. */
+export function resetShutdownState(): void {
+  shuttingDown = false;
+}
+
+export interface DependencyCheck {
+  status: 'ok' | 'failed';
+  latency_ms: number;
+  error?: string;
+}
+
+/**
+ * `SELECT 1` under a hard timeout.
+ *
+ * The timeout is the point. A probe without one inherits the dependency's failure mode:
+ * when PostgreSQL stops answering *without* refusing connections, an un-timed check hangs
+ * until the prober's own timeout, so the instance neither passes nor fails and simply
+ * stops reporting. A wedged dependency must read as `failed`, promptly.
+ */
+export async function checkDatabase(): Promise<DependencyCheck> {
+  const started = Date.now();
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      db.query('SELECT 1'),
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`database check exceeded ${READINESS_TIMEOUT_MS}ms`)),
+          READINESS_TIMEOUT_MS
+        );
+      }),
+    ]);
+    return { status: 'ok', latency_ms: Date.now() - started };
+  } catch (err) {
+    return {
+      status: 'failed',
+      latency_ms: Date.now() - started,
+      // The driver's message names the host and the failure kind and carries no
+      // credentials; `logger`'s scrubber removes a connection string if one ever appears.
+      error: err instanceof Error ? err.message : 'unknown error',
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface ReadinessResult {
+  ready: boolean;
+  reason?: 'shutting_down' | 'dependency_unavailable';
+  checks: { database: DependencyCheck };
+}
+
+export async function evaluateReadiness(): Promise<ReadinessResult> {
+  const database = await checkDatabase();
+  if (shuttingDown) {
+    return { ready: false, reason: 'shutting_down', checks: { database } };
+  }
+  if (database.status === 'failed') {
+    return { ready: false, reason: 'dependency_unavailable', checks: { database } };
+  }
+  return { ready: true, checks: { database } };
+}
+
+/**
+ * Liveness. Deliberately trivial and deliberately dependency-free: answering at all is
+ * the assertion. `uptime_s` is included because a liveness probe that keeps passing while
+ * uptime keeps resetting is the signature of a crash loop.
+ */
+export function livenessHandler(_req: Request, res: Response): void {
+  res.status(200).json({
+    status: 'alive',
+    uptime_s: Math.round(process.uptime()),
+    shutting_down: shuttingDown,
+  });
+}
+
+export async function readinessHandler(_req: Request, res: Response): Promise<void> {
+  const result = await evaluateReadiness();
+  if (!result.ready) {
+    logger.warn('Readiness check failed', {
+      reason: result.reason,
+      database_status: result.checks.database.status,
+      database_latency_ms: result.checks.database.latency_ms,
+    });
+  }
+  res.status(result.ready ? 200 : 503).json({
+    status: result.ready ? 'ready' : 'not_ready',
+    ...(result.reason ? { reason: result.reason } : {}),
+    checks: result.checks,
+  });
+}
+
+/**
+ * The pre-existing `/api/health`, preserved exactly — same envelope, same 503 message.
+ * Callers outside this repo (`e2e/support/globalSetup.ts`, `render.yaml`) assert on this
+ * shape, and an observability change is not the place to break them. New probes should
+ * use `/live` and `/ready`.
+ */
+export async function legacyHealthHandler(_req: Request, res: Response): Promise<void> {
+  const result = await evaluateReadiness();
+  if (result.ready) {
+    res.json({ success: true, data: { status: 'ok', timestamp: new Date().toISOString() } });
+    return;
+  }
+  res.status(503).json({
+    success: false,
+    error: result.reason === 'shutting_down' ? 'Server shutting down' : 'Database unreachable',
+  });
+}
+
+export { HEALTH_PATHS, isHealthPath } from './probePaths';

--- a/server/src/observability/metrics.ts
+++ b/server/src/observability/metrics.ts
@@ -1,0 +1,219 @@
+/**
+ * Service metrics.
+ *
+ * **Transport decision: the structured log stream, not a `/metrics` endpoint.**
+ *
+ * The alternative considered was `prom-client` plus a Prometheus-style `GET /metrics`.
+ * It was rejected for the same reason #46 used a PostgreSQL claim row instead of Redis:
+ * it is not the metric shape that costs, it is the *component*. A scrape endpoint is only
+ * a metrics system once somebody runs a Prometheus (or an agent) to scrape it, keeps it
+ * reachable from the API's network, and maintains a second retention and alerting stack
+ * beside the log pipeline that already exists. Nobody has agreed to run that. And the
+ * endpoint is not free while it waits for one: it is a new unauthenticated surface whose
+ * body enumerates every route and internal failure mode of the system.
+ *
+ * Every signal the issue names is derivable from the per-request line
+ * `requestLogging.ts` already emits — request rate (count of `http_request` lines),
+ * latency (`duration_ms`), error rate and the HTTP-vs-business split (`outcome`) — with
+ * the exception of two that no per-request line can carry: database pool saturation, and
+ * counts of critical business failures over time. Those are what the periodic
+ * `service_metrics` snapshot below exists for.
+ *
+ * The registry is a module with a `snapshot()`, so if a scrape endpoint is later agreed
+ * to, exposing one is a formatter over `snapshot()` — a small addition, not a redesign.
+ *
+ * Counters are cumulative since process start, which is what an aggregator's `rate()`
+ * expects; a restart shows as a counter reset, and `uptime_s` in the same line is how a
+ * reader tells a reset from a gap.
+ */
+import logger from '../../lib/logger';
+import { poolStats } from '../database/pool';
+
+/**
+ * How a finished request is classified. The split the issue asks for — "metrics
+ * distinguish HTTP failures from business validation failures" — is this enum:
+ *
+ *   - `success`       — 2xx/3xx.
+ *   - `business_rule` — the request was well-formed and authorized, and the *domain*
+ *                       rejected it: failed validation (400), a conflicting state (409),
+ *                       an unprocessable entity (422). These are normal traffic. A shop
+ *                       scanning an out-of-stock item produces them all day; alerting on
+ *                       them as errors trains operators to ignore the alert.
+ *   - `client_error`  — the caller got the protocol wrong or was refused: 401, 403, 404,
+ *                       405, 415, 429. A spike here is an auth or client-version problem.
+ *   - `server_error`  — 5xx. The only class that is unambiguously the server's fault, and
+ *                       the one worth paging on.
+ */
+export type RequestOutcome = 'success' | 'business_rule' | 'client_error' | 'server_error';
+
+/**
+ * Status codes that mean "the domain said no", as opposed to "the request was wrong".
+ * 400 is in both camps in principle; in this API a 400 is a `VALIDATION_ERROR` from a Zod
+ * schema, which is a business validation failure, so it is classified as one.
+ */
+const BUSINESS_STATUSES = new Set([400, 409, 422]);
+
+export function classifyOutcome(statusCode: number): RequestOutcome {
+  if (statusCode >= 500) return 'server_error';
+  if (statusCode >= 400) {
+    return BUSINESS_STATUSES.has(statusCode) ? 'business_rule' : 'client_error';
+  }
+  return 'success';
+}
+
+/**
+ * Latency histogram bucket upper bounds in milliseconds. Cumulative counts, so a reader
+ * can estimate any percentile; the bounds are chosen around a POS checkout, where 250ms
+ * is comfortable and 2.5s is a cashier waiting.
+ */
+export const LATENCY_BUCKETS_MS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000] as const;
+
+interface HttpMetrics {
+  total: number;
+  byOutcome: Record<RequestOutcome, number>;
+  durationSumMs: number;
+  durationMaxMs: number;
+  /** Cumulative counts: index i is "requests at or under LATENCY_BUCKETS_MS[i]". */
+  buckets: number[];
+  /** Requests slower than the largest bucket. */
+  overflow: number;
+}
+
+function emptyHttp(): HttpMetrics {
+  return {
+    total: 0,
+    byOutcome: { success: 0, business_rule: 0, client_error: 0, server_error: 0 },
+    durationSumMs: 0,
+    durationMaxMs: 0,
+    buckets: LATENCY_BUCKETS_MS.map(() => 0),
+    overflow: 0,
+  };
+}
+
+let http = emptyHttp();
+let businessFailures = new Map<string, number>();
+let startedAt = Date.now();
+
+export function recordRequest(outcome: RequestOutcome, durationMs: number): void {
+  http.total += 1;
+  http.byOutcome[outcome] += 1;
+  http.durationSumMs += durationMs;
+  if (durationMs > http.durationMaxMs) http.durationMaxMs = durationMs;
+  let counted = false;
+  for (let i = 0; i < LATENCY_BUCKETS_MS.length; i += 1) {
+    if (durationMs <= LATENCY_BUCKETS_MS[i]) {
+      http.buckets[i] += 1;
+      counted = true;
+      break;
+    }
+  }
+  if (!counted) http.overflow += 1;
+}
+
+/**
+ * Counts a business failure worth watching over time — a rejected checkout, a refused
+ * refund, a gift-card redemption that did not apply.
+ *
+ * `kind` is a low-cardinality label chosen by the caller (`checkout.insufficient_stock`),
+ * never an identifier: this map is unbounded by construction, and a per-sale label would
+ * grow it without limit. The error boundary records `<route>:<code>` for every
+ * `business_rule` outcome, which covers the endpoints generically; a module calls this
+ * directly when it wants a failure named more precisely than its status code names it.
+ */
+export function recordBusinessFailure(kind: string): void {
+  const label = kind.slice(0, 120);
+  businessFailures.set(label, (businessFailures.get(label) ?? 0) + 1);
+  // Bounded, so a caller that accidentally passes an identifier degrades the label set
+  // rather than the process.
+  if (businessFailures.size > 200) {
+    const [oldest] = businessFailures.keys();
+    businessFailures.delete(oldest);
+  }
+}
+
+export interface MetricsSnapshot {
+  uptime_s: number;
+  requests_total: number;
+  requests_by_outcome: Record<RequestOutcome, number>;
+  latency_ms: {
+    avg: number;
+    max: number;
+    buckets: Record<string, number>;
+    over_5000: number;
+  };
+  db_pool: { total: number; idle: number; waiting: number } | null;
+  business_failures: Record<string, number>;
+}
+
+export function snapshot(): MetricsSnapshot {
+  const buckets: Record<string, number> = {};
+  LATENCY_BUCKETS_MS.forEach((bound, i) => {
+    buckets[`le_${bound}`] = http.buckets[i];
+  });
+  return {
+    uptime_s: Math.round((Date.now() - startedAt) / 1000),
+    requests_total: http.total,
+    requests_by_outcome: { ...http.byOutcome },
+    latency_ms: {
+      avg: http.total === 0 ? 0 : Math.round(http.durationSumMs / http.total),
+      max: http.durationMaxMs,
+      buckets,
+      over_5000: http.overflow,
+    },
+    db_pool: poolStats(),
+    business_failures: Object.fromEntries(businessFailures),
+  };
+}
+
+/** Test seam. Production never resets — a counter reset is what a restart looks like. */
+export function resetMetrics(): void {
+  http = emptyHttp();
+  businessFailures = new Map();
+  startedAt = Date.now();
+}
+
+export const DEFAULT_METRICS_INTERVAL_MS = 60_000;
+
+/**
+ * Resolves `METRICS_LOG_INTERVAL_MS`. `0` disables the snapshot line; anything that is not
+ * a non-negative integer falls back to the default, the same posture `rateLimits.ts`
+ * takes with its ceilings — a typo must not take a shop's logging cadence to `NaN`.
+ */
+export function resolveMetricsInterval(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_METRICS_INTERVAL_MS;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return DEFAULT_METRICS_INTERVAL_MS;
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) return DEFAULT_METRICS_INTERVAL_MS;
+  if (parsed === 0) return 0;
+  // A sub-second snapshot is a log flood, not a metric.
+  return Math.max(parsed, 1000);
+}
+
+export interface MetricsReporter {
+  stop: () => void;
+}
+
+/**
+ * Emits `service_metrics` on an interval. The timer is `unref`'d so it never holds the
+ * process open during shutdown, and one final line is emitted on `stop()` so the last
+ * window before a deploy is not lost.
+ */
+export function startMetricsReporter(intervalMs: number): MetricsReporter {
+  if (intervalMs === 0) {
+    logger.info('service metrics snapshot disabled (METRICS_LOG_INTERVAL_MS=0)');
+    return { stop: () => undefined };
+  }
+  const timer = setInterval(() => emitSnapshot(), intervalMs);
+  timer.unref();
+  return {
+    stop: () => {
+      clearInterval(timer);
+      emitSnapshot();
+    },
+  };
+}
+
+export function emitSnapshot(): void {
+  logger.info('service_metrics', { event: 'service_metrics', ...snapshot() });
+}

--- a/server/src/observability/probePaths.ts
+++ b/server/src/observability/probePaths.ts
@@ -1,0 +1,20 @@
+/**
+ * The paths an uptime probe or orchestrator may call.
+ *
+ * A standalone, dependency-free module on purpose: it is the single list that both the
+ * route registration in `server/index.ts` and the rate-limit exemption in
+ * `src/http/rateLimits.ts` read. Splitting `/api/health` into liveness and readiness
+ * without updating the exemption would silently put the probes back on the shop's
+ * request budget — a regression that fails no test and surfaces as the monitoring
+ * reporting an outage it caused. One list, two readers, no way to update one and forget
+ * the other.
+ */
+export const HEALTH_PATHS = ['/api/health', '/api/health/live', '/api/health/ready'] as const;
+
+export type HealthPath = (typeof HEALTH_PATHS)[number];
+
+const HEALTH_PATH_SET: ReadonlySet<string> = new Set(HEALTH_PATHS);
+
+export function isHealthPath(path: string): boolean {
+  return HEALTH_PATH_SET.has(path);
+}

--- a/server/src/observability/redaction.ts
+++ b/server/src/observability/redaction.ts
@@ -1,0 +1,206 @@
+/**
+ * Log redaction.
+ *
+ * The rule this module enforces is *structural*, not a denylist someone has to remember
+ * to extend when a new field appears:
+ *
+ *   1. Nothing logs a request body, a header, a cookie, or a query *value* in the first
+ *      place. `requestLogging.ts` logs allow-listed query *key names* only, and the auth
+ *      module logs a 12-character digest prefix rather than token material (#74). An
+ *      allow-list cannot leak a field nobody thought of, because a field nobody thought
+ *      of is not on it.
+ *   2. Everything that does reach `logger` passes through `redactMeta` below, which is a
+ *      deny-list — the second layer, for the case where rule 1 is violated by a future
+ *      caller passing `{ user }` or `{ body }` wholesale into a log line.
+ *
+ * Layer 2 is deliberately fail-closed in both directions: a *key* whose name suggests a
+ * secret is replaced whatever its value, and a *value* shaped like a credential is
+ * replaced whatever its key. The key is always kept so the log line still shows the shape
+ * of what was there.
+ *
+ * What must never appear in a log line: passwords and hashes, access/refresh tokens and
+ * any JWT, `Authorization` headers, cookies, session identifiers, API keys, database
+ * connection strings with credentials, card/PIN/OTP material, and customer personal data
+ * — phone numbers, email addresses, postal addresses, names.
+ */
+
+export const REDACTED = '[REDACTED]';
+
+/**
+ * Key *words* whose values are never logged.
+ *
+ * Matching is on tokenized words rather than raw substrings: `refresh_token`,
+ * `refreshToken` and `REFRESH-TOKEN` all tokenize to `[refresh, token]` and so are one
+ * rule, while `company` does not become sensitive because it contains `pan`, and
+ * `shipping` does not because it contains `pin`. Substring matching on short words is
+ * how a redactor starts eating the fields operators actually need.
+ */
+const SENSITIVE_WORDS = new Set([
+  'password',
+  'passwd',
+  'pwd',
+  'secret',
+  'token',
+  'jwt',
+  'bearer',
+  'authorization',
+  'auth',
+  'cookie',
+  'cookies',
+  'session',
+  'credential',
+  'credentials',
+  'apikey',
+  'key',
+  'privatekey',
+  'signature',
+  'otp',
+  'pin',
+  'cvv',
+  'cvc',
+  'card',
+  'pan',
+  'iban',
+  'ssn',
+  'phone',
+  'msisdn',
+  'mobile',
+  'whatsapp',
+  'email',
+  'mail',
+  'address',
+  'passport',
+  'dob',
+  'birthdate',
+  'birthday',
+  'zip',
+  'postcode',
+  'postalcode',
+  'street',
+]);
+
+/** Multi-word key shapes that are personal data only in combination. */
+const SENSITIVE_KEY_PATTERNS = [
+  /(customer|first|last|full|middle|given|family|holder|recipient|contact)name/,
+  /national(id|number)/,
+];
+
+/**
+ * Keys that match a sensitive word but are safe and useful. A digest *prefix* is the auth
+ * module's established way of correlating two log lines about the same token without ever
+ * writing the token (`auth/service.ts`, #74). Listed explicitly so each exception is
+ * auditable rather than an accident of matching order.
+ */
+const ALLOWED_KEYS = new Set([
+  'tokendigestprefix',
+  'tokenfamily',
+  'tokencount',
+  'sessioncount',
+  'sessionid',
+  'authmethod',
+]);
+
+/** `refreshTokenTTL` -> `[refresh, token, ttl]`, `api_key` -> `[api, key]`. */
+function tokenizeKey(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((word) => word.toLowerCase());
+}
+
+function normalizeKey(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+export function isSensitiveKey(key: string): boolean {
+  const normalized = normalizeKey(key);
+  if (ALLOWED_KEYS.has(normalized)) return false;
+  if (tokenizeKey(key).some((word) => SENSITIVE_WORDS.has(word))) return true;
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+/**
+ * Value shapes that are credentials or personal data wherever they appear.
+ *
+ * Deliberately narrow patterns, not "any long string": a stack trace, a SQL statement or
+ * a file path is exactly the thing an operator needs to keep, and a scrubber that eats
+ * them makes people stop logging. Notably absent is "a run of digits" — a product id and
+ * a phone number are indistinguishable that way, so phone numbers are caught by key name
+ * (rule above) and, in free text, only in unambiguous E.164 form.
+ */
+const VALUE_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
+  // JWTs — three base64url segments. Covers access and refresh tokens in any context.
+  { pattern: /\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b/g, replacement: REDACTED },
+  // `Authorization: Bearer …` / `Basic …` copied into a message.
+  { pattern: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, replacement: `$1 ${REDACTED}` },
+  // Connection strings carrying credentials: scheme://user:password@host
+  { pattern: /\b([a-z][a-z0-9+.-]*:\/\/)[^\s:/@]+:[^\s@]+@/gi, replacement: `$1${REDACTED}@` },
+  // Email addresses.
+  { pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, replacement: REDACTED },
+  // E.164 phone numbers. `+` plus 8–15 digits is unambiguous; bare digit runs are not.
+  { pattern: /\+\d[\d\s().-]{7,20}\d/g, replacement: REDACTED },
+  // A full SHA-256/512 hex digest — token material at rest. 12-char prefixes stay.
+  { pattern: /\b[a-f0-9]{64,128}\b/gi, replacement: REDACTED },
+];
+
+/** Bounds, so one bad log call cannot flood the aggregator or stall the event loop. */
+const MAX_DEPTH = 5;
+const MAX_ARRAY_ITEMS = 25;
+const MAX_STRING_LENGTH = 4000;
+
+export function scrubString(value: string): string {
+  let out = value;
+  for (const { pattern, replacement } of VALUE_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+  if (out.length > MAX_STRING_LENGTH) {
+    out = `${out.slice(0, MAX_STRING_LENGTH)}…[truncated]`;
+  }
+  return out;
+}
+
+function redactValue(value: unknown, depth: number): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string') return scrubString(value);
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return value;
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: scrubString(value.message),
+      stack: value.stack ? scrubString(value.stack) : undefined,
+    };
+  }
+  if (depth >= MAX_DEPTH) return '[TRUNCATED]';
+  if (Array.isArray(value)) {
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((item) => redactValue(item, depth + 1));
+    if (value.length > MAX_ARRAY_ITEMS) {
+      items.push(`…${value.length - MAX_ARRAY_ITEMS} more`);
+    }
+    return items;
+  }
+  if (typeof value === 'object') {
+    return redactRecord(value as Record<string, unknown>, depth + 1);
+  }
+  // Functions, symbols: never meaningful in a log line, and can close over secrets.
+  return `[${typeof value}]`;
+}
+
+function redactRecord(record: Record<string, unknown>, depth: number): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    out[key] = isSensitiveKey(key) ? REDACTED : redactValue(value, depth);
+  }
+  return out;
+}
+
+/** Redacts a log line's metadata object. Safe to call on anything, including `undefined`. */
+export function redactMeta(
+  meta: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!meta) return meta;
+  return redactRecord(meta, 0);
+}

--- a/server/src/observability/requestLogging.ts
+++ b/server/src/observability/requestLogging.ts
@@ -1,0 +1,182 @@
+/**
+ * The per-request observability line.
+ *
+ * One `http_request` log line per finished request, carrying the correlation id, the
+ * normalized route, the outcome class, the duration, and who the actor was. This line is
+ * the metrics transport (see `metrics.ts`): request rate is its count, latency is
+ * `duration_ms`, error rate and the HTTP-vs-business split are `outcome`.
+ *
+ * What is *not* in it is the point. No request body, no headers, no cookies, no query
+ * *values* — only allow-listed query key *names*, which is the rule this file inherited
+ * from the middleware it replaces. An allow-list cannot leak a field nobody anticipated,
+ * which is why redaction here is structural rather than a list of things to strip.
+ * `logger`'s scrubber is the second layer, not the first.
+ */
+import type { NextFunction, Request, Response } from 'express';
+import logger from '../../lib/logger';
+import { correlationMiddleware, currentContext, type RequestContext } from './correlation';
+import { classifyOutcome, recordBusinessFailure, recordRequest } from './metrics';
+import { isHealthPath } from './probePaths';
+import { mapPublicError } from '../http/errors';
+
+/**
+ * Query parameters whose *names* may be logged. Values never are: a `search` value is
+ * customer-typed free text and can hold a name or a phone number.
+ */
+const allowedQueryKeys = new Set([
+  'page',
+  'pageSize',
+  'sortBy',
+  'sortOrder',
+  'status',
+  'categoryId',
+  'lowStock',
+  'dateFrom',
+  'dateTo',
+  'paymentMethod',
+  'cashierId',
+]);
+
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Collapses identifiers out of a path: `/api/v1/products/482` becomes
+ * `/api/v1/products/:id`.
+ *
+ * Two reasons, and the second is the load-bearing one. Cardinality: a `path` field with a
+ * distinct value per record makes "error rate for this route" un-aggregatable. And
+ * leakage: a path segment can *be* the datum — `/api/v1/customers/by-phone/+9715…` —
+ * so the safe default is that a segment which looks like an identifier never reaches the
+ * log store at all.
+ */
+export function normalizeRoutePath(path: string): string {
+  return path
+    .split('/')
+    .map((segment) => {
+      if (segment === '') return segment;
+      if (/^\d+$/.test(segment)) return ':id';
+      if (UUID.test(segment)) return ':id';
+      // Barcodes, SKUs, gift-card codes: long and mostly digits.
+      if (/^[A-Za-z0-9_-]{12,}$/.test(segment) && /\d/.test(segment)) return ':id';
+      return segment;
+    })
+    .join('/');
+}
+
+interface ActorMeta {
+  user_id?: number | string;
+  user_role?: string;
+}
+
+/**
+ * Actor metadata is the id and the role — never the email or the name, both of which are
+ * personal data and neither of which an operator needs to find the user. `req.user` is
+ * populated by `verifyToken` inside the routers, which have run by the time the response
+ * finishes, so this reads correctly despite the middleware being mounted first.
+ */
+function actorOf(req: Request): ActorMeta {
+  const user = (req as Request & { user?: { id?: number | string; role?: string } }).user;
+  if (!user) return {};
+  return {
+    ...(user.id === undefined ? {} : { user_id: user.id }),
+    ...(user.role === undefined ? {} : { user_role: user.role }),
+  };
+}
+
+/**
+ * Logs the finished request and feeds the metrics registry.
+ *
+ * Health probes are logged at `debug`: a probe every ten seconds is 8,640 lines a day per
+ * instance that say nothing, and an operator who has learned to filter `http_request`
+ * lines out is an operator who cannot use them. They are still counted in the metrics —
+ * silenced, not dropped.
+ */
+function logFinished(
+  req: Request,
+  res: Response,
+  durationMs: number,
+  context: RequestContext | undefined
+): void {
+  const rawPath = `${req.baseUrl || ''}${req.path}` || '/';
+  const path = normalizeRoutePath(rawPath);
+  const outcome = classifyOutcome(res.statusCode);
+
+  recordRequest(outcome, durationMs);
+  if (outcome === 'business_rule') {
+    recordBusinessFailure(`${req.method} ${path}:${context?.errorCode ?? res.statusCode}`);
+  }
+
+  const queryKeys = Object.keys(req.query)
+    .filter((key) => allowedQueryKeys.has(key))
+    .sort();
+
+  const level = isHealthPath(rawPath)
+    ? res.statusCode >= 500
+      ? 'error'
+      : 'debug'
+    : res.statusCode >= 500
+      ? 'error'
+      : res.statusCode >= 400
+        ? 'warn'
+        : 'info';
+
+  logger[level](`${req.method} ${path} ${res.statusCode}`, {
+    event: 'http_request',
+    request_id: context?.requestId,
+    ...(context?.clientRequestId ? { client_request_id: context.clientRequestId } : {}),
+    method: req.method,
+    path,
+    query_keys: queryKeys,
+    status: res.statusCode,
+    outcome,
+    ...(context?.errorCode ? { error_code: context.errorCode } : {}),
+    duration_ms: durationMs,
+    ...actorOf(req),
+  });
+}
+
+/**
+ * Timing and the finished-request line. Mounted by `observabilityMiddleware` below;
+ * exported separately so a test can drive it without an ALS context.
+ */
+export function requestLogger(req: Request, res: Response, next: NextFunction): void {
+  const start = Date.now();
+  /*
+   * The context is captured here rather than read inside the listener. `finish` is
+   * emitted by the writable stream when the response flushes, which is not guaranteed to
+   * happen inside the async context this middleware runs in — reading the store from the
+   * listener silently loses the correlation id on exactly the slow responses worth
+   * tracing. The object is shared, so a later `errorClassifier` mutation is still seen.
+   */
+  const context = currentContext();
+  res.on('finish', () => logFinished(req, res, Date.now() - start, context));
+  next();
+}
+
+/**
+ * Correlation plus request logging, in the order they have to run: the id must exist
+ * before anything can log under it.
+ */
+export function observabilityMiddleware(req: Request, res: Response, next: NextFunction): void {
+  correlationMiddleware(req, res, () => requestLogger(req, res, next));
+}
+
+/**
+ * Error-boundary tap. Records the public error code on the request context so the
+ * finished-request line can carry it, then re-throws into the real error handler.
+ *
+ * A separate tap rather than a change to `errorHandler` so that classification is
+ * observability's concern and stays beside the rest of it; `mapPublicError` is pure, so
+ * calling it twice costs nothing and cannot diverge from what the client is told.
+ */
+export function errorClassifier(
+  err: unknown,
+  _req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  const context = currentContext();
+  if (context) context.errorCode = mapPublicError(err).body.error.code;
+  next(err);
+}

--- a/server/tests/http/contracts.test.ts
+++ b/server/tests/http/contracts.test.ts
@@ -6,7 +6,7 @@ import { mapPublicError } from '../../src/http/errors';
 import { createListQuerySchema, paginationMeta } from '../../src/http/pagination';
 import { endpointManifest } from '../../src/http/endpointManifest';
 import { routeTable } from '../../src/router';
-import { requestLogger } from '../../middleware/requestLogger';
+import { requestLogger } from '../../src/observability/requestLogging';
 import logger from '../../lib/logger';
 import errorHandler from '../../middleware/errorHandler';
 import { requireRole, verifyToken } from '../../middleware/auth';

--- a/server/tests/http/rateLimit.test.ts
+++ b/server/tests/http/rateLimit.test.ts
@@ -31,6 +31,9 @@ import {
   trustProxySetting,
 } from '../../src/http/rateLimits';
 import jwt from 'jsonwebtoken';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { HEALTH_PATHS } from '../../src/observability/probePaths';
 
 const ENV_KEYS = ['RATE_LIMIT_MAX', 'AUTH_RATE_LIMIT_MAX', 'TRUST_PROXY'] as const;
 const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
@@ -114,7 +117,7 @@ async function keyedHarness(): Promise<Harness> {
       res.json({ ok: true });
     };
     app.get('/ping', handler);
-    app.get('/api/health', handler);
+    for (const path of HEALTH_PATHS) app.get(path, handler);
   }, counter);
 }
 
@@ -625,15 +628,17 @@ describe('trust proxy', () => {
 });
 
 describe('health check exemption', () => {
-  it('does not spend the shop’s budget on the uptime probe', async () => {
-    // Counting the probe means a shop that has spent its budget also fails its own health
-    // check — monitoring reporting an outage that the monitoring caused.
+  it.each(HEALTH_PATHS)('does not spend the shop’s budget on %s', async (probePath) => {
+    // Counting a probe means a shop that has spent its budget also fails its own health
+    // check — monitoring reporting an outage that the monitoring caused. #45 split
+    // `/api/health` into liveness and readiness; each new path has to be exempt too, or
+    // the exemption silently stops applying to the probes an orchestrator actually calls.
     process.env.RATE_LIMIT_MAX = '2';
     resetEnvCache();
 
     const h = await keyedHarness();
     try {
-      const statuses = await hitMany(`${h.url}/api/health`, 10);
+      const statuses = await hitMany(`${h.url}${probePath}`, 10);
       expect(statuses.filter((s) => s !== 200)).toEqual([]);
 
       // …and the probe has not eaten the budget the tills need.
@@ -643,11 +648,27 @@ describe('health check exemption', () => {
     }
   });
 
-  it('exempts only GET /api/health', () => {
-    expect(isRateLimitExempt({ method: 'GET', path: '/api/health' })).toBe(true);
-    expect(isRateLimitExempt({ method: 'POST', path: '/api/health' })).toBe(false);
+  it('exempts exactly the declared probe paths, on GET only', () => {
+    for (const path of HEALTH_PATHS) {
+      expect(isRateLimitExempt({ method: 'GET', path })).toBe(true);
+      expect(isRateLimitExempt({ method: 'POST', path })).toBe(false);
+    }
     expect(isRateLimitExempt({ method: 'GET', path: '/api/v1/sales' })).toBe(false);
     expect(isRateLimitExempt({ method: 'GET', path: '/api/health/extra' })).toBe(false);
+    expect(isRateLimitExempt({ method: 'GET', path: '/api/health/' })).toBe(false);
+  });
+
+  it('exempts every path the server actually registers as a probe', () => {
+    // The list and the predicate share one source; this pins that they still agree with
+    // the routes `server/index.ts` mounts.
+    const registered = readFileSync(resolve(__dirname, '../../index.ts'), 'utf8');
+    const mounted = [...registered.matchAll(/app\.get\('(\/api\/health[^']*)'/g)].map((m) => m[1]);
+
+    expect(mounted.length).toBeGreaterThan(0);
+    expect(new Set(mounted)).toEqual(new Set(HEALTH_PATHS));
+    for (const path of mounted) {
+      expect(isRateLimitExempt({ method: 'GET', path })).toBe(true);
+    }
   });
 });
 

--- a/server/tests/observability/correlation.test.ts
+++ b/server/tests/observability/correlation.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Correlation ids — the acceptance criterion is "a request can be traced through logs
+ * using one correlation id", which has three parts: the id exists, the client is told
+ * what it is, and *every* log line the request produces carries it, including lines
+ * emitted deep inside a service with no access to `req`.
+ *
+ * The trust decision is pinned here too: an inbound id is recorded, never adopted. A
+ * caller that could choose its own id could collide with another request's, or reuse one
+ * across thousands of requests to make its traffic unsearchable.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import {
+  REQUEST_ID_HEADER,
+  correlationMiddleware,
+  currentContext,
+  type RequestContext,
+  runWithContext,
+  sanitizeInboundRequestId,
+} from '../../src/observability/correlation';
+import logger from '../../lib/logger';
+
+afterEach(() => vi.restoreAllMocks());
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function run(headers: Record<string, string> = {}): {
+  setHeader: ReturnType<typeof vi.fn>;
+  context: RequestContext | undefined;
+} {
+  const setHeader = vi.fn();
+  let context: RequestContext | undefined;
+  const next: NextFunction = () => {
+    context = currentContext();
+  };
+  correlationMiddleware(
+    { headers } as unknown as Request,
+    { setHeader } as unknown as Response,
+    next
+  );
+  return { setHeader, context };
+}
+
+describe('correlation middleware', () => {
+  it('generates a UUID per request and returns it on the response header', () => {
+    const first = run();
+    const second = run();
+
+    expect(first.context?.requestId).toMatch(UUID);
+    expect(second.context?.requestId).toMatch(UUID);
+    expect(first.context?.requestId).not.toBe(second.context?.requestId);
+    expect(first.setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, first.context?.requestId);
+  });
+
+  it('never adopts a client-supplied id, so a caller cannot choose or collide with one', () => {
+    const forged = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const { context, setHeader } = run({ 'x-request-id': forged });
+
+    expect(context?.requestId).not.toBe(forged);
+    expect(setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, context?.requestId);
+  });
+
+  it('records a well-formed inbound id separately, so the join is still possible', () => {
+    const upstream = 'edge-7f3a2b19c4d5';
+    expect(run({ 'x-request-id': upstream }).context?.clientRequestId).toBe(upstream);
+    expect(run({ 'x-correlation-id': upstream }).context?.clientRequestId).toBe(upstream);
+  });
+
+  it('drops a malformed inbound id rather than logging caller-controlled junk', () => {
+    expect(run({ 'x-request-id': 'a\nb' }).context?.clientRequestId).toBeUndefined();
+  });
+});
+
+describe('inbound id sanitization', () => {
+  it('accepts a well-formed upstream id for recording alongside our own', () => {
+    expect(sanitizeInboundRequestId('  trace-abc.123:9  ')).toBe('trace-abc.123:9');
+  });
+
+  it.each([
+    ['too short', 'abc'],
+    ['newline injection', 'abcdefgh\n{"level":"error"}'],
+    ['json breakout', 'abcdefgh","evil":"1'],
+    ['oversized', 'a'.repeat(200)],
+    ['not a string', 42],
+    ['missing', undefined],
+  ])('drops an id that is %s', (_label, value) => {
+    expect(sanitizeInboundRequestId(value)).toBeUndefined();
+  });
+});
+
+describe('propagation into the logger', () => {
+  it('stamps request_id onto a line emitted with no access to the request', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    runWithContext({ requestId: 'req-under-test-0001' }, () => {
+      // Stands in for a repository or service line far from the HTTP boundary.
+      logger.info('stock deducted', { productId: 7 });
+    });
+
+    expect(spy.mock.calls[0][0]).toContain('req-under-test-0001');
+  });
+
+  it('emits no request_id outside a request, rather than inventing one', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    logger.info('scheduler tick');
+    expect(spy.mock.calls[0][0]).not.toContain('request_id');
+  });
+
+  it('lets an explicit request_id win, so a line can name another request', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    runWithContext({ requestId: 'ambient' }, () => {
+      logger.info('abandoned in-flight request', { request_id: 'explicit' });
+    });
+    const line = spy.mock.calls[0][0] as string;
+    expect(line).toContain('explicit');
+    expect(line).not.toContain('ambient');
+  });
+});

--- a/server/tests/observability/health.test.ts
+++ b/server/tests/observability/health.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Liveness / readiness split.
+ *
+ * The two criteria from #45 that this file exists to prove:
+ *
+ *   - "Liveness does not fail solely because a dependency is temporarily unavailable."
+ *   - "Readiness fails when the server cannot safely serve traffic."
+ *
+ * The readiness failure is exercised against a *genuinely* unavailable database — a real
+ * `pg.Pool` pointed at a port nothing is listening on — rather than a mock that throws.
+ * A mock proves the `catch` branch runs; it does not prove that a real driver failure
+ * takes that branch, nor that the probe answers promptly instead of hanging until the
+ * prober gives up, which is the failure mode that actually hurts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Pool } from 'pg';
+import express from 'express';
+import request from 'node:http';
+import { setPool, closePool } from '../../src/database/pool';
+import {
+  READINESS_TIMEOUT_MS,
+  beginShutdown,
+  checkDatabase,
+  evaluateReadiness,
+  legacyHealthHandler,
+  livenessHandler,
+  readinessHandler,
+  resetShutdownState,
+} from '../../src/observability/health';
+import { HEALTH_PATHS } from '../../src/observability/probePaths';
+import { createPgMemPool } from '../support/pgMem';
+
+/** A pool that cannot connect: nothing listens on this port on the loopback interface. */
+function deadPool(): Pool {
+  return new Pool({
+    host: '127.0.0.1',
+    port: 59_999,
+    database: 'nonexistent',
+    user: 'nobody',
+    connectionTimeoutMillis: 500,
+  });
+}
+
+interface FakeResponse {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => FakeResponse;
+  json: (body: unknown) => FakeResponse;
+}
+
+function fakeResponse(): FakeResponse {
+  const res: FakeResponse = {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body) {
+      res.body = body;
+      return res;
+    },
+  };
+  return res;
+}
+
+let live: Pool | undefined;
+
+beforeEach(() => {
+  resetShutdownState();
+});
+
+afterEach(async () => {
+  resetShutdownState();
+  vi.restoreAllMocks();
+  if (live) {
+    await live.end().catch(() => undefined);
+    live = undefined;
+  }
+  await closePool().catch(() => undefined);
+});
+
+describe('with a healthy database', () => {
+  beforeEach(() => {
+    setPool(createPgMemPool());
+  });
+
+  it('reports ready', async () => {
+    const result = await evaluateReadiness();
+    expect(result.ready).toBe(true);
+    expect(result.checks.database.status).toBe('ok');
+  });
+
+  it('answers the legacy /api/health in its original envelope', async () => {
+    const res = fakeResponse();
+    await legacyHealthHandler({} as never, res as never);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ success: true, data: { status: 'ok' } });
+    expect((res.body as { data: { timestamp: string } }).data.timestamp).toBeTypeOf('string');
+  });
+});
+
+describe('with a genuinely unavailable database', () => {
+  beforeEach(() => {
+    live = deadPool();
+    // Swallow the pool's own idle-client error events; the connection failure is the
+    // subject of the test, not an unhandled rejection.
+    live.on('error', () => undefined);
+    setPool(live);
+  });
+
+  it('fails readiness with a dependency reason and a 503', async () => {
+    const res = fakeResponse();
+    await readinessHandler({} as never, res as never);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({ status: 'not_ready', reason: 'dependency_unavailable' });
+    expect((res.body as { checks: { database: { status: string } } }).checks.database.status).toBe(
+      'failed'
+    );
+  });
+
+  it('answers promptly rather than hanging until the prober times out', async () => {
+    const started = Date.now();
+    const check = await checkDatabase();
+    expect(check.status).toBe('failed');
+    expect(Date.now() - started).toBeLessThan(READINESS_TIMEOUT_MS + 1500);
+  });
+
+  it('keeps liveness passing — a database blip must not get the process killed', () => {
+    const res = fakeResponse();
+    livenessHandler({} as never, res as never);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ status: 'alive' });
+  });
+
+  it('keeps the legacy endpoint on its original 503 contract', async () => {
+    const res = fakeResponse();
+    await legacyHealthHandler({} as never, res as never);
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ success: false, error: 'Database unreachable' });
+  });
+});
+
+describe('during graceful shutdown', () => {
+  beforeEach(() => {
+    setPool(createPgMemPool());
+    beginShutdown();
+  });
+
+  it('fails readiness so the load balancer drains before the socket closes', async () => {
+    const res = fakeResponse();
+    await readinessHandler({} as never, res as never);
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({ status: 'not_ready', reason: 'shutting_down' });
+  });
+
+  it('keeps liveness passing so the orchestrator does not SIGKILL the drain', () => {
+    const res = fakeResponse();
+    livenessHandler({} as never, res as never);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ status: 'alive', shutting_down: true });
+  });
+});
+
+describe('probe routing', () => {
+  it('serves every declared probe path', async () => {
+    setPool(createPgMemPool());
+    const app = express();
+    app.get('/api/health/live', livenessHandler);
+    app.get('/api/health/ready', readinessHandler);
+    app.get('/api/health', legacyHealthHandler);
+
+    const server = await new Promise<import('node:http').Server>((resolve) => {
+      const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    const { port } = server.address() as import('node:net').AddressInfo;
+
+    try {
+      for (const path of HEALTH_PATHS) {
+        const status = await new Promise<number>((resolve, reject) => {
+          request
+            .get({ host: '127.0.0.1', port, path }, (res) => {
+              res.resume();
+              resolve(res.statusCode ?? 0);
+            })
+            .on('error', reject);
+        });
+        expect(status, `${path} should be served`).toBe(200);
+      }
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/server/tests/observability/metrics.test.ts
+++ b/server/tests/observability/metrics.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The metrics registry and its transport.
+ *
+ * The transport decision — the structured log stream rather than a Prometheus-style
+ * `/metrics` endpoint — is argued in `src/observability/metrics.ts`. What it means for
+ * tests is that the *snapshot line* is the deliverable: it has to carry the two signals no
+ * per-request line can (pool saturation, business-failure counts), be emitted on a
+ * schedule an aggregator can rate(), and never hold the process open at shutdown.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import logger from '../../lib/logger';
+import {
+  DEFAULT_METRICS_INTERVAL_MS,
+  classifyOutcome,
+  emitSnapshot,
+  recordBusinessFailure,
+  recordRequest,
+  resetMetrics,
+  resolveMetricsInterval,
+  snapshot,
+  startMetricsReporter,
+} from '../../src/observability/metrics';
+import { closePool, setPool, poolStats } from '../../src/database/pool';
+import { createPgMemPool } from '../support/pgMem';
+
+beforeEach(() => resetMetrics());
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await closePool().catch(() => undefined);
+});
+
+describe('outcome classification', () => {
+  it.each([
+    [200, 'success'],
+    [204, 'success'],
+    [302, 'success'],
+    [400, 'business_rule'],
+    [409, 'business_rule'],
+    [422, 'business_rule'],
+    [401, 'client_error'],
+    [403, 'client_error'],
+    [404, 'client_error'],
+    [429, 'client_error'],
+    [500, 'server_error'],
+    [503, 'server_error'],
+  ])('classifies %i as %s', (status, expected) => {
+    expect(classifyOutcome(status)).toBe(expected);
+  });
+});
+
+describe('the snapshot', () => {
+  it('accumulates counts, latency and a histogram an aggregator can take percentiles from', () => {
+    recordRequest('success', 3);
+    recordRequest('success', 40);
+    recordRequest('server_error', 9000);
+
+    const metrics = snapshot();
+    expect(metrics.requests_total).toBe(3);
+    expect(metrics.requests_by_outcome.success).toBe(2);
+    expect(metrics.requests_by_outcome.server_error).toBe(1);
+    expect(metrics.latency_ms.max).toBe(9000);
+    expect(metrics.latency_ms.avg).toBe(Math.round((3 + 40 + 9000) / 3));
+    expect(metrics.latency_ms.buckets.le_5).toBe(1);
+    expect(metrics.latency_ms.buckets.le_50).toBe(1);
+    expect(metrics.latency_ms.over_5000).toBe(1);
+  });
+
+  it('counts critical business failures by low-cardinality label', () => {
+    recordBusinessFailure('checkout.insufficient_stock');
+    recordBusinessFailure('checkout.insufficient_stock');
+    recordBusinessFailure('refund.window_expired');
+
+    expect(snapshot().business_failures).toEqual({
+      'checkout.insufficient_stock': 2,
+      'refund.window_expired': 1,
+    });
+  });
+
+  it('bounds the label set so a stray identifier degrades the labels, not the process', () => {
+    for (let i = 0; i < 500; i += 1) recordBusinessFailure(`sale.${i}`);
+    expect(Object.keys(snapshot().business_failures).length).toBeLessThanOrEqual(200);
+  });
+
+  // Ordered before the pool is installed: `poolStats` must not lazily create one, since
+  // it is read by the metrics reporter and the readiness probe.
+  it('does not open a pool just to be observed', () => {
+    expect(poolStats()).toBeNull();
+    expect(snapshot().db_pool).toBeNull();
+  });
+
+  it('reports database pool saturation, which no per-request line can carry', () => {
+    setPool(createPgMemPool());
+    expect(snapshot().db_pool).toMatchObject({
+      total: expect.any(Number),
+      idle: expect.any(Number),
+      waiting: expect.any(Number),
+    });
+  });
+});
+
+describe('the reporter', () => {
+  it('emits a service_metrics line on its interval and once more on stop', () => {
+    vi.useFakeTimers();
+    const info = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    try {
+      const reporter = startMetricsReporter(1000);
+      vi.advanceTimersByTime(2500);
+      expect(info).toHaveBeenCalledTimes(2);
+      reporter.stop();
+      expect(info).toHaveBeenCalledTimes(3);
+      vi.advanceTimersByTime(5000);
+      expect(info).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tags the line so an aggregator can select it', () => {
+    const info = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    emitSnapshot();
+    expect(info.mock.calls[0][1]).toMatchObject({ event: 'service_metrics' });
+  });
+
+  it('can be switched off entirely', () => {
+    const info = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    const reporter = startMetricsReporter(0);
+    reporter.stop();
+    // Only the "disabled" boot line; no snapshots.
+    expect(info).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('METRICS_LOG_INTERVAL_MS', () => {
+  it('defaults when unset', () => {
+    expect(resolveMetricsInterval(undefined)).toBe(DEFAULT_METRICS_INTERVAL_MS);
+  });
+
+  it('falls back to the default on anything that is not a non-negative integer', () => {
+    for (const raw of ['', 'soon', '-1', '1.5', '1O']) {
+      expect(resolveMetricsInterval(raw)).toBe(DEFAULT_METRICS_INTERVAL_MS);
+    }
+  });
+
+  it('honours an explicit value, treats 0 as off, and raises a log flood to 1s', () => {
+    expect(resolveMetricsInterval('15000')).toBe(15000);
+    expect(resolveMetricsInterval('0')).toBe(0);
+    expect(resolveMetricsInterval('50')).toBe(1000);
+  });
+});

--- a/server/tests/observability/redaction.test.ts
+++ b/server/tests/observability/redaction.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Redaction is an acceptance criterion of #45 ("sensitive fields are redacted and
+ * verified by tests"), so these tests are the specification of what may never appear in a
+ * log line rather than a check that a function returns a string.
+ *
+ * Two directions are pinned, because a redactor that only does one of them is a redactor
+ * that leaks: a *key* that names a secret is redacted whatever it holds, and a *value*
+ * shaped like a credential is redacted whatever it is called. And the negative cases —
+ * stack traces, SQL, ids, durations — matter as much: a scrubber that eats diagnostics is
+ * one people work around by not logging.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { REDACTED, isSensitiveKey, redactMeta, scrubString } from '../../src/observability/redaction';
+import logger from '../../lib/logger';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('sensitive key detection', () => {
+  it.each([
+    'password',
+    'Password',
+    'password_hash',
+    'passwordHash',
+    'accessToken',
+    'access_token',
+    'refreshToken',
+    'REFRESH-TOKEN',
+    'jwt',
+    'authorization',
+    'Authorization',
+    'cookie',
+    'setCookie',
+    'apiKey',
+    'api_key',
+    'privateKey',
+    'jwtSecret',
+    'otp',
+    'pin',
+    'cvv',
+    'cardNumber',
+    'iban',
+    'phone',
+    'customerPhone',
+    'whatsappNumber',
+    'email',
+    'customerEmail',
+    'address',
+    'shippingAddress',
+    'customerName',
+    'nationalId',
+    'dob',
+  ])('treats %s as sensitive', (key) => {
+    expect(isSensitiveKey(key)).toBe(true);
+  });
+
+  it.each([
+    // Substring matching on short words is how a redactor starts eating useful fields:
+    // "company" contains "pan", "shipping" contains "pin", "author" contains "auth".
+    'company',
+    'companyId',
+    'shippingStatus',
+    'author',
+    'name',
+    'status',
+    'duration_ms',
+    'productId',
+    'quantity',
+    'stack',
+    'errorType',
+    'panel',
+    // The auth module's established safe correlator (#74): a digest prefix, never the token.
+    'tokenDigestPrefix',
+  ])('leaves %s alone', (key) => {
+    expect(isSensitiveKey(key)).toBe(false);
+  });
+});
+
+describe('redactMeta', () => {
+  it('replaces sensitive values but keeps the key, so the shape stays readable', () => {
+    const out = redactMeta({ email: 'sarah@moon.com', role: 'Cashier' });
+    expect(out).toEqual({ email: REDACTED, role: 'Cashier' });
+  });
+
+  it('redacts through nesting and arrays', () => {
+    const out = redactMeta({
+      user: { id: 7, role: 'Admin', password: 'hunter2', phone: '+971500000000' },
+      items: [{ sku: 'ABC', customerEmail: 'x@y.com' }],
+    }) as Record<string, Record<string, unknown>>;
+
+    expect(out.user).toEqual({ id: 7, role: 'Admin', password: REDACTED, phone: REDACTED });
+    expect(out.items).toEqual([{ sku: 'ABC', customerEmail: REDACTED }]);
+  });
+
+  it('redacts credential-shaped values even under an innocuous key', () => {
+    const jwtLike = 'eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MX0.c2lnbmF0dXJlLXZhbHVl';
+    const out = redactMeta({
+      note: `header was Bearer ${jwtLike}`,
+      dsn: 'postgresql://postgres:supersecret@db.internal:5432/moon',
+      contact: 'reach sarah@moon.com or +971 50 123 4567',
+      digest: 'a'.repeat(64),
+    }) as Record<string, string>;
+
+    expect(out.note).not.toContain(jwtLike);
+    expect(out.note).toContain(REDACTED);
+    expect(out.dsn).toBe(`postgresql://${REDACTED}@db.internal:5432/moon`);
+    expect(out.contact).not.toContain('sarah@moon.com');
+    expect(out.contact).not.toContain('971 50 123 4567');
+    expect(out.digest).toBe(REDACTED);
+  });
+
+  it('keeps a 12-character digest prefix, the auth module\'s safe correlator', () => {
+    const out = redactMeta({ tokenDigestPrefix: 'a1b2c3d4e5f6' }) as Record<string, string>;
+    expect(out.tokenDigestPrefix).toBe('a1b2c3d4e5f6');
+  });
+
+  it('preserves diagnostics a scrubber must not eat', () => {
+    const stack = 'Error: nope\n    at handler (/srv/app/server/src/modules/sales/service.ts:42:9)';
+    const out = redactMeta({
+      stack,
+      sql: 'SELECT id FROM products WHERE stock < $1',
+      path: '/api/v1/products/:id',
+      duration_ms: 1234567,
+      status: 500,
+    }) as Record<string, unknown>;
+
+    expect(out.stack).toBe(stack);
+    expect(out.sql).toBe('SELECT id FROM products WHERE stock < $1');
+    expect(out.path).toBe('/api/v1/products/:id');
+    expect(out.duration_ms).toBe(1234567);
+  });
+
+  it('bounds depth, array length and string length so one bad call cannot flood the log', () => {
+    const shallowEnough = { a: { b: { c: { d: { e: 'still visible' } } } } };
+    expect(JSON.stringify(redactMeta(shallowEnough))).toContain('still visible');
+
+    const deep = { a: { b: { c: { d: { e: { f: { g: 'too deep' } } } } } } };
+    expect(JSON.stringify(redactMeta(deep))).toContain('[TRUNCATED]');
+
+    const wide = redactMeta({ items: Array.from({ length: 100 }, (_, i) => i) }) as {
+      items: unknown[];
+    };
+    expect(wide.items).toHaveLength(26);
+    expect(wide.items[25]).toBe('…75 more');
+
+    const long = redactMeta({ blob: 'x'.repeat(9000) }) as { blob: string };
+    expect(long.blob.endsWith('…[truncated]')).toBe(true);
+    expect(long.blob.length).toBeLessThan(5000);
+  });
+
+  it('does not choke on null, undefined, dates, errors or functions', () => {
+    const out = redactMeta({
+      nothing: null,
+      missing: undefined,
+      when: new Date('2026-01-01T00:00:00.000Z'),
+      err: new Error('boom'),
+      fn: () => undefined,
+    }) as Record<string, unknown>;
+
+    expect(out.nothing).toBeNull();
+    expect(out.when).toBe('2026-01-01T00:00:00.000Z');
+    expect((out.err as { message: string }).message).toBe('boom');
+    expect(out.fn).toBe('[function]');
+  });
+});
+
+describe('logger redaction', () => {
+  it('scrubs both the message and the metadata of every line it emits', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    logger.error('login failed for sarah@moon.com', {
+      password: 'hunter2',
+      attempt: 3,
+    });
+
+    const line = spy.mock.calls[0][0] as string;
+    expect(line).not.toContain('sarah@moon.com');
+    expect(line).not.toContain('hunter2');
+    expect(line).toContain('"attempt":3');
+  });
+});
+
+describe('scrubString', () => {
+  it('leaves an ordinary message untouched', () => {
+    expect(scrubString('MOON Fashion API running on port 3001')).toBe(
+      'MOON Fashion API running on port 3001'
+    );
+  });
+});

--- a/server/tests/observability/requestLogging.test.ts
+++ b/server/tests/observability/requestLogging.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The `http_request` line and the metrics it feeds.
+ *
+ * This line is the metrics transport for request rate, latency, error rate and the
+ * HTTP-vs-business-failure split, so its field set is a contract: an aggregator's queries
+ * break silently when a field is renamed or a value's cardinality explodes. It is also
+ * the highest-volume log in the system, which makes it the one most likely to leak — so
+ * the negative assertions (no query values, no body, no headers, no email) carry as much
+ * weight as the positive ones.
+ */
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import logger from '../../lib/logger';
+import { runWithContext } from '../../src/observability/correlation';
+import {
+  errorClassifier,
+  normalizeRoutePath,
+  requestLogger,
+} from '../../src/observability/requestLogging';
+import { resetMetrics, snapshot } from '../../src/observability/metrics';
+import { PublicError } from '../../src/http/errors';
+
+interface Captured {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  meta: Record<string, unknown>;
+}
+
+let captured: Captured[] = [];
+
+beforeEach(() => {
+  captured = [];
+  resetMetrics();
+  for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+    vi.spyOn(logger, level).mockImplementation((message, meta) => {
+      captured.push({ level, message, meta: (meta ?? {}) as Record<string, unknown> });
+    });
+  }
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+interface FinishOptions {
+  method?: string;
+  baseUrl?: string;
+  path?: string;
+  query?: Record<string, unknown>;
+  status?: number;
+  user?: { id: number; role: string; email?: string; name?: string };
+  requestId?: string;
+  error?: unknown;
+}
+
+/** Drives the middleware through a request that finishes with the given status. */
+function finish(options: FinishOptions = {}): Captured {
+  const res = new EventEmitter() as EventEmitter & Response;
+  (res as unknown as { statusCode: number }).statusCode = options.status ?? 200;
+
+  const req = {
+    method: options.method ?? 'GET',
+    baseUrl: options.baseUrl ?? '',
+    path: options.path ?? '/',
+    query: options.query ?? {},
+    ...(options.user ? { user: options.user } : {}),
+  } as unknown as Request;
+
+  runWithContext({ requestId: options.requestId ?? 'req-0001' }, () => {
+    requestLogger(req, res, () => undefined);
+    if (options.error !== undefined) {
+      errorClassifier(options.error, req, res, () => undefined);
+    }
+    res.emit('finish');
+  });
+
+  const line = captured.at(-1);
+  if (!line) throw new Error('no log line emitted');
+  return line;
+}
+
+describe('the http_request line', () => {
+  it('carries the correlation id, route, status, duration and actor', () => {
+    const line = finish({
+      method: 'POST',
+      baseUrl: '/api/v1/sales',
+      path: '/',
+      status: 201,
+      user: { id: 42, role: 'Cashier' },
+    });
+
+    expect(line.level).toBe('info');
+    expect(line.meta).toMatchObject({
+      event: 'http_request',
+      request_id: 'req-0001',
+      method: 'POST',
+      path: '/api/v1/sales/',
+      status: 201,
+      outcome: 'success',
+      user_id: 42,
+      user_role: 'Cashier',
+    });
+    expect(line.meta.duration_ms).toBeTypeOf('number');
+  });
+
+  it('logs no actor for an unauthenticated request', () => {
+    const line = finish({ baseUrl: '/api/v1/auth', path: '/login', method: 'POST', status: 401 });
+    expect(line.meta).not.toHaveProperty('user_id');
+    expect(line.meta).not.toHaveProperty('user_role');
+  });
+
+  it('never logs the actor\'s email or name, which are personal data', () => {
+    const line = finish({
+      user: { id: 42, role: 'Cashier', email: 'sarah@moon.com', name: 'Sarah' },
+    });
+    expect(JSON.stringify(line.meta)).not.toContain('sarah@moon.com');
+    expect(JSON.stringify(line.meta)).not.toContain('Sarah');
+  });
+
+  it('logs allow-listed query key names and never a query value', () => {
+    const line = finish({
+      baseUrl: '/api/v1/customers',
+      path: '/',
+      query: { page: '2', search: 'Fatima +971500000000', secretFilter: 'x' },
+    });
+
+    expect(line.meta.query_keys).toEqual(['page']);
+    expect(JSON.stringify(line.meta)).not.toContain('Fatima');
+    expect(JSON.stringify(line.meta)).not.toContain('971500000000');
+  });
+
+  it('escalates the level with the status class', () => {
+    expect(finish({ status: 200 }).level).toBe('info');
+    expect(finish({ status: 404 }).level).toBe('warn');
+    expect(finish({ status: 500 }).level).toBe('error');
+  });
+
+  it('demotes health probes to debug so 8,640 lines a day do not bury the signal', () => {
+    expect(finish({ path: '/api/health/live' }).level).toBe('debug');
+    expect(finish({ path: '/api/health/ready' }).level).toBe('debug');
+    // A failing probe is still loud.
+    expect(finish({ path: '/api/health', status: 503 }).level).toBe('error');
+  });
+});
+
+describe('outcome classification', () => {
+  it('separates business validation failures from HTTP failures', () => {
+    expect(finish({ status: 200 }).meta.outcome).toBe('success');
+    expect(finish({ status: 400 }).meta.outcome).toBe('business_rule');
+    expect(finish({ status: 409 }).meta.outcome).toBe('business_rule');
+    expect(finish({ status: 401 }).meta.outcome).toBe('client_error');
+    expect(finish({ status: 403 }).meta.outcome).toBe('client_error');
+    expect(finish({ status: 404 }).meta.outcome).toBe('client_error');
+    expect(finish({ status: 429 }).meta.outcome).toBe('client_error');
+    expect(finish({ status: 500 }).meta.outcome).toBe('server_error');
+  });
+
+  it('records the public error code when the error boundary saw one', () => {
+    const line = finish({
+      method: 'POST',
+      baseUrl: '/api/v1/sales',
+      path: '/',
+      status: 409,
+      error: new PublicError('CONFLICT'),
+    });
+    expect(line.meta.error_code).toBe('CONFLICT');
+  });
+
+  it('feeds the metrics registry, keeping the four classes apart', () => {
+    finish({ status: 200 });
+    finish({ status: 200 });
+    finish({ status: 400, baseUrl: '/api/v1/sales', path: '/', method: 'POST' });
+    finish({ status: 401 });
+    finish({ status: 500 });
+
+    const metrics = snapshot();
+    expect(metrics.requests_total).toBe(5);
+    expect(metrics.requests_by_outcome).toEqual({
+      success: 2,
+      business_rule: 1,
+      client_error: 1,
+      server_error: 1,
+    });
+    expect(Object.keys(metrics.business_failures)).toEqual(['POST /api/v1/sales/:400']);
+  });
+});
+
+describe('route normalization', () => {
+  it.each([
+    ['/api/v1/products/482', '/api/v1/products/:id'],
+    ['/api/v1/sales/9/items/3', '/api/v1/sales/:id/items/:id'],
+    ['/api/v1/products/8f14e45f-ceea-467a-9c3a-1c2f1a0b0000', '/api/v1/products/:id'],
+    ['/api/v1/products/barcode/6291041500213', '/api/v1/products/barcode/:id'],
+    ['/api/v1/products', '/api/v1/products'],
+    ['/api/health/ready', '/api/health/ready'],
+  ])('%s -> %s', (input, expected) => {
+    expect(normalizeRoutePath(input)).toBe(expected);
+  });
+
+  it('keeps identifiers out of the logged path entirely', () => {
+    const line = finish({ baseUrl: '/api/v1/customers', path: '/8821', method: 'GET' });
+    expect(line.meta.path).toBe('/api/v1/customers/:id');
+    expect(JSON.stringify(line.meta)).not.toContain('8821');
+  });
+});


### PR DESCRIPTION
Closes #45.

## Metrics: the structured log stream, not a `/metrics` endpoint

Rejected `prom-client` and a Prometheus-style scrape endpoint. It is not the metric *shape* that costs — it is the component. A scrape endpoint only becomes a metrics system once somebody runs a Prometheus or agent, keeps it network-reachable, and maintains a second retention and alerting stack beside the log pipeline that already exists. Nobody has agreed to run that. Meanwhile it is immediately a new unauthenticated surface enumerating every route and internal failure mode.

Same reasoning that led #46 to a PostgreSQL claim row rather than Redis: prefer the primitive already in the stack.

Request rate, latency and error rate all fall out of the per-request `http_request` line. The two signals no per-request line can carry — database-pool saturation and business-failure counts — go in a periodic `service_metrics` snapshot (`METRICS_LOG_INTERVAL_MS`, default 60s, `0` disables). The registry is a module with `snapshot()`, so exposing a scrape endpoint later is a formatter, not a redesign.

## Liveness and readiness

- **`/api/health/live`** answers from the event loop and touches nothing. A failed liveness probe gets the process **killed**, so a database round-trip there turns a 30-second blip into a rolling restart of every healthy instance. It keeps returning 200 during shutdown so the orchestrator does not SIGKILL the drain, and carries `uptime_s` because a crash loop otherwise looks perfectly healthy to a liveness probe.
- **`/api/health/ready`** does `SELECT 1` under a hard 2s timeout. The timeout is the point: a database that stops answering *without refusing connections* would otherwise hang the probe until the prober gives up, leaving the instance neither passing nor failing. It also fails while shutting down, so the load balancer drains before the socket closes.
- **`/api/health`** is unchanged byte-for-byte, including its legacy `{success, data}` envelope. `e2e/support/globalSetup.ts`, the Playwright `webServer` gate and `render.yaml` all assert on it.

Shutdown now marks not-ready **first**, then stops the scheduler and reporter, then closes.

## The trap this issue was carrying

`rateLimits.ts` exempted the uptime probe by exact path match on `/api/health`. Splitting the endpoint without updating that predicate would silently put the probes back on the shop's request budget — the "monitoring reports an outage that monitoring caused" failure the exemption was added in #71 to prevent, and one that fails no test.

Fixed structurally rather than by remembering: both the route registration in `index.ts` and the exemption in `rateLimits.ts` now read `HEALTH_PATHS` from `src/observability/probePaths.ts`. One list, two readers.

Three tests hold it: every declared probe path survives a `RATE_LIMIT_MAX=2` flood while `/ping` does not; exact GET-only matching (`POST`, `/api/health/extra`, `/api/health/` are all non-exempt); and a test that **parses `server/index.ts`** and asserts the mounted `/api/health*` routes are exactly `HEALTH_PATHS` and all exempt — so adding a fourth probe without listing it fails the build.

## Redaction: structural first, deny-list second

**Layer 1** — nothing logs a body, header, cookie or query *value*. Only allow-listed query key *names*; the actor is `user_id` / `user_role`, never email or name; path segments that look like identifiers collapse to `:id`.

**Layer 2** — everything reaching `logger` is scrubbed in both directions: a key naming a secret whatever it holds, and a credential-shaped value whatever it is called (JWTs, `Bearer`/`Basic`, connection strings with credentials, emails, E.164 numbers, full SHA-256 digests), with depth, array and string bounds.

Key matching is on **tokenized words, not substrings**, so `company` is not sensitive for containing `pan` and `shipping` is not for containing `pin`. Follows #74's precedent: `tokenDigestPrefix` is explicitly allow-listed, token material never is.

54 assertions, including the negative cases — stack traces, SQL and ids must survive, or the logs become useless in a different way.

## Correlation IDs: always generated, never adopted

A caller-chosen ID is an attacker-chosen primary key for the log store: collide with another request's ID, reuse one to make your own traffic unsearchable, or inject newlines into every line — none of it requires privilege. A well-formed inbound `X-Request-Id` / `X-Correlation-Id` is recorded as `client_request_id` so an upstream join stays possible, but the searchable field is server-minted.

Propagated by `AsyncLocalStorage`, so `logger` stamps `request_id` on every line including deep service and repository lines. The middleware mounts **ahead of the rate limiter** — a 429 is exactly the response a shop phones support about.

## Testing

- `tsc --noEmit` clean; `eslint` 0 errors.
- `npm test` (pg-mem): 35 files / 508 passed.
- With `TEST_DATABASE_URL` against a real database: **50 files / 618 tests, all passed, zero skipped** — every real-PostgreSQL concurrency and idempotency suite ran for real.
- 116 new tests in `server/tests/observability/`. Readiness failure is exercised against a real `pg.Pool` pointed at a dead port rather than a mock, asserting both the 503 **and** that the probe answers promptly instead of hanging.

## Follow-up

`server/middleware/requestLogger.ts` is now unreferenced — the implementation moved to `src/observability/requestLogging.ts`, where correlation, logging and metrics are one unit. `server/middleware/**` was outside this branch's permitted files, so the orphan is left for a follow-up rather than deleted here.

## Post-Deploy Monitoring & Validation

- **First check after deploy:** pick any request and confirm you can retrieve its whole life from one `request_id`, including service and repository lines. That is the acceptance criterion and it either works or it does not.
- **Watch:** the `service_metrics` snapshot line. Database-pool `waiting` climbing above zero for sustained periods is the leading indicator this instrumentation exists to give you.
- **Confirm the probes are exempt in production**: hammer `/api/health/ready` past `RATE_LIMIT_MAX` and confirm no 429. The unit tests assert it, but this is the failure mode that hides.
- **Orchestrator config must be updated alongside**: point liveness at `/api/health/live` and readiness at `/api/health/ready`. Leaving both on `/api/health` preserves today's behaviour (it is unchanged), so this is safe to do after the deploy rather than during.
- **Failure signals / rollback trigger:** liveness returning non-200 while the process is healthy (would cause restart loops — the most dangerous possible regression here), or any secret appearing in a log line. Both are covered by tests, and both are worth eyeballing once in real logs.
- **Window:** 24h, with the first restart cycle watched.
- **Owner:** @zhamdy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
