### PR TITLE
perf: measure route bundles and gate them in CI (#55 phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,15 @@ jobs:
 
       - run: npm test
 
+      - name: Build
+        run: npm run build
+
+      - name: Bundle budgets
+        # Measures the *static closure* per route, gzipped -- what a till actually waits
+        # for -- and fails when a route grows past its budget or when charting, xlsx or
+        # the scanner become reachable from the initial load without a dynamic import.
+        run: npm run budget
+
   e2e-smoke:
     name: E2E smoke (pull requests)
     # The PR gate: the money paths that would be catastrophic to break silently, held to

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint . && npm run lint:cycles",
     "typecheck": "tsc --noEmit",
+    "budget": "node scripts/bundleBudget.mjs",
     "lint:fix": "eslint . --fix",
     "lint:cycles": "madge --circular --extensions ts,tsx src",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",

--- a/client/scripts/budgets.json
+++ b/client/scripts/budgets.json
@@ -1,0 +1,9 @@
+{
+  "gzipKb": {
+    "initial": 414,
+    "pos": 20,
+    "inventory": 16,
+    "analytics": 9,
+    "sales": 14
+  }
+}

--- a/client/scripts/bundleBudget.mjs
+++ b/client/scripts/bundleBudget.mjs
@@ -1,0 +1,185 @@
+/**
+ * Measures what a route actually costs to load, and fails when that grows past its budget.
+ *
+ * ## Why not just check chunk sizes
+ *
+ * A per-chunk size cap answers the wrong question. What a cashier waits for on `/pos` is
+ * the entry chunk *plus every chunk statically reachable from it* — a 20 kB route chunk
+ * that statically imports 400 kB of charting costs 420 kB, and a per-chunk cap would pass
+ * it. So this walks the static import graph from each route's chunk and sums the closure.
+ *
+ * Static is the operative word. `import()` is a boundary the browser does not cross until
+ * something asks it to, so a dynamically imported chunk is deliberately *not* counted —
+ * that is the whole mechanism by which analytics or a scanner stays off the POS path, and
+ * counting it would make lazy-loading look like a regression.
+ *
+ * ## Why gzip
+ *
+ * Bytes on the wire are what a till on shop wifi waits for. Raw size is what a bundler
+ * reports and roughly triples the number, so budgets written against it drift away from
+ * anything a user experiences.
+ *
+ * Usage:
+ *   node scripts/bundleBudget.mjs            # check against budgets.json
+ *   node scripts/bundleBudget.mjs --update   # rewrite budgets.json from this build
+ */
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { gzipSync } from 'node:zlib';
+import path from 'node:path';
+
+const DIST = path.join(import.meta.dirname, '..', 'dist');
+const ASSETS = path.join(DIST, 'assets');
+const BUDGETS = path.join(import.meta.dirname, 'budgets.json');
+
+/**
+ * A chunk's *static* imports. Vite emits these as `from"./x.js"` / `import"./x.js"`;
+ * a dynamic one appears inside `import("./x.js")` and in the `__vitePreload` dependency
+ * array, and neither of those forms matches here — which is the point.
+ */
+function staticImports(source) {
+  const found = new Set();
+  // Two forms, and the whitespace matters: minified output is `}from"./x.js"` with no
+  // space before `from`, so a pattern requiring one silently matches nothing and every
+  // closure comes out too small. That is exactly how this was wrong first time round.
+  const withFrom = /from\s*["']\.\/([A-Za-z0-9_.-]+\.js)["']/g;
+  // A bare side-effect import. `import(` — a dynamic one — cannot match, because the
+  // quote must follow directly, and NOT counting those is the entire point.
+  const sideEffect = /(?:^|[;}\s])import\s*["']\.\/([A-Za-z0-9_.-]+\.js)["']/g;
+  for (const re of [withFrom, sideEffect]) {
+    let m;
+    while ((m = re.exec(source))) found.add(m[1]);
+  }
+  return found;
+}
+
+const files = readdirSync(ASSETS).filter((f) => f.endsWith('.js'));
+const sources = new Map(files.map((f) => [f, readFileSync(path.join(ASSETS, f), 'utf8')]));
+const gzipped = new Map(
+  files.map((f) => [f, gzipSync(readFileSync(path.join(ASSETS, f))).length])
+);
+const graph = new Map([...sources].map(([f, s]) => [f, staticImports(s)]));
+
+/** Everything the browser must have before this chunk can run. */
+function closure(entries) {
+  const seen = new Set();
+  const stack = Array.isArray(entries) ? [...entries] : [entries];
+  while (stack.length) {
+    const file = stack.pop();
+    if (!file || seen.has(file) || !graph.has(file)) continue;
+    seen.add(file);
+    for (const dep of graph.get(file)) stack.push(dep);
+  }
+  return seen;
+}
+
+const totalOf = (set) => [...set].reduce((n, f) => n + (gzipped.get(f) ?? 0), 0);
+
+/**
+ * Everything index.html itself pulls — the entry module plus every vendor chunk it lists
+ * as a script or modulepreload. Seeding from the entry alone undercounts: `vendor-motion`
+ * is referenced by the HTML but not statically imported by the entry, and the browser
+ * fetches it on first load regardless of which of the two asked for it.
+ */
+const html = readFileSync(path.join(DIST, 'index.html'), 'utf8');
+const entryFiles = [...html.matchAll(/assets\/([A-Za-z0-9_.-]+\.js)/g)]
+  .map((m) => m[1])
+  .filter((f) => graph.has(f));
+if (entryFiles.length === 0) throw new Error('could not find any entry chunk in index.html');
+
+/**
+ * Routes are matched by chunk name rather than by reading the router: Vite names a route's
+ * chunk after its module, and a rename that silently stopped matching would make a budget
+ * pass by measuring nothing — so an unmatched route is a failure below, not a skip.
+ */
+const ROUTES = ['pos', 'inventory', 'analytics', 'sales'];
+
+const measured = { initial: Math.round(totalOf(closure(entryFiles)) / 1024) };
+const missing = [];
+for (const route of ROUTES) {
+  const chunk = files.find((f) => new RegExp(`^${route}-[A-Za-z0-9_-]+\\.js$`).test(f));
+  if (!chunk) {
+    missing.push(route);
+    continue;
+  }
+  // The route's own closure minus what the entry already brought: the marginal cost of
+  // navigating there, which is what a budget on a route should mean.
+  const own = closure(chunk);
+  const shared = closure(entryFiles);
+  const marginal = [...own].filter((f) => !shared.has(f));
+  measured[route] = Math.round(totalOf(new Set(marginal)) / 1024);
+}
+
+if (missing.length) {
+  console.error(`\n✗ No chunk found for: ${missing.join(', ')}.`);
+  console.error('  A renamed route would otherwise make this gate pass while measuring nothing.');
+  process.exit(1);
+}
+
+/**
+ * Heavy dependencies that must not be reachable *statically* from the initial load. These
+ * are the ones the issue names: charting, spreadsheet export, and the barcode scanner —
+ * none of which a cashier needs before the first sale.
+ */
+const HEAVY = {
+  recharts: /recharts|vendor-charts/,
+  xlsx: /exportUtils/,
+  quagga: /barcode|quagga/,
+};
+const initialClosure = closure(entryFiles);
+const leaked = Object.entries(HEAVY).filter(([, re]) => [...initialClosure].some((f) => re.test(f)));
+
+/**
+ * Budgets sit above the measurement, not on it. A budget equal to the current size fails
+ * on rounding and on an unrelated dependency bump, and a gate that cries wolf earns a
+ * `--update` reflex rather than a reading. The 5 KiB floor matters for the small route
+ * numbers, where 5% is less than the difference between two builds of the same source.
+ */
+const headroom = (kb) => Math.max(Math.ceil(kb * 1.05), kb + 5);
+
+if (process.argv.includes('--update')) {
+  const withHeadroom = Object.fromEntries(
+    Object.entries(measured).map(([k, v]) => [k, headroom(v)])
+  );
+  writeFileSync(BUDGETS, `${JSON.stringify({ gzipKb: withHeadroom }, null, 2)}\n`);
+  console.log('Measured this build:');
+  console.log(JSON.stringify(measured, null, 2));
+  console.log('\nWrote budgets.json (measurement plus headroom):');
+  console.log(JSON.stringify(withHeadroom, null, 2));
+  process.exit(0);
+}
+
+const budgets = JSON.parse(readFileSync(BUDGETS, 'utf8')).gzipKb;
+let failed = false;
+
+console.log('\nRoute cost (gzipped KiB, static closure):\n');
+for (const [name, actual] of Object.entries(measured)) {
+  const budget = budgets[name];
+  if (budget === undefined) {
+    console.log(`  ${name.padEnd(12)} ${String(actual).padStart(5)}  (no budget set)`);
+    continue;
+  }
+  const over = actual > budget;
+  failed ||= over;
+  const delta = actual - budget;
+  console.log(
+    `  ${name.padEnd(12)} ${String(actual).padStart(5)} / ${String(budget).padStart(5)}  ${
+      over ? `✗ over by ${delta}` : `✓${delta < 0 ? ` (${delta})` : ''}`
+    }`
+  );
+}
+
+if (leaked.length) {
+  failed = true;
+  console.error(
+    `\n✗ Reachable from the initial load without a dynamic import: ${leaked
+      .map(([n]) => n)
+      .join(', ')}.`
+  );
+  console.error('  These must stay behind a route split; a cashier should not wait for them.');
+}
+
+if (failed) {
+  console.error('\nIf the growth is intended, re-run with --update and say why in the PR.\n');
+  process.exit(1);
+}
+console.log('\nWithin budget.\n');

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,95 @@
+# Frontend performance budgets
+
+The thing being protected is a cashier on shop wifi. Everything below is measured against
+that, not against a developer's laptop.
+
+## Reproducing the baseline
+
+```bash
+npm run build --prefix client
+npm run budget --prefix client            # check against scripts/budgets.json
+npm run budget --prefix client -- --update  # rewrite budgets from this build
+```
+
+`client/scripts/bundleBudget.mjs` runs in CI as its own step of the client job.
+
+## What is measured, and why it is not chunk sizes
+
+A per-chunk size cap answers the wrong question. What a till waits for on `/pos` is the
+entry **plus every chunk statically reachable from it** — a 20 kB route chunk that
+statically imports 400 kB of charting costs 420 kB, and a per-chunk cap passes it happily.
+So the script walks the static import graph and sums the closure, **gzipped**, because
+bytes on the wire are what the user waits for and raw size roughly triples the number.
+
+Dynamic imports are deliberately excluded. `import()` is a boundary the browser does not
+cross until something asks it to; counting those chunks would make lazy-loading register
+as a regression, which is exactly backwards.
+
+Two mistakes are baked into the script's comments because both produced confidently wrong
+numbers on the way here:
+
+- The import regex must not require whitespace before `from`. Minified output is
+  `}from"./x.js"`, and a pattern expecting a space silently matches nothing, so every
+  closure comes out too small and the gate measures air.
+- The initial closure must be seeded from **every** script `index.html` references, not
+  just the entry module. `vendor-motion` is referenced by the HTML but not statically
+  imported by the entry; seeding from the entry alone under-reported the initial load as
+  150 KiB when it is 394 KiB.
+
+## Baseline (2026-09-05)
+
+Gzipped KiB. Route figures are **marginal** — what navigating there costs on top of what
+the initial load already fetched.
+
+| Surface | Measured | Budget |
+| --- | --- | --- |
+| initial load | 394 | 414 |
+| `/pos` | 15 | 20 |
+| `/inventory` | 11 | 16 |
+| `/analytics` | 4 | 9 |
+| `/sales` | 9 | 14 |
+
+Budgets are the measurement plus 5%, floored at +5 KiB. A budget set exactly at the
+current size fails on rounding and on an unrelated dependency bump, and a gate that cries
+wolf earns an `--update` reflex rather than a reading.
+
+**The initial 394 KiB is the number worth attacking next.** The route chunks are already
+small; almost all of the initial cost is the vendor set (`vendor-ui-hero`, `vendor-router`,
+`vendor-query`, `vendor-motion`, `vendor-forms`) that `index.html` loads up front.
+
+## Heavy capabilities are off the initial path
+
+The script fails if charting (`recharts`), spreadsheet export (`xlsx`) or the barcode
+scanner (`quagga`) becomes reachable from the initial load without a dynamic import.
+Verified: none of them is today. The check itself was verified by pointing it at a chunk
+that *is* on the initial path and confirming it fails — a gate that cannot fail proves
+nothing.
+
+## Virtualization: measured, and not justified
+
+The issue asks for virtualization "only where measurements justify it". They do not.
+
+- **POS product grid** renders **25** cards, from `useProductCatalog`'s default page size,
+  behind an explicit "Load more" button.
+- **DataTable** paginates at **10** rows.
+
+Virtualization exists to stop thousands of DOM nodes being rendered. Neither surface
+renders an unbounded list, so it would add complexity — and a known conflict with the row
+and grid semantics established in #54 — to solve a problem that is not there.
+
+Revisit if either bound changes: a page size raised into the hundreds, or an infinite
+scroll replacing the explicit "Load more", would make this measurement stale. That is the
+trigger to re-run the numbers, not a calendar date.
+
+## Interaction latency
+
+Not yet gated, and deliberately so. POS search, add-to-cart, quantity change and checkout
+opening are all local state updates over data already in memory; the honest place to
+measure them is a real browser, and a CI runner's timing variance is wider than the
+differences worth catching. A latency gate built on that would flake, and a flaky gate
+gets skipped.
+
+What exists instead: `e2e/specs/a11y.spec.ts` drives all four interactions in a real
+browser, so a change that made one of them hang fails the suite on the timeout. Closing
+the gap properly means a stable measurement environment, which is a bigger piece of work
+than this one.


### PR DESCRIPTION
Part of #55 — phase 1 only (measure, baseline, budgets, CI gate). **Phase 2 (virtualization) is measured and not justified**; see below. Deliberately not `Closes`, because two acceptance criteria are addressed by documented reasoning rather than by a gate.

## What is measured, and why not chunk sizes

A per-chunk size cap answers the wrong question. What a till waits for on `/pos` is the entry **plus every chunk statically reachable from it** — a 20 kB route chunk that statically imports 400 kB of charting costs 420 kB, and a per-chunk cap passes it happily. So the script walks the static import graph and sums the closure, gzipped, because bytes on the wire are what a cashier waits for.

Dynamic imports are excluded on purpose: `import()` is a boundary the browser does not cross until something asks it to, and counting those chunks would make lazy-loading register as a regression.

## Two measurement bugs, both caught by testing the gate rather than trusting it

Recording these because both produced confident, wrong numbers:

1. **The import regex required whitespace before `from`.** Minified output is `}from"./x.js"`, so it matched nothing, every closure came out too small, and the heavy-dependency check was blind. I caught it by pointing that check at a chunk *known* to be on the initial path and finding it did not fire.
2. **The initial closure was seeded from the entry module alone.** `index.html` also loads `vendor-motion`, which the entry never statically imports — the browser fetches it regardless of which one asked. That under-reported the initial load as **150 KiB** when it is **394 KiB**.

The first published number would have been wrong by 2.6×. The script's comments carry both, so the next person to touch it does not reintroduce either.

## Baseline

Gzipped KiB; route figures are *marginal* — what navigating there costs on top of the initial load.

| Surface | Measured | Budget |
| --- | --- | --- |
| initial | 394 | 414 |
| `/pos` | 15 | 20 |
| `/inventory` | 11 | 16 |
| `/analytics` | 4 | 9 |
| `/sales` | 9 | 14 |

Budgets are measurement + 5%, floored at +5 KiB — a budget set exactly at the current size fails on rounding and earns an `--update` reflex rather than a reading.

**The 394 KiB initial load is the number worth attacking next.** Route chunks are already small; nearly all of it is the vendor set `index.html` loads up front.

## Heavy capabilities stay off the initial path

The gate fails if `recharts`, `xlsx` or `quagga` becomes statically reachable from the initial load. None is today — verified, and the check itself verified by making it fail on a chunk that *is* on that path.

## Phase 2: measured, and not justified

The issue asks for virtualization "only where measurements justify it". They do not:

- **POS grid** renders **25** cards (`useProductCatalog` default page size) behind an explicit "Load more".
- **DataTable** paginates at **10** rows.

Virtualization exists to stop thousands of DOM nodes rendering. Neither surface renders an unbounded list, so it would add complexity — plus a known conflict with the row/grid semantics established in #54 — to solve a problem that is not there. `docs/PERFORMANCE.md` records the *trigger* to re-measure (a page size raised into the hundreds, or infinite scroll replacing "Load more") rather than a date.

## What is not gated

**Interaction latency.** POS search, add-to-cart, quantity change and checkout opening are local state updates over in-memory data; the honest place to measure them is a real browser, and a CI runner's timing variance is wider than the differences worth catching. A latency gate built on that flakes, and a flaky gate gets skipped. The e2e suite already drives all four, so a change that made one hang fails on the timeout. Closing this properly needs a stable measurement environment — a bigger piece of work than this one, and I would rather say so than ship a number that means nothing.

## Testing

- Gate verified failing in **both** directions: over-budget (`initial 394 / 300 ✗ over by 94`, exit 1) and heavy-dependency leak (exit 1 on a seeded probe).
- An unmatched route name is a **failure**, not a skip — a renamed chunk would otherwise make the gate pass while measuring nothing, which is the same class of bug as the regex above.
- `lint` 0 errors, `typecheck` clean.

## Post-Deploy Monitoring & Validation

No runtime impact — this adds a build-time CI step and two documentation files; no application code changes. The gate's own failure mode is a red CI step with the offending route and delta named.

If a future PR legitimately grows a route, `npm run budget --prefix client -- --update` rewrites the budgets and the PR should say why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN