### PR TITLE
fix(server): make PUT partial, so an omitted field is no longer silently overwritten

### DIFF
--- a/client/src/features/inventory/pages/Collections.test.tsx
+++ b/client/src/features/inventory/pages/Collections.test.tsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '../../../shared/lib/transport';
+import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
+import { useSettingsStore } from '../../../shared/store/settingsStore';
+import CollectionsPage from './Collections';
+
+function wrapperFor(transport: MemoryTransport) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+const product = (id: number, name: string) => ({
+  id,
+  name,
+  sku: `SKU-${id}`,
+  price: 100,
+  stock: 5,
+  position: id,
+});
+
+const featuredCollection = () => ({
+  id: 1,
+  name: 'Autumn window',
+  season: 'Fall',
+  year: 2026,
+  status: 'active',
+  description: 'The window',
+  is_featured: true,
+  product_count: 1,
+  products: [product(20, 'Ivory coat')],
+});
+
+/**
+ * The wire shape of a product edit, not the rendering.
+ *
+ * Adding or removing one product used to PUT most-but-not-all of the record: every
+ * field the detail view happened to hold, which never included `is_featured`. The
+ * server treated the omission as "set to default" and the collection quietly stopped
+ * being featured (#78). The endpoint is now PATCH-style, so the fix on this side is
+ * that the dialog sends only what it actually changed.
+ */
+describe('Collections product editing wire contract', () => {
+  beforeEach(() => useSettingsStore.setState({ locale: 'en' }));
+
+  const openDetail = async (transport: MemoryTransport) => {
+    render(<CollectionsPage />, { wrapper: wrapperFor(transport) });
+    fireEvent.click(await screen.findByText('Autumn window'));
+    return screen.findByRole('button', { name: 'Add Product' });
+  };
+
+  it('sends only the product set when a product is removed, never the whole record', async () => {
+    const transport = createMemoryTransport({
+      collections: [featuredCollection()],
+      products: [product(21, 'Slate dress')],
+    });
+    await openDetail(transport);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() =>
+      expect(transport.calls()).toContainEqual(
+        expect.objectContaining({ method: 'PUT', path: 'collections/1', body: { product_ids: [] } })
+      )
+    );
+  });
+
+  it('sends only the product set when a product is added', async () => {
+    const transport = createMemoryTransport({
+      collections: [featuredCollection()],
+      products: [product(21, 'Slate dress')],
+    });
+    await openDetail(transport);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Product' }));
+    fireEvent.click(await screen.findByText('Slate dress'));
+
+    await waitFor(() =>
+      expect(transport.calls()).toContainEqual(
+        expect.objectContaining({
+          method: 'PUT',
+          path: 'collections/1',
+          body: { product_ids: [20, 21] },
+        })
+      )
+    );
+  });
+
+  it('never mentions is_featured on a product edit, so the server cannot reset it', async () => {
+    const transport = createMemoryTransport({
+      collections: [featuredCollection()],
+      products: [product(21, 'Slate dress')],
+    });
+    await openDetail(transport);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(transport.peek('collections')[0].product_ids).toEqual([]));
+    const writes = transport.calls().filter((call) => call.method === 'PUT');
+    expect(writes).not.toHaveLength(0);
+    for (const write of writes) {
+      expect(Object.keys(write.body as Record<string, unknown>)).toEqual(['product_ids']);
+    }
+    // The memory transport merges a PUT onto the stored row exactly as the endpoint now
+    // does, so the flag surviving here is the same assertion the server test makes.
+    expect(transport.peek('collections')[0].is_featured).toBe(true);
+  });
+});

--- a/client/src/features/inventory/pages/Collections.tsx
+++ b/client/src/features/inventory/pages/Collections.tsx
@@ -46,13 +46,18 @@ const collectionToForm = (col: Collection) => ({
   description: col.description || '',
 });
 
+/**
+ * Editing a collection's products changes its products and nothing else, so this sends
+ * exactly that.
+ *
+ * It used to echo back most-but-not-all of the record — every field the detail view
+ * happened to hold, which never included `is_featured`. `PUT collections/:id` is
+ * PATCH-style, so replaying fields this dialog does not own only widens the window for
+ * overwriting a change someone else made between the read and the write (#81), and the
+ * one field it forgot was silently reset on every product edit (#78).
+ */
 const withProducts = (detail: CollectionDetail, productIds: number[]) => ({
   id: detail.id,
-  name: detail.name,
-  season: detail.season || undefined,
-  year: detail.year || undefined,
-  status: detail.status,
-  description: detail.description || undefined,
   product_ids: productIds,
 });
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -155,6 +155,62 @@ fields all follow this shape; it is what lets a cashier update mid-shift without
 
 ---
 
+## Partial-update contract (server)
+
+Every `PUT /:id` in this codebase is **PATCH-style**: a field the body omits is left alone,
+a field it sets to `null` is cleared. This is a contract, not an implementation detail, and
+it exists because the alternative produced a silent data-loss bug (#78).
+
+The shape to recognise and never write again:
+
+```ts
+// The create schema. Every field optional, some with defaults.
+const thingSchema = z.object({ name: z.string(), is_featured: z.boolean().optional() });
+// The update handler re-parses with it...
+const parsed = thingSchema.parse(req.body);
+// ...and the repository SETs every column from it.
+`UPDATE things SET name = $1, is_featured = $2 ...`
+```
+
+A body that names three of four fields parses cleanly — the missing one is optional, so it
+is not a validation error — and the fourth column is then written back as its default. The
+request returns 200 and a field nobody mentioned is gone, with nothing in the logs. An audit
+in #78 found this in fourteen update paths; four were losing data in production.
+
+**The rules.**
+
+1. An update endpoint gets its **own** schema, never the create schema. Name it
+   `<thing>UpdateSchema` and export it, so a test can assert on it directly.
+2. That schema carries **no `.default()`**. A default is exactly what turns "absent" back
+   into "write this value", and it does so below the point where the repository could tell
+   the difference.
+3. Nullable columns are `.nullable().optional()` — the schema has to distinguish *absent*
+   from *explicitly null*, because they mean different things.
+4. The repository builds its SET clause with `buildPartialUpdate`
+   (`server/src/database/partialUpdate.ts`). Guard on `!== undefined`, never on truthiness:
+   `0`, `''` and `false` are values a caller needs to be able to set.
+5. Nullable text columns pass through `orNull`, which preserves the existing "an empty
+   string means NULL" behaviour for a *present* field while leaving an absent one absent.
+6. Anything the update DTO drops from the create DTO is a **separate interface**
+   (`UpdateThingDTO`), not `export type UpdateThingDTO = CreateThingDTO`. The alias is what
+   let the two shapes drift into one in the first place.
+7. If a service validates a cross-field invariant (a percentage ceiling, a date range), it
+   validates the **effective row** — the stored values merged with the body — not the body
+   alone. A partial body can otherwise walk past a check by simply not mentioning the field
+   the check reads.
+
+**The client side of the same contract.** `resource().useSave` PUTs exactly the keys a page
+put in its draft, so every page already sends a partial body. A dialog therefore sends what
+it *changed*, not a re-serialization of the record it happens to be holding. Echoing back
+fields the dialog does not own is what made #78 reachable, and it widens the window for
+overwriting a concurrent edit (#81).
+
+**Still to convert.** Ten update paths carry the old shape but are not losing data today —
+their client sends a full body, or 400s before reaching the repository: customers, segments,
+storefront banners, branches, delivery orders, expenses, bundles, distributors, label
+templates, products (and product variants), stock-count items. Any change to one of those
+clients' payloads makes its module's loss live, so convert the server side first.
+
 ## When to split or merge a slice
 
 Split a slice when **both** of these are true:

--- a/server/src/database/partialUpdate.ts
+++ b/server/src/database/partialUpdate.ts
@@ -1,0 +1,76 @@
+/**
+ * Builds the SET clause of a PATCH-style UPDATE from the columns a caller actually named.
+ *
+ * The bug this exists to stop (#78) is not a typo, it is a shape. An update endpoint that
+ * parses a body with an all-optional schema and then writes every column from it treats a
+ * missing field as "set to default" rather than "leave alone". The request succeeds, the
+ * response is a 200, and a field nobody mentioned is quietly gone. `is_featured` on
+ * collections is the field that exposed it; an audit found the same shape in a dozen other
+ * update paths.
+ *
+ * So the rule is stated once, here, instead of being re-derived at each repository:
+ *
+ * - `undefined` means the body did not mention the column. It is not written.
+ * - `null` means the body asked for the column to be cleared. It is written.
+ *
+ * That distinction is the whole point, which is why the guard is `!== undefined` and never
+ * a truthiness test.
+ */
+export interface PartialUpdate {
+  /** e.g. `name = $1, is_featured = $2` — never empty; see `alwaysSet`. */
+  setClause: string;
+  /** Positional parameters for `setClause`, in order, starting at `$1`. */
+  params: unknown[];
+  /** How many parameters `setClause` consumed, so the caller can number its WHERE. */
+  nextIndex: number;
+}
+
+export interface PartialUpdateOptions {
+  /**
+   * Raw SQL fragments appended to every SET clause, whatever the caller named — an
+   * `updated_at = NOW()` belongs here. They take no parameters, so nothing user-supplied
+   * reaches them.
+   *
+   * They also guarantee the clause is non-empty: a body that named no columns at all (a
+   * collection edit that only changed its product set) still produces valid SQL and still
+   * touches the row, rather than making every caller special-case zero assignments.
+   */
+  alwaysSet?: readonly string[];
+  /** First positional parameter to use. Defaults to 1. */
+  startIndex?: number;
+}
+
+export function buildPartialUpdate(
+  columns: Readonly<Record<string, unknown>>,
+  { alwaysSet = ['updated_at = NOW()'], startIndex = 1 }: PartialUpdateOptions = {}
+): PartialUpdate {
+  const assignments: string[] = [];
+  const params: unknown[] = [];
+
+  for (const [column, value] of Object.entries(columns)) {
+    if (value === undefined) continue;
+    params.push(value);
+    assignments.push(`${column} = $${startIndex + params.length - 1}`);
+  }
+
+  assignments.push(...alwaysSet);
+
+  return {
+    setClause: assignments.join(', '),
+    params,
+    nextIndex: startIndex + params.length,
+  };
+}
+
+/**
+ * Carries "the body did not mention this" through a nullable text column.
+ *
+ * These columns have always stored NULL for an empty string — a cleared form field and an
+ * absent one used to be indistinguishable because both ended up NULL anyway. Now that they
+ * differ, `''` keeps meaning NULL and `undefined` keeps meaning untouched. Changing what a
+ * *present* empty string does is a separate decision from fixing what an *absent* field
+ * does, and this fix is only the second one.
+ */
+export function orNull<T>(value: T | null | undefined): T | null | undefined {
+  return value === undefined ? undefined : value || null;
+}

--- a/server/src/modules/commerce/coupons/controller.ts
+++ b/server/src/modules/commerce/coupons/controller.ts
@@ -39,6 +39,37 @@ export const couponSchema = z.object({
   stackable: z.boolean().optional().default(false),
 });
 
+/**
+ * The update body is a genuine partial — same reasoning as #78 on collections.
+ *
+ * The create schema is all-optional-with-defaults, and the repository wrote all twelve
+ * columns from it, so the Promotions page — whose form has no field for
+ * `max_uses_per_customer` or `scope_ids` — cleared a per-customer limit and a
+ * category/product restriction on every edit. A coupon scoped to one category quietly
+ * became valid on everything.
+ *
+ * No `.default()` here: a default turns "absent" back into "write this value".
+ */
+export const couponUpdateSchema = z.object({
+  code: z
+    .string()
+    .min(3, 'Coupon code must be at least 3 characters')
+    .max(50)
+    .transform((v) => v.toUpperCase().trim())
+    .optional(),
+  type: z.enum(['percentage', 'fixed']).optional(),
+  value: z.number().positive('Value must be positive').optional(),
+  min_purchase: z.number().min(0).nullable().optional(),
+  max_discount: z.number().positive().nullable().optional(),
+  starts_at: z.string().nullable().optional(),
+  expires_at: z.string().nullable().optional(),
+  max_uses: z.number().int().positive().nullable().optional(),
+  max_uses_per_customer: z.number().int().positive().nullable().optional(),
+  scope: z.enum(['all', 'category', 'product']).optional(),
+  scope_ids: z.array(z.number().int().positive()).nullable().optional(),
+  stackable: z.boolean().optional(),
+});
+
 export const validateCouponSchema = z.object({
   code: z.string().min(1, 'Coupon code is required'),
   subtotal: z.number().min(0, 'Subtotal must be non-negative'),
@@ -87,17 +118,20 @@ export class CouponsController {
 
   async updateCoupon(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const parsed = couponSchema.safeParse(req.body);
+      const parsed = couponUpdateSchema.safeParse(req.body);
       if (!parsed.success) {
         throw parsed.error;
       }
 
       const id = req.params.id as string;
       const coupon = await couponsService.update(id, parsed.data);
+      // The audit entry reads the *result*, not the request: a partial body may not
+      // mention code/type/value at all, and an audit line of three undefineds records
+      // nothing about what the coupon now is.
       logAuditFromReq(req, 'update', 'coupon', id, {
-        code: parsed.data.code,
-        type: parsed.data.type,
-        value: parsed.data.value,
+        code: coupon.code,
+        type: coupon.type,
+        value: coupon.value,
       });
 
       res.json(success(coupon));

--- a/server/src/modules/commerce/coupons/repository.ts
+++ b/server/src/modules/commerce/coupons/repository.ts
@@ -1,6 +1,7 @@
 import { Queryable } from '../../../database/transaction';
 import pool from '../../../database/pool';
-import { CouponData, CouponFilters, CouponListResult } from './types';
+import { buildPartialUpdate } from '../../../database/partialUpdate';
+import { CouponData, CouponFilters, CouponListResult, UpdateCouponData } from './types';
 
 export interface ICouponsRepository {
   list(filters: CouponFilters, queryable?: Queryable): Promise<CouponListResult>;
@@ -10,7 +11,7 @@ export interface ICouponsRepository {
   create(data: CouponData, queryable?: Queryable): Promise<Record<string, any>>;
   update(
     id: string | number,
-    data: CouponData,
+    data: UpdateCouponData,
     queryable?: Queryable
   ): Promise<Record<string, any> | null>;
   delete(id: string | number, queryable?: Queryable): Promise<boolean>;
@@ -151,15 +152,41 @@ export class CouponsRepository implements ICouponsRepository {
     return this.parseScopeIds(result.rows[0]);
   }
 
+  /**
+   * Merges a partial update onto the stored row — see `buildPartialUpdate` for the rule.
+   *
+   * This used to write all twelve columns from an all-optional body, so a field the client
+   * did not send was written back as NULL (or as the schema's default). The Promotions form
+   * has no input for `max_uses_per_customer` or `scope_ids`, so every edit dropped a
+   * per-customer limit and widened a category-scoped coupon to everything.
+   *
+   * `scope_ids` is the one column whose SQL value is not its DTO value: it is stored as
+   * JSON text. `null` still means "clear it"; only `undefined` skips the column.
+   */
   async update(
     id: string | number,
-    data: CouponData,
+    data: UpdateCouponData,
     queryable?: Queryable
   ): Promise<Record<string, any> | null> {
+    const { setClause, params, nextIndex } = buildPartialUpdate({
+      code: data.code,
+      type: data.type,
+      value: data.value,
+      min_purchase: data.min_purchase,
+      max_discount: data.max_discount,
+      starts_at: data.starts_at,
+      expires_at: data.expires_at,
+      max_uses: data.max_uses,
+      max_uses_per_customer: data.max_uses_per_customer,
+      scope: data.scope,
+      scope_ids:
+        data.scope_ids === undefined ? undefined : data.scope_ids && JSON.stringify(data.scope_ids),
+      stackable: data.stackable === undefined ? undefined : data.stackable ? 1 : 0,
+    });
+
     const result = await this.q(queryable).query(
-      `UPDATE coupons SET code=$1, type=$2, value=$3, min_purchase=$4, max_discount=$5, starts_at=$6, expires_at=$7, max_uses=$8, max_uses_per_customer=$9, scope=$10, scope_ids=$11, stackable=$12, updated_at=NOW()
-       WHERE id=$13 AND status='active' RETURNING *`,
-      [...this.buildCouponParams(data), id]
+      `UPDATE coupons SET ${setClause} WHERE id=$${nextIndex} AND status='active' RETURNING *`,
+      [...params, id]
     );
     return result.rows[0] ? this.parseScopeIds(result.rows[0]) : null;
   }

--- a/server/src/modules/commerce/coupons/service.ts
+++ b/server/src/modules/commerce/coupons/service.ts
@@ -6,6 +6,7 @@ import {
   CouponError,
   CouponFilters,
   CouponListResult,
+  UpdateCouponData,
   ValidateCouponInput,
   ValidateCouponResult,
 } from './types';
@@ -44,8 +45,21 @@ export class CouponsService {
     }
   }
 
-  async update(id: string | number, data: CouponData): Promise<Record<string, any>> {
-    this.validatePercentage(data.type, data.value);
+  /**
+   * A partial update is validated against the *effective* coupon, not against the body.
+   *
+   * Raising `value` to 150 without re-sending `type` would otherwise skip the percentage
+   * ceiling entirely, because the body's `type` is absent. The rule belongs to the row the
+   * update produces, so the check reads the stored row for whatever the body left out.
+   */
+  async update(id: string | number, data: UpdateCouponData): Promise<Record<string, any>> {
+    if (data.type !== undefined || data.value !== undefined) {
+      const existing = await this.repo.findById(id);
+      if (!existing) {
+        throw new CouponError('Coupon not found or already inactive', 404);
+      }
+      this.validatePercentage(data.type ?? existing.type, data.value ?? Number(existing.value));
+    }
 
     try {
       const coupon = await this.repo.update(id, data);

--- a/server/src/modules/commerce/coupons/types.ts
+++ b/server/src/modules/commerce/coupons/types.ts
@@ -51,6 +51,27 @@ export interface CouponData {
   stackable: boolean;
 }
 
+/**
+ * A *partial* coupon update: absent means "leave the stored value alone", explicit `null`
+ * means "clear it". Deliberately not `CouponData` — sharing the create shape is what wiped
+ * `max_uses_per_customer` and `scope_ids` on every edit from the Promotions page, which
+ * never sends them.
+ */
+export interface UpdateCouponData {
+  code?: string;
+  type?: 'percentage' | 'fixed';
+  value?: number;
+  min_purchase?: number | null;
+  max_discount?: number | null;
+  starts_at?: string | null;
+  expires_at?: string | null;
+  max_uses?: number | null;
+  max_uses_per_customer?: number | null;
+  scope?: 'all' | 'category' | 'product';
+  scope_ids?: number[] | null;
+  stackable?: boolean;
+}
+
 export interface ValidateCouponInput {
   code: string;
   subtotal: number;

--- a/server/src/modules/commerce/vendors/controller.ts
+++ b/server/src/modules/commerce/vendors/controller.ts
@@ -19,6 +19,29 @@ export const vendorSchema = z.object({
   status: z.enum(['active', 'inactive']).default('active'),
 });
 
+/**
+ * The update body is a genuine partial, and deliberately not `vendorSchema`.
+ *
+ * Re-using the create schema here meant every field was optional *and* two of them carried
+ * a `.default()`, so a body that named only some fields parsed cleanly and the repository
+ * then wrote defaults over the rest. The Vendors page never sends `contact_person`,
+ * `tax_number` or `status` — so editing an inactive vendor silently reactivated it and
+ * cleared its tax number. Same shape as #78 on collections.
+ *
+ * No `.default()` here: a default is what turns "absent" back into "write this value",
+ * which is exactly what a partial update must not do.
+ */
+export const vendorUpdateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  contact_person: z.string().max(100).nullable().optional(),
+  email: z.string().email().nullable().optional(),
+  phone: z.string().max(30).nullable().optional(),
+  address: z.string().max(255).nullable().optional(),
+  tax_number: z.string().max(50).nullable().optional(),
+  commission_rate: z.number().min(0).max(100).optional(),
+  status: z.enum(['active', 'inactive']).optional(),
+});
+
 export class VendorsController {
   async listVendors(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
@@ -52,7 +75,7 @@ export class VendorsController {
   async updateVendor(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const { id } = req.params;
-      const parsed = vendorSchema.safeParse(req.body);
+      const parsed = vendorUpdateSchema.safeParse(req.body);
       if (!parsed.success) {
         throw parsed.error;
       }

--- a/server/src/modules/commerce/vendors/repository.ts
+++ b/server/src/modules/commerce/vendors/repository.ts
@@ -1,7 +1,9 @@
 import { Queryable } from '../../../database/transaction';
 import pool from '../../../database/pool';
+import { buildPartialUpdate, orNull } from '../../../database/partialUpdate';
 import {
   CreateVendorPayoutDTO,
+  UpdateVendorDTO,
   VendorDTO,
   VendorFilters,
   VendorPayoutRecord,
@@ -16,7 +18,11 @@ export interface IVendorsRepository {
   ): Promise<{ rows: VendorRecord[]; total: number }>;
   findById(id: number | string, queryable?: Queryable): Promise<VendorRecord | null>;
   create(data: VendorDTO, queryable?: Queryable): Promise<VendorRecord>;
-  update(id: number | string, data: VendorDTO, queryable?: Queryable): Promise<VendorRecord | null>;
+  update(
+    id: number | string,
+    data: UpdateVendorDTO,
+    queryable?: Queryable
+  ): Promise<VendorRecord | null>;
   getPayouts(
     vendorId: number | string,
     filters: VendorPayoutFilters,
@@ -106,26 +112,33 @@ export class VendorsRepository implements IVendorsRepository {
     return result.rows[0];
   }
 
+  /**
+   * Merges a partial update onto the stored row — see `buildPartialUpdate` for the rule.
+   *
+   * This used to SET all eight columns from an all-optional body, so the fields the client
+   * did not send were written back as defaults: `status` reverted to `'active'`,
+   * reactivating a vendor an admin had just deactivated, and `contact_person` and
+   * `tax_number` were cleared on every edit.
+   */
   async update(
     id: number | string,
-    data: VendorDTO,
+    data: UpdateVendorDTO,
     queryable?: Queryable
   ): Promise<VendorRecord | null> {
+    const { setClause, params, nextIndex } = buildPartialUpdate({
+      name: data.name,
+      contact_person: orNull(data.contact_person),
+      email: orNull(data.email),
+      phone: orNull(data.phone),
+      address: orNull(data.address),
+      tax_number: orNull(data.tax_number),
+      commission_rate: data.commission_rate,
+      status: data.status,
+    });
+
     const result = await this.q(queryable).query<VendorRecord>(
-      `UPDATE vendors SET name = $1, contact_person = $2, email = $3, phone = $4, address = $5,
-              tax_number = $6, commission_rate = $7, status = $8, updated_at = NOW()
-       WHERE id = $9 RETURNING *`,
-      [
-        data.name,
-        data.contact_person || null,
-        data.email || null,
-        data.phone || null,
-        data.address || null,
-        data.tax_number || null,
-        data.commission_rate ?? 0,
-        data.status || 'active',
-        id,
-      ]
+      `UPDATE vendors SET ${setClause} WHERE id = $${nextIndex} RETURNING *`,
+      [...params, id]
     );
     return result.rows[0] || null;
   }

--- a/server/src/modules/commerce/vendors/service.ts
+++ b/server/src/modules/commerce/vendors/service.ts
@@ -1,6 +1,7 @@
 import { IVendorsRepository, vendorsRepository as defaultRepo } from './repository';
 import {
   CreateVendorPayoutDTO,
+  UpdateVendorDTO,
   VendorDTO,
   VendorFilters,
   VendorPayoutRecord,
@@ -42,7 +43,7 @@ export class VendorsService {
     return this.repo.create(data);
   }
 
-  async update(id: number | string, data: VendorDTO): Promise<VendorRecord | null> {
+  async update(id: number | string, data: UpdateVendorDTO): Promise<VendorRecord | null> {
     return this.repo.update(id, data);
   }
 

--- a/server/src/modules/commerce/vendors/types.ts
+++ b/server/src/modules/commerce/vendors/types.ts
@@ -24,6 +24,22 @@ export interface VendorDTO {
   status?: 'active' | 'inactive';
 }
 
+/**
+ * A *partial* update: absent means "leave the stored value alone", an explicit `null`
+ * means "clear it". Not `VendorDTO`, because sharing the create DTO is what let an
+ * omitted `status` reactivate a deactivated vendor.
+ */
+export interface UpdateVendorDTO {
+  name?: string;
+  contact_person?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  address?: string | null;
+  tax_number?: string | null;
+  commission_rate?: number;
+  status?: 'active' | 'inactive';
+}
+
 export interface VendorPayoutRecord {
   id: number;
   vendor_id: number;

--- a/server/src/modules/fulfillment/shippingCompanies/controller.ts
+++ b/server/src/modules/fulfillment/shippingCompanies/controller.ts
@@ -13,6 +13,22 @@ const shippingCompanySchema = z.object({
   is_active: z.boolean().default(true),
 });
 
+/**
+ * The update body is a genuine partial — same reasoning as #78 on collections, and this is
+ * one of the modules where it was losing data today.
+ *
+ * `ShippingCompaniesDialog` sends `{ name, phone, website }`. Re-using the create schema
+ * meant `email` and `tracking_url_template` were absent-but-valid and got written back as
+ * NULL, and `is_active`'s `.default(true)` reactivated a company someone had disabled.
+ */
+export const shippingCompanyUpdateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  phone: z.string().max(30).nullable().optional(),
+  email: z.string().email().nullable().optional(),
+  tracking_url_template: z.string().max(255).nullable().optional(),
+  is_active: z.boolean().optional(),
+});
+
 export class ShippingCompaniesController {
   async getShippingCompanies(_req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
@@ -45,7 +61,7 @@ export class ShippingCompaniesController {
   async updateShippingCompany(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const { id } = req.params;
-      const parsed = shippingCompanySchema.safeParse(req.body);
+      const parsed = shippingCompanyUpdateSchema.safeParse(req.body);
       if (!parsed.success) {
         throw parsed.error;
       }

--- a/server/src/modules/fulfillment/shippingCompanies/repository.ts
+++ b/server/src/modules/fulfillment/shippingCompanies/repository.ts
@@ -1,5 +1,6 @@
 import { Queryable } from '../../../database/transaction';
 import pool from '../../../database/pool';
+import { buildPartialUpdate, orNull } from '../../../database/partialUpdate';
 import { CreateShippingCompanyDTO, UpdateShippingCompanyDTO } from './types';
 
 export interface IShippingCompaniesRepository {
@@ -58,22 +59,29 @@ export class ShippingCompaniesRepository implements IShippingCompaniesRepository
     return res.rows[0];
   }
 
+  /**
+   * Merges a partial update onto the stored row — see `buildPartialUpdate` for the rule.
+   *
+   * Note the `is_active` default that used to sit on the last parameter: an absent flag
+   * meant `1`, so every edit re-enabled a disabled company. That is the whole class of bug
+   * in one expression.
+   */
   async update(
     id: number | string,
     data: UpdateShippingCompanyDTO,
     queryable?: Queryable
   ): Promise<Record<string, any> | null> {
+    const { setClause, params, nextIndex } = buildPartialUpdate({
+      name: data.name,
+      phone: orNull(data.phone),
+      email: orNull(data.email),
+      tracking_url_template: orNull(data.tracking_url_template),
+      is_active: data.is_active === undefined ? undefined : data.is_active ? 1 : 0,
+    });
+
     const res = await this.q(queryable).query(
-      `UPDATE shipping_companies SET name = $1, phone = $2, email = $3, tracking_url_template = $4, is_active = $5, updated_at = NOW()
-       WHERE id = $6 RETURNING *`,
-      [
-        data.name,
-        data.phone || null,
-        data.email || null,
-        data.tracking_url_template || null,
-        data.is_active !== undefined ? (data.is_active ? 1 : 0) : 1,
-        id,
-      ]
+      `UPDATE shipping_companies SET ${setClause} WHERE id = $${nextIndex} RETURNING *`,
+      [...params, id]
     );
     return res.rows[0] || null;
   }

--- a/server/src/modules/fulfillment/shippingCompanies/types.ts
+++ b/server/src/modules/fulfillment/shippingCompanies/types.ts
@@ -18,4 +18,15 @@ export interface CreateShippingCompanyDTO {
   is_active?: boolean;
 }
 
-export type UpdateShippingCompanyDTO = CreateShippingCompanyDTO;
+/**
+ * A *partial* update: absent means "leave it alone", explicit `null` means "clear it".
+ * Deliberately not `CreateShippingCompanyDTO` — sharing that is what cleared `email` and
+ * `tracking_url_template` on every edit and silently re-enabled a disabled company.
+ */
+export interface UpdateShippingCompanyDTO {
+  name?: string;
+  phone?: string | null;
+  email?: string | null;
+  tracking_url_template?: string | null;
+  is_active?: boolean;
+}

--- a/server/src/modules/inventory/collections/controller.ts
+++ b/server/src/modules/inventory/collections/controller.ts
@@ -15,6 +15,29 @@ const collectionSchema = z.object({
   product_ids: z.array(z.number().int().positive()).optional(),
 });
 
+/**
+ * The update body is a genuine partial, and deliberately not the create schema.
+ *
+ * `PUT /api/v1/collections/:id` is PATCH-style: a field the body omits is left alone, a
+ * field it sets to `null` is cleared. Re-using the create schema here is what caused #78 —
+ * every field was optional, so an omitted `is_featured` parsed cleanly and was then written
+ * back as the default. The distinction the schema has to carry is *absent* vs *explicitly
+ * null*, which is why the nullable columns are `.nullable().optional()` and `name` — a
+ * NOT NULL column — is only `.optional()`.
+ *
+ * PATCH-style rather than requiring a whole record because the client is already written as
+ * if this were true: `resource().useSave` PUTs exactly the keys a page put in its draft, so
+ * every page in the app sends a partial body. Demanding a full record would have meant every
+ * caller learning every column — the same coupling, moved rather than removed.
+ */
+const collectionUpdateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().max(500).nullable().optional(),
+  season: z.string().max(50).nullable().optional(),
+  is_featured: z.boolean().optional(),
+  product_ids: z.array(z.number().int().positive()).optional(),
+});
+
 export class CollectionsController {
   async getCollections(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
@@ -58,7 +81,7 @@ export class CollectionsController {
   async updateCollection(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const { id } = req.params;
-      const parsed = collectionSchema.parse(req.body);
+      const parsed = collectionUpdateSchema.parse(req.body);
 
       const result = await collectionsService.update(id as string, parsed);
       if (!result.success) {

--- a/server/src/modules/inventory/collections/repository.ts
+++ b/server/src/modules/inventory/collections/repository.ts
@@ -1,5 +1,6 @@
 import { Queryable, withTransaction } from '../../../database/transaction';
 import pool from '../../../database/pool';
+import { buildPartialUpdate, orNull } from '../../../database/partialUpdate';
 import {
   CollectionRecord,
   CollectionProductRecord,
@@ -132,29 +133,16 @@ export class CollectionsRepository implements ICollectionsRepository {
     data: UpdateCollectionDTO,
     queryable?: Queryable
   ): Promise<CollectionRecord | null> {
-    const assignments: string[] = [];
-    const params: unknown[] = [];
-
-    const assign = (column: string, value: unknown): void => {
-      params.push(value);
-      assignments.push(`${column} = $${params.length}`);
-    };
-
-    if (data.name !== undefined) assign('name', data.name);
-    // `|| null` on the nullable columns, not `??`: an empty string from a cleared form
-    // field has always meant NULL here, and this fix is about what an *absent* field
-    // means, not about changing what a present one does.
-    if (data.description !== undefined) assign('description', data.description || null);
-    if (data.season !== undefined) assign('season', data.season || null);
-    if (data.is_featured !== undefined) assign('is_featured', data.is_featured ? 1 : 0);
-
-    assignments.push('updated_at = NOW()');
-    params.push(id);
+    const { setClause, params, nextIndex } = buildPartialUpdate({
+      name: data.name,
+      description: orNull(data.description),
+      season: orNull(data.season),
+      is_featured: data.is_featured === undefined ? undefined : data.is_featured ? 1 : 0,
+    });
 
     const res = await this.q(queryable).query<CollectionRecord>(
-      `UPDATE collections SET ${assignments.join(', ')}
-       WHERE id = $${params.length} RETURNING *`,
-      params
+      `UPDATE collections SET ${setClause} WHERE id = $${nextIndex} RETURNING *`,
+      [...params, id]
     );
     return res.rows[0] || null;
   }

--- a/server/src/modules/inventory/collections/repository.ts
+++ b/server/src/modules/inventory/collections/repository.ts
@@ -113,15 +113,48 @@ export class CollectionsRepository implements ICollectionsRepository {
     return res.rows[0];
   }
 
+  /**
+   * Merges a partial update onto the stored row: only the columns the caller actually
+   * named are written.
+   *
+   * The previous shape set every column on every call, from a body whose fields were all
+   * optional — so a request that mentioned three of four fields wrote the default over the
+   * fourth. That is #78: editing a collection's product list cleared `is_featured`, with a
+   * 200 and nothing in the logs. Absent now means untouched; an explicit `null` on a
+   * nullable column still clears it, which is why the guard is `!== undefined` rather than
+   * a truthiness test.
+   *
+   * `updated_at` is bumped unconditionally, including when the only change was the product
+   * set, so the column stays an honest "when was this collection last changed".
+   */
   async update(
     id: number | string,
     data: UpdateCollectionDTO,
     queryable?: Queryable
   ): Promise<CollectionRecord | null> {
+    const assignments: string[] = [];
+    const params: unknown[] = [];
+
+    const assign = (column: string, value: unknown): void => {
+      params.push(value);
+      assignments.push(`${column} = $${params.length}`);
+    };
+
+    if (data.name !== undefined) assign('name', data.name);
+    // `|| null` on the nullable columns, not `??`: an empty string from a cleared form
+    // field has always meant NULL here, and this fix is about what an *absent* field
+    // means, not about changing what a present one does.
+    if (data.description !== undefined) assign('description', data.description || null);
+    if (data.season !== undefined) assign('season', data.season || null);
+    if (data.is_featured !== undefined) assign('is_featured', data.is_featured ? 1 : 0);
+
+    assignments.push('updated_at = NOW()');
+    params.push(id);
+
     const res = await this.q(queryable).query<CollectionRecord>(
-      `UPDATE collections SET name = $1, description = $2, season = $3, is_featured = $4, updated_at = NOW()
-       WHERE id = $5 RETURNING *`,
-      [data.name, data.description || null, data.season || null, data.is_featured ? 1 : 0, id]
+      `UPDATE collections SET ${assignments.join(', ')}
+       WHERE id = $${params.length} RETURNING *`,
+      params
     );
     return res.rows[0] || null;
   }

--- a/server/src/modules/inventory/collections/types.ts
+++ b/server/src/modules/inventory/collections/types.ts
@@ -39,7 +39,21 @@ export interface CreateCollectionDTO {
   product_ids?: number[];
 }
 
-export type UpdateCollectionDTO = CreateCollectionDTO;
+/**
+ * A *partial* update. This DTO is deliberately not `CreateCollectionDTO`.
+ *
+ * Absent means "leave the stored value alone"; an explicit `null` on a nullable
+ * column means "clear it". Sharing the create DTO is what made #78 possible: every
+ * field was optional, so an omitted `is_featured` was not a validation error, it was
+ * a write of the default — and editing a collection's products un-featured it.
+ */
+export interface UpdateCollectionDTO {
+  name?: string;
+  description?: string | null;
+  season?: string | null;
+  is_featured?: boolean;
+  product_ids?: number[];
+}
 
 export interface CollectionFilters {
   season?: string;

--- a/server/tests/collections.test.ts
+++ b/server/tests/collections.test.ts
@@ -158,3 +158,123 @@ describe('collection product ordering', () => {
     expect(detail!.products.map((p) => p.id)).toEqual([10, 12, 13]);
   });
 });
+
+/**
+ * Partial updates must not clear the fields they do not mention (#78).
+ *
+ * `PUT /api/v1/collections/:id` is reached from a client that sends a *partial* record:
+ * `resource().useSave` PUTs exactly the keys the page put in the draft, and the
+ * Collections page's product-editing path sends name/season/description/product_ids and
+ * nothing else. Every field the body omits must therefore be left alone, not written back
+ * as its default. `is_featured` is the field that exposed this, but the rule is the shape,
+ * not the field.
+ */
+describe('collections partial update', () => {
+  let testPool: PgPool;
+  const repo = new CollectionsRepository();
+  const service = new CollectionsService(repo);
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM collection_products');
+    await testPool.query('DELETE FROM collections');
+    await testPool.query('DELETE FROM products');
+    await testPool.query(
+      `INSERT INTO products (id, name, sku, price, stock)
+       VALUES (20, 'Ivory coat', 'SKU-20', 100, 5),
+              (21, 'Slate dress', 'SKU-21', 200, 5)`
+    );
+  });
+
+  const featuredCollection = async () => {
+    const { rows } = await testPool.query<{ id: number }>(
+      `INSERT INTO collections (name, description, season, is_featured, status)
+       VALUES ('Autumn window', 'The window', 'Fall', 1, 'active') RETURNING id`
+    );
+    return rows[0].id;
+  };
+
+  const rowOf = async (id: number) => {
+    const { rows } = await testPool.query('SELECT * FROM collections WHERE id = $1', [id]);
+    return rows[0];
+  };
+
+  it('keeps a collection featured when only its product list is edited', async () => {
+    const id = await featuredCollection();
+    await repo.addProducts(id, [20]);
+
+    // Exactly what the Collections page sends when a merchandiser adds a product:
+    // the identifying fields it happens to hold, plus the new product set. No
+    // `is_featured` — because the page never loaded one.
+    const result = await service.update(id, {
+      name: 'Autumn window',
+      season: 'Fall',
+      description: 'The window',
+      product_ids: [20, 21],
+    });
+
+    expect(result.success).toBe(true);
+    expect(Number((await rowOf(id)).is_featured)).toBe(1);
+    const detail = await service.findById(id);
+    expect(detail!.products.map((p) => p.id)).toEqual([20, 21]);
+  });
+
+  it('leaves every unmentioned column alone, not just is_featured', async () => {
+    const id = await featuredCollection();
+
+    const result = await service.update(id, { product_ids: [20] });
+
+    expect(result.success).toBe(true);
+    const row = await rowOf(id);
+    expect(row.name).toBe('Autumn window');
+    expect(row.description).toBe('The window');
+    expect(row.season).toBe('Fall');
+    expect(Number(row.is_featured)).toBe(1);
+  });
+
+  it('still applies the fields the body does mention', async () => {
+    const id = await featuredCollection();
+
+    await service.update(id, { name: 'Autumn window II', is_featured: false });
+
+    const row = await rowOf(id);
+    expect(row.name).toBe('Autumn window II');
+    expect(Number(row.is_featured)).toBe(0);
+    // ...and does not disturb the ones it did not.
+    expect(row.season).toBe('Fall');
+  });
+
+  it('clears a nullable field when the body says null explicitly', async () => {
+    const id = await featuredCollection();
+
+    await service.update(id, { description: null, season: null });
+
+    const row = await rowOf(id);
+    expect(row.description).toBeNull();
+    expect(row.season).toBeNull();
+    expect(row.name).toBe('Autumn window');
+    expect(Number(row.is_featured)).toBe(1);
+  });
+
+  it('is a no-op on the row when the body carries only a product set', async () => {
+    const id = await featuredCollection();
+    const before = await rowOf(id);
+
+    await service.update(id, { product_ids: [21] });
+
+    const after = await rowOf(id);
+    expect(after.name).toBe(before.name);
+    expect(after.is_featured).toBe(before.is_featured);
+    const detail = await service.findById(id);
+    expect(detail!.products.map((p) => p.id)).toEqual([21]);
+  });
+});

--- a/server/tests/coupons.partial.test.ts
+++ b/server/tests/coupons.partial.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Coupons: a partial PUT must not widen a scoped coupon (#78, same shape).
+ *
+ * `PUT /api/v1/coupons/:id` parsed the body with the create schema and then wrote all
+ * twelve columns. The Promotions form has no input for `max_uses_per_customer` or
+ * `scope_ids`, so every edit dropped a per-customer limit and cleared the scope list — a
+ * coupon restricted to one category quietly became valid on the whole catalogue, which is
+ * money rather than metadata.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { CouponsRepository } from '../src/modules/commerce/coupons/repository';
+import { CouponsService } from '../src/modules/commerce/coupons/service';
+import { couponUpdateSchema } from '../src/modules/commerce/coupons/controller';
+import { CouponError } from '../src/modules/commerce/coupons/types';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+
+describe('coupons partial update', () => {
+  let testPool: PgPool;
+  let couponId: number;
+  const repo = new CouponsRepository();
+  const service = new CouponsService(repo);
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM coupon_usage');
+    await testPool.query('DELETE FROM coupons');
+    const created = await testPool.query<{ id: number }>(
+      `INSERT INTO coupons (code, type, value, min_purchase, max_uses, max_uses_per_customer, scope, scope_ids, stackable)
+       VALUES ('EID20', 'percentage', 20, 500, 100, 1, 'category', '[3,4]', 1)
+       RETURNING id`
+    );
+    couponId = created.rows[0].id;
+  });
+
+  it('keeps the per-customer limit and the scope the form cannot send', async () => {
+    // Exactly the fields the Promotions form carries.
+    await repo.update(couponId, {
+      code: 'EID20',
+      type: 'percentage',
+      value: 25,
+      min_purchase: 500,
+      max_uses: 100,
+      scope: 'category',
+      stackable: true,
+    });
+
+    const coupon = await repo.findById(couponId);
+    expect(coupon!.max_uses_per_customer).toBe(1);
+    expect(coupon!.scope_ids).toEqual([3, 4]);
+    expect(Number(coupon!.value)).toBe(25);
+  });
+
+  it('clears the scope list only when the body says null', async () => {
+    await repo.update(couponId, { scope: 'all', scope_ids: null });
+
+    const coupon = await repo.findById(couponId);
+    expect(coupon!.scope).toBe('all');
+    expect(coupon!.scope_ids).toBeNull();
+  });
+
+  it('keeps stackable off when the body omits it', async () => {
+    await testPool.query('UPDATE coupons SET stackable = 0 WHERE id = $1', [couponId]);
+
+    await repo.update(couponId, { value: 30 });
+
+    expect(Number((await repo.findById(couponId))!.stackable)).toBe(0);
+  });
+
+  it('validates the percentage ceiling against the stored type, not the absent one', async () => {
+    // The body raises the value without re-sending `type`. Reading the ceiling off the
+    // body alone would let a 150% coupon through, because `type` is undefined there.
+    await expect(service.update(couponId, { value: 150 })).rejects.toBeInstanceOf(CouponError);
+
+    expect(Number((await repo.findById(couponId))!.value)).toBe(20);
+  });
+
+  it('allows a value above 100 once the body also switches the type to fixed', async () => {
+    const updated = await service.update(couponId, { type: 'fixed', value: 150 });
+
+    expect(updated.type).toBe('fixed');
+    expect(Number(updated.value)).toBe(150);
+  });
+});
+
+describe('couponUpdateSchema', () => {
+  it('carries no defaults, so absent scope and stackable stay absent', () => {
+    const parsed = couponUpdateSchema.parse({ value: 25 });
+
+    expect(parsed).toEqual({ value: 25 });
+    expect('scope' in parsed).toBe(false);
+    expect('stackable' in parsed).toBe(false);
+  });
+
+  it('still normalises and validates what is present', () => {
+    expect(couponUpdateSchema.parse({ code: ' eid20 ' })).toEqual({ code: 'EID20' });
+    expect(couponUpdateSchema.safeParse({ value: -1 }).success).toBe(false);
+    expect(couponUpdateSchema.safeParse({ code: 'ab' }).success).toBe(false);
+  });
+});

--- a/server/tests/database/partialUpdate.test.ts
+++ b/server/tests/database/partialUpdate.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The absent/null distinction, asserted on its own.
+ *
+ * Every repository that merges a partial update depends on exactly one rule: `undefined`
+ * is "the body did not mention this column", `null` is "the body asked to clear it". Get
+ * that backwards and the endpoint is back to #78 — a 200 and a field nobody mentioned
+ * quietly reset. Testing it here means each adopting repository only has to prove it wired
+ * its own columns up, not re-prove the rule.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildPartialUpdate, orNull } from '../../src/database/partialUpdate';
+
+describe('buildPartialUpdate', () => {
+  it('writes only the columns whose values are defined', () => {
+    const { setClause, params, nextIndex } = buildPartialUpdate({
+      name: 'Autumn window',
+      description: undefined,
+      is_featured: 1,
+    });
+
+    expect(setClause).toBe('name = $1, is_featured = $2, updated_at = NOW()');
+    expect(params).toEqual(['Autumn window', 1]);
+    expect(nextIndex).toBe(3);
+  });
+
+  it('writes an explicit null, because clearing a column is a real instruction', () => {
+    const { setClause, params } = buildPartialUpdate({ description: null, season: undefined });
+
+    expect(setClause).toBe('description = $1, updated_at = NOW()');
+    expect(params).toEqual([null]);
+  });
+
+  it('writes falsy values that are not undefined', () => {
+    // The bug this guards: a truthiness test would drop all three of these, and `0` on a
+    // boolean-ish column is exactly the value a caller most needs to be able to set.
+    const { setClause, params } = buildPartialUpdate({ is_featured: 0, rate: 0, note: '' });
+
+    expect(setClause).toBe('is_featured = $1, rate = $2, note = $3, updated_at = NOW()');
+    expect(params).toEqual([0, 0, '']);
+  });
+
+  it('still produces valid SQL when the body named no columns at all', () => {
+    // A collection edit that only replaced the product set reaches here with nothing to
+    // assign. It must still be a legal UPDATE that touches the row, not `SET  WHERE`.
+    const { setClause, params, nextIndex } = buildPartialUpdate({ name: undefined });
+
+    expect(setClause).toBe('updated_at = NOW()');
+    expect(params).toEqual([]);
+    expect(nextIndex).toBe(1);
+  });
+
+  it('numbers parameters from a caller-supplied offset', () => {
+    const { setClause, nextIndex } = buildPartialUpdate({ a: 1, b: 2 }, { startIndex: 4 });
+
+    expect(setClause).toBe('a = $4, b = $5, updated_at = NOW()');
+    expect(nextIndex).toBe(6);
+  });
+
+  it('takes the always-set fragments the caller names, or none', () => {
+    expect(buildPartialUpdate({ a: 1 }, { alwaysSet: [] }).setClause).toBe('a = $1');
+    expect(buildPartialUpdate({ a: 1 }, { alwaysSet: ['touched_at = NOW()'] }).setClause).toBe(
+      'a = $1, touched_at = NOW()'
+    );
+  });
+});
+
+describe('orNull', () => {
+  it('keeps undefined undefined, so an absent field stays absent', () => {
+    expect(orNull(undefined)).toBeUndefined();
+  });
+
+  it('maps a cleared form field to NULL, as these columns have always done', () => {
+    expect(orNull('')).toBeNull();
+    expect(orNull(null)).toBeNull();
+  });
+
+  it('passes a real value through', () => {
+    expect(orNull('Fall')).toBe('Fall');
+  });
+});

--- a/server/tests/shippingCompanies.test.ts
+++ b/server/tests/shippingCompanies.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Shipping companies: a partial PUT must not re-enable a disabled company (#78, same shape).
+ *
+ * `ShippingCompaniesDialog` sends `{ name, phone, website }` and nothing else. The endpoint
+ * parsed that with the create schema and SET all five columns, so `email` and
+ * `tracking_url_template` were wiped on every edit and `is_active`'s `.default(true)`
+ * re-enabled a company an admin had just disabled — a courier that had been taken out of
+ * service silently reappearing in the delivery form.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { ShippingCompaniesRepository } from '../src/modules/fulfillment/shippingCompanies/repository';
+import { shippingCompanyUpdateSchema } from '../src/modules/fulfillment/shippingCompanies/controller';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+
+describe('shipping companies partial update', () => {
+  let testPool: PgPool;
+  let companyId: number;
+  const repo = new ShippingCompaniesRepository();
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM shipping_companies');
+    const created = await testPool.query<{ id: number }>(
+      `INSERT INTO shipping_companies (name, phone, email, tracking_url_template, is_active)
+       VALUES ('Delta Courier', '01000000000', 'ops@delta.example', 'https://delta.example/t/{code}', 0)
+       RETURNING id`
+    );
+    companyId = created.rows[0].id;
+  });
+
+  const rowOf = async (id: number) => {
+    const { rows } = await testPool.query('SELECT * FROM shipping_companies WHERE id = $1', [id]);
+    return rows[0];
+  };
+
+  it('does not re-enable a disabled company when the body omits is_active', async () => {
+    // Exactly what the dialog sends.
+    await repo.update(companyId, { name: 'Delta Courier', phone: '01011112222' });
+
+    const row = await rowOf(companyId);
+    expect(Number(row.is_active)).toBe(0);
+    expect(row.phone).toBe('01011112222');
+  });
+
+  it('keeps the fields the dialog never sends', async () => {
+    await repo.update(companyId, { name: 'Delta Courier', phone: '01011112222' });
+
+    const row = await rowOf(companyId);
+    expect(row.email).toBe('ops@delta.example');
+    expect(row.tracking_url_template).toBe('https://delta.example/t/{code}');
+  });
+
+  it('still applies an explicit enable and an explicit clear', async () => {
+    await repo.update(companyId, { is_active: true });
+    expect(Number((await rowOf(companyId)).is_active)).toBe(1);
+
+    await repo.update(companyId, { tracking_url_template: null });
+    const row = await rowOf(companyId);
+    expect(row.tracking_url_template).toBeNull();
+    expect(Number(row.is_active)).toBe(1);
+  });
+});
+
+describe('shippingCompanyUpdateSchema', () => {
+  it('carries no is_active default, so an absent flag stays absent', () => {
+    const parsed = shippingCompanyUpdateSchema.parse({ name: 'Delta Courier' });
+
+    expect(parsed).toEqual({ name: 'Delta Courier' });
+    expect('is_active' in parsed).toBe(false);
+  });
+
+  it('still validates what is present', () => {
+    expect(shippingCompanyUpdateSchema.safeParse({ email: 'nope' }).success).toBe(false);
+    expect(shippingCompanyUpdateSchema.safeParse({ email: null }).success).toBe(true);
+  });
+});

--- a/server/tests/vendors.test.ts
+++ b/server/tests/vendors.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Vendors: a partial PUT must not reactivate a vendor (#78, same shape).
+ *
+ * `PUT /api/v1/vendors/:id` parsed the body with the create schema — every field optional,
+ * `commission_rate` and `status` carrying a `.default()` — and then SET all eight columns.
+ * The Vendors page sends four of them. So editing a vendor's phone number reset `status` to
+ * `'active'`, undoing a deactivation, and cleared `contact_person` and `tax_number`.
+ *
+ * pg-mem is enough: this is single-connection merge behaviour, not concurrency.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { VendorsRepository } from '../src/modules/commerce/vendors/repository';
+import { vendorUpdateSchema } from '../src/modules/commerce/vendors/controller';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+
+describe('vendors partial update', () => {
+  let testPool: PgPool;
+  let vendorId: number;
+  const repo = new VendorsRepository();
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM vendors');
+    const created = await testPool.query<{ id: number }>(
+      `INSERT INTO vendors (name, contact_person, email, phone, address, tax_number, commission_rate, status)
+       VALUES ('Nile Textiles', 'Mona', 'mona@nile.example', '01000000000', '5 Corniche', 'TAX-9', 12, 'inactive')
+       RETURNING id`
+    );
+    vendorId = created.rows[0].id;
+  });
+
+  const rowOf = async (id: number) => {
+    const { rows } = await testPool.query('SELECT * FROM vendors WHERE id = $1', [id]);
+    return rows[0];
+  };
+
+  it('does not reactivate a deactivated vendor when the body omits status', async () => {
+    // Exactly the four fields the Vendors page's edit form sends.
+    await repo.update(vendorId, {
+      name: 'Nile Textiles',
+      email: 'mona@nile.example',
+      phone: '01011112222',
+      address: '5 Corniche',
+    });
+
+    const row = await rowOf(vendorId);
+    expect(row.status).toBe('inactive');
+    expect(row.phone).toBe('01011112222');
+  });
+
+  it('keeps the fields the body never mentions', async () => {
+    await repo.update(vendorId, { phone: '01011112222' });
+
+    const row = await rowOf(vendorId);
+    expect(row.contact_person).toBe('Mona');
+    expect(row.tax_number).toBe('TAX-9');
+    expect(Number(row.commission_rate)).toBe(12);
+    expect(row.name).toBe('Nile Textiles');
+  });
+
+  it('still applies the fields it does mention, including a deliberate deactivation', async () => {
+    await repo.update(vendorId, { status: 'active', commission_rate: 0 });
+    expect((await rowOf(vendorId)).status).toBe('active');
+    // commission_rate 0 is falsy and must survive: a truthiness guard would drop it.
+    expect(Number((await rowOf(vendorId)).commission_rate)).toBe(0);
+
+    await repo.update(vendorId, { status: 'inactive' });
+    expect((await rowOf(vendorId)).status).toBe('inactive');
+  });
+
+  it('clears a nullable column when the body says null', async () => {
+    await repo.update(vendorId, { tax_number: null });
+
+    const row = await rowOf(vendorId);
+    expect(row.tax_number).toBeNull();
+    expect(row.contact_person).toBe('Mona');
+  });
+
+  it('leaves the row otherwise untouched when the body names nothing', async () => {
+    const before = await rowOf(vendorId);
+    const updated = await repo.update(vendorId, {});
+
+    expect(updated).not.toBeNull();
+    expect(updated!.name).toBe(before.name);
+    expect(updated!.status).toBe('inactive');
+  });
+});
+
+describe('vendorUpdateSchema', () => {
+  it('carries no defaults, so an absent field stays absent', () => {
+    // The create schema defaults `commission_rate` to 0 and `status` to 'active'. If the
+    // update schema kept those, the repository would receive them as *present* values and
+    // write them — the merge below the schema could not tell the difference.
+    const parsed = vendorUpdateSchema.parse({ phone: '01011112222' });
+
+    expect(parsed).toEqual({ phone: '01011112222' });
+    expect('status' in parsed).toBe(false);
+    expect('commission_rate' in parsed).toBe(false);
+  });
+
+  it('accepts an explicit null on a nullable column', () => {
+    expect(vendorUpdateSchema.parse({ tax_number: null })).toEqual({ tax_number: null });
+  });
+
+  it('still validates the fields that are present', () => {
+    expect(vendorUpdateSchema.safeParse({ email: 'not-an-email' }).success).toBe(false);
+    expect(vendorUpdateSchema.safeParse({ status: 'archived' }).success).toBe(false);
+    expect(vendorUpdateSchema.safeParse({ name: '' }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #78.

The ticket was one field on one page. The audit found **fourteen update paths with the same shape, four of them losing data in production right now.**

## The shape

```ts
// The create schema. Every field optional, some with defaults.
const thingSchema = z.object({ name: z.string(), is_featured: z.boolean().optional() });
// The update handler re-parses with it...
const parsed = thingSchema.parse(req.body);
// ...and the repository SETs every column from it.
`UPDATE things SET name = $1, is_featured = $2 ...`
```

A body naming three of four fields parses cleanly — the missing one is *optional*, so it is not a validation error — and the fourth column is written back as its default. The request returns 200 and a field nobody mentioned is gone, with nothing in the logs.

## What was actually being lost

| Module | Field | Consequence |
|---|---|---|
| `inventory/collections` | `is_featured` | The reported bug: editing products un-features the collection |
| `commerce/coupons` | `scope_ids`, `max_uses_per_customer` | **A coupon scoped to one category silently became valid on the whole catalogue** |
| `fulfillment/shippingCompanies` | `is_active`, `email`, `tracking_url_template` | A courier taken out of service reappearing |
| `commerce/vendors` | `status`, `contact_person`, `tax_number` | A deactivated vendor reactivated |

The coupon one is the expensive failure: an unnoticed scope reset is money out of the till, discovered from the revenue side rather than the error log.

## Direction: PATCH-style merge, not "send the full record"

The deciding evidence is in the client. `resource().useSave` PUTs exactly the keys a page put in its draft (`client/src/shared/lib/resource.ts`), so **every page in this app already sends a partial body**. The client was written as if the API were PATCH; the server just was not.

Demanding a whole record would have meant every caller learning every column — the same coupling, relocated rather than removed — and would have broken pages well beyond the one in the issue.

Implemented as a separate update schema, nullable where the column is and **with no `.default()`** — a default is precisely what turns "absent" back into "write this value" — plus a repository SET clause built only from the fields the body named. `undefined` means untouched, `null` means clear. Named once in `buildPartialUpdate` rather than re-derived per module.

Client side: `withProducts` now sends `{ id, product_ids }` and nothing else. It changes products, so it says products.

## Ten more, deliberately deferred

`customers`, `segments`, `storefront` banners, `branches`, `delivery`, `expenses`, `bundles`, `distributors`, `labelTemplates`, `products` + variants, `stockCounts` items.

Each is latent **only because its client happens to send a full body** — or, for `branches`/`bundles`/`stockCounts`, because the client sends a field name the schema rejects and 400s first. That is the part worth internalising:

> [!WARNING]
> **Fixing one of those client bugs turns its module into live data loss.** An omitted `stock` on products would zero inventory; an omitted `is_main` could demote the main branch.

Which is why the list is written into `docs/CONVENTIONS.md` under a new **Partial-update contract** section rather than left as folklore in a PR comment.

Converting all fourteen here would have been unreviewable, and the remaining ten need their client payloads inspected alongside. Five paths were already safe and are documented as the patterns to copy: `core/users` (separate schema, service merges with the stored row), `commerce/warranty` (`COALESCE($n, col)`), `core/settings` (per-key upsert), `inventory/categories`, `products/bulk-update` (`!== undefined` guards).

## Relation to #81

**Does not fix it, does not conflict with it.** `product_ids` present still means delete-all-and-reinsert, so the interleaving that drops a concurrently-appended product is unchanged.

Two real interactions:

1. **It shrinks the contended surface.** Both writers used to send all four scalar columns on every product edit, so a rename racing a reorder was *also* last-writer-wins on the row. A product edit now writes no scalar columns at all, so the two classes of edit no longer contend.
2. **`updated_at` semantics are preserved deliberately.** `alwaysSet: ['updated_at = NOW()']` carries the existing "every update touches the row" behaviour into the new zero-assignment case, so `updated_at` remains usable as a version column for #81's preferred optimistic-concurrency fix.

## Testing

The regression test was written first and watched fail. Before the fix all five cases in `collections partial update` failed, with the product-set case issuing a literal `UPDATE collections SET name = null, ...`.

| Check | Result |
|---|---|
| server `npm test` with `TEST_DATABASE_URL` | 533 passed / 49 files, all real-PG suites; `collections.concurrency` 7/7 |
| server `tsc --noEmit` | clean, delta 0 |
| server `eslint` | 0 errors |
| client `npm test` | 454 passed / 50 files |
| client `tsc --noEmit` | delta 0 against baseline (see #80 — the client typecheck is not CI-gated) |
| client `eslint` + `lint:cycles` | 0 errors, no cycles |

New: `collections.test.ts` partial-update cases, `coupons.partial.test.ts`, `vendors.test.ts`, `shippingCompanies.test.ts`, `database/partialUpdate.test.ts`, and `Collections.test.tsx` asserting the wire shape.

## Follow-up filed

**#83** — the same modal sends `status` and `year`, and both are silently discarded: `status` is not in the server schema and `year` has no column at all. That is the inverse defect (fields sent with nowhere to go rather than fields omitted and overwritten) and needs a migration, so it did not belong in a data-loss fix.

## Post-Deploy Monitoring & Validation

- **Verify the four fixed modules by hand once, in this order of value:** create a coupon scoped to one category, edit any other field, confirm the scope survives. Deactivate a shipping company, edit its name, confirm it stays inactive. Deactivate a vendor, edit it, confirm it stays deactivated. Feature a collection, edit its products, confirm it stays featured.
- **Watch:** `SELECT COUNT(*) FROM coupons WHERE scope_ids IS NULL AND scope_type IS NOT NULL` should stop growing. Same for shipping companies flipping back to `is_active = true` without an admin action.
- **Failure signal / rollback trigger:** a 400 on an update that used to succeed would mean the new schema is stricter than intended somewhere — the update schemas are deliberately *more* permissive than the create schemas, so this should not happen, but it is the regression to watch for.
- **Data already lost is not recovered by this.** Collections un-featured, coupons widened and vendors reactivated before this deploy stay that way; they need a manual audit against whatever record exists of their intended state.
- **Window:** 48h, plus one deliberate pass through the four flows above on day one.
- **Owner:** @zhamdy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN
