### PR TITLE
feat(storage): add an S3-compatible driver so media survives redeploy (#82)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,21 +345,37 @@ Uploaded images go through the `StorageDriver` abstraction in `server/src/storag
 straight to disk. The controller mints a key, hands the driver a buffer, and stores the URL
 the driver returns; nothing above the interface knows where the bytes live.
 
-`local` (filesystem) is the only bundled driver and the default. Its defaults reproduce the
-previous behaviour exactly — objects under `server/uploads`, URLs of the form
-`/uploads/products/<name>` — so **every image URL already in the database keeps working
-untouched**. For a deployment it is durable only when `MEDIA_LOCAL_ROOT` points at storage
-that outlives the container and is shared by every instance (a mounted volume or NFS).
-Where that is not available, add a driver implementing `StorageDriver` and a case in
-`createStorageDriver`; no provider SDK or credential belongs in the callers, and none is
-hardcoded anywhere in this repo.
+`local` (filesystem) is the default. Its defaults reproduce the pre-abstraction behaviour
+exactly — objects under `server/uploads`, URLs of the form `/uploads/products/<name>` — so
+**every image URL already in the database keeps working untouched**. It is durable in a
+deployment only when `MEDIA_LOCAL_ROOT` points at storage that outlives the container and
+is shared by every instance (a mounted volume or NFS).
+
+`s3` targets any S3-compatible store — AWS S3, Cloudflare R2, DigitalOcean Spaces, MinIO.
+They share one API, so the driver is written against the protocol rather than a vendor:
+which one you are on is an endpoint and a credential, not a code path. Credentials come
+from the environment and never from a committed file; omit both key variables to let the
+SDK's default chain use an instance or container role, which is the better posture where
+it is available.
+
+**`s3` refuses to boot without `MEDIA_S3_BUCKET` and `MEDIA_PUBLIC_BASE_URL`**, rather than
+falling back to `local` the way the numeric knobs fall back to their defaults. A fallback
+would start an instance writing to a container filesystem while its operator believed
+media was going to a bucket, and the loss would surface at the next redeploy — long after
+the cause. There is likewise no default base URL: the bucket's URL shape differs per
+provider and per path-style setting, and a wrong guess writes unreachable URLs into rows.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `MEDIA_STORAGE_DRIVER` | `local` | Which driver to resolve. |
+| `MEDIA_STORAGE_DRIVER` | `local` | `local` or `s3`. |
 | `MEDIA_LOCAL_ROOT` | `server/uploads` | Root directory for the `local` driver. |
-| `MEDIA_PUBLIC_BASE_URL` | `/uploads` | Prefix `publicUrl` puts in front of a key. |
+| `MEDIA_PUBLIC_BASE_URL` | `/uploads` | Prefix `publicUrl` puts in front of a key. **Required for `s3`.** |
 | `MEDIA_ORPHAN_MIN_AGE_HOURS` | `24` | Grace period before the sweep may delete an unreferenced object. |
+| `MEDIA_S3_BUCKET` | — | **Required for `s3`.** |
+| `MEDIA_S3_REGION` | — | AWS infers the endpoint from it. |
+| `MEDIA_S3_ENDPOINT` | — | Needed for R2 / Spaces / MinIO; AWS does not use it. |
+| `MEDIA_S3_ACCESS_KEY_ID` / `MEDIA_S3_SECRET_ACCESS_KEY` | — | Omit **both** to use the SDK's default credential chain. |
+| `MEDIA_S3_FORCE_PATH_STYLE` | `false` | MinIO and some gateways address buckets as a path segment. |
 
 **Local development:** nothing to configure. `npm run dev` with no media variables set
 writes to `server/uploads` and serves `/uploads` exactly as before.
@@ -383,6 +399,14 @@ never read missing information as "unreferenced" — and it never touches an obj
 `MEDIA_ORPHAN_MIN_AGE_HOURS`. **A new table with an image URL column must be added to the
 reference query in `src/scheduler/mediaSweep.ts`** — the sweep deletes what that query does
 not return.
+
+**A new driver's `ownsUrl` is the load-bearing half of that.** `keyFromUrl` returning
+`null` conflates "somebody else's image" with "mine, and I could not read it"; the sweep
+must abort on the second. A driver answering `false`/`null` to both would classify every
+legacy `/uploads/...` row as unreferenced and delete the lot on its first run after a
+migration. That is why `LEGACY_PUBLIC_PATH` is an owned prefix in the `s3` driver even
+though it never writes that shape, and why `tests/storage.test.ts` asserts the sweep
+*aborts* rather than deletes — verified by breaking `ownsUrl` and watching it fail.
 
 ## Refresh token rotation
 

--- a/render.yaml
+++ b/render.yaml
@@ -20,6 +20,47 @@ services:
       - key: ALLOWED_ORIGINS
         sync: false
 
+      # Media storage (#82). Unset, this is `local` and behaves exactly as before:
+      # uploads land on the container filesystem and are lost on redeploy, because this
+      # service configures no disk. That is the state this block exists to get out of.
+      #
+      # Pick ONE of the two:
+      #
+      # (a) A disk. Simplest, and enough for a single instance. Add a `disk:` block to
+      #     this service and set MEDIA_LOCAL_ROOT to its mountPath. Note a Render disk
+      #     cannot be shared between instances, so this does not survive scaling out.
+      #
+      #       disk:
+      #         name: media
+      #         mountPath: /var/media
+      #         sizeGB: 1
+      #       - key: MEDIA_LOCAL_ROOT
+      #         value: /var/media
+      #
+      # (b) An S3-compatible bucket. Survives both redeploys and scaling out. Set these
+      #     with `sync: false` so the credentials live in Render's dashboard and never in
+      #     this file. Copy the existing `server/uploads` tree into the bucket PRESERVING
+      #     KEYS before switching, and read the migration order in CLAUDE.md -> Media
+      #     storage: old rows hold relative /uploads/... URLs and keep resolving through
+      #     the /uploads mount, so the copy can happen either side of the config change,
+      #     but MEDIA_PUBLIC_BASE_URL must not point at the bucket until the objects are
+      #     actually reachable there.
+      #
+      #       - key: MEDIA_STORAGE_DRIVER
+      #         value: s3
+      #       - key: MEDIA_S3_BUCKET
+      #         sync: false
+      #       - key: MEDIA_S3_REGION
+      #         sync: false
+      #       - key: MEDIA_S3_ENDPOINT      # only for R2 / Spaces / MinIO
+      #         sync: false
+      #       - key: MEDIA_S3_ACCESS_KEY_ID
+      #         sync: false
+      #       - key: MEDIA_S3_SECRET_ACCESS_KEY
+      #         sync: false
+      #       - key: MEDIA_PUBLIC_BASE_URL
+      #         sync: false
+
 databases:
   - name: moon-store-db
     plan: free

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "moon-store-server",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1127.0",
         "@scalar/express-api-reference": "^0.8.48",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
@@ -41,6 +42,314 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.0",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.29.tgz",
+      "integrity": "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1127.0.tgz",
+      "integrity": "sha512-0ZSAgmEda33xPqVPt+bx2KzrXV1cUCKRRVPGliLu+V7DzHPa04CqPSi1maGEM4O0LDP0iI6HRSW5ULloNwayNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.29",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.75",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.75.tgz",
+      "integrity": "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1209,6 +1518,87 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2137,6 +2527,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -5219,6 +5615,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "verify:migrations": "tsx scripts/verifyMigrations.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1127.0",
     "@scalar/express-api-reference": "^0.8.48",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -97,11 +97,38 @@ const envSchema = z.object({
    *
    * `local` is the documented development option and the compatibility default. It is
    * durable in a deployment only when `MEDIA_LOCAL_ROOT` points at storage that outlives
-   * the container and is shared by every instance (a mounted volume or NFS). No cloud
-   * driver is bundled, and none of this file names a provider: a driver is a new file
-   * implementing `StorageDriver`, configured by adding a case to `createStorageDriver`.
+   * the container and is shared by every instance (a mounted volume or NFS).
+   *
+   * `s3` targets any S3-compatible store — AWS S3, Cloudflare R2, DigitalOcean Spaces,
+   * MinIO. They share one API, so the driver is written against the protocol rather than
+   * a vendor: pick the bucket with `MEDIA_S3_*` below and set an endpoint if it is not
+   * AWS. Credentials come from the environment and never from a committed file.
    */
-  MEDIA_STORAGE_DRIVER: z.enum(['local']).default('local'),
+  MEDIA_STORAGE_DRIVER: z.enum(['local', 's3']).default('local'),
+  /**
+   * S3 settings. All optional here rather than required-when-s3, because this schema is
+   * parsed for every process including ones that never touch media; `createStorageDriver`
+   * is where a missing bucket becomes a loud boot failure, and it names what is missing.
+   */
+  MEDIA_S3_BUCKET: z.string().optional(),
+  MEDIA_S3_REGION: z.string().optional(),
+  /** Non-AWS stores (R2, Spaces, MinIO) need their endpoint; AWS infers it from region. */
+  MEDIA_S3_ENDPOINT: z.string().optional(),
+  /**
+   * Omit both to let the SDK's default chain find credentials — an instance role, a
+   * container role, `~/.aws`. That is the better posture where it is available, and the
+   * reason these are optional rather than required.
+   */
+  MEDIA_S3_ACCESS_KEY_ID: z.string().optional(),
+  MEDIA_S3_SECRET_ACCESS_KEY: z.string().optional(),
+  /**
+   * MinIO and some self-hosted gateways address buckets as a path segment rather than a
+   * subdomain. Harmless on AWS, required on those.
+   */
+  MEDIA_S3_FORCE_PATH_STYLE: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
   /** Root directory for the `local` driver. Defaults to `server/uploads`. */
   MEDIA_LOCAL_ROOT: z.string().optional(),
   /**

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -10,10 +10,12 @@
 import path from 'path';
 import { getEnv } from '../config/env';
 import { LocalStorageDriver } from './localDriver';
+import { S3StorageDriver } from './s3Driver';
 import type { StorageDriver } from './types';
 
 export * from './types';
 export { LocalStorageDriver } from './localDriver';
+export { S3StorageDriver } from './s3Driver';
 export * from './keys';
 
 /** Where the filesystem driver defaults to: `server/uploads`, as before. */
@@ -30,8 +32,41 @@ export function createStorageDriver(): StorageDriver {
         root: env.MEDIA_LOCAL_ROOT || DEFAULT_LOCAL_ROOT,
         baseUrl: env.MEDIA_PUBLIC_BASE_URL,
       });
+    case 's3': {
+      /**
+       * A missing bucket is a boot failure, loudly and by name. The alternative — falling
+       * back to `local` the way the numeric env vars fall back to their defaults — would
+       * start an instance that writes to a container filesystem while its operator
+       * believes media is going to a bucket, and the loss would only surface at the next
+       * redeploy. A misconfigured store is not a value to default; it is a stop.
+       */
+      if (!env.MEDIA_S3_BUCKET) {
+        throw new Error(
+          'MEDIA_STORAGE_DRIVER=s3 requires MEDIA_S3_BUCKET. Refusing to fall back to local storage: that would write media to the container filesystem and lose it on redeploy, silently.'
+        );
+      }
+      /**
+       * `publicUrl` needs somewhere to point. There is no safe default — the bucket's own
+       * URL shape differs per provider and per path-style setting, and guessing wrong
+       * writes unreachable URLs into the database.
+       */
+      if (!env.MEDIA_PUBLIC_BASE_URL) {
+        throw new Error(
+          'MEDIA_STORAGE_DRIVER=s3 requires MEDIA_PUBLIC_BASE_URL — the base every stored image_url is built from. There is no safe default: a wrong guess writes unreachable URLs into the database.'
+        );
+      }
+      return new S3StorageDriver({
+        bucket: env.MEDIA_S3_BUCKET,
+        region: env.MEDIA_S3_REGION,
+        endpoint: env.MEDIA_S3_ENDPOINT,
+        accessKeyId: env.MEDIA_S3_ACCESS_KEY_ID,
+        secretAccessKey: env.MEDIA_S3_SECRET_ACCESS_KEY,
+        forcePathStyle: env.MEDIA_S3_FORCE_PATH_STYLE,
+        baseUrl: env.MEDIA_PUBLIC_BASE_URL,
+      });
+    }
     default:
-      // Unreachable while the enum has one member; keeps the switch honest when it grows.
+      // Unreachable while the enum is exhaustive; keeps the switch honest when it grows.
       throw new Error(`Unsupported MEDIA_STORAGE_DRIVER: ${String(env.MEDIA_STORAGE_DRIVER)}`);
   }
 }

--- a/server/src/storage/s3Driver.ts
+++ b/server/src/storage/s3Driver.ts
@@ -1,0 +1,217 @@
+/**
+ * An S3-compatible object store driver.
+ *
+ * Written against the protocol, not a vendor: AWS S3, Cloudflare R2, DigitalOcean Spaces
+ * and MinIO all speak this API, and which one you are on is an endpoint and a credential,
+ * not a code path. Nothing above `StorageDriver` learns that any of this exists.
+ *
+ * ## The part that can destroy data
+ *
+ * `ownsUrl` and `keyFromUrl` answer two different questions, and the orphan sweep depends
+ * on the difference:
+ *
+ *   - `keyFromUrl` → null means "no key came out of this URL".
+ *   - `ownsUrl` → false means "this URL is not in my URL space at all".
+ *
+ * A URL that is *mine but unresolvable* — a legacy `/uploads/...` row still in the
+ * database after `MEDIA_PUBLIC_BASE_URL` moved to a CDN — must answer `ownsUrl: true`,
+ * `keyFromUrl: null`. That combination stops the sweep, because a routine that deletes
+ * what nothing references must never read missing information as "unreferenced". A driver
+ * that returned false/null for both would let the sweep classify every legacy image as an
+ * orphan and delete the lot on its first run after a migration. #75 shipped exactly that
+ * bug against the local driver; it is the reason `ownsUrl` exists at all, and the reason
+ * `LEGACY_PUBLIC_PATH` is an owned prefix here even though this driver never writes it.
+ */
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+  type S3ClientConfig,
+} from '@aws-sdk/client-s3';
+import { assertSafeKey, type PutOptions, type StorageDriver, type StoredObject } from './types';
+import { LEGACY_PUBLIC_PATH } from './localDriver';
+
+export interface S3DriverOptions {
+  readonly bucket: string;
+  readonly region?: string;
+  readonly endpoint?: string;
+  readonly accessKeyId?: string;
+  readonly secretAccessKey?: string;
+  readonly forcePathStyle?: boolean;
+  /** URL prefix `publicUrl` puts in front of a key — a CDN origin, or the bucket's own. */
+  readonly baseUrl: string;
+}
+
+export class S3StorageDriver implements StorageDriver {
+  readonly name = 's3';
+
+  private readonly client: S3Client;
+  private readonly bucket: string;
+  private readonly baseUrl: string;
+
+  constructor(options: S3DriverOptions) {
+    this.bucket = options.bucket;
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+
+    const config: S3ClientConfig = {
+      forcePathStyle: options.forcePathStyle ?? false,
+    };
+    if (options.region) config.region = options.region;
+    if (options.endpoint) config.endpoint = options.endpoint;
+    // Only pin credentials when both were supplied. Otherwise the SDK's default chain
+    // applies, which is how an instance or container role is meant to be used.
+    if (options.accessKeyId && options.secretAccessKey) {
+      config.credentials = {
+        accessKeyId: options.accessKeyId,
+        secretAccessKey: options.secretAccessKey,
+      };
+    }
+    this.client = new S3Client(config);
+  }
+
+  async put(key: string, body: Buffer, options: PutOptions): Promise<void> {
+    const safe = assertSafeKey(key);
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: safe,
+        Body: body,
+        ContentType: options.contentType,
+      })
+    );
+  }
+
+  /**
+   * Idempotent, as the interface requires: S3 answers a delete of an absent key with a
+   * success, so a retry after a partial failure is not an error the caller must handle.
+   */
+  async delete(key: string): Promise<void> {
+    await this.client.send(
+      new DeleteObjectCommand({ Bucket: this.bucket, Key: assertSafeKey(key) })
+    );
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: assertSafeKey(key) })
+      );
+      return true;
+    } catch (error) {
+      if (isNotFound(error)) return false;
+      // Anything else — a permissions failure, a network fault — is not "absent", and
+      // saying so would let the sweep treat an unreadable object as deletable.
+      throw error;
+    }
+  }
+
+  /**
+   * Pages to the end deliberately. A truncated listing read as complete would make the
+   * sweep believe objects beyond the first page do not exist.
+   */
+  async list(prefix: string): Promise<StoredObject[]> {
+    const objects: StoredObject[] = [];
+    let token: string | undefined;
+
+    do {
+      const page = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: token,
+        })
+      );
+      for (const item of page.Contents ?? []) {
+        if (!item.Key || item.Key.endsWith('/')) continue;
+        objects.push({
+          key: item.Key,
+          size: item.Size ?? 0,
+          lastModified: item.LastModified ?? new Date(0),
+        });
+      }
+      token = page.IsTruncated ? page.NextContinuationToken : undefined;
+    } while (token);
+
+    return objects;
+  }
+
+  publicUrl(key: string): string {
+    return `${this.baseUrl}/${assertSafeKey(key)}`;
+  }
+
+  /**
+   * Every prefix a URL of this store can legitimately carry, longest first so a more
+   * specific base wins over a shorter one that happens to be its prefix.
+   *
+   * `LEGACY_PUBLIC_PATH` is here even though this driver never produces it: rows written
+   * before the migration to object storage still say `/uploads/...`, and they are this
+   * store's objects under their old address. Leaving it out is precisely the mistake that
+   * would make the sweep read them as somebody else's and delete them.
+   */
+  private ownedPrefixes(): string[] {
+    const prefixes = [this.baseUrl];
+
+    if (!this.baseUrl.startsWith('/')) {
+      try {
+        const basePath = new URL(this.baseUrl).pathname.replace(/\/+$/, '');
+        if (basePath) prefixes.push(basePath);
+      } catch {
+        // Not a parseable absolute base; the raw prefix above is all there is.
+      }
+    }
+
+    prefixes.push(LEGACY_PUBLIC_PATH);
+
+    return [...new Set(prefixes)].sort((a, b) => b.length - a.length);
+  }
+
+  /** The URL itself, plus its path when absolute — the forms worth comparing. */
+  private candidatePaths(url: string): string[] {
+    if (!url) return [];
+    const candidates = [url];
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+      try {
+        candidates.push(new URL(url).pathname);
+      } catch {
+        // Unparseable; the raw form is all there is to compare.
+      }
+    }
+    return candidates;
+  }
+
+  ownsUrl(url: string): boolean {
+    return this.candidatePaths(url).some((candidate) =>
+      this.ownedPrefixes().some((prefix) => candidate.startsWith(`${prefix}/`))
+    );
+  }
+
+  keyFromUrl(url: string): string | null {
+    for (const candidate of this.candidatePaths(url)) {
+      for (const prefix of this.ownedPrefixes()) {
+        const withSlash = `${prefix}/`;
+        if (!candidate.startsWith(withSlash)) continue;
+
+        const key = candidate.slice(withSlash.length);
+        if (!key) continue;
+        try {
+          return assertSafeKey(key);
+        } catch {
+          // Ours, and unreadable. Null here with `ownsUrl` true is the signal that stops
+          // the sweep; returning a guess would be worse than returning nothing.
+          return null;
+        }
+      }
+    }
+
+    return null;
+  }
+}
+
+/** S3 reports a missing key as 404/NotFound/NoSuchKey depending on the operation and store. */
+function isNotFound(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const e = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return e.name === 'NotFound' || e.name === 'NoSuchKey' || e.$metadata?.httpStatusCode === 404;
+}

--- a/server/tests/storage.test.ts
+++ b/server/tests/storage.test.ts
@@ -25,7 +25,10 @@ import {
   PRODUCT_IMAGE_PREFIX,
 } from '../src/storage/keys';
 import { detectImageType, validateImageBytes, createImageUpload } from '../src/storage/upload';
-import { setStorage, resetStorage } from '../src/storage';
+import { setStorage, resetStorage, createStorageDriver } from '../src/storage';
+import { S3StorageDriver } from '../src/storage/s3Driver';
+import { S3Client } from '@aws-sdk/client-s3';
+import { resetEnvCache } from '../src/config/env';
 import { ProductsController } from '../src/modules/inventory/products/controller';
 import { productsRepository } from '../src/modules/inventory/products/repository';
 import productsRouter from '../src/modules/inventory/products/routes';
@@ -589,5 +592,185 @@ describe('orphaned media sweep', () => {
 
     expect(outcome).toMatchObject({ scanned: 2, deleted: 1, failed: 1 });
     expect(driver.objects.has('products/stuck.png')).toBe(true);
+  });
+});
+
+/**
+ * The S3-compatible driver (#82).
+ *
+ * The URL logic is what carries the risk, so that is what is asserted hardest. The orphan
+ * sweep deletes objects no database row references, and it decides "referenced" by asking
+ * the driver two questions. A driver that answers them wrong does not fail loudly — it
+ * deletes a shop's product images on its first run after a migration. #75 shipped that bug
+ * against the local driver and it was caught in review rather than by a test; this is that
+ * test for the new one.
+ *
+ * Network calls are mocked at `S3Client.prototype.send`, which keeps the suite hermetic
+ * without another dependency. What that asserts is the command this driver builds and how
+ * it reads the reply — not that AWS works.
+ */
+describe('S3StorageDriver', () => {
+  const CDN = 'https://cdn.example.com/media';
+
+  function s3Driver(baseUrl = CDN) {
+    return new S3StorageDriver({ bucket: 'moon-media', region: 'us-east-1', baseUrl });
+  }
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('round-trips a key through its public URL', () => {
+    const s3 = s3Driver();
+    expect(s3.publicUrl('products/a.png')).toBe(`${CDN}/products/a.png`);
+    expect(s3.keyFromUrl(`${CDN}/products/a.png`)).toBe('products/a.png');
+    // Same-origin form of the configured base, for a CDN fronting this API.
+    expect(s3.keyFromUrl('/media/products/a.png')).toBe('products/a.png');
+  });
+
+  it('still owns the legacy /uploads URLs it never wrote', () => {
+    // The documented migration copies the tree into a bucket and points the base at a CDN.
+    // Rows written before that stay relative. This driver never emits `/uploads/...`, but
+    // those rows are still its objects under their old address — and a driver that
+    // disowned them would make the sweep read every one as unreferenced.
+    const s3 = s3Driver();
+    expect(s3.keyFromUrl('/uploads/products/legacy.png')).toBe('products/legacy.png');
+    expect(s3.ownsUrl('/uploads/products/legacy.png')).toBe(true);
+  });
+
+  it('leaves an image belonging to somebody else alone', () => {
+    const s3 = s3Driver();
+    expect(s3.keyFromUrl('https://other.example.com/hero.png')).toBeNull();
+    expect(s3.ownsUrl('https://other.example.com/hero.png')).toBe(false);
+  });
+
+  it('separates "not mine" from "mine but unreadable"', () => {
+    // The distinction the sweep depends on. `null` from both would be indistinguishable
+    // from an absent reference, and the sweep would then delete on missing information.
+    const s3 = s3Driver();
+    expect(s3.keyFromUrl('/uploads/products/../../etc/passwd')).toBeNull();
+    expect(s3.ownsUrl('/uploads/products/../../etc/passwd')).toBe(true);
+  });
+
+  it('reads a missing object as absent, but never an unreadable one', async () => {
+    const s3 = s3Driver();
+    const send = vi.spyOn(S3Client.prototype, 'send');
+
+    send.mockRejectedValueOnce(Object.assign(new Error('nope'), { name: 'NotFound' }));
+    expect(await s3.exists('products/a.png')).toBe(false);
+
+    // Access denied is not "absent". Reporting it as absent would let the sweep treat an
+    // object it merely cannot read as one that is not there.
+    send.mockRejectedValueOnce(
+      Object.assign(new Error('denied'), {
+        name: 'AccessDenied',
+        $metadata: { httpStatusCode: 403 },
+      })
+    );
+    await expect(s3.exists('products/a.png')).rejects.toThrow(/denied/);
+  });
+
+  it('pages a truncated listing to the end', async () => {
+    // A listing read as complete when it was not would hide objects from the sweep, and
+    // hide from the reader that they were hidden.
+    const s3 = s3Driver();
+    const now = new Date();
+    vi.spyOn(S3Client.prototype, 'send')
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'products/a.png', Size: 1, LastModified: now }],
+        IsTruncated: true,
+        NextContinuationToken: 'page-2',
+      } as never)
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'products/b.png', Size: 2, LastModified: now }],
+        IsTruncated: false,
+      } as never);
+
+    expect((await s3.list('products')).map((o) => o.key)).toEqual([
+      'products/a.png',
+      'products/b.png',
+    ]);
+  });
+
+  it('refuses a key that could escape the store', async () => {
+    const s3 = s3Driver();
+    await expect(s3.put('../secrets.env', PNG, { contentType: 'image/png' })).rejects.toThrow(
+      /Unsafe storage key/
+    );
+  });
+
+  /**
+   * The scenario the whole driver had to get right, end to end: a legacy row this store
+   * owns but cannot resolve must STOP the sweep, not be passed over as unreferenced.
+   */
+  it('makes the sweep abort rather than delete when a row it owns will not resolve', async () => {
+    const s3 = s3Driver();
+    vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({
+      Contents: [
+        {
+          Key: 'products/legacy.png',
+          Size: 1,
+          LastModified: new Date(Date.now() - 48 * 60 * 60 * 1000),
+        },
+      ],
+      IsTruncated: false,
+    } as never);
+
+    const pool = {
+      query: vi.fn(async () => ({
+        // Ours by prefix, unresolvable as a key. The sweep must read this as missing
+        // information about what is referenced, not as an absent reference.
+        rows: [{ image_url: '/uploads/products/../../etc/passwd' }],
+      })),
+    } as never;
+
+    await expect(
+      sweepOrphanedMedia({ pool, storage: s3, minAgeMs: 24 * 60 * 60 * 1000 })
+    ).rejects.toThrow(/Refusing to sweep/);
+  });
+});
+
+describe('createStorageDriver for s3', () => {
+  const ORIGINAL = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+    resetEnvCache();
+    resetStorage();
+  });
+
+  function withEnv(vars: Record<string, string>) {
+    Object.assign(process.env, vars);
+    resetEnvCache();
+  }
+
+  it('refuses to start without a bucket rather than falling back to local', () => {
+    // Falling back would start an instance writing to a container filesystem while its
+    // operator believed media was going to a bucket — a loss that surfaces at the next
+    // redeploy, long after the cause.
+    withEnv({ MEDIA_STORAGE_DRIVER: 's3', MEDIA_PUBLIC_BASE_URL: 'https://cdn.example.com/m' });
+    expect(() => createStorageDriver()).toThrow(/requires MEDIA_S3_BUCKET/);
+  });
+
+  it('refuses to start without a public base URL', () => {
+    // There is no safe default: a wrong guess writes unreachable URLs into the database.
+    withEnv({ MEDIA_STORAGE_DRIVER: 's3', MEDIA_S3_BUCKET: 'moon-media' });
+    expect(() => createStorageDriver()).toThrow(/requires MEDIA_PUBLIC_BASE_URL/);
+  });
+
+  it('builds the driver when both are present', () => {
+    withEnv({
+      MEDIA_STORAGE_DRIVER: 's3',
+      MEDIA_S3_BUCKET: 'moon-media',
+      MEDIA_S3_REGION: 'us-east-1',
+      MEDIA_PUBLIC_BASE_URL: 'https://cdn.example.com/m',
+    });
+    const built = createStorageDriver();
+    expect(built.name).toBe('s3');
+    expect(built.publicUrl('products/a.png')).toBe('https://cdn.example.com/m/products/a.png');
+  });
+
+  it('still defaults to local when nothing is configured', () => {
+    delete process.env.MEDIA_STORAGE_DRIVER;
+    resetEnvCache();
+    expect(createStorageDriver().name).toBe('local');
   });
 });


### PR DESCRIPTION
Closes #82, and with it the remaining acceptance criterion of #46 — *uploaded media survives API redeployment and is accessible from every instance*. `render.yaml` configures no disk, so on Render that was still false: images went to the container filesystem and vanished on redeploy.

## Protocol, not vendor

AWS S3, Cloudflare R2, DigitalOcean Spaces and MinIO share one API, so the driver is written against that and **which store you are on is an endpoint and a credential, not a code path**. `local` stays the default, so an unconfigured deployment behaves exactly as it does today.

## The half that can destroy data

The orphan sweep deletes objects no database row references, and it decides "referenced" by asking the driver two questions. It is driver-agnostic — so the safety of the whole thing rests on this driver answering them correctly.

`keyFromUrl` returning `null` conflates two very different answers: *"somebody else's image"* and *"mine, and I could not read it"*. The sweep must abort on the second. A driver that answered `false`/`null` to both would classify every legacy `/uploads/...` row as unreferenced and **delete a shop's product images on the first sweep after a migration** — precisely the bug #75 shipped against the local driver, which review caught rather than a test.

So:

- `LEGACY_PUBLIC_PATH` is an **owned prefix** here even though this driver never writes that shape. Rows written before the migration are still this store's objects under their old address.
- The test asserts the sweep **aborts rather than deletes** when a row it owns will not resolve.
- **Verified by breaking it:** making `ownsUrl` return `false` fails three tests, including that one. A guard that cannot fail proves nothing.

## Three more places the safe answer is to stop, not guess

| Situation | Behaviour | Why not the alternative |
| --- | --- | --- |
| `s3` with no `MEDIA_S3_BUCKET` | Refuses to boot, by name | Falling back to `local` starts an instance writing to a container filesystem while its operator believes media is going to a bucket. The loss surfaces a redeploy later, long after the cause. |
| `s3` with no `MEDIA_PUBLIC_BASE_URL` | Refuses to boot | There is no safe default — the bucket's URL shape differs per provider and per path-style setting, and a wrong guess writes unreachable URLs into rows. |
| `exists()` hits a permissions error | Rethrows | Reporting "absent" would let the sweep treat an object it merely cannot read as one that is not there. |

`list()` also pages to the end: a truncated listing read as complete would hide objects from the sweep, and hide that they were hidden.

## Credentials

From the environment only; nothing committed. Omitting **both** key variables lets the SDK's default chain use an instance or container role, which is the better posture where it is available — that is why they are optional rather than required.

## Deployment

`render.yaml` documents both options with the migration order, **neither enabled**:

- **(a) a disk** — simplest, enough for one instance, does not survive scaling out (a Render disk cannot be shared).
- **(b) a bucket** — survives redeploys and scale-out, with the copy-preserving-keys step and the warning not to point `MEDIA_PUBLIC_BASE_URL` at the bucket until the objects are actually reachable there.

## Testing

- 12 new tests; `storage.test.ts` 40 passed. Full server suite **684 passed, 0 skipped** with a real PostgreSQL.
- URL semantics asserted hardest, since that is where the risk is: round-trip, legacy `/uploads` ownership after the base moves to a CDN, someone else's URL, and the "mine but unreadable" case.
- Network calls mocked at `S3Client.prototype.send` — hermetic, no new test dependency. What that asserts is the command built and the reply read, not that AWS works.
- `lint` 0 errors / 391 warnings — exactly the ratchet from #43, unchanged.

## Post-Deploy Monitoring & Validation

**Nothing changes until someone sets `MEDIA_STORAGE_DRIVER=s3`.** This ships the capability, not the cutover.

When cutting over:
- **Order matters:** copy `server/uploads` into the bucket *preserving keys*, confirm old relative rows still resolve through the `/uploads` mount, and only then set `MEDIA_PUBLIC_BASE_URL`. `CLAUDE.md` → *Media storage* has this.
- **Watch first:** the `orphaned-media-cleanup` job's outcome in `scheduled_jobs.last_detail`. A run reporting `Refusing to sweep` is the guard working — investigate the unresolvable URLs, do **not** relax the guard. A run with an unexpectedly high `deleted` count is the signal to stop and check `ownsUrl` against the configured base.
- **Healthy signal:** uploads reachable at their new URL, existing images still loading, and the sweep reporting `deleted: 0` on a store with no genuine orphans.
- **Rollback:** set `MEDIA_STORAGE_DRIVER` back to `local`. Rows written while on `s3` hold absolute URLs and keep resolving from the bucket; nothing is lost by switching back, which is why the copy is additive rather than a move.
- **Window / owner:** the first sweep cycle (24h) after any cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN