### PR TITLE
build(client): split vite.config.ts into config/pwa.ts and config/build.ts

### DIFF
--- a/client/config/build.ts
+++ b/client/config/build.ts
@@ -1,0 +1,17 @@
+import type { BuildOptions } from 'vite';
+
+export const buildOptions: BuildOptions = {
+  rollupOptions: {
+    output: {
+      manualChunks: {
+        'vendor-react': ['react', 'react-dom'],
+        'vendor-router': ['@tanstack/react-router'],
+        'vendor-query': ['@tanstack/react-query', '@tanstack/react-table'],
+        'vendor-charts': ['recharts'],
+        'vendor-ui-hero': ['@heroui/react'],
+        'vendor-motion': ['framer-motion'],
+        'vendor-forms': ['react-hook-form', '@hookform/resolvers', 'zod'],
+      },
+    },
+  },
+};

--- a/client/config/pwa.ts
+++ b/client/config/pwa.ts
@@ -1,0 +1,36 @@
+import type { VitePWAOptions } from 'vite-plugin-pwa';
+
+export const pwaOptions: Partial<VitePWAOptions> = {
+  registerType: 'autoUpdate',
+  includeAssets: ['moon-logo.svg'],
+  manifest: {
+    name: 'MOON Fashion & Style',
+    short_name: 'MOON',
+    description: 'Shop management for MOON Fashion & Style',
+    theme_color: '#C9A96E',
+    background_color: '#0D0D0D',
+    display: 'standalone',
+    start_url: '/',
+    icons: [
+      { src: '/pwa-192x192.png', sizes: '192x192', type: 'image/png' },
+      { src: '/pwa-512x512.png', sizes: '512x512', type: 'image/png' },
+      { src: '/pwa-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'any maskable' },
+    ],
+  },
+  workbox: {
+    maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+    globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+    runtimeCaching: [
+      {
+        urlPattern: /\/api\/v1\/products/,
+        handler: 'StaleWhileRevalidate',
+        options: { cacheName: 'products-cache', expiration: { maxEntries: 200, maxAgeSeconds: 86400 } },
+      },
+      {
+        urlPattern: /\/api\/v1\/sales/,
+        handler: 'NetworkFirst',
+        options: { cacheName: 'sales-cache', expiration: { maxEntries: 50, maxAgeSeconds: 3600 } },
+      },
+    ],
+  },
+};

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -37,8 +37,9 @@ export default tseslint.config(
   {
     // scripts/restructure/ is temporary Node tooling for the feature-slice
     // migration codemods (deleted in Unit 12), not application source -- it
-    // runs under Node, not the browser/React lint ruleset below.
-    ignores: ['dist/', 'node_modules/', 'tailwind.config.js', 'postcss.config.js', 'scripts/'],
+    // runs under Node, not the browser/React lint ruleset below. config/ is
+    // Vite/Node build config (split out of vite.config.ts), same rationale.
+    ignores: ['dist/', 'node_modules/', 'tailwind.config.js', 'postcss.config.js', 'scripts/', 'config/'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,6 +3,8 @@ import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
+import { pwaOptions } from './config/pwa';
+import { buildOptions } from './config/build';
 
 export default defineConfig({
   plugins: [
@@ -12,61 +14,14 @@ export default defineConfig({
       autoCodeSplitting: true,
     }),
     react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: ['moon-logo.svg'],
-      manifest: {
-        name: 'MOON Fashion & Style',
-        short_name: 'MOON',
-        description: 'Shop management for MOON Fashion & Style',
-        theme_color: '#C9A96E',
-        background_color: '#0D0D0D',
-        display: 'standalone',
-        start_url: '/',
-        icons: [
-          { src: '/pwa-192x192.png', sizes: '192x192', type: 'image/png' },
-          { src: '/pwa-512x512.png', sizes: '512x512', type: 'image/png' },
-          { src: '/pwa-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'any maskable' }
-        ]
-      },
-      workbox: {
-        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-        runtimeCaching: [
-          {
-            urlPattern: /\/api\/v1\/products/,
-            handler: 'StaleWhileRevalidate',
-            options: { cacheName: 'products-cache', expiration: { maxEntries: 200, maxAgeSeconds: 86400 } }
-          },
-          {
-            urlPattern: /\/api\/v1\/sales/,
-            handler: 'NetworkFirst',
-            options: { cacheName: 'sales-cache', expiration: { maxEntries: 50, maxAgeSeconds: 3600 } }
-          }
-        ]
-      }
-    })
+    VitePWA(pwaOptions),
   ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')
     }
   },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom'],
-          'vendor-router': ['@tanstack/react-router'],
-          'vendor-query': ['@tanstack/react-query', '@tanstack/react-table'],
-          'vendor-charts': ['recharts'],
-          'vendor-ui-hero': ['@heroui/react'],
-          'vendor-motion': ['framer-motion'],
-          'vendor-forms': ['react-hook-form', '@hookform/resolvers', 'zod'],
-        },
-      },
-    },
-  },
+  build: buildOptions,
   server: {
     port: 5173
   }


### PR DESCRIPTION
## Summary
- Splits `client/vite.config.ts` into `client/config/pwa.ts` (VitePWA options) and `client/config/build.ts` (rollup/manualChunks), per Unit 1 of `docs/plans/2026-09-04-001-refactor-parallel-issue-execution-map-plan.md`.
- Pure move — no behavioral change. This is prep so wave-1 lane #53 (PWA/offline) and wave-2 lane #55p1 (bundle budgets) never write the same file.
- Added `config/` to the eslint boundaries `ignores` list (same rationale as the existing `scripts/` entry — Node/Vite tooling, not application source), since the new files fall outside `src/**` and would otherwise trip `boundaries/no-unknown-files`.

## Testing
- `npm run build --prefix client`: chunk names/count identical before and after the split (diffed asset lists with hashes stripped); PWA precache manifest unchanged (127 entries, 2901.80 KiB).
- `npm run lint --prefix client`: 0 errors (pre-existing warnings only), no circular deps.
- `npm run typecheck --prefix client`: passes.
- `npm run dev --prefix client`: starts, PWA plugin registers, root route returns 200.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — this is a build-config refactor with no runtime behavior change (verified via identical build output above).