### PR TITLE
fix(collections): refuse a whole-set replace computed from a stale read (#81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,43 @@ till is confirmed to be sending the header. The observable is that
 matches the day's sale count. Flipping is a config change, not a deploy, so it is
 reversible in seconds.
 
+## Optimistic concurrency on collections
+
+`PUT /api/v1/collections/:id` replaces a collection's **entire** product set — the join
+rows are deleted and re-inserted from the list in the body. Last-writer-wins is therefore
+inherent to the endpoint's shape, and it used to be silent: a reorder computed before a
+colleague's append simply erased that product, and both admins got a 200.
+
+So a write may carry `expected_updated_at`, the `updated_at` value the caller read. The
+service takes `SELECT ... FOR UPDATE` on the collection row and compares before writing —
+the lock is what makes check-then-write atomic, not a fix on its own, which is why a bare
+row lock was rejected: the loser would still overwrite from stale data. A mismatch is a
+`409` whose `details[]` carries the code `COLLECTION_MODIFIED`, and the whole transaction
+rolls back.
+
+The token is `updated_at` rendered by `toISOString()` — literally the call `res.json()`
+makes on that column — so what is compared is byte-identical to what the client was given,
+rather than two formats kept in agreement. A JS `Date` holds milliseconds while
+`timestamptz` holds microseconds, so the comparison is millisecond-resolution by
+necessity: the finer digits are gone before any client sees them. Two writes to one
+collection inside the same millisecond are therefore indistinguishable, which needs a read
+interleaved between them, and writers to a single collection are serialized by the row
+lock — so consecutive writes are a whole transaction commit apart.
+
+**The response deliberately does not include the current token.** The recovery for a
+conflict is *review*: re-read, look at what changed, decide. Handing back a fresh token
+would make blind resubmission the easiest thing to do, which is the overwrite the refusal
+exists to prevent.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `expected_updated_at` | absent | Absent means the caller stakes no claim on the version, and the write behaves exactly as it did before optimistic concurrency existed. |
+
+Optional for the same reason `Idempotency-Key` is: a cached PWA client running older code
+keeps working rather than breaking on a 409 it cannot explain. Every client this repo
+ships sends it. The token must come from the read the edit was **composed against** — a
+page that re-reads it at submit time always matches and has quietly turned the check off.
+
 ## Scheduled jobs
 
 Background maintenance runs through `server/src/scheduler`, not through a `setInterval`

--- a/client/src/features/inventory/pages/Collections.test.tsx
+++ b/client/src/features/inventory/pages/Collections.test.tsx
@@ -25,6 +25,9 @@ const product = (id: number, name: string) => ({
   position: id,
 });
 
+/** The version token as the server serializes it — a JSON `Date`, so millisecond ISO. */
+const READ_VERSION = '2026-09-04T12:00:00.000Z';
+
 const featuredCollection = () => ({
   id: 1,
   name: 'Autumn window',
@@ -34,6 +37,7 @@ const featuredCollection = () => ({
   description: 'The window',
   is_featured: true,
   product_count: 1,
+  updated_at: READ_VERSION,
   products: [product(20, 'Ivory coat')],
 });
 
@@ -45,6 +49,12 @@ const featuredCollection = () => ({
  * server treated the omission as "set to default" and the collection quietly stopped
  * being featured (#78). The endpoint is now PATCH-style, so the fix on this side is
  * that the dialog sends only what it actually changed.
+ *
+ * Every write also carries `expected_updated_at`, the version of the read it was
+ * computed from (#81). A `PUT` replaces the whole product set, so one composed against
+ * a stale read erases what it never saw; the token is what lets the server refuse it.
+ * A write that forgets the token is not a lint error, it is a silent return to
+ * last-writer-wins — which is why the assertions below are on the exact body keys.
  */
 describe('Collections product editing wire contract', () => {
   beforeEach(() => useSettingsStore.setState({ locale: 'en' }));
@@ -66,7 +76,11 @@ describe('Collections product editing wire contract', () => {
 
     await waitFor(() =>
       expect(transport.calls()).toContainEqual(
-        expect.objectContaining({ method: 'PUT', path: 'collections/1', body: { product_ids: [] } })
+        expect.objectContaining({
+          method: 'PUT',
+          path: 'collections/1',
+          body: { product_ids: [], expected_updated_at: READ_VERSION },
+        })
       )
     );
   });
@@ -86,7 +100,7 @@ describe('Collections product editing wire contract', () => {
         expect.objectContaining({
           method: 'PUT',
           path: 'collections/1',
-          body: { product_ids: [20, 21] },
+          body: { product_ids: [20, 21], expected_updated_at: READ_VERSION },
         })
       )
     );
@@ -105,10 +119,47 @@ describe('Collections product editing wire contract', () => {
     const writes = transport.calls().filter((call) => call.method === 'PUT');
     expect(writes).not.toHaveLength(0);
     for (const write of writes) {
-      expect(Object.keys(write.body as Record<string, unknown>)).toEqual(['product_ids']);
+      expect(Object.keys(write.body as Record<string, unknown>).sort()).toEqual([
+        'expected_updated_at',
+        'product_ids',
+      ]);
     }
     // The memory transport merges a PUT onto the stored row exactly as the endpoint now
     // does, so the flag surviving here is the same assertion the server test makes.
     expect(transport.peek('collections')[0].is_featured).toBe(true);
+  });
+
+  it('stakes the edit dialog on the version it was opened with', async () => {
+    const transport = createMemoryTransport({
+      collections: [featuredCollection()],
+      products: [product(21, 'Slate dress')],
+    });
+    render(<CollectionsPage />, { wrapper: wrapperFor(transport) });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      const write = transport.calls().find((call) => call.method === 'PUT');
+      expect(write).toBeDefined();
+      // The token the dialog opened on, not one re-read at submit time. Re-reading it
+      // would always match and quietly turn the check into a no-op.
+      expect((write!.body as Record<string, unknown>).expected_updated_at).toBe(READ_VERSION);
+    });
+  });
+
+  it('sends no version when creating, because there is no prior read to stake', async () => {
+    const transport = createMemoryTransport({ collections: [], products: [] });
+    render(<CollectionsPage />, { wrapper: wrapperFor(transport) });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Create Collection' }));
+    fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Spring window' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      const write = transport.calls().find((call) => call.method === 'POST');
+      expect(write).toBeDefined();
+      expect((write!.body as Record<string, unknown>).expected_updated_at).toBeUndefined();
+    });
   });
 });

--- a/client/src/features/inventory/pages/Collections.tsx
+++ b/client/src/features/inventory/pages/Collections.tsx
@@ -36,14 +36,23 @@ const emptyCollection = () => ({
   year: String(new Date().getFullYear()),
   status: 'upcoming',
   description: '',
+  // A collection being created has no prior version to stake a claim on.
+  updatedAt: '',
 });
 
+/**
+ * `updatedAt` rides in the form values rather than being looked up at submit time, and
+ * that is the whole point of it (#81): the token has to be the one from the read this
+ * edit was composed against. Re-reading it on save would hand the server whatever is
+ * current — which always matches, silently defeating the check the field exists for.
+ */
 const collectionToForm = (col: Collection) => ({
   name: col.name,
   season: col.season || '',
   year: String(col.year || ''),
   status: col.status,
   description: col.description || '',
+  updatedAt: col.updated_at,
 });
 
 /**
@@ -55,10 +64,16 @@ const collectionToForm = (col: Collection) => ({
  * PATCH-style, so replaying fields this dialog does not own only widens the window for
  * overwriting a change someone else made between the read and the write (#81), and the
  * one field it forgot was silently reset on every product edit (#78).
+ *
+ * The version token comes from the same `detail` the product list is computed from, so
+ * the two cannot disagree: if this set was derived from a read that is no longer
+ * current, the token is stale too and the server refuses the write instead of erasing
+ * whatever landed in between (#81).
  */
 const withProducts = (detail: CollectionDetail, productIds: number[]) => ({
   id: detail.id,
   product_ids: productIds,
+  expected_updated_at: detail.updated_at,
 });
 
 export default function CollectionsPage() {
@@ -73,7 +88,7 @@ export default function CollectionsPage() {
 
   const { data: rows, meta } = collections.useList({ page, pageSize: 25 });
   const pagination = meta?.pagination as PaginationMeta | undefined;
-  const { data: detail } = collectionDetail.useOne(selectedCol);
+  const { data: detail, isFetching: detailIsFetching } = collectionDetail.useOne(selectedCol);
 
   const {
     products: allProducts,
@@ -95,6 +110,16 @@ export default function CollectionsPage() {
 
   const addProduct = collections.useSave({ message: t('common.save') });
   const removeProduct = collections.useSave();
+
+  /**
+   * Each product edit sends the whole set, computed from `detail`. While the read that
+   * produced `detail` is being refreshed, that set is one edit behind — a second click
+   * would submit a list missing the product the first click just added, and ask the
+   * server to make it so. That erased it silently before #81 and is refused with a 409
+   * after it; neither is what the merchandiser asked for. So the edit waits for the
+   * data it is computed from, which is the only version of this that is actually right.
+   */
+  const productEditsBlocked = detailIsFetching || addProduct.isSaving || removeProduct.isSaving;
 
   // Detail view
   if (selectedCol && detail) {
@@ -160,6 +185,7 @@ export default function CollectionsPage() {
                       color="danger"
                       size="sm"
                       className="h-6 w-6 text-muted-foreground hover:text-danger"
+                      isDisabled={productEditsBlocked}
                       onClick={() =>
                         removeProduct.save(
                           withProducts(
@@ -223,7 +249,8 @@ export default function CollectionsPage() {
                       .map((p) => (
                         <button
                           key={p.id}
-                          className="w-full flex items-center justify-between p-2 rounded-lg hover:bg-muted/50 text-start transition-colors"
+                          className="w-full flex items-center justify-between p-2 rounded-lg hover:bg-muted/50 text-start transition-colors disabled:opacity-50"
+                          disabled={productEditsBlocked}
                           onClick={() =>
                             addProduct.save(
                               withProducts(detail, [...detail.products.map((dp) => dp.id), p.id])
@@ -391,6 +418,7 @@ export default function CollectionsPage() {
                   year: Number(form.year) || undefined,
                   status: form.status,
                   description: form.description || undefined,
+                  expected_updated_at: form.updatedAt || undefined,
                 });
               }}
             >

--- a/client/src/features/inventory/types.ts
+++ b/client/src/features/inventory/types.ts
@@ -70,6 +70,13 @@ export interface Collection {
   status: string;
   description: string | null;
   product_count: number;
+  /**
+   * Doubles as the optimistic-concurrency token (#81). Echoed back as
+   * `expected_updated_at` on a write, which the server refuses if the row has moved
+   * since — `PUT` replaces the whole product set, so a write from a stale read erases
+   * whatever it did not know about rather than merging with it.
+   */
+  updated_at: string;
 }
 
 /**

--- a/client/src/shared/lib/resource.test.tsx
+++ b/client/src/shared/lib/resource.test.tsx
@@ -315,6 +315,58 @@ describe('resource', () => {
     });
   });
 
+  /**
+   * A conflict is the one failure whose recovery — `review` in `mutationError` — depends
+   * on the screen being refreshed. Without this, a page holding an optimistic-concurrency
+   * token (`expected_updated_at` on collections, #81) resubmits the same stale token
+   * forever and the user has no way out but a manual reload.
+   */
+  const countingReads = (transport: MemoryTransport, reads: string[]): MemoryTransport => ({
+    ...transport,
+    request(req) {
+      if (req.method === 'GET') reads.push(req.path);
+      return transport.request(req);
+    },
+  });
+
+  it('refreshes what a write depended on when the server reports a conflict', async () => {
+    const transport = createMemoryTransport({ expenses: [RENT] });
+    const reads: string[] = [];
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => ({ list: expenses.useList(), saver: expenses.useSave() }), {
+      wrapper: wrapperFor(countingReads(transport, reads)),
+    });
+    await waitFor(() => expect(result.current.list.data).toHaveLength(1));
+    const readsBeforeWrite = reads.length;
+
+    transport.failNext('Changed by someone else', 409);
+    result.current.saver.save({ id: 1, category: 'rent', amount: 1300 });
+
+    await waitFor(() => expect(result.current.saver.failure).toMatchObject({ kind: 'conflict' }));
+    await waitFor(() => expect(reads.length).toBeGreaterThan(readsBeforeWrite));
+  });
+
+  it('does not refresh on a failure the user fixes in place', async () => {
+    // The control. A validation rejection keeps the form and its values as they are —
+    // refetching underneath a user mid-correction would be the opposite of helpful.
+    const transport = createMemoryTransport({ expenses: [RENT] });
+    const reads: string[] = [];
+    const expenses = resource<Expense>('expenses');
+
+    const { result } = renderHook(() => ({ list: expenses.useList(), saver: expenses.useSave() }), {
+      wrapper: wrapperFor(countingReads(transport, reads)),
+    });
+    await waitFor(() => expect(result.current.list.data).toHaveLength(1));
+    const readsBeforeWrite = reads.length;
+
+    transport.failNext('Amount must be positive', 400);
+    result.current.saver.save({ id: 1, category: 'rent', amount: -5 });
+
+    await waitFor(() => expect(result.current.saver.failure).toMatchObject({ kind: 'validation' }));
+    expect(reads).toHaveLength(readsBeforeWrite);
+  });
+
   it('drops a second write fired before the first has settled', async () => {
     const transport = createMemoryTransport({ expenses: [RENT] });
     const requests: string[] = [];

--- a/client/src/shared/lib/resource.ts
+++ b/client/src/shared/lib/resource.ts
@@ -59,7 +59,20 @@ function useWrite<Args>(
       queryClient.invalidateQueries({ queryKey: key });
       onDone?.();
     },
-    onFailure,
+    onFailure: (failure) => {
+      // A conflict means the world moved under the request, and `mutationError` already
+      // names the recovery for it: *review* — refresh what it depended on, then let the
+      // user look before resubmitting. Refreshing here rather than at each call site is
+      // the same reasoning as invalidating on success: what to invalidate is this
+      // module's knowledge, and a page that forgets it strands the user resubmitting a
+      // request that cannot start succeeding (an optimistic-concurrency token the page
+      // never re-reads is refused forever). Nothing auto-retries; this only makes the
+      // screen honest about what is now there.
+      if (failure.kind === 'conflict') {
+        queryClient.invalidateQueries({ queryKey: key });
+      }
+      return onFailure?.(failure);
+    },
   });
 }
 

--- a/server/src/modules/inventory/collections/controller.ts
+++ b/server/src/modules/inventory/collections/controller.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { logAuditFromReq } from '../../../../middleware/auditLogger';
 import { collectionsService } from './service';
-import { parseCollectionListQuery } from './types';
+import { parseCollectionListQuery, CollectionConflictError } from './types';
 import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
@@ -55,6 +55,10 @@ export const collectionUpdateSchema = z
     status: collectionStatusSchema.optional(),
     is_featured: z.boolean().optional(),
     product_ids: z.array(z.number().int().positive()).optional(),
+    // The `updated_at` the caller read (#81). Validated as a datetime here so a
+    // malformed value is a 400 from the schema rather than a cast error from the
+    // database; whether it is *current* is decided under the row lock in the service.
+    expected_updated_at: z.string().datetime().optional(),
   })
   .strict();
 
@@ -111,6 +115,17 @@ export class CollectionsController {
       logAuditFromReq(req, 'update', 'collection', Number(id));
       res.json(success(result.data));
     } catch (err) {
+      if (err instanceof CollectionConflictError) {
+        // The envelope code stays one of the seven public ones; the domain code rides
+        // in `details[]`, where `IDEMPOTENCY_KEY_REUSED` and `INSUFFICIENT_STOCK`
+        // already ride. `field` names the request key the client must refresh.
+        next(
+          new PublicError('CONFLICT', err.message, [
+            { field: 'expected_updated_at', code: err.code, message: err.message },
+          ])
+        );
+        return;
+      }
       next(err);
     }
   }

--- a/server/src/modules/inventory/collections/repository.ts
+++ b/server/src/modules/inventory/collections/repository.ts
@@ -7,6 +7,7 @@ import {
   CollectionFilters,
   CreateCollectionDTO,
   UpdateCollectionDTO,
+  collectionVersionToken,
 } from './types';
 
 export interface ICollectionsRepository {
@@ -15,6 +16,10 @@ export interface ICollectionsRepository {
     queryable?: Queryable
   ): Promise<{ rows: CollectionRecord[]; total: number }>;
   findById(id: number | string, queryable?: Queryable): Promise<CollectionRecord | null>;
+  lockById(
+    id: number | string,
+    queryable: Queryable
+  ): Promise<{ id: number; token: string } | null>;
   findProductsByCollectionId(
     collectionId: number | string,
     queryable?: Queryable
@@ -88,6 +93,33 @@ export class CollectionsRepository implements ICollectionsRepository {
       [id]
     );
     return res.rows[0] || null;
+  }
+
+  /**
+   * Locks a collection row and returns its concurrency token (#81).
+   *
+   * Two things have to be true at once for an optimistic check to mean anything: the
+   * token must be read *after* every earlier writer has committed, and no later writer
+   * may commit between the read and this caller's write. `FOR UPDATE` gives both — it
+   * is what makes check-then-write atomic, not a fix on its own. (The issue rejects a
+   * bare row lock for exactly that reason: serializing the two writers still lets the
+   * loser overwrite from stale data. The lock is the mechanism; the comparison is the
+   * fix.) It also matches the order `addProducts` takes its locks in — parent row
+   * first, then the join table — so the two paths cannot deadlock against each other.
+   *
+   * The token is rendered here rather than compared here, so the "is this stale"
+   * decision stays in the service with the rest of the policy.
+   */
+  async lockById(
+    id: number | string,
+    queryable: Queryable
+  ): Promise<{ id: number; token: string } | null> {
+    const res = await queryable.query<{ id: number; updated_at: Date }>(
+      'SELECT id, updated_at FROM collections WHERE id = $1 FOR UPDATE',
+      [id]
+    );
+    const row = res.rows[0];
+    return row ? { id: row.id, token: collectionVersionToken(row.updated_at) } : null;
   }
 
   async findProductsByCollectionId(

--- a/server/src/modules/inventory/collections/service.ts
+++ b/server/src/modules/inventory/collections/service.ts
@@ -6,6 +6,7 @@ import {
   UpdateCollectionDTO,
   CollectionRecord,
   CollectionDetailRecord,
+  CollectionConflictError,
 } from './types';
 
 export class CollectionsService {
@@ -40,27 +41,46 @@ export class CollectionsService {
     });
   }
 
+  /**
+   * A whole-set replace, guarded by the caller's version token (#81).
+   *
+   * The existence check used to run on its own unlocked read before the transaction
+   * opened, which made it a second stale read on a path whose entire problem is stale
+   * reads. Both the check and the guard now happen against the locked row, inside the
+   * transaction that writes — otherwise the row could move between deciding to write
+   * and writing.
+   *
+   * A stale token throws rather than returning `success: false`, because it is not the
+   * same kind of answer: "no such collection" is about the request's target, while this
+   * is a domain refusal the controller has to turn into a typed 409. Same shape as
+   * `InsufficientStockError` on the POS path.
+   */
   async update(
     id: number | string,
     data: UpdateCollectionDTO
   ): Promise<{ success: boolean; data?: CollectionRecord; error?: string }> {
-    const existing = await this.repo.findById(id);
-    if (!existing) {
-      return { success: false, error: 'Collection not found' };
-    }
+    return withTransaction(async (client) => {
+      const current = await this.repo.lockById(id, client);
+      if (!current) {
+        return { success: false, error: 'Collection not found' };
+      }
 
-    const updated = await withTransaction(async (client) => {
-      const c = await this.repo.update(id, data, client);
+      if (data.expected_updated_at !== undefined && data.expected_updated_at !== current.token) {
+        throw new CollectionConflictError(
+          'This collection was changed by someone else after you opened it. Reload to see the current products before saving.'
+        );
+      }
+
+      const updated = await this.repo.update(id, data, client);
       if (data.product_ids !== undefined) {
         await this.repo.deleteProductsByCollectionId(id, client);
         if (data.product_ids.length > 0) {
           await this.repo.addProducts(id, data.product_ids, client);
         }
       }
-      return c;
-    });
 
-    return { success: true, data: updated! };
+      return { success: true, data: updated! };
+    });
   }
 
   async delete(id: number | string): Promise<{ success: boolean; error?: string }> {

--- a/server/src/modules/inventory/collections/types.ts
+++ b/server/src/modules/inventory/collections/types.ts
@@ -59,6 +59,69 @@ export interface UpdateCollectionDTO {
   status?: string;
   is_featured?: boolean;
   product_ids?: number[];
+  /**
+   * The `updated_at` the caller read, echoed back so the write can be refused if the
+   * row moved underneath it (#81). Not a column — see {@link COLLECTION_MODIFIED_CODE}.
+   *
+   * Optional on purpose: absent means "no opinion about the version", and the write
+   * behaves exactly as it did before optimistic concurrency existed. A cached PWA
+   * client running older code therefore keeps working, the same compatibility posture
+   * the `Idempotency-Key` rollout takes.
+   */
+  expected_updated_at?: string;
+}
+
+/** Stable, documented code for a write refused because the row moved under the caller. */
+export const COLLECTION_MODIFIED_CODE = 'COLLECTION_MODIFIED';
+
+/**
+ * Renders `collections.updated_at` as the version token a client can echo back.
+ *
+ * This is deliberately `toISOString()` and not a hand-written format: it is the *same
+ * call* `res.json()` makes when it serializes the row, because `JSON.stringify` invokes
+ * `Date.prototype.toJSON`, which is `toISOString`. So the token compared here is
+ * byte-identical to the string the client was given, by construction rather than by two
+ * formats being kept in agreement.
+ *
+ * ## The precision this settles
+ *
+ * `updated_at` is `timestamptz`, which PostgreSQL keeps to the microsecond, while a JS
+ * `Date` — what node-pg parses the column into, and the only thing a JSON client ever
+ * sees — holds milliseconds. The sub-millisecond digits are therefore already gone
+ * before any client can echo anything back, so the comparison has to happen at
+ * millisecond resolution or it could never match at all.
+ *
+ * The residual is that two writes to one collection landing inside the same millisecond
+ * are indistinguishable. Reaching that needs both writes plus a read interleaved between
+ * them, and writers to a single collection are serialized by the `FOR UPDATE` in
+ * `lockById` — so consecutive writes are separated by a whole transaction commit, which
+ * is not a sub-millisecond event on storage that durably persists anything.
+ */
+export function collectionVersionToken(updatedAt: Date): string {
+  return updatedAt.toISOString();
+}
+
+/**
+ * Thrown when a whole-set replace carries a version token that is no longer current.
+ *
+ * `PUT /api/v1/collections/:id` replaces the entire product set, so a request computed
+ * from a stale read does not merge with what it missed — it erases it. Before this
+ * existed the loser of that race got a 200 and their product was simply gone (#81).
+ *
+ * Deliberately carries no "current" token. The recovery for a conflict is *review* —
+ * re-read, look at what changed, decide — and handing the client a fresh token would
+ * make blind resubmission the easiest thing to do, which is the silent overwrite this
+ * refusal exists to prevent.
+ */
+export class CollectionConflictError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string = COLLECTION_MODIFIED_CODE,
+    public readonly statusCode: number = 409
+  ) {
+    super(message);
+    this.name = 'CollectionConflictError';
+  }
 }
 
 export interface CollectionFilters {

--- a/server/tests/concurrency/collections.concurrency.test.ts
+++ b/server/tests/concurrency/collections.concurrency.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../support/realPostgres';
 import { CollectionsRepository } from '../../src/modules/inventory/collections/repository';
 import { CollectionsService } from '../../src/modules/inventory/collections/service';
+import { COLLECTION_MODIFIED_CODE } from '../../src/modules/inventory/collections/types';
 import { withTransaction, type Queryable } from '../../src/database/transaction';
 
 describeWithPostgres('collection product position under concurrency', () => {
@@ -69,6 +70,16 @@ describeWithPostgres('collection product position under concurrency', () => {
       [collectionId]
     );
     return rows.map((r) => r.product_id);
+  };
+
+  /**
+   * The version token as an *admin's browser* holds it: whatever `GET` put on the wire,
+   * read back through a real JSON round-trip rather than reconstructed by hand. A token
+   * the client cannot actually produce would make every test below prove nothing.
+   */
+  const tokenFromApi = async (): Promise<string> => {
+    const detail = await service.findById(collectionId);
+    return (JSON.parse(JSON.stringify(detail)) as { updated_at: string }).updated_at;
   };
 
   it('gives four simultaneous appenders four distinct consecutive slots', async () => {
@@ -149,7 +160,7 @@ describeWithPostgres('collection product position under concurrency', () => {
     expect(await orderedProducts()).toEqual(reversed);
   });
 
-  it('survives a reorder racing an append', async () => {
+  it('survives a reorder racing an append, when neither caller claims a version', async () => {
     await repo.addProducts(collectionId, productIds.slice(0, 3));
     const rotated = [productIds[2], productIds[0], productIds[1]];
 
@@ -173,14 +184,19 @@ describeWithPostgres('collection product position under concurrency', () => {
     //   - the append commits first and update's DELETE then sees it   -> slots 0,1,2
     //   - the append commits between update's DELETE and its inserts  -> slots 3,4,5,6
     //
-    // The middle outcome DROPS the appended product. That is not a defect this PR
-    // introduces or that `position` causes: `PUT /api/v1/collections/:id` replaces the
-    // whole product set, so a reorder legitimately removes anything it did not list, and
-    // the loser of the race is whoever's read was stale. Last-writer-wins on a whole-set
-    // replace is a pre-existing property of the endpoint. Asserting a fixed membership
-    // here would encode one scheduling outcome as if it were the contract.
+    // The middle outcome DROPS the appended product, and this case still permits it —
+    // because neither caller here sends `expected_updated_at`. That is the whole of the
+    // compatibility window (#81): a request that stakes no claim about the version it
+    // read gets exactly the last-writer-wins behaviour it always got, so a cached client
+    // running older code keeps working rather than breaking on a 409 it cannot explain.
+    // The tests below cover the callers that DO claim a version, which is every caller
+    // this repo ships. Asserting a fixed membership here would encode one scheduling
+    // outcome as if it were the contract.
     //
-    // So the assertions are on what must hold in every outcome.
+    // So the assertions are on what must hold in every outcome. This case also remains
+    // the coverage for the unique constraint under a genuine reorder/append interleaving
+    // — once a token is in play one of the two writers is refused, so it never gets
+    // that far.
     const slots = await positions();
     // Distinct: the unique constraint held and no two products share a slot.
     expect(new Set(slots).size).toBe(slots.length);
@@ -193,6 +209,117 @@ describeWithPostgres('collection product position under concurrency', () => {
     // intact — a concurrent append may sit after it, never inside it.
     expect(finalProducts.every((id) => productIds.includes(id))).toBe(true);
     expect(finalProducts.filter((id) => rotated.includes(id))).toEqual(rotated);
+  });
+
+  // ── Optimistic concurrency: the silent drop, refused rather than committed (#81) ────
+
+  it('hands the client a token it can actually echo back', async () => {
+    // Everything below rests on the token surviving JSON. If the server ever compared
+    // something the client never receives — microseconds, a Date, a different format —
+    // every write would be refused and the tests would still pass without this case.
+    const token = await tokenFromApi();
+
+    const result = await service.update(collectionId, {
+      name: 'Autumn window',
+      expected_updated_at: token,
+    });
+
+    expect(result.success).toBe(true);
+    expect(token).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it('refuses a whole-set replace computed from a read that is no longer current', async () => {
+    await repo.addProducts(collectionId, productIds.slice(0, 3));
+    // What an admin's open page is holding.
+    const stale = await tokenFromApi();
+
+    // A second admin appends a product. A whole-set replace, so it moves the version.
+    await service.update(collectionId, {
+      product_ids: [...productIds.slice(0, 3), productIds[3]],
+    });
+    expect(await tokenFromApi()).not.toBe(stale);
+
+    // The first admin now saves a reorder computed before that append existed. Under
+    // the old behaviour this returned 200 and erased the appended product.
+    const rotated = [productIds[2], productIds[0], productIds[1]];
+    await expect(
+      service.update(collectionId, { product_ids: rotated, expected_updated_at: stale })
+    ).rejects.toMatchObject({ code: COLLECTION_MODIFIED_CODE, statusCode: 409 });
+
+    // The refusal is the point, but this is the assertion the issue is actually about.
+    expect(await orderedProducts()).toEqual([...productIds.slice(0, 3), productIds[3]]);
+  });
+
+  it('leaves the collection untouched when it refuses', async () => {
+    await repo.addProducts(collectionId, productIds.slice(0, 3));
+    const stale = await tokenFromApi();
+    await service.update(collectionId, { name: 'Someone else got here first' });
+
+    await expect(
+      service.update(collectionId, {
+        name: 'Autumn window',
+        status: 'archived',
+        product_ids: [productIds[0]],
+        expected_updated_at: stale,
+      })
+    ).rejects.toMatchObject({ code: COLLECTION_MODIFIED_CODE });
+
+    // A refused write must roll back whole. A partial one — the row updated, the
+    // products not, or the reverse — would be a worse outcome than the bug.
+    const { rows } = await harness.pool.query<{ name: string; status: string }>(
+      'SELECT name, status FROM collections WHERE id = $1',
+      [collectionId]
+    );
+    expect(rows[0].name).toBe('Someone else got here first');
+    expect(rows[0].status).toBe('active');
+    expect(await orderedProducts()).toEqual(productIds.slice(0, 3));
+  });
+
+  it('lets exactly one of two concurrent replaces win, and tells the loser', async () => {
+    await repo.addProducts(collectionId, productIds.slice(0, 3));
+    // Both admins loaded the page at the same time, so both hold the same version.
+    const token = await tokenFromApi();
+
+    const rotated = [productIds[2], productIds[0], productIds[1]];
+    const appended = [...productIds.slice(0, 3), productIds[3]];
+
+    const results = await Promise.allSettled([
+      service.update(collectionId, { product_ids: rotated, expected_updated_at: token }),
+      service.update(collectionId, { product_ids: appended, expected_updated_at: token }),
+    ]);
+
+    // Which of the two wins the row lock is genuinely nondeterministic. That exactly one
+    // wins, and that the other is told rather than silently discarded, is not.
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      code: COLLECTION_MODIFIED_CODE,
+    });
+
+    // The stored set is exactly one of the two submissions, never a blend of both.
+    expect([rotated, appended]).toContainEqual(await orderedProducts());
+  });
+
+  it('accepts the loser once it re-reads, which is the recovery the 409 asks for', async () => {
+    await repo.addProducts(collectionId, productIds.slice(0, 3));
+    const stale = await tokenFromApi();
+    await service.update(collectionId, { product_ids: [...productIds.slice(0, 3), productIds[3]] });
+
+    await expect(
+      service.update(collectionId, { product_ids: [productIds[0]], expected_updated_at: stale })
+    ).rejects.toMatchObject({ code: COLLECTION_MODIFIED_CODE });
+
+    // The refusal must be recoverable without a special path: re-read, look, resubmit.
+    const fresh = await tokenFromApi();
+    const result = await service.update(collectionId, {
+      product_ids: [productIds[0], productIds[3]],
+      expected_updated_at: fresh,
+    });
+
+    expect(result.success).toBe(true);
+    expect(await orderedProducts()).toEqual([productIds[0], productIds[3]]);
   });
 
   it('makes a second appender wait for the first transaction to commit', async () => {


### PR DESCRIPTION
Closes #81. Wave 2, lane A of `docs/plans/2026-09-04-001-refactor-parallel-issue-execution-map-plan.md` — unblocked by #83 (PR #92), which this builds directly on.

## The bug

`PUT /api/v1/collections/:id` replaces a collection's **entire** product set. So a reorder computed before a colleague's append erased that product, and both admins got a 200. Nothing marked it, because to the endpoint a whole-set replace that omits a product is an ordinary request. `server/tests/concurrency/collections.concurrency.test.ts` already proved this and *documented the drop as accepted behaviour*.

## The fix

A write may carry `expected_updated_at`, the version it read. The service takes `SELECT ... FOR UPDATE` on the collection row and compares before writing; a mismatch is a `409` carrying `COLLECTION_MODIFIED` in `details[]` — the shape `INSUFFICIENT_STOCK` (PR #90) and `IDEMPOTENCY_KEY_REUSED` already use.

The lock is what makes check-then-write atomic, **not a fix on its own** — which is exactly why the issue rejects a bare row lock: the loser would still overwrite from stale data. The lock is the mechanism; the comparison is the fix.

Decisions worth flagging for review:

- **The token is `updated_at` via `toISOString()`** — literally the call `res.json()` makes on that column, so what's compared is byte-identical to what the client was handed, rather than two formats kept in agreement. A JS `Date` holds milliseconds where `timestamptz` holds microseconds, so the comparison is millisecond-resolution by necessity: the finer digits are gone before any client sees them. The residual (two writes to one collection inside the same millisecond) needs a read interleaved between them, and writers are serialized by the row lock — so consecutive writes are a whole transaction commit apart. Documented at `collectionVersionToken`.
- **No migration.** `updated_at` already exists and `buildPartialUpdate`'s `alwaysSet` already bumps it unconditionally — including when only the product set changed, which is precisely the race being fixed.
- **The 409 does not return the current token.** The recovery is *review*; handing back a fresh token makes blind resubmission the easiest thing to do, which is the overwrite the refusal exists to prevent.
- **The field is optional**, as `Idempotency-Key` is, so a cached PWA client running older code keeps working. Every client this repo ships sends it.
- **The existence check moved inside the transaction** — it was a second *unlocked* read on a path whose entire problem is stale reads.

## Two consequences beyond the endpoint

Both are called out because they touch shared code, not just the collections lane:

- `resource()`'s `useWrite` now refreshes on a conflict. `mutationError.ts` already documents `conflict → review` as "refresh what it depended on and let the user look before resubmitting"; without implementing it, a page holding a token it never re-reads is refused **forever**. It lives in `useWrite` for the same reason invalidate-on-success does — that module's docstring says deciding what to invalidate is its job, once, not each call site's. Nothing auto-retries.
- The Collections page blocks a product edit while the read it's computed from is refetching. A second rapid click submitted a set *missing* what the first click added — that erased it silently before this change and is refused with a 409 after it. Neither is what the merchandiser asked for.

## Testing

- **The four new concurrency cases all fail against the unfixed service** (verified by neutering the guard and re-running): stale token refused with the appended product intact; a refusal rolls back whole; two concurrent replaces → exactly one wins and the loser is told; the loser succeeds after re-reading. Plus a case asserting the token survives a real JSON round-trip — without it, the server could compare something no client can produce and every test would still pass.
- The `'survives a reorder racing an append'` case kept its assertions but its comment now scopes the drop to callers claiming no version, and it remains the unique-constraint coverage (once a token is in play, one writer is refused before it gets that far).
- The client conflict-refresh test also verified to fail without the change, with a validation-failure control proving it does *not* refetch under a user mid-correction.
- `server`: 672 passed / 0 skipped with `TEST_DATABASE_URL` set — real-PostgreSQL suites all ran. Lint 0 errors / 391 warnings (the documented ratchet, unchanged). Typecheck clean.
- `client`: typecheck and lint clean (0 errors, 19 pre-existing warnings). Touched files 25/25.
- One note for the reviewer: the full 58-file client suite showed 9 failures on my Windows box, 6 of them exceeding the configured 20s `testTimeout`. All 6 affected files pass together (54/54) and individually; none of them exercises a 409, and the change is a literal pass-through for every non-conflict failure. `vitest.config.ts`'s own comment describes this contention flake class. CI is the authoritative check.

## Post-Deploy Monitoring & Validation

- **Log query:** `409` responses on `PUT /api/v1/collections/:id` with `details[].code === 'COLLECTION_MODIFIED'`. A low, non-zero rate is the feature working — it is the silent overwrite becoming visible.
- **Expected healthy signal:** collection edits and product add/remove return 200 as before; conflicts appear only when two admins genuinely overlap.
- **Failure signals / rollback trigger:** a *sustained* 409 rate on that endpoint (would suggest a client sending a token it never refreshes — the loop this PR's `useWrite` change exists to prevent), or any `400` with `unrecognized_keys` on `expected_updated_at` (would mean a client/schema mismatch). Rollback is a plain revert; the field is optional on both sides, so a half-deployed state degrades to today's behaviour rather than breaking.
- **Validation window / owner:** first 48h after deploy, whoever merges.

Related: #78 (partial-update contract), #68/#73 (the `position` column), #83 (PR #92, this PR's precondition). The genuine partial add/remove/reorder API remains the better end state and a separate, larger issue — this stops the silent loss now without blocking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN