### PR TITLE
test(ci): gate the lint warning count and prove migrations roll back (#43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,56 @@ jobs:
         if: always()
         run: node scripts/assertRealPostgresSuitesRan.mjs vitest-report.json
 
+  migrations:
+    name: Migrations (up, down, re-apply)
+    # Its own job rather than a step on `server`, so the report says which gate failed
+    # without anyone opening a log: a broken rollback and a failing unit test are
+    # different problems with different owners.
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: moon_store_migrations_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      MIGRATION_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/moon_store_migrations_test
+      JWT_SECRET: ci-jwt-secret-key-at-least-32-characters-long
+      JWT_REFRESH_SECRET: ci-jwt-refresh-secret-key-at-least-32-chars
+
+    defaults:
+      run:
+        working-directory: server
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - run: npm ci
+
+      - name: Every migration's down must reverse its up
+        # Migrations otherwise only ever run forwards, on an empty database, inside
+        # tests/support/realPostgres.ts. A down that does not undo its up is invisible
+        # until a rollback is needed, which is the worst moment to find out. The script
+        # fails on an empty migrations directory too, so it cannot pass by finding
+        # nothing to check.
+        run: npm run verify:migrations
+
   client:
     name: Client (lint, typecheck, test)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,53 @@ Full checklist detail, the global string-coupling contract (persist keys, shared
 duplicated Sidebar route strings, global i18n files), and slice split/merge criteria:
 `docs/CONVENTIONS.md`.
 
+## CI gates
+
+Each gate is its own job, so the checks list says what broke without anyone opening a log.
+
+| Job | What it proves |
+| --- | --- |
+| `Server (lint, typecheck, test)` | ESLint clean of errors and **not above the warning ratchet**, `tsc --noEmit`, the full suite with a real PostgreSQL, plus a guard that the real-PG suites were not silently skipped. |
+| `Migrations (up, down, re-apply)` | Every `.down.sql` actually reverses its `.sql`. |
+| `Client (lint, typecheck, test)` | ESLint, `tsc --noEmit`, vitest. |
+| `E2E smoke (pull requests)` | The money paths, under a ~3 minute budget. |
+| `E2E full (main)` / `E2E settings` | The sharded suite and the serial settings project. |
+
+### The lint warning ratchet
+
+`npm run lint --prefix server` runs `eslint . --max-warnings 391`. The number is today's
+count, essentially all `@typescript-eslint/no-explicit-any`. It exists so the count can
+only fall: errors were already fatal, but warnings gated nothing, so nothing stopped the
+next `any` from landing.
+
+**Lowering it is #47's job**, as it replaces `any` with real types. Lower the number in
+`server/package.json` in the same PR that removes the warnings — a ratchet left above the
+true count silently stops ratcheting. Never raise it.
+
+### Migration verification
+
+```bash
+cd server && MIGRATION_TEST_DATABASE_URL=postgresql://.../moon_store_migrations_test npm run verify:migrations
+```
+
+Rolls back the top *k* migrations and re-applies them, for every *k*, comparing a schema
+snapshot (columns, constraints, indexes) each time. Stepping one at a time is the point:
+migration 001 creates every core table, so a full down-then-up destroys the evidence of
+any later migration's broken rollback and passes. Measured — blanking
+`008_collection_year.down.sql` survives a naive full round trip.
+
+Two failures it reports separately: a down that leaves something behind (the re-apply no
+longer matches the snapshot) and a down that does nothing at all (the schema is unchanged
+by the rollback). The second cannot be caught by comparison alone, because an idempotent
+up like `ADD COLUMN IF NOT EXISTS` re-applies happily over its own leftover.
+
+A down migration that *should* change nothing — `002` inserts a settings row and cannot
+prove on rollback which row was its own — declares it with the line
+`Intentionally a no-op.` in its `.down.sql`. That marker is load-bearing, not a comment.
+
+The script refuses to run against a database whose name does not look disposable, and
+works in its own `migration_verify` schema.
+
 ## Testing
 
 ```bash

--- a/server/package.json
+++ b/server/package.json
@@ -9,12 +9,13 @@
     "migrate": "tsx src/database/migrate.ts up",
     "migrate:down": "tsx src/database/migrate.ts down",
     "seed": "tsx src/database/seed.ts",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 391",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.ts\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "verify:migrations": "tsx scripts/verifyMigrations.ts"
   },
   "dependencies": {
     "@scalar/express-api-reference": "^0.8.48",

--- a/server/scripts/verifyMigrations.ts
+++ b/server/scripts/verifyMigrations.ts
@@ -1,0 +1,195 @@
+/**
+ * Proves every migration's `.down.sql` actually reverses its `.sql`.
+ *
+ * Nothing else checks this. Migrations run implicitly inside `tests/support/realPostgres.ts`
+ * when a suite asks for a schema, which exercises `up` on an empty database and nothing
+ * else — so a down migration that quietly fails to undo its up is invisible until someone
+ * needs to roll back a deploy, which is the worst possible moment to find out.
+ *
+ * ## Why this steps through one migration at a time
+ *
+ * The obvious test — migrate all the way up, all the way down, then up again — is close
+ * to worthless here, and it is worth saying why so nobody "simplifies" it back. The first
+ * migration creates every core table, so its down drops them; any object a *later* down
+ * migration forgot to remove is destroyed by that anyway, and the re-apply then succeeds.
+ * Confirmed empirically: blanking `008_collection_year.down.sql` entirely still passed a
+ * full-stack round trip.
+ *
+ * So instead each migration is rolled back and re-applied on its own, against the schema
+ * as it stands at that point, and the schema is compared before and after. That is the
+ * comparison a broken down migration cannot survive: the leftover column, index or
+ * constraint is still there when the same migration runs again.
+ *
+ * Deliberately destructive: it drops and recreates its own scratch schema, and refuses to
+ * run against a database whose name does not look disposable.
+ *
+ * Usage: MIGRATION_TEST_DATABASE_URL=postgres://... tsx scripts/verifyMigrations.ts
+ */
+import { Pool } from 'pg';
+import path from 'path';
+import fs from 'fs';
+import { runMigrationsUp, runMigrationsDown, getAppliedMigrations } from '../src/database/migrate';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+const url = process.env.MIGRATION_TEST_DATABASE_URL ?? process.env.TEST_DATABASE_URL;
+const SCHEMA = 'migration_verify';
+
+function fail(message: string): never {
+  console.error(`\n✗ ${message}\n`);
+  process.exit(1);
+}
+
+if (!url) {
+  fail(
+    'MIGRATION_TEST_DATABASE_URL (or TEST_DATABASE_URL) is required. This script DROPs a schema; point it at a disposable database.'
+  );
+}
+if (!/test|ci|tmp|scratch/i.test(url)) {
+  fail(
+    `Refusing to run against "${url.replace(/:[^:@]+@/, ':***@')}" — the name does not look disposable.`
+  );
+}
+
+const expected = fs
+  .readdirSync(MIGRATIONS_DIR)
+  .filter((f) => f.endsWith('.sql') && !f.endsWith('.down.sql'))
+  .sort();
+
+if (expected.length === 0) {
+  fail('Found no migrations to verify. This gate would otherwise pass while proving nothing.');
+}
+
+/**
+ * Everything a migration can leave behind: columns and their types, constraints, and
+ * indexes. Compared as one sorted string so a difference reports as a readable diff
+ * rather than a deep-equality failure on an object nobody can read.
+ */
+async function snapshot(pool: Pool): Promise<string> {
+  const columns = await pool.query<{ line: string }>(
+    `SELECT table_name || '.' || column_name || ' ' || data_type ||
+            CASE WHEN is_nullable = 'NO' THEN ' NOT NULL' ELSE '' END ||
+            COALESCE(' DEFAULT ' || column_default, '') AS line
+       FROM information_schema.columns
+      WHERE table_schema = $1
+      ORDER BY table_name, column_name`,
+    [SCHEMA]
+  );
+  const constraints = await pool.query<{ line: string }>(
+    `SELECT rel.relname || ' ' || con.conname || ' ' || pg_get_constraintdef(con.oid) AS line
+       FROM pg_constraint con
+       JOIN pg_class rel ON rel.oid = con.conrelid
+       JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+      WHERE ns.nspname = $1
+      ORDER BY rel.relname, con.conname`,
+    [SCHEMA]
+  );
+  const indexes = await pool.query<{ line: string }>(
+    `SELECT indexdef AS line FROM pg_indexes WHERE schemaname = $1 ORDER BY indexname`,
+    [SCHEMA]
+  );
+
+  return [
+    ...columns.rows.map((r) => `col  ${r.line}`),
+    ...constraints.rows.map((r) => `con  ${r.line}`),
+    ...indexes.rows.map((r) => `idx  ${r.line}`),
+  ].join('\n');
+}
+
+/**
+ * A down migration may legitimately change no schema at all — 002 inserts a settings row
+ * and cannot prove on rollback which row was its own, so it deliberately does nothing.
+ * That is a decision, and it has to be written down to be told apart from an oversight.
+ */
+function isDeclaredNoop(migration: string): boolean {
+  const downFile = path.join(MIGRATIONS_DIR, migration.replace(/\.sql$/, '.down.sql'));
+  if (!fs.existsSync(downFile)) return false;
+  return /intentionally a no-op/i.test(fs.readFileSync(downFile, 'utf8'));
+}
+
+function diff(before: string, after: string): string {
+  const b = new Set(before.split('\n'));
+  const a = new Set(after.split('\n'));
+  const lines = [
+    ...[...b].filter((l) => !a.has(l)).map((l) => `  - ${l}`),
+    ...[...a].filter((l) => !b.has(l)).map((l) => `  + ${l}`),
+  ];
+  return lines.slice(0, 20).join('\n');
+}
+
+async function main(): Promise<void> {
+  const admin = new Pool({ connectionString: url, max: 1 });
+  await admin.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+  await admin.query(`CREATE SCHEMA ${SCHEMA}`);
+  await admin.end();
+
+  // Every connection from this pool resolves unqualified names inside the scratch schema,
+  // so nothing here can touch what is already in the database.
+  const pool = new Pool({ connectionString: url, max: 2, options: `-c search_path=${SCHEMA}` });
+
+  try {
+    console.log(`Verifying ${expected.length} migrations in schema "${SCHEMA}".\n`);
+
+    const applied = await runMigrationsUp(pool, MIGRATIONS_DIR);
+    if (applied.length !== expected.length) {
+      fail(`up on an empty database applied ${applied.length} of ${expected.length} migrations.`);
+    }
+    console.log(`✓ up   applied all ${applied.length} migrations to an empty database`);
+
+    const canonical = await snapshot(pool);
+
+    // Roll back the top k and re-apply them, for every k. Always returning to the full
+    // state before the next round is not tidiness — `runMigrationsUp` applies everything
+    // pending, so leaving a migration rolled back would make the next round's re-apply
+    // cover two migrations and blame the wrong one.
+    //
+    // Rolling back only as far as k means a migration whose down left something behind is
+    // caught: nothing below it runs to destroy the evidence, and re-applying it meets its
+    // own leftover.
+    let previous = canonical;
+    for (let k = 1; k <= expected.length; k += 1) {
+      const name = expected[expected.length - k];
+
+      const rolledBack = await runMigrationsDown(k, pool, MIGRATIONS_DIR);
+      if (rolledBack.length !== k) {
+        fail(
+          `${name}: rolling back the top ${k} rolled back ${rolledBack.length}. A migration with no .down.sql is skipped rather than failed, so it would otherwise pass here silently.`
+        );
+      }
+      const rolledBackTo = await snapshot(pool);
+
+      // A down that changes nothing is the defect a schema comparison cannot see on its
+      // own, because an idempotent up (`ADD COLUMN IF NOT EXISTS`) will happily re-apply
+      // over the leftover and match. A down that means to change nothing has to say so.
+      if (rolledBackTo === previous && !isDeclaredNoop(name)) {
+        fail(
+          `${name}: rolling it back changed nothing in the schema. If that is correct, say so in its .down.sql with the line "Intentionally a no-op." — as 002 does — so the next reader knows it was a decision.`
+        );
+      }
+      previous = rolledBackTo;
+
+      const reapplied = await runMigrationsUp(pool, MIGRATIONS_DIR);
+      if (reapplied.length !== k) {
+        fail(`${name}: re-applying after that rollback applied ${reapplied.length} of ${k}.`);
+      }
+
+      const restored = await snapshot(pool);
+      if (restored !== canonical) {
+        fail(`${name}: down + up does not restore the schema.\n\n${diff(canonical, restored)}`);
+      }
+      console.log(`✓ ${name} — down reverses up`);
+    }
+
+    const applied2 = await getAppliedMigrations(pool);
+    if (applied2.length !== expected.length) {
+      fail(`ended with ${applied2.length} of ${expected.length} applied.`);
+    }
+    console.log(`\nAll ${expected.length} migrations round-trip.`);
+  } finally {
+    await pool.end();
+    const cleanup = new Pool({ connectionString: url, max: 1 });
+    await cleanup.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await cleanup.end();
+  }
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));


### PR DESCRIPTION
Closes #43. Wave 1, lane C of `docs/plans/2026-09-04-001-refactor-parallel-issue-execution-map-plan.md`. Unblocks #47, which needs the ratchet in place to measure its own progress against.

## Most of this issue had already landed

Worth stating so the diff's size is not mistaken for the issue's scope. CI already provisions an ephemeral `postgres:16`, sets `TEST_DATABASE_URL`, runs the real-PostgreSQL suites, and guards against them silently skipping (`assertRealPostgresSuitesRan.mjs`). The client typecheck gate landed in #89. Two acceptance criteria were genuinely open:

### 1. "ESLint has no errors; warning count cannot increase"

`npm run lint --prefix server` exited **0 with 391 warnings** — essentially all `@typescript-eslint/no-explicit-any`. Errors were already fatal, but warnings gated nothing, so nothing stopped the next `any` from landing. Now `eslint . --max-warnings 391`. Verified it passes at 391 and fails at 392.

Lowering the number is **#47's** job, in the same PR that removes the warnings — documented in CLAUDE.md, because a ratchet left above the true count silently stops ratcheting.

### 2. "Verify migrations from an empty database and rollback behavior"

Migrations only ever ran *forwards*, on an empty database, implicitly inside `realPostgres.ts` when a suite asks for a schema. Nothing checked that a `.down.sql` reverses its `.sql` — discovered when a rollback is needed, which is the worst possible moment.

**The obvious implementation of this gate does not work, and that is the interesting part.** Migrate all the way up, all the way down, then up again: migration 001 creates every core table, so its down drops them, and any object a *later* down forgot to remove is destroyed along with the table. The re-apply then succeeds. I measured this rather than reasoning about it — blanking `008_collection_year.down.sql` entirely **passed** a full-stack round trip.

So the script rolls back the top *k* and re-applies, for every *k*, comparing a schema snapshot (columns with types/nullability/defaults, constraints via `pg_get_constraintdef`, indexes) each round. Rolling back only as far as *k* means nothing below runs to destroy the evidence.

It reports two failure modes separately, because a snapshot comparison alone cannot see the second:

| Failure | How it is caught |
| --- | --- |
| A down that leaves an object behind | Re-applying no longer matches the canonical snapshot |
| A down that does nothing at all | The rollback did not change the schema — needed because an idempotent up (`ADD COLUMN IF NOT EXISTS`) re-applies happily *over its own leftover* and matches |

Both verified to fail, with exit code 1. The leftover case names the lost object (`- col  collections.season text`).

A down that *legitimately* changes nothing declares `Intentionally a no-op.` in its `.down.sql`. `002` already said exactly that in prose — it inserts a settings row and cannot prove on rollback which row was its own — so the marker is now load-bearing rather than decoration.

Safety: the script refuses a database whose name does not look disposable, works in its own `migration_verify` schema, and fails on an empty migrations directory so it cannot pass by finding nothing to check.

## Its own job, not a step

`Migrations (up, down, re-apply)` is a separate job so the checks list says which gate failed without anyone opening a log — a broken rollback and a failing unit test are different problems with different owners. That is the issue's "CI reports each gate independently" criterion.

## Testing

- Ratchet: `npm run lint` exits 0 at 391 warnings, exits 1 with one more (`ESLint found too many warnings (maximum: 391)`).
- Verifier: all 8 migrations round-trip against a real PostgreSQL. Both failure modes verified to fail with exit 1 by deliberately breaking a down migration each way, then restoring it.
- The no-URL guard was verified to refuse rather than default to something.
- `npm run typecheck --prefix server` clean; workflow YAML parses with the new job registered.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this changes CI configuration and adds a script that only ever runs against a disposable test database. It has no production code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN