### PR TITLE
feat(sales): send the typed INSUFFICIENT_STOCK code with the numbers behind it

### DIFF
--- a/client/src/features/pos/components/checkout/StockConflictNotice.test.tsx
+++ b/client/src/features/pos/components/checkout/StockConflictNotice.test.tsx
@@ -8,6 +8,7 @@ function recovery(overrides: Partial<StockConflictRecovery> = {}): StockConflict
   return {
     shortfalls: [],
     isChecking: false,
+    adopt: vi.fn(),
     check: vi.fn(),
     resolve: vi.fn(),
     clear: vi.fn(),
@@ -37,8 +38,8 @@ describe('StockConflictNotice', () => {
       <StockConflictNotice
         conflict={recovery({
           shortfalls: [
-            { productId: 7, name: 'Silk Dress', requested: 4, available: 1 },
-            { productId: 9, name: 'Cashmere Scarf', requested: 2, available: 0 },
+            { productId: 7, variantId: null, name: 'Silk Dress', requested: 4, available: 1 },
+            { productId: 9, variantId: null, name: 'Cashmere Scarf', requested: 2, available: 0 },
           ],
         })}
       />
@@ -55,7 +56,9 @@ describe('StockConflictNotice', () => {
       <StockConflictNotice
         conflict={recovery({
           resolve,
-          shortfalls: [{ productId: 7, name: 'Silk Dress', requested: 4, available: 1 }],
+          shortfalls: [
+            { productId: 7, variantId: null, name: 'Silk Dress', requested: 4, available: 1 },
+          ],
         })}
       />
     );

--- a/client/src/features/pos/components/checkout/StockConflictNotice.tsx
+++ b/client/src/features/pos/components/checkout/StockConflictNotice.tsx
@@ -38,7 +38,10 @@ export default function StockConflictNotice({
       </p>
       <ul className="space-y-1">
         {conflict.shortfalls.map((shortfall) => (
-          <li key={shortfall.productId} className="text-xs text-foreground">
+          <li
+            key={`${shortfall.productId}:${shortfall.variantId ?? 0}`}
+            className="text-xs text-foreground"
+          >
             {t('cart.stockConflictLine', {
               name: shortfall.name,
               requested: shortfall.requested,

--- a/client/src/features/pos/hooks/useCheckoutSubmission.test.tsx
+++ b/client/src/features/pos/hooks/useCheckoutSubmission.test.tsx
@@ -331,16 +331,59 @@ describe('recovering from a rejected checkout', () => {
     );
   }
 
-  it('says which line is short and by how much, without parsing the server sentence', async () => {
-    const transport = transportWithStock(1);
-    const { result, settled } = renderSubmission(transport);
+  /** One INSUFFICIENT_STOCK detail, in the shape the sales controller now sends. */
+  function stockDetail(meta: Record<string, number | null>) {
+    return {
+      field: 'items',
+      code: 'INSUFFICIENT_STOCK',
+      message: 'Insufficient stock for product ID 7',
+      meta,
+    };
+  }
 
-    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+  it('takes the server’s own numbers and never re-reads stock for them', async () => {
+    const transport = transportWithStock(1);
+    const { result } = renderSubmission(transport);
+
+    transport.failNext(
+      'Insufficient stock for product ID 7',
+      400,
+      'VALIDATION_ERROR',
+      [stockDetail({ productId: 7, variantId: null, requested: 2, available: 1 })],
+      'sales'
+    );
     act(() => result.current.submit(COMPOSITION));
 
     await waitFor(() => expect(result.current.stockConflict.shortfalls).toHaveLength(1));
     expect(result.current.stockConflict.shortfalls[0]).toEqual({
       productId: 7,
+      variantId: null,
+      name: 'Silk Dress',
+      requested: 2,
+      available: 1,
+    });
+
+    // The point of the typed detail: no second trip to the server at the till.
+    expect(transport.calls().some((call) => call.path === 'products/lookup')).toBe(false);
+  });
+
+  it('says which line is short and by how much, without parsing the server sentence', async () => {
+    const transport = transportWithStock(1);
+    const { result, settled } = renderSubmission(transport);
+
+    transport.failNext(
+      'Insufficient stock for product ID 7',
+      400,
+      'VALIDATION_ERROR',
+      undefined,
+      'sales'
+    );
+    act(() => result.current.submit(COMPOSITION));
+
+    await waitFor(() => expect(result.current.stockConflict.shortfalls).toHaveLength(1));
+    expect(result.current.stockConflict.shortfalls[0]).toEqual({
+      productId: 7,
+      variantId: null,
       name: 'Silk Dress',
       requested: 2,
       available: 1,
@@ -354,7 +397,13 @@ describe('recovering from a rejected checkout', () => {
     const transport = transportWithStock(1);
     const { result } = renderSubmission(transport);
 
-    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    transport.failNext(
+      'Insufficient stock for product ID 7',
+      400,
+      'VALIDATION_ERROR',
+      undefined,
+      'sales'
+    );
     act(() => result.current.submit(COMPOSITION));
     await waitFor(() => expect(result.current.stockConflict.shortfalls).toHaveLength(1));
     expect(useCartStore.getState().items[0].quantity).toBe(2);
@@ -366,10 +415,18 @@ describe('recovering from a rejected checkout', () => {
   });
 
   it('removes a line whose product is gone entirely', async () => {
-    const transport = withSaleReply(createMemoryTransport({}, { reads: { 'products/lookup': [] } }));
+    const transport = withSaleReply(
+      createMemoryTransport({}, { reads: { 'products/lookup': [] } })
+    );
     const { result } = renderSubmission(transport);
 
-    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    transport.failNext(
+      'Insufficient stock for product ID 7',
+      400,
+      'VALIDATION_ERROR',
+      undefined,
+      'sales'
+    );
     act(() => result.current.submit(COMPOSITION));
     await waitFor(() => expect(result.current.stockConflict.shortfalls).toHaveLength(1));
 
@@ -407,7 +464,13 @@ describe('recovering from a rejected checkout', () => {
     const { result } = renderSubmission(transport);
 
     // No `reads` entry for products/lookup, so the memory transport rejects it.
-    transport.failNext('Insufficient stock for product ID 7', 400, 'VALIDATION_ERROR', undefined, 'sales');
+    transport.failNext(
+      'Insufficient stock for product ID 7',
+      400,
+      'VALIDATION_ERROR',
+      undefined,
+      'sales'
+    );
     act(() => result.current.submit(COMPOSITION));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));

--- a/client/src/features/pos/hooks/useCheckoutSubmission.ts
+++ b/client/src/features/pos/hooks/useCheckoutSubmission.ts
@@ -27,6 +27,7 @@ import {
   type SaleComposition,
 } from '../lib/salePayload';
 import { buildReceipt } from '../lib/saleReceipt';
+import { shortfallsFromDetails } from '../lib/stockConflict';
 import { useCartStore } from '../store/cartStore';
 import { useStockConflictRecovery, type StockConflictRecovery } from './useStockConflictRecovery';
 import type { CheckoutAttempt, SaleData, SaleResponse } from '../types';
@@ -186,13 +187,19 @@ export function useCheckoutSubmission(params: {
         return true;
       }
 
-      // Anything the server rejected on the state of the world -- stock,
-      // coupon, loyalty, a bundle -- arrives as a bare validation or conflict
-      // failure. Re-read stock to find out whether the cart is the reason and,
-      // if so, say which line and by how much. The toast still fires: this
-      // check is asynchronous and additive, not a replacement for telling the
-      // cashier immediately that the sale did not go through.
-      if (failure.recovery === 'fix' || failure.recovery === 'review') {
+      // A stock refusal now says so outright, one detail per oversold line with
+      // the product, the variant and the two numbers. Showing it costs nothing
+      // and is the only path that can speak for a variant line, whose stock the
+      // client cannot look up.
+      const stated = shortfallsFromDetails(failure.details, useCartStore.getState().items);
+      if (stated.length > 0) {
+        stockConflict.adopt(stated);
+      } else if (failure.recovery === 'fix' || failure.recovery === 'review') {
+        // No stock detail. The rejection may still have been about the cart --
+        // a coupon, loyalty or bundle failure reads the same from here -- so
+        // fall back to re-reading stock and comparing. The toast still fires:
+        // this check is asynchronous and additive, not a replacement for
+        // telling the cashier immediately that the sale did not go through.
         stockConflict.check();
       }
       // `saleFailed` only stands in when the server said nothing of its own;

--- a/client/src/features/pos/hooks/useStockConflictRecovery.ts
+++ b/client/src/features/pos/hooks/useStockConflictRecovery.ts
@@ -1,7 +1,11 @@
 /**
- * The recovery half of a rejected checkout: re-read stock for what is in the
- * cart, say what changed, and offer the one action that makes the cart
- * sellable again.
+ * The recovery half of a rejected checkout: say what no longer fits, and offer
+ * the one action that makes the cart sellable again.
+ *
+ * Two ways in. `adopt` takes the shortfalls the server stated in its rejection
+ * — the normal path, instant, and the only one that can speak for a variant
+ * line. `check` re-reads stock and works them out, for a rejection that named
+ * no stock detail but might still have been about the cart.
  *
  * Deliberately explicit rather than automatic. The cart is money the cashier
  * has already agreed with a customer standing in front of them; silently
@@ -24,6 +28,8 @@ import { useCartStore } from '../store/cartStore';
 export interface StockConflictRecovery {
   shortfalls: StockShortfall[];
   isChecking: boolean;
+  /** Show the shortfalls the server already named. No request. */
+  adopt: (shortfalls: StockShortfall[]) => void;
   /** Re-read stock for the cart and work out what no longer fits. */
   check: () => void;
   /** Apply the proposal: trim oversold lines, drop the ones with nothing left. */
@@ -41,6 +47,15 @@ export function useStockConflictRecovery(): StockConflictRecovery {
 
   const [shortfalls, setShortfalls] = useState<StockShortfall[]>([]);
   const [isChecking, setIsChecking] = useState(false);
+
+  const adopt = useCallback(
+    (next: StockShortfall[]) => {
+      setShortfalls(next);
+      // The POS grid is showing stock the server has just contradicted.
+      queryClient.invalidateQueries({ queryKey: ['products'] });
+    },
+    [queryClient]
+  );
 
   const check = useCallback(() => {
     const ids = checkableProductIds(useCartStore.getState().items);
@@ -81,5 +96,5 @@ export function useStockConflictRecovery(): StockConflictRecovery {
 
   const clear = useCallback(() => setShortfalls([]), []);
 
-  return { shortfalls, isChecking, check, resolve, clear };
+  return { shortfalls, isChecking, adopt, check, resolve, clear };
 }

--- a/client/src/features/pos/lib/stockConflict.test.ts
+++ b/client/src/features/pos/lib/stockConflict.test.ts
@@ -3,8 +3,10 @@ import {
   checkableProductIds,
   findStockShortfalls,
   planCartAdjustment,
+  shortfallsFromDetails,
   type StockShortfall,
 } from './stockConflict';
+import type { ValidationDetail } from '../../../shared/lib/transport/types';
 import type { CartItem } from '../store/cartStore';
 
 function line(overrides: Partial<CartItem> & { product_id: number }): CartItem {
@@ -44,7 +46,7 @@ describe('findStockShortfalls', () => {
     const items = [line({ product_id: 7, name: 'Silk Dress', quantity: 4 })];
 
     expect(findStockShortfalls(items, new Map([[7, 1]]))).toEqual<StockShortfall[]>([
-      { productId: 7, name: 'Silk Dress', requested: 4, available: 1 },
+      { productId: 7, variantId: null, name: 'Silk Dress', requested: 4, available: 1 },
     ]);
   });
 
@@ -55,7 +57,7 @@ describe('findStockShortfalls', () => {
     ];
 
     expect(findStockShortfalls(items, new Map([[7, 1]]))).toEqual<StockShortfall[]>([
-      { productId: 7, name: 'Silk Dress', requested: 2, available: 1 },
+      { productId: 7, variantId: null, name: 'Silk Dress', requested: 2, available: 1 },
     ]);
   });
 
@@ -64,7 +66,7 @@ describe('findStockShortfalls', () => {
     const items = [line({ product_id: 7, name: 'Silk Dress', quantity: 2 })];
 
     expect(findStockShortfalls(items, new Map())).toEqual<StockShortfall[]>([
-      { productId: 7, name: 'Silk Dress', requested: 2, available: 0 },
+      { productId: 7, variantId: null, name: 'Silk Dress', requested: 2, available: 0 },
     ]);
   });
 
@@ -84,7 +86,9 @@ describe('findStockShortfalls', () => {
 describe('planCartAdjustment', () => {
   it('trims an oversold line to what is left', () => {
     const items = [line({ product_id: 7, quantity: 4 })];
-    const shortfalls = [{ productId: 7, name: 'Silk Dress', requested: 4, available: 1 }];
+    const shortfalls = [
+      { productId: 7, variantId: null, name: 'Silk Dress', requested: 4, available: 1 },
+    ];
 
     expect(planCartAdjustment(items, shortfalls)).toEqual([
       { productId: 7, variantId: null, quantity: 1 },
@@ -93,7 +97,9 @@ describe('planCartAdjustment', () => {
 
   it('removes a line whose product has nothing left', () => {
     const items = [line({ product_id: 7, quantity: 2 })];
-    const shortfalls = [{ productId: 7, name: 'Silk Dress', requested: 2, available: 0 }];
+    const shortfalls = [
+      { productId: 7, variantId: null, name: 'Silk Dress', requested: 2, available: 0 },
+    ];
 
     expect(planCartAdjustment(items, shortfalls)).toEqual([
       { productId: 7, variantId: null, quantity: 0 },
@@ -105,7 +111,9 @@ describe('planCartAdjustment', () => {
       line({ product_id: 7, quantity: 1, memo: 'first' }),
       line({ product_id: 7, quantity: 1, memo: 'second' }),
     ];
-    const shortfalls = [{ productId: 7, name: 'Silk Dress', requested: 2, available: 1 }];
+    const shortfalls = [
+      { productId: 7, variantId: null, name: 'Silk Dress', requested: 2, available: 1 },
+    ];
 
     // The first line keeps its single unit and is therefore not adjusted at
     // all; only the second is emptied.
@@ -116,10 +124,97 @@ describe('planCartAdjustment', () => {
 
   it('leaves lines of products that are not short alone', () => {
     const items = [line({ product_id: 7, quantity: 1 }), line({ product_id: 9, quantity: 3 })];
-    const shortfalls = [{ productId: 9, name: 'Scarf', requested: 3, available: 2 }];
+    const shortfalls = [
+      { productId: 9, variantId: null, name: 'Scarf', requested: 3, available: 2 },
+    ];
 
     expect(planCartAdjustment(items, shortfalls)).toEqual([
       { productId: 9, variantId: null, quantity: 2 },
+    ]);
+  });
+});
+
+describe('shortfallsFromDetails', () => {
+  function detail(meta: ValidationDetail['meta']): ValidationDetail {
+    return { field: 'items', code: 'INSUFFICIENT_STOCK', message: 'Insufficient stock', meta };
+  }
+
+  it('reads the numbers the server stated, straight off the rejection', () => {
+    const items = [line({ product_id: 7, name: 'Silk Dress', quantity: 4 })];
+    const details = [detail({ productId: 7, variantId: null, requested: 4, available: 1 })];
+
+    expect(shortfallsFromDetails(details, items)).toEqual<StockShortfall[]>([
+      { productId: 7, variantId: null, name: 'Silk Dress', requested: 4, available: 1 },
+    ]);
+  });
+
+  it('speaks for a variant line, which the stock re-read cannot judge at all', () => {
+    const items = [line({ product_id: 7, variant_id: 3, name: 'Silk Dress / M', quantity: 2 })];
+    const details = [detail({ productId: 7, variantId: 3, requested: 2, available: 0 })];
+
+    expect(shortfallsFromDetails(details, items)).toEqual<StockShortfall[]>([
+      { productId: 7, variantId: 3, name: 'Silk Dress / M', requested: 2, available: 0 },
+    ]);
+  });
+
+  it('does not match a variant detail to the product-level line of the same product', () => {
+    const items = [line({ product_id: 7, name: 'Silk Dress', quantity: 2 })];
+    const details = [detail({ productId: 7, variantId: 3, requested: 2, available: 0 })];
+
+    expect(shortfallsFromDetails(details, items)).toEqual([]);
+  });
+
+  it('reports every oversold line the rejection named', () => {
+    const items = [
+      line({ product_id: 7, name: 'Silk Dress', quantity: 4 }),
+      line({ product_id: 9, name: 'Scarf', quantity: 3 }),
+    ];
+    const details = [
+      detail({ productId: 7, variantId: null, requested: 4, available: 1 }),
+      detail({ productId: 9, variantId: null, requested: 3, available: 2 }),
+    ];
+
+    expect(shortfallsFromDetails(details, items)).toHaveLength(2);
+  });
+
+  it('ignores details carrying any other code', () => {
+    const items = [line({ product_id: 7, quantity: 4 })];
+    const details: ValidationDetail[] = [
+      { field: 'payments', code: 'SPLIT_PAYMENT_MISMATCH', message: 'Mismatch' },
+    ];
+
+    expect(shortfallsFromDetails(details, items)).toEqual([]);
+  });
+
+  it('drops a detail naming a line the cart no longer has, rather than showing it nameless', () => {
+    const items = [line({ product_id: 7, quantity: 1 })];
+    const details = [detail({ productId: 999, variantId: null, requested: 1, available: 0 })];
+
+    expect(shortfallsFromDetails(details, items)).toEqual([]);
+  });
+
+  it('drops a detail whose meta is missing or malformed rather than rendering NaN', () => {
+    const items = [line({ product_id: 7, quantity: 1 })];
+
+    expect(shortfallsFromDetails([detail(undefined)], items)).toEqual([]);
+    expect(
+      shortfallsFromDetails([detail({ productId: 7, requested: 'four', available: 1 })], items)
+    ).toEqual([]);
+  });
+});
+
+describe('planCartAdjustment for variant lines', () => {
+  it('trims the variant line the server named and leaves the product line alone', () => {
+    const items = [
+      line({ product_id: 7, quantity: 2 }),
+      line({ product_id: 7, variant_id: 3, quantity: 4 }),
+    ];
+    const shortfalls = [
+      { productId: 7, variantId: 3, name: 'Silk Dress / M', requested: 4, available: 1 },
+    ];
+
+    expect(planCartAdjustment(items, shortfalls)).toEqual([
+      { productId: 7, variantId: 3, quantity: 1 },
     ]);
   });
 });

--- a/client/src/features/pos/lib/stockConflict.ts
+++ b/client/src/features/pos/lib/stockConflict.ts
@@ -1,37 +1,38 @@
 /**
- * What a rejected checkout means for the cart, worked out from stock rather
- * than from the rejection's wording.
+ * What a rejected checkout means for the cart.
  *
- * The server refuses an oversold line with `Insufficient stock for product ID
- * 7` under a bare VALIDATION_ERROR — the typed `INSUFFICIENT_STOCK` code
- * exists in `server/src/modules/pos/sales/types.ts` but the controller drops
- * it before the response is built. So the client has no reliable code to
- * branch on, and the message is an English sentence naming a database id: not
- * translatable, and not something a cashier can act on.
+ * The server now names it outright: a checkout refused on stock comes back with
+ * one `INSUFFICIENT_STOCK` detail per oversold line, carrying the product, the
+ * variant, how many were asked for and how many are really left
+ * (`server/src/modules/pos/stockConflict.ts`). `shortfallsFromDetails` reads
+ * that directly — no round-trip, and correct for variant lines, whose stock the
+ * client cannot look up at all.
  *
- * Rather than parse that sentence, this module re-reads the stock for what is
- * in the cart and reports the difference. That says *which product*, *how many
- * were asked for* and *how many are left*, in the cashier's own language, and
- * it keeps working if the server's wording ever changes.
+ * The stock re-read below is the fallback for a rejection that carries no such
+ * detail: a coupon, loyalty or bundle failure, where the cart may still be the
+ * real reason. It compares the cart against fresh stock and reports the
+ * difference. That path is why `findStockShortfalls` still exists.
  *
- * ## Variant lines are not checked
+ * ## Variant lines and the fallback
  *
  * `GET /api/v1/products/lookup` returns product-level stock only, and variant
- * stock is a separate column decremented by a separate statement
- * (`decrementVariantStock`). There is no bulk endpoint for it, so a variant
- * line is left out entirely rather than compared against a number that is not
- * its own. A checkout that failed purely on a variant line therefore falls
- * back to the plain classified message — which is the behaviour that existed
- * before this module, not a regression.
+ * stock is a separate column decremented by a separate statement. So the
+ * fallback still leaves variant lines out rather than comparing them against a
+ * number that is not their own. Only the typed detail can speak for them, and
+ * now it does.
  */
 import type { CartItem } from '../store/cartStore';
+import type { ValidationDetail } from '../../../shared/lib/transport/types';
+import { INSUFFICIENT_STOCK_CODE } from '../../../shared/lib/mutationError';
 
 export interface StockShortfall {
   productId: number;
+  /** Null for a product-level line; set when it is one specific variant that is short. */
+  variantId: number | null;
   name: string;
-  /** Total quantity the cart asks for across every non-variant line. */
+  /** How many the cart asks for. */
   requested: number;
-  /** What the server says is left. Zero for a product that has disappeared. */
+  /** What the server says is left. Zero for a line that can no longer be sold at all. */
   available: number;
 }
 
@@ -71,7 +72,13 @@ export function findStockShortfalls(
   for (const [productId, { name, quantity }] of requested) {
     const available = freshStock.get(productId) ?? 0;
     if (quantity > available) {
-      shortfalls.push({ productId, name, requested: quantity, available: Math.max(0, available) });
+      shortfalls.push({
+        productId,
+        variantId: null,
+        name,
+        requested: quantity,
+        available: Math.max(0, available),
+      });
     }
   }
   return shortfalls;
@@ -91,27 +98,73 @@ export interface LineAdjustment {
   quantity: number;
 }
 
+/** A shortfall and a cart line address the same stock only if both halves match. */
+function lineKey(productId: number, variantId: number | null): string {
+  return variantId ? `v:${variantId}` : `p:${productId}`;
+}
+
 export function planCartAdjustment(
   items: readonly CartItem[],
   shortfalls: readonly StockShortfall[]
 ): LineAdjustment[] {
-  const remaining = new Map(shortfalls.map((s) => [s.productId, s.available]));
+  const remaining = new Map(
+    shortfalls.map((s) => [lineKey(s.productId, s.variantId), s.available])
+  );
   const adjustments: LineAdjustment[] = [];
 
   for (const item of items) {
-    if (item.variant_id) continue;
-    const left = remaining.get(item.product_id);
+    const variantId = item.variant_id ?? null;
+    const key = lineKey(item.product_id, variantId);
+    const left = remaining.get(key);
+    // A line the shortfalls do not name is one the server did not refuse: leave it alone.
     if (left === undefined) continue;
     const quantity = Math.min(item.quantity, left);
-    remaining.set(item.product_id, left - quantity);
+    remaining.set(key, left - quantity);
     if (quantity !== item.quantity) {
-      adjustments.push({
-        productId: item.product_id,
-        variantId: item.variant_id ?? null,
-        quantity,
-      });
+      adjustments.push({ productId: item.product_id, variantId, quantity });
     }
   }
 
   return adjustments;
+}
+
+/**
+ * The shortfalls a rejection stated outright, or an empty list when it stated none.
+ *
+ * The cart supplies only the product name — the server sends ids, and a cashier needs
+ * to be told which garment, not which row. A detail naming a line no longer in the cart
+ * is dropped rather than shown nameless: the cart has moved on and adjusting it against
+ * that line would mean nothing.
+ */
+export function shortfallsFromDetails(
+  details: readonly ValidationDetail[],
+  items: readonly CartItem[]
+): StockShortfall[] {
+  const names = new Map(
+    items.map((item) => [lineKey(item.product_id, item.variant_id ?? null), item.name])
+  );
+  const shortfalls: StockShortfall[] = [];
+
+  for (const detail of details) {
+    if (detail.code !== INSUFFICIENT_STOCK_CODE) continue;
+    const productId = asCount(detail.meta?.productId);
+    const requested = asCount(detail.meta?.requested);
+    const available = asCount(detail.meta?.available);
+    if (productId === null || requested === null || available === null) continue;
+
+    const rawVariant = detail.meta?.variantId;
+    const variantId = typeof rawVariant === 'number' && rawVariant > 0 ? rawVariant : null;
+
+    const name = names.get(lineKey(productId, variantId));
+    if (name === undefined) continue;
+
+    shortfalls.push({ productId, variantId, name, requested, available });
+  }
+
+  return shortfalls;
+}
+
+/** Guards against a malformed `meta`: a number the client can count with, or nothing. */
+function asCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
 }

--- a/client/src/shared/lib/mutationError.ts
+++ b/client/src/shared/lib/mutationError.ts
@@ -17,19 +17,16 @@
  *   VALIDATION_ERROR (400) · UNAUTHORIZED (401) · FORBIDDEN (403)
  *   NOT_FOUND (404) · CONFLICT (409) · RATE_LIMITED (429) · INTERNAL_ERROR (500)
  *
- * `details[]` carries `{ field, code, message }` triples — Zod issues for a
- * validation rejection, and a handful of hand-written domain codes riding
- * under a generic parent (`IDEMPOTENCY_KEY_REUSED` and `IDEMPOTENCY_UNRESOLVED`
- * under CONFLICT, `SPLIT_PAYMENT_MISMATCH` under VALIDATION_ERROR).
+ * `details[]` carries `{ field, code, message }` triples, optionally with a
+ * scalar `meta` — Zod issues for a validation rejection, and a handful of
+ * hand-written domain codes riding under a generic parent
+ * (`IDEMPOTENCY_KEY_REUSED` and `IDEMPOTENCY_UNRESOLVED` under CONFLICT,
+ * `SPLIT_PAYMENT_MISMATCH` and `INSUFFICIENT_STOCK` under VALIDATION_ERROR).
  *
- * Deliberately NOT invented here: codes the server does not send. Notably
- * `INSUFFICIENT_STOCK` exists in `server/src/modules/pos/sales/types.ts` but
- * the controller drops it, re-wrapping the error as a bare VALIDATION_ERROR
- * with an English sentence. So this module cannot classify a stock conflict,
- * and does not pretend to: POS recovers from one by comparing the cart against
- * freshly-fetched stock (`features/pos/lib/stockConflict.ts`) rather than by
- * parsing a message. The constant below is honoured if the server ever starts
- * sending it, and costs nothing until then.
+ * Deliberately NOT invented here: codes the server does not send. A code this
+ * module recognises must be one some controller demonstrably puts on the wire,
+ * because a code that never arrives reads as a contract that exists when it
+ * does not.
  *
  * ## Message safety
  *
@@ -110,8 +107,9 @@ export interface MutationFailure {
 }
 
 /**
- * Recognised if the server ever forwards it (see the header note); today the
- * sales controller drops the code, so nothing matches this in practice.
+ * Sent by both POS refusal paths, one detail per oversold line, with the
+ * product, variant, requested and available in `meta`. POS reads it through
+ * `features/pos/lib/stockConflict.ts` rather than parsing the message.
  */
 export const INSUFFICIENT_STOCK_CODE = 'INSUFFICIENT_STOCK';
 

--- a/client/src/shared/lib/transport/memory.ts
+++ b/client/src/shared/lib/transport/memory.ts
@@ -1,5 +1,11 @@
 import { isValidIdempotencyKey } from './idempotency';
-import { ApiError, type Transport, type TransportRequest, type TransportResult } from './types';
+import {
+  ApiError,
+  type Transport,
+  type TransportRequest,
+  type TransportResult,
+  type ValidationDetail,
+} from './types';
 
 type Row = Record<string, unknown>;
 
@@ -39,7 +45,7 @@ export interface MemoryTransport extends Transport {
     message: string,
     status?: number,
     code?: string,
-    details?: { field: string; code: string; message: string }[],
+    details?: ValidationDetail[],
     matchPath?: string
   ): void;
 }

--- a/client/src/shared/lib/transport/types.ts
+++ b/client/src/shared/lib/transport/types.ts
@@ -53,6 +53,13 @@ export interface ValidationDetail {
   field: string;
   code: string;
   message: string;
+  /**
+   * Machine-readable specifics for a detail whose `code` names a domain event rather
+   * than a Zod issue. `message` is English prose written for a person, so anything a
+   * program must branch on arrives here instead. Keys are documented by the code that
+   * sends them (see `server/src/modules/pos/stockConflict.ts` for INSUFFICIENT_STOCK).
+   */
+  meta?: Record<string, string | number | boolean | null>;
 }
 
 export interface StructuredApiError {

--- a/server/src/docs/openapi.ts
+++ b/server/src/docs/openapi.ts
@@ -1726,6 +1726,14 @@ export const openApiSpec = {
           'no `sale_payments` rows are created and no sum check applies. A mismatched/invalid split is ' +
           'rejected with `400 VALIDATION_ERROR` and a `details[].code` of `SPLIT_PAYMENT_MISMATCH`, and ' +
           'persists nothing (no sale, items, payments, or register movement).\n\n' +
+          '**Insufficient stock:** a line that cannot be taken out of stock is rejected with ' +
+          '`400 VALIDATION_ERROR` carrying one `details[]` entry per oversold line, each with ' +
+          '`code === "INSUFFICIENT_STOCK"` and a `meta` of `{ productId, variantId, requested, ' +
+          'available }`. `variantId` is null for a product-level line. `available` is what the ' +
+          'caller could actually have had: the refused transaction rolls back, so its own writes ' +
+          'are excluded from that figure, and a row that no longer exists reports 0. The ' +
+          'pre-check reports every short line at once; a refusal from the guarded decrement can ' +
+          'only report the single line it refused. Nothing is persisted either way.\n\n' +
           '**Idempotency:** supply an `Idempotency-Key` header to make a retry return the original ' +
           'sale instead of ringing up a second one. A replayed response is byte-identical and carries ' +
           '`Idempotent-Replay: true`; it also suppresses the sale notification and the audit entry, so ' +
@@ -1823,7 +1831,8 @@ export const openApiSpec = {
           '400': {
             description:
               'Validation error / Bad request. A split-payment mismatch is reported here with ' +
-              '`details[].code === "SPLIT_PAYMENT_MISMATCH"`.',
+              '`details[].code === "SPLIT_PAYMENT_MISMATCH"`, and an oversold line with ' +
+              '`details[].code === "INSUFFICIENT_STOCK"`.',
           },
           '401': {
             description: 'Unauthorized / Missing or invalid token',

--- a/server/src/http/errors.ts
+++ b/server/src/http/errors.ts
@@ -13,6 +13,15 @@ export interface ValidationDetail {
   field: string;
   code: string;
   message: string;
+  /**
+   * Machine-readable specifics for a detail whose `code` names a domain event rather
+   * than a Zod issue — the numbers a client needs to render the rejection without
+   * parsing `message`, which is English and not addressed to a program.
+   *
+   * Deliberately untyped beyond scalars: the HTTP layer stays free of any one module's
+   * vocabulary, and each domain code documents its own keys where it is thrown.
+   */
+  meta?: Record<string, string | number | boolean | null>;
 }
 
 export interface ErrorBody {

--- a/server/src/modules/pos/exchanges/controller.ts
+++ b/server/src/modules/pos/exchanges/controller.ts
@@ -4,6 +4,7 @@ import { AuthRequest } from '../../../../middleware/auth';
 import { logAuditFromReq } from '../../../../middleware/auditLogger';
 import { exchangesService, ExchangeStockError, IExchangesService } from './service';
 import { PublicError } from '../../../http/errors';
+import { stockConflictDetail } from '../stockConflict';
 import {
   IDEMPOTENCY_REPLAY_HEADER,
   readIdempotencyKey,
@@ -86,7 +87,20 @@ export class ExchangesController {
         return;
       }
       if (err instanceof ExchangeStockError) {
-        next(new PublicError('VALIDATION_ERROR', err.message));
+        // Same detail shape the checkout path sends: one stock refusal, one contract.
+        next(
+          new PublicError('VALIDATION_ERROR', err.message, [
+            stockConflictDetail(
+              {
+                productId: err.productId,
+                variantId: err.variantId,
+                requested: err.requested,
+                available: err.available,
+              },
+              err.message
+            ),
+          ])
+        );
         return;
       }
       next(

--- a/server/src/modules/pos/exchanges/controller.ts
+++ b/server/src/modules/pos/exchanges/controller.ts
@@ -4,7 +4,7 @@ import { AuthRequest } from '../../../../middleware/auth';
 import { logAuditFromReq } from '../../../../middleware/auditLogger';
 import { exchangesService, ExchangeStockError, IExchangesService } from './service';
 import { PublicError } from '../../../http/errors';
-import { stockConflictDetail } from '../stockConflict';
+import { stockConflictDetails } from '../stockConflict';
 import {
   IDEMPOTENCY_REPLAY_HEADER,
   readIdempotencyKey,
@@ -89,17 +89,11 @@ export class ExchangesController {
       if (err instanceof ExchangeStockError) {
         // Same detail shape the checkout path sends: one stock refusal, one contract.
         next(
-          new PublicError('VALIDATION_ERROR', err.message, [
-            stockConflictDetail(
-              {
-                productId: err.productId,
-                variantId: err.variantId,
-                requested: err.requested,
-                available: err.available,
-              },
-              err.message
-            ),
-          ])
+          new PublicError(
+            'VALIDATION_ERROR',
+            err.message,
+            stockConflictDetails(err.conflicts, err.message)
+          )
         );
         return;
       }

--- a/server/src/modules/pos/exchanges/repository.ts
+++ b/server/src/modules/pos/exchanges/repository.ts
@@ -36,6 +36,8 @@ export interface IExchangesRepository {
     quantity: number,
     queryable: Queryable
   ): Promise<number | null>;
+  getProductStock(productId: number, queryable: Queryable): Promise<number | null>;
+  getVariantStock(variantId: number, queryable: Queryable): Promise<number | null>;
   listExchanges(
     filters: {
       search?: string;
@@ -170,6 +172,30 @@ export class ExchangesRepository implements IExchangesRepository {
         WHERE id = $2 AND stock >= $1::int
         RETURNING stock`,
       [quantity, productId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /**
+   * Reads stock without taking it, for the refusal path only: the guarded UPDATEs above
+   * return nothing when they match no row, so how much was actually there has to be
+   * asked for separately.
+   *
+   * @returns the current stock, or null when the row no longer exists.
+   */
+  async getProductStock(productId: number, queryable: Queryable): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /** Variant counterpart of {@link getProductStock}. */
+  async getVariantStock(variantId: number, queryable: Queryable): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      'SELECT stock FROM product_variants WHERE id = $1',
+      [variantId]
     );
     return res.rows[0] ? Number(res.rows[0].stock) : null;
   }

--- a/server/src/modules/pos/exchanges/service.ts
+++ b/server/src/modules/pos/exchanges/service.ts
@@ -2,7 +2,7 @@ import { Queryable, withTransaction } from '../../../database/transaction';
 import { IExchangesRepository, exchangesRepository as defaultRepo } from './repository';
 import { CreateExchangeDTO, ExchangeFilters, ExchangeRow, ExchangeDetail } from './types';
 import { sortForStockWrites } from '../stockWriteOrder';
-import { INSUFFICIENT_STOCK_CODE } from '../sales/types';
+import { INSUFFICIENT_STOCK_CODE, type StockConflict } from '../sales/types';
 
 /**
  * A new exchange line could not be taken out of stock. Rolls the whole exchange back.
@@ -12,10 +12,7 @@ import { INSUFFICIENT_STOCK_CODE } from '../sales/types';
 export class ExchangeStockError extends Error {
   constructor(
     message: string,
-    public readonly productId: number,
-    public readonly variantId: number | null,
-    public readonly requested: number = 0,
-    public readonly available: number = 0,
+    public readonly conflicts: readonly StockConflict[],
     public readonly code: string = INSUFFICIENT_STOCK_CODE,
     public readonly statusCode: number = 400
   ) {
@@ -165,12 +162,16 @@ export class ExchangesService implements IExchangesService {
           write.variant_id
             ? `Insufficient stock for variant ID ${write.variant_id}`
             : `Insufficient stock for product ID ${write.product_id}`,
-          write.product_id,
-          write.variant_id ?? null,
-          quantity,
-          // A deleted row reads as null, and is reported as zero available: for a
-          // cashier, "not enough" and "gone" mean the same thing here.
-          Math.max(0, (current ?? 0) - (appliedSoFar.get(stockKey) ?? 0))
+          [
+            {
+              productId: write.product_id,
+              variantId: write.variant_id ?? null,
+              requested: quantity,
+              // A deleted row reads as null, and is reported as zero available: for a
+              // cashier, "not enough" and "gone" mean the same thing here.
+              available: Math.max(0, (current ?? 0) - (appliedSoFar.get(stockKey) ?? 0)),
+            },
+          ]
         );
       }
 

--- a/server/src/modules/pos/exchanges/service.ts
+++ b/server/src/modules/pos/exchanges/service.ts
@@ -14,6 +14,8 @@ export class ExchangeStockError extends Error {
     message: string,
     public readonly productId: number,
     public readonly variantId: number | null,
+    public readonly requested: number = 0,
+    public readonly available: number = 0,
     public readonly code: string = INSUFFICIENT_STOCK_CODE,
     public readonly statusCode: number = 400
   ) {
@@ -123,13 +125,24 @@ export class ExchangesService implements IExchangesService {
       ...data.new_items.map((item) => ({ ...item, delta: -item.quantity })),
     ]);
 
+    // The net change this transaction has already made to each stock row. Read only on
+    // the refusal path: every one of these writes is about to be rolled back, so they
+    // have to come back out of the figure reported to the cashier. A returned item
+    // restocked a moment ago is not stock they can sell on this exchange.
+    const appliedSoFar = new Map<string, number>();
+    const stockKeyOf = (write: { product_id: number; variant_id?: number | null }): string =>
+      write.variant_id ? `v:${write.variant_id}` : `p:${write.product_id}`;
+
     for (const write of stockWrites) {
+      const stockKey = stockKeyOf(write);
+
       if (write.delta > 0) {
         if (write.variant_id) {
           await this.repo.restockVariant(write.variant_id, write.delta, client);
         } else {
           await this.repo.restockProduct(write.product_id, write.delta, client);
         }
+        appliedSoFar.set(stockKey, (appliedSoFar.get(stockKey) ?? 0) + write.delta);
         continue;
       }
 
@@ -141,14 +154,27 @@ export class ExchangesService implements IExchangesService {
       if (remaining === null) {
         // The guarded UPDATE matched nothing: not enough stock, or the row is gone.
         // Throwing rolls the whole exchange back, so no returned-item restock survives.
+        //
+        // Read the row first: this is the only point where the true figure exists, and
+        // sending it saves the client a round-trip to rediscover it.
+        const current = write.variant_id
+          ? await this.repo.getVariantStock(write.variant_id, client)
+          : await this.repo.getProductStock(write.product_id, client);
+
         throw new ExchangeStockError(
           write.variant_id
             ? `Insufficient stock for variant ID ${write.variant_id}`
             : `Insufficient stock for product ID ${write.product_id}`,
           write.product_id,
-          write.variant_id ?? null
+          write.variant_id ?? null,
+          quantity,
+          // A deleted row reads as null, and is reported as zero available: for a
+          // cashier, "not enough" and "gone" mean the same thing here.
+          Math.max(0, (current ?? 0) - (appliedSoFar.get(stockKey) ?? 0))
         );
       }
+
+      appliedSoFar.set(stockKey, (appliedSoFar.get(stockKey) ?? 0) + write.delta);
     }
 
     return exchange;

--- a/server/src/modules/pos/sales/controller.ts
+++ b/server/src/modules/pos/sales/controller.ts
@@ -6,6 +6,7 @@ import { saleSchema, refundSchema } from '../../../../validators/saleSchema';
 import { salesService } from './service';
 import { salesRepository } from './repository';
 import { parseSaleListQuery, SalesValidationError, InsufficientStockError } from './types';
+import { stockConflictDetail } from '../stockConflict';
 import { CouponError } from '../../commerce/coupons/types';
 import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
@@ -128,9 +129,22 @@ export class SalesController {
         return;
       }
       if (err instanceof InsufficientStockError) {
-        // Same 400 and same wording as before; the error is merely typed now, so the
-        // string-matching list below stops growing.
-        next(new PublicError('VALIDATION_ERROR', err.message));
+        // Same 400 and same wording as before. The typed code and the numbers ride in
+        // `details[]`, where every other domain code rides: the envelope's code stays
+        // one of the seven public ones so a client never has to widen that union.
+        next(
+          new PublicError('VALIDATION_ERROR', err.message, [
+            stockConflictDetail(
+              {
+                productId: err.productId,
+                variantId: err.variantId,
+                requested: err.requested,
+                available: err.available,
+              },
+              err.message
+            ),
+          ])
+        );
         return;
       }
       if (err instanceof CouponError) {

--- a/server/src/modules/pos/sales/controller.ts
+++ b/server/src/modules/pos/sales/controller.ts
@@ -6,7 +6,7 @@ import { saleSchema, refundSchema } from '../../../../validators/saleSchema';
 import { salesService } from './service';
 import { salesRepository } from './repository';
 import { parseSaleListQuery, SalesValidationError, InsufficientStockError } from './types';
-import { stockConflictDetail } from '../stockConflict';
+import { stockConflictDetails } from '../stockConflict';
 import { CouponError } from '../../commerce/coupons/types';
 import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
@@ -133,17 +133,11 @@ export class SalesController {
         // `details[]`, where every other domain code rides: the envelope's code stays
         // one of the seven public ones so a client never has to widen that union.
         next(
-          new PublicError('VALIDATION_ERROR', err.message, [
-            stockConflictDetail(
-              {
-                productId: err.productId,
-                variantId: err.variantId,
-                requested: err.requested,
-                available: err.available,
-              },
-              err.message
-            ),
-          ])
+          new PublicError(
+            'VALIDATION_ERROR',
+            err.message,
+            stockConflictDetails(err.conflicts, err.message)
+          )
         );
         return;
       }

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -84,6 +84,8 @@ export interface ISalesRepository {
     quantity: number,
     queryable: Queryable
   ): Promise<number | null>;
+  getProductStock(productId: number, queryable: Queryable): Promise<number | null>;
+  getVariantStock(variantId: number, queryable: Queryable): Promise<number | null>;
   createStockAdjustment(data: Record<string, any>, queryable: Queryable): Promise<void>;
   getSetting(key: string, queryable?: Queryable): Promise<string | undefined>;
   getCouponByCode(code: string, queryable?: Queryable): Promise<Record<string, any> | null>;
@@ -557,6 +559,30 @@ export class SalesRepository implements ISalesRepository {
         WHERE id = $2 AND stock >= $1::int
         RETURNING stock`,
       [quantity, variantId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /**
+   * Reads stock without taking it. Used only on the refusal path, to report how much was
+   * actually there — the guarded UPDATE above returns nothing when it matches no row, so
+   * the number the cashier needs is not otherwise recoverable.
+   *
+   * @returns the current stock, or null when the row no longer exists.
+   */
+  async getProductStock(productId: number, queryable: Queryable): Promise<number | null> {
+    const res = await queryable.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /** Variant counterpart of {@link getProductStock}. */
+  async getVariantStock(variantId: number, queryable: Queryable): Promise<number | null> {
+    const res = await queryable.query<{ stock: number }>(
+      'SELECT stock FROM product_variants WHERE id = $1',
+      [variantId]
     );
     return res.rows[0] ? Number(res.rows[0].stock) : null;
   }

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -257,7 +257,13 @@ export class SalesService {
         );
         if (!variant) throw new Error(`Variant not found: ID ${item.variant_id}`);
         if (checkStock && Number(variant.stock) < item.quantity) {
-          throw new Error(`Insufficient stock for variant ID ${item.variant_id}`);
+          throw new InsufficientStockError(
+            `Insufficient stock for variant ID ${item.variant_id}`,
+            item.product_id,
+            item.variant_id,
+            item.quantity,
+            Math.max(0, Number(variant.stock))
+          );
         }
         const unitPrice = Number(variant.price);
         resolvedItems.push({
@@ -274,7 +280,13 @@ export class SalesService {
         const product = await this.repo.getProductById(item.product_id, queryable);
         if (!product) throw new Error(`Product not found: ID ${item.product_id}`);
         if (checkStock && Number(product.stock) < item.quantity) {
-          throw new Error(`Insufficient stock for product ID ${item.product_id}`);
+          throw new InsufficientStockError(
+            `Insufficient stock for product ID ${item.product_id}`,
+            item.product_id,
+            null,
+            item.quantity,
+            Math.max(0, Number(product.stock))
+          );
         }
         const unitPrice = Number(product.price);
         resolvedItems.push({
@@ -400,7 +412,13 @@ export class SalesService {
       const product = await this.repo.getProductById(bi.product_id, queryable);
       if (!product) throw new Error(`Product not found: ID ${bi.product_id}`);
       if (checkStock && Number(product.stock) < requestedQty) {
-        throw new Error(`Insufficient stock for product ID ${bi.product_id}`);
+        throw new InsufficientStockError(
+          `Insufficient stock for product ID ${bi.product_id}`,
+          bi.product_id,
+          null,
+          requestedQty,
+          Math.max(0, Number(product.stock))
+        );
       }
 
       const lineTotalMinor = lineTotalsMinor[i];
@@ -692,8 +710,14 @@ export class SalesService {
       // Stock writes run in a canonical order instead of the request's. Two concurrent
       // two-line checkouts naming the same products in opposite order would otherwise
       // take row locks in opposite order and deadlock. Sorting removes the cycle.
+      // What this transaction has already taken, per stock row. Only read on the refusal
+      // path, where it is added back to turn the mid-transaction stock into the figure
+      // the cashier could actually have had — the rollback un-takes all of it.
+      const takenSoFar = new Map<string, number>();
+
       for (const item of sortForStockWrites(resolvedItems)) {
         const isVariantLine = Boolean(item.isVariant && item.variant_id);
+        const stockKey = isVariantLine ? `v:${item.variant_id}` : `p:${item.product_id}`;
 
         const newStock = isVariantLine
           ? await this.repo.decrementVariantStock(item.variant_id!, item.quantity, client)
@@ -704,14 +728,28 @@ export class SalesService {
           // deleted between resolve and write. Either way the transaction rolls back and
           // no partial sale survives. The check in resolveLines is only a fail-fast
           // courtesy; this is the authority.
+          //
+          // Before unwinding, read what is actually there. This is the only point at
+          // which the true number is known, and sending it spares the client a second
+          // round-trip at the till to rediscover it.
+          const remaining = isVariantLine
+            ? await this.repo.getVariantStock(item.variant_id!, client)
+            : await this.repo.getProductStock(item.product_id, client);
+
           throw new InsufficientStockError(
             isVariantLine
               ? `Insufficient stock for variant ID ${item.variant_id}`
               : `Insufficient stock for product ID ${item.product_id}`,
             item.product_id,
-            isVariantLine ? item.variant_id! : null
+            isVariantLine ? item.variant_id! : null,
+            item.quantity,
+            // A deleted row reads as null and is reported as zero available, which is
+            // what it means for a cashier: this line cannot be sold.
+            (remaining ?? 0) + (takenSoFar.get(stockKey) ?? 0)
           );
         }
+
+        takenSoFar.set(stockKey, (takenSoFar.get(stockKey) ?? 0) + item.quantity);
 
         await this.repo.createStockAdjustment(
           {

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -33,6 +33,7 @@ import {
   SaleCalculationSnapshot,
   SalesValidationError,
   InsufficientStockError,
+  type StockConflict,
   SPLIT_PAYMENT_MISMATCH_CODE,
   STRICT_SPLIT_PAYMENT_VALIDATION,
 } from './types';
@@ -232,6 +233,11 @@ export class SalesService {
     queryable: Queryable,
     checkStock: boolean
   ): Promise<ResolvedLines> {
+    // Every line that cannot be sold, not just the first. The pre-check reads all of
+    // them anyway, and a cashier told about one line at a time would fix it, resubmit,
+    // and be refused again on the next.
+    const stockConflicts: StockConflict[] = [];
+
     const resolvedItems: ResolvedSaleLine[] = [];
     const calcLines: SaleCalculationLineInput[] = [];
 
@@ -257,13 +263,12 @@ export class SalesService {
         );
         if (!variant) throw new Error(`Variant not found: ID ${item.variant_id}`);
         if (checkStock && Number(variant.stock) < item.quantity) {
-          throw new InsufficientStockError(
-            `Insufficient stock for variant ID ${item.variant_id}`,
-            item.product_id,
-            item.variant_id,
-            item.quantity,
-            Math.max(0, Number(variant.stock))
-          );
+          stockConflicts.push({
+            productId: item.product_id,
+            variantId: item.variant_id,
+            requested: item.quantity,
+            available: Math.max(0, Number(variant.stock)),
+          });
         }
         const unitPrice = Number(variant.price);
         resolvedItems.push({
@@ -280,13 +285,12 @@ export class SalesService {
         const product = await this.repo.getProductById(item.product_id, queryable);
         if (!product) throw new Error(`Product not found: ID ${item.product_id}`);
         if (checkStock && Number(product.stock) < item.quantity) {
-          throw new InsufficientStockError(
-            `Insufficient stock for product ID ${item.product_id}`,
-            item.product_id,
-            null,
-            item.quantity,
-            Math.max(0, Number(product.stock))
-          );
+          stockConflicts.push({
+            productId: item.product_id,
+            variantId: null,
+            requested: item.quantity,
+            available: Math.max(0, Number(product.stock)),
+          });
         }
         const unitPrice = Number(product.price);
         resolvedItems.push({
@@ -304,9 +308,21 @@ export class SalesService {
 
     for (const [bundleId, group] of bundleGroups) {
       const { resolvedItems: bundleResolved, calcLines: bundleCalcLines } =
-        await this.resolveBundleGroup(bundleId, group, queryable, checkStock);
+        await this.resolveBundleGroup(bundleId, group, queryable, checkStock, stockConflicts);
       resolvedItems.push(...bundleResolved);
       calcLines.push(...bundleCalcLines);
+    }
+
+    if (stockConflicts.length > 0) {
+      // The message names the first line only: it is prose for a person, and the machine
+      // -readable list is what a client reads. Wording unchanged from before this was typed.
+      const first = stockConflicts[0];
+      throw new InsufficientStockError(
+        first.variantId
+          ? `Insufficient stock for variant ID ${first.variantId}`
+          : `Insufficient stock for product ID ${first.productId}`,
+        stockConflicts
+      );
     }
 
     return { resolvedItems, calcLines };
@@ -330,7 +346,9 @@ export class SalesService {
     bundleId: number,
     requestedItems: SaleItemInput[],
     queryable: Queryable,
-    checkStock: boolean
+    checkStock: boolean,
+    /** Appended to rather than thrown from, so one cart reports every oversold line. */
+    stockConflicts: StockConflict[]
   ): Promise<ResolvedLines> {
     const bundle = await this.bundles.findById(bundleId, queryable);
     if (!bundle || bundle.status !== 'active') {
@@ -412,13 +430,12 @@ export class SalesService {
       const product = await this.repo.getProductById(bi.product_id, queryable);
       if (!product) throw new Error(`Product not found: ID ${bi.product_id}`);
       if (checkStock && Number(product.stock) < requestedQty) {
-        throw new InsufficientStockError(
-          `Insufficient stock for product ID ${bi.product_id}`,
-          bi.product_id,
-          null,
-          requestedQty,
-          Math.max(0, Number(product.stock))
-        );
+        stockConflicts.push({
+          productId: bi.product_id,
+          variantId: null,
+          requested: requestedQty,
+          available: Math.max(0, Number(product.stock)),
+        });
       }
 
       const lineTotalMinor = lineTotalsMinor[i];
@@ -740,12 +757,16 @@ export class SalesService {
             isVariantLine
               ? `Insufficient stock for variant ID ${item.variant_id}`
               : `Insufficient stock for product ID ${item.product_id}`,
-            item.product_id,
-            isVariantLine ? item.variant_id! : null,
-            item.quantity,
-            // A deleted row reads as null and is reported as zero available, which is
-            // what it means for a cashier: this line cannot be sold.
-            (remaining ?? 0) + (takenSoFar.get(stockKey) ?? 0)
+            [
+              {
+                productId: item.product_id,
+                variantId: isVariantLine ? item.variant_id! : null,
+                requested: item.quantity,
+                // A deleted row reads as null and is reported as zero available, which is
+                // what it means for a cashier: this line cannot be sold.
+                available: (remaining ?? 0) + (takenSoFar.get(stockKey) ?? 0),
+              },
+            ]
           );
         }
 

--- a/server/src/modules/pos/sales/types.ts
+++ b/server/src/modules/pos/sales/types.ts
@@ -295,12 +295,18 @@ export const INSUFFICIENT_STOCK_CODE = 'INSUFFICIENT_STOCK';
  * Thrown when the guarded stock decrement matched no row — the line's stock was gone by
  * the time the write ran. Typed rather than string-matched so the controller's message
  * list stops growing, while the client-facing wording stays exactly as it was.
+ *
+ * `requested` and `available` are what the client needs to say which line is wrong and
+ * by how much. They are carried here rather than left for the client to rediscover with
+ * a second round-trip: this is the one moment where the true numbers are known.
  */
 export class InsufficientStockError extends Error {
   constructor(
     message: string,
     public readonly productId: number,
     public readonly variantId: number | null = null,
+    public readonly requested: number = 0,
+    public readonly available: number = 0,
     public readonly code: string = INSUFFICIENT_STOCK_CODE,
     public readonly statusCode: number = 400
   ) {

--- a/server/src/modules/pos/sales/types.ts
+++ b/server/src/modules/pos/sales/types.ts
@@ -288,25 +288,42 @@ export class SalesValidationError extends Error {
   }
 }
 
+/** One line that could not be taken out of stock, and the numbers behind the refusal. */
+export interface StockConflict {
+  productId: number;
+  variantId: number | null;
+  requested: number;
+  /**
+   * What the caller could actually have had. On the write path this is the row's stock
+   * with this (doomed) transaction's own writes added back — it is about to roll back, so
+   * the mid-transaction figure would be a number that stops being true immediately.
+   * Zero when the row is gone: for a cashier, "not enough" and "gone" mean the same thing.
+   */
+  available: number;
+}
+
 /** Stable, documented code for a checkout rejected because stock ran out. */
 export const INSUFFICIENT_STOCK_CODE = 'INSUFFICIENT_STOCK';
 
 /**
- * Thrown when the guarded stock decrement matched no row — the line's stock was gone by
- * the time the write ran. Typed rather than string-matched so the controller's message
- * list stops growing, while the client-facing wording stays exactly as it was.
+ * Thrown when a line cannot be taken out of stock — either the fail-fast check saw too
+ * little, or the guarded decrement matched no row because it was gone by the time the
+ * write ran. Typed rather than string-matched so the controller's message list stops
+ * growing, while the client-facing wording stays exactly as it was.
  *
- * `requested` and `available` are what the client needs to say which line is wrong and
- * by how much. They are carried here rather than left for the client to rediscover with
- * a second round-trip: this is the one moment where the true numbers are known.
+ * Carries every line it can speak for, not just the first. The pre-check knows all of
+ * them, and a cashier told about one oversold line at a time would fix, resubmit, and be
+ * refused again. The guarded decrement can only ever report the one line it was refusing,
+ * so a conflict list of one is normal.
+ *
+ * `requested` and `available` are what the client needs to say which line is wrong and by
+ * how much. They are carried here rather than left for the client to rediscover with a
+ * second round-trip: this is the one moment where the true numbers are known.
  */
 export class InsufficientStockError extends Error {
   constructor(
     message: string,
-    public readonly productId: number,
-    public readonly variantId: number | null = null,
-    public readonly requested: number = 0,
-    public readonly available: number = 0,
+    public readonly conflicts: readonly StockConflict[],
     public readonly code: string = INSUFFICIENT_STOCK_CODE,
     public readonly statusCode: number = 400
   ) {

--- a/server/src/modules/pos/stockConflict.ts
+++ b/server/src/modules/pos/stockConflict.ts
@@ -1,30 +1,20 @@
 import type { ValidationDetail } from '../../http/errors';
-import { INSUFFICIENT_STOCK_CODE } from './sales/types';
+import { INSUFFICIENT_STOCK_CODE, type StockConflict } from './sales/types';
 
 /**
  * The one shape in which any POS path reports "this line could not be taken out of
  * stock". Checkout and exchange refuse for the same reason and a client should not have
- * to special-case them per endpoint, so both build their detail here.
+ * to special-case them per endpoint, so both build their details here.
  *
- * `available` is what the caller could actually have had: the row's committed stock,
- * with any decrement this same (now doomed) transaction already applied added back.
- * Reporting the mid-transaction figure would understate it — the transaction rolls back,
- * so those decrements never happened as far as anyone else is concerned.
- *
- * `available` is 0 when the row is gone entirely. The guarded UPDATE cannot tell
- * "not enough" from "deleted", and for a cashier both mean the same thing: this line
- * cannot be sold right now.
+ * One detail per refused line. `field` names the request array the line sits in, as Zod
+ * details do; the numbers ride in `meta`, because `message` is English prose written for
+ * a person and a client must never have to parse it.
  */
-export interface StockConflict {
-  productId: number;
-  variantId: number | null;
-  requested: number;
-  available: number;
-}
-
-/** `field` names the request array the offending line sits in, as Zod details do. */
-export function stockConflictDetail(conflict: StockConflict, message: string): ValidationDetail {
-  return {
+export function stockConflictDetails(
+  conflicts: readonly StockConflict[],
+  message: string
+): ValidationDetail[] {
+  return conflicts.map((conflict) => ({
     field: 'items',
     code: INSUFFICIENT_STOCK_CODE,
     message,
@@ -34,5 +24,5 @@ export function stockConflictDetail(conflict: StockConflict, message: string): V
       requested: conflict.requested,
       available: conflict.available,
     },
-  };
+  }));
 }

--- a/server/src/modules/pos/stockConflict.ts
+++ b/server/src/modules/pos/stockConflict.ts
@@ -1,0 +1,38 @@
+import type { ValidationDetail } from '../../http/errors';
+import { INSUFFICIENT_STOCK_CODE } from './sales/types';
+
+/**
+ * The one shape in which any POS path reports "this line could not be taken out of
+ * stock". Checkout and exchange refuse for the same reason and a client should not have
+ * to special-case them per endpoint, so both build their detail here.
+ *
+ * `available` is what the caller could actually have had: the row's committed stock,
+ * with any decrement this same (now doomed) transaction already applied added back.
+ * Reporting the mid-transaction figure would understate it — the transaction rolls back,
+ * so those decrements never happened as far as anyone else is concerned.
+ *
+ * `available` is 0 when the row is gone entirely. The guarded UPDATE cannot tell
+ * "not enough" from "deleted", and for a cashier both mean the same thing: this line
+ * cannot be sold right now.
+ */
+export interface StockConflict {
+  productId: number;
+  variantId: number | null;
+  requested: number;
+  available: number;
+}
+
+/** `field` names the request array the offending line sits in, as Zod details do. */
+export function stockConflictDetail(conflict: StockConflict, message: string): ValidationDetail {
+  return {
+    field: 'items',
+    code: INSUFFICIENT_STOCK_CODE,
+    message,
+    meta: {
+      productId: conflict.productId,
+      variantId: conflict.variantId,
+      requested: conflict.requested,
+      available: conflict.available,
+    },
+  };
+}

--- a/server/tests/concurrency/checkout.concurrency.test.ts
+++ b/server/tests/concurrency/checkout.concurrency.test.ts
@@ -148,9 +148,7 @@ describeWithPostgres('checkout stock under concurrency', () => {
         )
       ).rejects.toMatchObject({
         name: 'InsufficientStockError',
-        productId,
-        requested: 1,
-        available: 5,
+        conflicts: [{ productId, variantId: null, requested: 1, available: 5 }],
       });
 
       expect(await stockOf(productId)).toBe(5);

--- a/server/tests/concurrency/checkout.concurrency.test.ts
+++ b/server/tests/concurrency/checkout.concurrency.test.ts
@@ -127,6 +127,37 @@ describeWithPostgres('checkout stock under concurrency', () => {
       expect(await countRows('stock_adjustments')).toBe(0);
     });
 
+    it('reports available as what was really on the shelf, not the mid-transaction figure', async () => {
+      // Two lines of one product, 5 in stock. The first decrement succeeds and drives the
+      // row to 0; the second is refused. Reporting 0 would be a number that stops being
+      // true the instant this transaction rolls back -- and the cashier would be told to
+      // remove a line they can in fact still sell 5 of. Only a real database can prove
+      // this, because it needs the rollback to actually happen.
+      const productId = await makeProduct('SKU-SPLIT', 5);
+
+      await expect(
+        salesService.executeSale(
+          {
+            items: [
+              { product_id: productId, quantity: 5, unit_price: 100, memo: 'gift wrap' },
+              { product_id: productId, quantity: 1, unit_price: 100 },
+            ],
+            payment_method: 'Cash',
+          } as never,
+          cashierId
+        )
+      ).rejects.toMatchObject({
+        name: 'InsufficientStockError',
+        productId,
+        requested: 1,
+        available: 5,
+      });
+
+      expect(await stockOf(productId)).toBe(5);
+      expect(await countRows('sales')).toBe(0);
+      expect(await countRows('stock_adjustments')).toBe(0);
+    });
+
     it('is authoritative when stock disappears after the fail-fast pre-check passed', async () => {
       const productId = await makeProduct('SKU-VANISH', 1);
 

--- a/server/tests/exchanges.test.ts
+++ b/server/tests/exchanges.test.ts
@@ -162,9 +162,7 @@ describe('Exchange stock invariants', () => {
     ).rejects.toMatchObject({
       name: 'ExchangeStockError',
       message: 'Insufficient stock for product ID 4',
-      productId: 4,
-      requested: 1,
-      available: 1,
+      conflicts: [{ productId: 4, variantId: null, requested: 1, available: 1 }],
     });
   });
 
@@ -188,14 +186,21 @@ describe('Exchange stock invariants', () => {
         1,
         client
       )
-    ).rejects.toMatchObject({ name: 'ExchangeStockError', productId: 4, available: 2 });
+    ).rejects.toMatchObject({
+      name: 'ExchangeStockError',
+      conflicts: [{ productId: 4, available: 2 }],
+    });
   });
 
   it('maps a stock error to a 400 rather than an unhandled 500', async () => {
     const service = {
       createExchange: vi
         .fn()
-        .mockRejectedValue(new ExchangeStockError('Insufficient stock for product ID 4', 4, null)),
+        .mockRejectedValue(
+          new ExchangeStockError('Insufficient stock for product ID 4', [
+            { productId: 4, variantId: null, requested: 1, available: 0 },
+          ])
+        ),
     } as unknown as IExchangesService;
     const next = vi.fn();
 

--- a/server/tests/exchanges.test.ts
+++ b/server/tests/exchanges.test.ts
@@ -105,6 +105,8 @@ describe('Exchange stock invariants', () => {
         deducted.push({ productId, variantId: null });
         return 1;
       }),
+      getProductStock: vi.fn().mockResolvedValue(0),
+      getVariantStock: vi.fn().mockResolvedValue(0),
       listExchanges: vi.fn(),
       findById: vi.fn(),
       findReturnedItems: vi.fn(),
@@ -146,7 +148,10 @@ describe('Exchange stock invariants', () => {
   });
 
   it('raises a typed stock error when the guarded deduction matches nothing', async () => {
-    const repo = fakeRepo({ deductProductStock: vi.fn().mockResolvedValue(null) });
+    const repo = fakeRepo({
+      deductProductStock: vi.fn().mockResolvedValue(null),
+      getProductStock: vi.fn().mockResolvedValue(1),
+    });
 
     await expect(
       new ExchangesService(repo).createExchange(
@@ -158,7 +163,32 @@ describe('Exchange stock invariants', () => {
       name: 'ExchangeStockError',
       message: 'Insufficient stock for product ID 4',
       productId: 4,
+      requested: 1,
+      available: 1,
     });
+  });
+
+  it('reports what was available before this exchange restocked the same row', async () => {
+    // The returned item and the new item are the same product: the restock above has
+    // already run when the deduction is refused, and it is about to be rolled back. The
+    // figure the cashier needs is the stock without it.
+    const repo = fakeRepo({
+      deductProductStock: vi.fn().mockResolvedValue(null),
+      // 2 on the shelf, plus the 1 this doomed transaction just restocked.
+      getProductStock: vi.fn().mockResolvedValue(3),
+    });
+
+    await expect(
+      new ExchangesService(repo).createExchange(
+        {
+          original_sale_id: 1,
+          returned_items: [{ ...returnedItem, product_id: 4, quantity: 1, condition: 'good' }],
+          new_items: [newItem(4)],
+        },
+        1,
+        client
+      )
+    ).rejects.toMatchObject({ name: 'ExchangeStockError', productId: 4, available: 2 });
   });
 
   it('maps a stock error to a 400 rather than an unhandled 500', async () => {

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -82,7 +82,9 @@ describe('Sales - Mutation Contract', () => {
 
   it('sends the typed stock code and the numbers, not just an English sentence', async () => {
     vi.spyOn(salesService, 'executeSale').mockRejectedValueOnce(
-      new InsufficientStockError('Insufficient stock for product ID 7', 7, null, 3, 1)
+      new InsufficientStockError('Insufficient stock for product ID 7', [
+        { productId: 7, variantId: null, requested: 3, available: 1 },
+      ])
     );
     const next = vi.fn();
 
@@ -117,7 +119,9 @@ describe('Sales - Mutation Contract', () => {
     // The gap this closes: variant stock is a separate column with no bulk lookup, so a
     // client cannot rediscover this number by re-reading products.
     vi.spyOn(salesService, 'executeSale').mockRejectedValueOnce(
-      new InsufficientStockError('Insufficient stock for variant ID 12', 7, 12, 2, 0)
+      new InsufficientStockError('Insufficient stock for variant ID 12', [
+        { productId: 7, variantId: 12, requested: 2, available: 0 },
+      ])
     );
     const next = vi.fn();
 
@@ -889,14 +893,34 @@ describe('Unit 2 - SalesService authoritative calculation and snapshot persisten
       )
     ).rejects.toMatchObject({
       name: 'InsufficientStockError',
-      productId: 2,
-      variantId: null,
-      requested: 7,
-      available: 5,
+      conflicts: [{ productId: 2, variantId: null, requested: 7, available: 5 }],
     });
 
     const sales = await testPool.query('SELECT * FROM sales');
     expect(sales.rows).toHaveLength(0);
+  });
+
+  it('error path: every oversold line is reported, not just the first', async () => {
+    // Product 1 has 10, product 2 has 5. Both lines are short. Reporting only the first
+    // would have the cashier fix one line, resubmit, and be refused again on the other.
+    await expect(
+      salesService.executeSale(
+        {
+          items: [
+            { product_id: 1, quantity: 11 },
+            { product_id: 2, quantity: 7 },
+          ],
+          payment_method: 'Cash',
+        } as any,
+        1
+      )
+    ).rejects.toMatchObject({
+      name: 'InsufficientStockError',
+      conflicts: [
+        { productId: 1, requested: 11, available: 10 },
+        { productId: 2, requested: 7, available: 5 },
+      ],
+    });
   });
 
   it('error path: available excludes what this same rolled-back transaction already took', async () => {
@@ -915,7 +939,10 @@ describe('Unit 2 - SalesService authoritative calculation and snapshot persisten
         } as any,
         1
       )
-    ).rejects.toMatchObject({ name: 'InsufficientStockError', productId: 2, available: 5 });
+    ).rejects.toMatchObject({
+      name: 'InsufficientStockError',
+      conflicts: [{ productId: 2, available: 5 }],
+    });
     // That the rollback actually restores the 5 needs a real engine, so it is asserted in
     // `tests/concurrency/checkout.concurrency.test.ts` rather than here.
   });

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -18,6 +18,8 @@ import {
   STRICT_SPLIT_PAYMENT_VALIDATION,
   SPLIT_PAYMENT_MISMATCH_CODE,
   SalesValidationError,
+  InsufficientStockError,
+  INSUFFICIENT_STOCK_CODE,
 } from '../src/modules/pos/sales/types';
 import { SalesRepository } from '../src/modules/pos/sales/repository';
 import { SalesController } from '../src/modules/pos/sales/controller';
@@ -76,6 +78,69 @@ describe('Sales - Mutation Contract', () => {
     expect(next).toHaveBeenCalledWith(
       expect.objectContaining<Partial<PublicError>>({ code: 'VALIDATION_ERROR' })
     );
+  });
+
+  it('sends the typed stock code and the numbers, not just an English sentence', async () => {
+    vi.spyOn(salesService, 'executeSale').mockRejectedValueOnce(
+      new InsufficientStockError('Insufficient stock for product ID 7', 7, null, 3, 1)
+    );
+    const next = vi.fn();
+
+    await new SalesController().createSale(
+      {
+        body: {
+          items: [{ product_id: 7, quantity: 3, unit_price: 10 }],
+          payment_method: 'Card',
+        },
+        user: { id: 1, name: 'Cashier' },
+        headers: {},
+      } as unknown as Request,
+      { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response,
+      next as NextFunction
+    );
+
+    // The envelope code stays one of the seven public ones; the domain code rides in
+    // details[], which is where the client already reads SPLIT_PAYMENT_MISMATCH from.
+    const forwarded = next.mock.calls[0][0] as PublicError;
+    expect(forwarded.code).toBe('VALIDATION_ERROR');
+    expect(forwarded.details).toEqual([
+      {
+        field: 'items',
+        code: INSUFFICIENT_STOCK_CODE,
+        message: 'Insufficient stock for product ID 7',
+        meta: { productId: 7, variantId: null, requested: 3, available: 1 },
+      },
+    ]);
+  });
+
+  it('carries the variant id when it is a variant line that was refused', async () => {
+    // The gap this closes: variant stock is a separate column with no bulk lookup, so a
+    // client cannot rediscover this number by re-reading products.
+    vi.spyOn(salesService, 'executeSale').mockRejectedValueOnce(
+      new InsufficientStockError('Insufficient stock for variant ID 12', 7, 12, 2, 0)
+    );
+    const next = vi.fn();
+
+    await new SalesController().createSale(
+      {
+        body: {
+          items: [{ product_id: 7, variant_id: 12, quantity: 2, unit_price: 10 }],
+          payment_method: 'Card',
+        },
+        user: { id: 1, name: 'Cashier' },
+        headers: {},
+      } as unknown as Request,
+      { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response,
+      next as NextFunction
+    );
+
+    const forwarded = next.mock.calls[0][0] as PublicError;
+    expect(forwarded.details?.[0].meta).toEqual({
+      productId: 7,
+      variantId: 12,
+      requested: 2,
+      available: 0,
+    });
   });
 
   it('maps a missing refund sale to the canonical not-found error', async () => {
@@ -812,6 +877,47 @@ describe('Unit 2 - SalesService authoritative calculation and snapshot persisten
 
     const sales = await testPool.query('SELECT * FROM sales');
     expect(sales.rows).toHaveLength(0);
+  });
+
+  it('error path: an oversold line is refused with the requested and available counts attached', async () => {
+    // Product 2 has 5 in stock. Asking for 7 is refused by the fail-fast check, which is
+    // the common case -- the cart was already oversold before the write ran.
+    await expect(
+      salesService.executeSale(
+        { items: [{ product_id: 2, quantity: 7 }], payment_method: 'Cash' } as any,
+        1
+      )
+    ).rejects.toMatchObject({
+      name: 'InsufficientStockError',
+      productId: 2,
+      variantId: null,
+      requested: 7,
+      available: 5,
+    });
+
+    const sales = await testPool.query('SELECT * FROM sales');
+    expect(sales.rows).toHaveLength(0);
+  });
+
+  it('error path: available excludes what this same rolled-back transaction already took', async () => {
+    // Two lines of one product, together more than the shelf holds. The first decrement
+    // succeeds and drives stock to 0 before the second is refused -- but that decrement is
+    // about to be rolled back, so reporting 0 would tell the cashier something that will
+    // not be true a millisecond later. The honest figure is the 5 that were really there.
+    await expect(
+      salesService.executeSale(
+        {
+          items: [
+            { product_id: 2, quantity: 5, memo: 'gift wrap' },
+            { product_id: 2, quantity: 1 },
+          ],
+          payment_method: 'Cash',
+        } as any,
+        1
+      )
+    ).rejects.toMatchObject({ name: 'InsufficientStockError', productId: 2, available: 5 });
+    // That the rollback actually restores the 5 needs a real engine, so it is asserted in
+    // `tests/concurrency/checkout.concurrency.test.ts` rather than here.
   });
 
   it('error path: an invalid coupon code is rejected deterministically -- never silently omitted from the total', async () => {


### PR DESCRIPTION
Closes #88.

The sales module has defined `INSUFFICIENT_STOCK` all along, but both POS controllers
re-wrapped the error as a bare `VALIDATION_ERROR` carrying the English sentence
`Insufficient stock for product ID 7`. A cashier got a database id, in English regardless
of locale, and the client had no code to branch on — so #52 recovers by re-reading stock
for every line in the cart, **an extra round-trip at the till with a customer waiting**,
to rediscover what the server had just thrown away.

## What the server sends now

The code rides in `details[]`, where `SPLIT_PAYMENT_MISMATCH` and the idempotency codes
already ride. The envelope stays one of the seven public codes, so no client has to widen
that union. `ValidationDetail` gains an optional scalar `meta` — generic, so the HTTP
layer stays free of any one module's vocabulary.

```json
{ "field": "items", "code": "INSUFFICIENT_STOCK",
  "message": "Insufficient stock for product ID 7",
  "meta": { "productId": 7, "variantId": null, "requested": 4, "available": 1 } }
```

**One detail per oversold line, not just the first.** The fail-fast pre-check reads every
line's stock anyway; stopping at the first would have a cashier fix one line, resubmit,
and be refused again on the next — worse than the re-read it replaces. The guarded
decrement can only ever speak for the line it is refusing, so a list of one is normal
there. Bundle groups append to the same list, so a mixed cart reports both kinds together.

**`available` is what the caller could actually have had** — the row's stock with this
transaction's own writes added back, because the transaction is about to roll back.
Reporting the mid-transaction figure would tell a cashier to drop a line they can still
sell: two lines of one product against a stock of 5 drives the row to 0 before the second
line is refused, and 0 stops being true a millisecond later. Same rule on the exchange
path, where a returned item may have restocked the very row being refused.

Checkout and exchange build the same detail through one shared helper — it is one event,
and a client should not special-case it per endpoint.

## What the client does with it

POS renders the conflict straight from the rejection: no `products/lookup` call. The stock
re-read is kept as the fallback for a rejection carrying no stock detail (coupon, loyalty,
bundle), where the cart may still be the real cause.

**This also closes the variant gap** #88 describes. `products/lookup` carries product-level
stock only and variant stock has no bulk endpoint, so #52 had to exclude variant lines
entirely. The server knows the variant's stock at the point it refuses, so those lines are
now handled like any other. `StockShortfall` gains `variantId` and cart adjustment is keyed
on the product/variant pair, so a variant shortfall no longer trims the wrong line.

Malformed or absent `meta` drops the detail rather than rendering `NaN` at a cashier, and a
detail naming a line the cart no longer holds is dropped rather than shown without a name.

## The audit #88 asked for

Grepped for typed codes no response carries. `SPLIT_PAYMENT_MISMATCH` does reach the wire
via `SalesValidationError`; `INSUFFICIENT_STOCK` was the only one being dropped.

## Testing

- `server`: 659 pass, including the 11 real-PostgreSQL suites (run locally against a
  throwaway database, not skipped). New: the multi-line report, the rollback-aware
  `available` (real Postgres — pg-mem cannot prove it, since it needs the rollback to
  actually happen), the exchange restock case, and both controller shapes.
- `client`: 549 pass. New: `shortfallsFromDetails` incl. variant matching and malformed
  meta, variant-aware `planCartAdjustment`, and a test asserting **no `products/lookup`
  call** happens when the server states the shortfall.
- `tsc --noEmit` clean both halves; `npm run lint` clean.

One test I wrote and then removed: "available is 0 when the row vanished". The FK from
`sale_items` blocks deleting the product mid-transaction, so the case is unreachable
without contriving state the schema prevents. The `?? 0` guard stays, documented.

## Note on merge order

Overlaps #89 only in `client/src/shared/lib/transport/types.ts` (both add to that file, in
different places). Either order merges cleanly.

## Post-Deploy Monitoring & Validation

- **Watch:** the rate of `GET /api/v1/products/lookup` immediately following a failed
  `POST /api/v1/sales`. It should fall to near zero — that call is the round-trip this
  removes. If it does not, the client is not seeing the detail.
- **Log query:** filter for `POST /api/v1/sales` responses with status 400 and inspect
  `details[].code`; expect `INSUFFICIENT_STOCK` where the message says insufficient stock.
- **Healthy signal:** the stock notice in the checkout drawer names the product and shows
  two numbers, and now appears for variant lines too (previously a generic toast).
- **Failure signal / rollback trigger:** stock notices showing `0 left` for lines that are
  in fact sellable would mean the rollback-aware `available` is wrong — revert. A 500 on
  checkout would mean the new `getProductStock` read is failing on the refusal path.
- **Window / owner:** first busy trading day after deploy, whoever merges.

Nothing here changes schema, persisted data, or the success path: every change is on the
refusal branch, which persists nothing by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN