### PR TITLE
fix(collections): write status and year, which the modal has always sent (#83)

### DIFF
--- a/server/src/database/migrations/008_collection_year.down.sql
+++ b/server/src/database/migrations/008_collection_year.down.sql
@@ -1,0 +1,2 @@
+-- 008_collection_year.down.sql
+ALTER TABLE collections DROP COLUMN IF EXISTS year;

--- a/server/src/database/migrations/008_collection_year.sql
+++ b/server/src/database/migrations/008_collection_year.sql
@@ -1,0 +1,12 @@
+-- 008_collection_year.sql
+-- Fixes #83: the Collections edit modal has always sent `year`, and the server has
+-- always had nowhere to put it -- there is no `year` column on `collections`, so Zod
+-- strips it before the repository ever sees it. The client type already declares
+-- `year: number | null` and the i18n catalogue already carries `collections.year`, so
+-- the UI's intent predates this column by design, not by accident.
+--
+-- `status` needs no migration -- 001_initial_schema.sql already added it
+-- (`status TEXT DEFAULT 'active'`) and the repository already selects it. Only the
+-- write path (collectionUpdateSchema / repository.update) was missing it, which is a
+-- code fix, not a schema change.
+ALTER TABLE collections ADD COLUMN IF NOT EXISTS year INTEGER;

--- a/server/src/modules/inventory/collections/controller.ts
+++ b/server/src/modules/inventory/collections/controller.ts
@@ -7,10 +7,15 @@ import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
 
-const collectionSchema = z.object({
+// Kept in sync with the client's `statuses` enum in Collections.tsx.
+const collectionStatusSchema = z.enum(['upcoming', 'active', 'on_sale', 'archived']);
+
+export const collectionSchema = z.object({
   name: z.string().min(1).max(100),
   description: z.string().max(500).optional(),
   season: z.string().max(50).optional(),
+  year: z.number().int().min(1900).max(2100).nullable().optional(),
+  status: collectionStatusSchema.optional(),
   is_featured: z.boolean().optional(),
   product_ids: z.array(z.number().int().positive()).optional(),
 });
@@ -29,14 +34,29 @@ const collectionSchema = z.object({
  * if this were true: `resource().useSave` PUTs exactly the keys a page put in its draft, so
  * every page in the app sends a partial body. Demanding a full record would have meant every
  * caller learning every column — the same coupling, moved rather than removed.
+ *
+ * `year` and `status` (#83): the modal has always sent both, and the server had nowhere
+ * to put either — `year` had no column at all, and `status`, though it has had a column
+ * since 001_initial_schema.sql, was never in this schema or in `repository.update`'s
+ * write set. Zod stripped the unknown key before the repository ever saw it, so the
+ * request returned a normal 200 with the change silently discarded.
+ *
+ * `.strict()` on this schema specifically: an unknown field is now a 400 at the moment a
+ * client/schema mismatch is introduced, rather than a silent no-op discovered by a user
+ * days later. Scoped to this one schema rather than repo-wide — a global sweep is its own
+ * change with its own blast radius.
  */
-const collectionUpdateSchema = z.object({
-  name: z.string().min(1).max(100).optional(),
-  description: z.string().max(500).nullable().optional(),
-  season: z.string().max(50).nullable().optional(),
-  is_featured: z.boolean().optional(),
-  product_ids: z.array(z.number().int().positive()).optional(),
-});
+export const collectionUpdateSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    description: z.string().max(500).nullable().optional(),
+    season: z.string().max(50).nullable().optional(),
+    year: z.number().int().min(1900).max(2100).nullable().optional(),
+    status: collectionStatusSchema.optional(),
+    is_featured: z.boolean().optional(),
+    product_ids: z.array(z.number().int().positive()).optional(),
+  })
+  .strict();
 
 export class CollectionsController {
   async getCollections(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/server/src/modules/inventory/collections/repository.ts
+++ b/server/src/modules/inventory/collections/repository.ts
@@ -68,12 +68,12 @@ export class CollectionsRepository implements ICollectionsRepository {
     const offsetIdx = params.length + 2;
 
     const collections = await this.q(queryable).query<CollectionRecord>(
-      `SELECT c.id, c.name, c.description, c.image_url, c.is_featured, c.season, c.status, c.created_at, c.updated_at,
+      `SELECT c.id, c.name, c.description, c.image_url, c.is_featured, c.season, c.year, c.status, c.created_at, c.updated_at,
               COUNT(cp.product_id)::int as product_count
        FROM collections c
        LEFT JOIN collection_products cp ON cp.collection_id = c.id
        ${where}
-       GROUP BY c.id, c.name, c.description, c.image_url, c.is_featured, c.season, c.status, c.created_at, c.updated_at
+       GROUP BY c.id, c.name, c.description, c.image_url, c.is_featured, c.season, c.year, c.status, c.created_at, c.updated_at
        ORDER BY ${sortColumn} ${direction}, c.id ${direction}
        LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
       [...params, pageSize, (page - 1) * pageSize]
@@ -107,9 +107,16 @@ export class CollectionsRepository implements ICollectionsRepository {
 
   async create(data: CreateCollectionDTO, queryable?: Queryable): Promise<CollectionRecord> {
     const res = await this.q(queryable).query<CollectionRecord>(
-      `INSERT INTO collections (name, description, season, is_featured)
-       VALUES ($1, $2, $3, $4) RETURNING *`,
-      [data.name, data.description || null, data.season || null, data.is_featured ? 1 : 0]
+      `INSERT INTO collections (name, description, season, year, status, is_featured)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [
+        data.name,
+        data.description || null,
+        data.season || null,
+        data.year ?? null,
+        data.status || 'active',
+        data.is_featured ? 1 : 0,
+      ]
     );
     return res.rows[0];
   }
@@ -137,6 +144,8 @@ export class CollectionsRepository implements ICollectionsRepository {
       name: data.name,
       description: orNull(data.description),
       season: orNull(data.season),
+      year: data.year,
+      status: data.status,
       is_featured: data.is_featured === undefined ? undefined : data.is_featured ? 1 : 0,
     });
 

--- a/server/src/modules/inventory/collections/types.ts
+++ b/server/src/modules/inventory/collections/types.ts
@@ -3,6 +3,8 @@ export interface CollectionRecord {
   name: string;
   description?: string | null;
   season?: string | null;
+  year?: number | null;
+  status: string;
   is_featured: number | boolean;
   product_count?: number;
   created_at: string;
@@ -35,6 +37,8 @@ export interface CreateCollectionDTO {
   name: string;
   description?: string | null;
   season?: string | null;
+  year?: number | null;
+  status?: string;
   is_featured?: boolean;
   product_ids?: number[];
 }
@@ -45,12 +49,14 @@ export interface CreateCollectionDTO {
  * Absent means "leave the stored value alone"; an explicit `null` on a nullable
  * column means "clear it". Sharing the create DTO is what made #78 possible: every
  * field was optional, so an omitted `is_featured` was not a validation error, it was
- * a write of the default — and editing a collection's products un-featured it.
+ * a write of the default ï¿½ and editing a collection's products un-featured it.
  */
 export interface UpdateCollectionDTO {
   name?: string;
   description?: string | null;
   season?: string | null;
+  year?: number | null;
+  status?: string;
   is_featured?: boolean;
   product_ids?: number[];
 }

--- a/server/tests/collections.test.ts
+++ b/server/tests/collections.test.ts
@@ -18,6 +18,7 @@ import { setPool, closePool } from '../src/database/pool';
 import { runMigrationsUp } from '../src/database/migrate';
 import { CollectionsRepository } from '../src/modules/inventory/collections/repository';
 import { CollectionsService } from '../src/modules/inventory/collections/service';
+import { collectionUpdateSchema } from '../src/modules/inventory/collections/controller';
 
 const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
 
@@ -276,5 +277,79 @@ describe('collections partial update', () => {
     expect(after.is_featured).toBe(before.is_featured);
     const detail = await service.findById(id);
     expect(detail!.products.map((p) => p.id)).toEqual([21]);
+  });
+
+  /**
+   * #83: the edit modal has always sent `status` and `year`. `status` had a column but
+   * neither the schema nor the write set carried it; `year` had no column at all. Both are
+   * asserted here because the bug was symmetric — a field can go missing at the schema, at
+   * the repository's write set, or (for `year`) at the database, and only one column had
+   * been fixed at each of #78's audits before this issue.
+   */
+  it('writes status and year, which the client has always sent and the server always dropped', async () => {
+    const id = await featuredCollection();
+
+    const result = await service.update(id, {
+      name: 'Autumn window',
+      season: 'Fall',
+      status: 'on_sale',
+      year: 2026,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data!.status).toBe('on_sale');
+    expect(result.data!.year).toBe(2026);
+    const row = await rowOf(id);
+    expect(row.status).toBe('on_sale');
+    expect(Number(row.year)).toBe(2026);
+  });
+
+  it('clears year when the body says null explicitly, same as the other nullable columns', async () => {
+    const id = await featuredCollection();
+    await service.update(id, { year: 2025 });
+
+    await service.update(id, { year: null });
+
+    const row = await rowOf(id);
+    expect(row.year).toBeNull();
+  });
+
+  it('leaves status and year alone when the body only edits the product set', async () => {
+    const id = await featuredCollection();
+    await service.update(id, { status: 'active', year: 2026 });
+
+    await service.update(id, { product_ids: [20] });
+
+    const row = await rowOf(id);
+    expect(row.status).toBe('active');
+    expect(Number(row.year)).toBe(2026);
+  });
+});
+
+describe('collectionUpdateSchema', () => {
+  it('accepts status and year alongside the existing partial fields', () => {
+    const parsed = collectionUpdateSchema.parse({ status: 'on_sale', year: 2026 });
+    expect(parsed).toEqual({ status: 'on_sale', year: 2026 });
+  });
+
+  it('rejects a status outside the known enum', () => {
+    expect(collectionUpdateSchema.safeParse({ status: 'discontinued' }).success).toBe(false);
+  });
+
+  it('rejects a year outside the sane range', () => {
+    expect(collectionUpdateSchema.safeParse({ year: 1899 }).success).toBe(false);
+    expect(collectionUpdateSchema.safeParse({ year: 2101 }).success).toBe(false);
+  });
+
+  it('rejects a field the schema does not know about, rather than silently dropping it', () => {
+    // The shape of #83: before `.strict()`, an unknown key parsed away clean and the
+    // caller never learned their write did nothing.
+    expect(collectionUpdateSchema.safeParse({ nickname: 'Autumn window' }).success).toBe(false);
+  });
+
+  it('still treats an absent field as untouched, not as null', () => {
+    const parsed = collectionUpdateSchema.parse({ name: 'Autumn window' });
+    expect('year' in parsed).toBe(false);
+    expect('status' in parsed).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- The Collections edit modal has always sent `status` and `year`; the server had nowhere to put either, so both were silently discarded and the request returned a normal 200. Closes #83.
- `status` has had a column since `001_initial_schema.sql` but was never in `collectionUpdateSchema` or `repository.update`'s write set. `year` had no column at all — migration `008_collection_year.sql` adds it (nullable, no backfill needed).
- Resolved the "real fields vs. remove from UI" question in the issue in favor of real fields: the client type already declares `year: number | null` and the i18n catalogue already carries `collections.year`/`season`/`spring`/etc. — the UI's intent predates this fix.
- Checked the `status`/`is_featured` overlap the issue flagged: `is_featured` is a separate, unrelated flag not exposed anywhere in the edit modal, so there's no overlap to resolve.
- `collectionUpdateSchema` also gets `.strict()`, scoped to this one schema only (per the plan's decision — not a repo-wide sweep): an unknown field is now a 400 at the moment a client/schema mismatch is introduced, instead of a silent no-op a user discovers later.
- No client changes needed — `Collections.tsx` and `features/inventory/types.ts` already read/wrote `status`/`year` end-to-end; only the backend plumbing was missing.

## Testing
- `server/tests/collections.test.ts`: added coverage for status/year being written and read back, year being clearable (nullable), status/year surviving a product-only edit, and the new `.strict()` schema (accepts status+year, rejects an unknown field, rejects out-of-enum status, rejects out-of-range year, still treats an absent field as untouched).
- `npx vitest run` (server): 557 passed (full suite green; a `seed.test.ts` timeout seen once under full-suite parallel load reproduced identically on `main` before this change — confirmed as a pre-existing flake, not a regression).
- `npm run lint --prefix server`: 0 errors, 391 warnings (matches the documented ratchet baseline exactly — no new warnings).
- `npm run typecheck --prefix server`: passes.
- `npx vitest run` (client, `Collections.test.tsx`): 3 passed — unaffected, since the client side was already correct.

## Post-Deploy Monitoring & Validation
- **Log queries:** watch for `ZodError` / `400` responses on `PUT /api/v1/collections/:id` immediately after deploy — the new `.strict()` would surface any caller sending a field this schema doesn't know about (none currently exist in this codebase, but this is the failure mode to watch for).
- **Expected healthy signal:** `PUT /api/v1/collections/:id` from the edit modal returns 200 and the response body's `status`/`year` match what was submitted (previously these were silently dropped).
- **Failure signal / rollback trigger:** a spike in 400s on the collections update endpoint, or a support report that editing a collection's status/season/year still doesn't persist.
- **Validation window:** first 24h after deploy; owner: whoever merges this PR.

Related: #78 (partial-update contract, already landed), #81 (whole-set replace race — this PR is its stated precondition, per `docs/plans/2026-09-04-001-refactor-parallel-issue-execution-map-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN