### PR TITLE
refactor(api): type errors at the throw site instead of parsing messages (#47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,14 +63,14 @@ Each gate is its own job, so the checks list says what broke without anyone open
 
 ### The lint warning ratchet
 
-`npm run lint --prefix server` runs `eslint . --max-warnings 391`. The number is today's
+`npm run lint --prefix server` runs `eslint . --max-warnings 387`. The number is today's
 count, essentially all `@typescript-eslint/no-explicit-any`. It exists so the count can
 only fall: errors were already fatal, but warnings gated nothing, so nothing stopped the
 next `any` from landing.
 
 **Lowering it is #47's job**, as it replaces `any` with real types. Lower the number in
 `server/package.json` in the same PR that removes the warnings — a ratchet left above the
-true count silently stops ratcheting. Never raise it.
+true count silently stops ratcheting. Never raise it. It has gone 391 → 387 so far.
 
 ### Migration verification
 
@@ -295,6 +295,60 @@ Optional for the same reason `Idempotency-Key` is: a cached PWA client running o
 keeps working rather than breaking on a 409 it cannot explain. Every client this repo
 ships sends it. The token must come from the read the edit was **composed against** — a
 page that re-reads it at submit time always matches and has quietly turned the check off.
+
+## Error contracts: typed at the throw site
+
+A service says what kind of refusal something is; a controller does not work it out from
+the wording. Services throw `PublicError` with one of the seven public codes, and the
+controller's `catch` passes it to `next` unchanged.
+
+Before #47 this was inverted: services threw bare `Error`s and controllers recovered the
+status by testing the message. `layaway` chose 404 on `message.includes('not found')`, and
+the checkout path had **eight** substring tests — one of them the bare word `'Bundle'`.
+That made every one of those strings part of the API without anyone declaring it, in both
+directions:
+
+- Rewording "Plan not found" turned a 404 into a 400, silently.
+- A genuine server fault whose message happened to contain `Bundle` or `not found` reached
+  the till as a 400 telling a cashier to fix their cart.
+
+An unexpected error is now a 500, which is the truth, and `tests/sales.test.ts` pins that
+as well as the happy path.
+
+### Database constraint failures
+
+Recognised by SQLSTATE, never by message text — `src/database/constraintErrors.ts`.
+
+```ts
+if (isUniqueViolation(err)) throw new PublicError('CONFLICT', 'SKU already exists');
+```
+
+A dozen controllers used to ask `err.message?.includes('UNIQUE')`, which depends on the
+server's `lc_messages`, on the driver, and on nobody rephrasing anything. It also matched
+too much: a validation message containing the word "unique" read as a duplicate key and
+was answered with a 409. And `'UNIQUE'` is SQLite wording — PostgreSQL says
+`duplicate key value violates unique constraint`, lowercase — so half of every one of
+those checks had been dead since the migration without anyone noticing. Which is the
+argument against the technique, not just against that string.
+
+### OpenAPI: not generated from contracts, and why
+
+#47 asks to "generate or verify OpenAPI from those contracts". **That is not done, and it
+is not a small remainder.** `src/docs/openapi.ts` is 11,865 hand-maintained lines, and
+`scripts/generateOpenApi.ts` is a regex scraper over the manifest's source text rather
+than anything derived from the Zod schemas that actually validate requests.
+
+Closing it means picking one of two routes and paying for it:
+
+1. Derive the spec from the Zod schemas (`zod-to-openapi` or equivalent), which makes the
+   schemas the single source and deletes most of that file — but changes the published
+   spec's shape, so every consumer of it has to be checked.
+2. Keep the hand-written spec and add a drift check that fails when a registered route is
+   missing from it. Cheaper, and catches the common omission, but the *shape* of a
+   documented request can still drift from the schema that enforces it.
+
+Route 2 is the smaller step and the one to take first. Neither is in #47's diff, and
+saying so is better than a generator nobody trusts.
 
 ## Scheduled jobs
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -2,7 +2,8 @@
 
 > This document was rewritten for the feature-slice refactor (2026-08-20-001). The previous version
 > (pre-slice) is recoverable at `76a7ab0^` in git history. Sections below that are unaffected by the
-> refactor (server routes, SQLite gotchas, forms, formatting) are carried forward from it.
+> refactor (forms, formatting) are carried forward from it. The SQLite section it used to
+> carry was deleted after the PostgreSQL migration made it wrong.
 
 ## Project Structure Rules
 
@@ -93,11 +94,12 @@ decision, not an oversight — do not "fix" it as a drive-by during unrelated wo
   `features/pos/components/CartPanel.tsx` — all reading/invalidating the same server-side settings
   resource. This is intentional cache sharing, not an accidental collision; each call site comments the
   sharing at its use.
-- **Route path strings are duplicated** between `client/src/app/App.tsx`'s `RouteConfig[]` table (the
-  router source of truth) and `client/src/app/Sidebar.tsx`'s `navItems[]` (the nav source of truth,
-  which also carries icons, labels and role gates the router doesn't need). Both live in `app/`, so
-  there is no cross-layer coupling — but a renamed route requires editing both files by hand. Unifying
-  them into one route-registry module is legitimate follow-up work, out of scope here.
+- **Route path strings are duplicated** between the file-based route tree under
+  `client/src/routes/` (the router's source of truth — the path *is* the filename, and
+  `routeTree.gen.ts` is generated from it) and `client/src/app/Sidebar.tsx`'s `navItems[]` (the nav
+  source of truth, which also carries icons, labels and role gates the router doesn't need). A renamed
+  route therefore means renaming a file *and* editing the sidebar by hand, with nothing checking they
+  still agree. Deriving the nav from the route tree is legitimate follow-up work.
 - **The two global i18n files** (`shared/i18n/en.json`, `shared/i18n/ar.json`, ~180 keys each) are not
   split per slice. Every slice's copy lives in the same flat `section.action` keyspace (see Naming
   Conventions below). This was a pre-existing pattern before the refactor and stays that way: splitting
@@ -619,57 +621,45 @@ if (!parsed.success) {
 
 ---
 
-## SQLite Gotchas
+## Adding a feature
 
-### ALTER TABLE Limitations
+Paths, not prose — the previous version of this section named `server/db/migrations/`,
+`server/routes/`, `client/src/app/App.tsx` and `FEATURES_ROADMAP.md`, of which the first
+two moved and the last two do not exist. A checklist that sends people to the wrong
+directory is worse than none.
 
-SQLite cannot `ALTER TABLE` with `REFERENCES`, `DEFAULT`, or `CHECK` in one statement:
+**Server**
 
-```sql
--- WRONG: will fail
-ALTER TABLE products ADD COLUMN distributor_id INTEGER REFERENCES distributors(id) DEFAULT NULL;
+1. **Migration** — `server/src/database/migrations/NNN_name.sql`, plus a matching
+   `NNN_name.down.sql`. The down file is not optional: CI rolls every migration back and
+   re-applies it (`npm run verify:migrations`). If the down genuinely changes nothing, say
+   `Intentionally a no-op.` in it — that marker is load-bearing.
+2. **Module** — `server/src/modules/<domain>/<module>/` with `routes.ts`, `controller.ts`,
+   `service.ts`, `repository.ts`, `types.ts`. Validation lives in the controller as a Zod
+   schema; the update schema is a genuine partial and is `.strict()` where it has been
+   tightened.
+3. **Register** — add the router to the module manifest, not to `index.ts` by hand.
+4. **Errors** — throw `PublicError` from the service with the code you mean. Never let a
+   controller recover a status by reading a message; see *Error contracts* in `CLAUDE.md`.
+5. **Apply it** — `cd server && npm run migrate`.
 
--- CORRECT: split into two
-ALTER TABLE products ADD COLUMN distributor_id INTEGER;
-UPDATE products SET distributor_id = NULL;
-```
+**Client**
 
-### Enforce Constraints in App Code
+6. **Page** — `client/src/features/<slice>/pages/Feature.tsx`. Run the R5 placement
+   checklist above if it is not obviously one slice's.
+7. **Route** — routing is file-based (TanStack Router): add a file under
+   `client/src/routes/`. `routeTree.gen.ts` is generated; never edit it.
+8. **Barrel** — export from the slice's `index.ts` only if `app/` or another slice needs it.
+9. **Sidebar** — add an entry to `navItems[]` in `client/src/app/Sidebar.tsx`.
+10. **i18n** — add keys to **both** `en.json` and `ar.json`. A key present in one and not
+    the other renders the key name to a user.
+11. **Shared components** — import from the barrel (`@/shared`), never from the directory a
+    component happens to live in. See *Shared components have one import path* above.
 
-SQLite `ALTER TABLE` doesn't support adding `CHECK` constraints. Validate in the application layer instead.
+### Route ordering
 
-### Transaction Pattern
-
-```typescript
-const rawDb = db.db;
-const doWork = rawDb.transaction(() => {
-  // multiple statements here
-});
-doWork();  // invoke the transaction
-```
-
----
-
-## Adding New Features
-
-### Checklist
-
-1. **Migration**: Create `server/db/migrations/NNN_feature.sql`
-2. **Route**: Create `server/routes/feature.ts` with CRUD endpoints
-3. **Register route**: Add import + `app.use()` in `server/index.ts`
-4. **Validator** (optional): Create `server/validators/featureSchema.ts`
-5. **Page**: Create `client/src/features/<slice>/pages/Feature.tsx` (run the R5 checklist above if it's
-   not obviously one existing slice's)
-6. **Barrel**: Export the page from that slice's `index.ts` only if `app/` or another slice needs it
-7. **Route config**: Add route in `client/src/app/App.tsx` (lazy or eager)
-8. **Sidebar**: Add entry to `navItems[]` in `client/src/app/Sidebar.tsx`
-9. **i18n**: Add keys to both `en.json` and `ar.json`
-10. **Roadmap**: Update `FEATURES_ROADMAP.md`
-11. **Run migrate**: `cd server && npm run migrate`
-
-### Route Ordering Reminder
-
-When adding routes in `server/index.ts`, order doesn't matter since each route file has its own prefix. But **within** a route file, specific paths must come before `/:id`.
+Within a route file, specific paths must come before `/:id`, or `/products/categories`
+resolves as a product with the id "categories".
 
 ---
 

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "migrate": "tsx src/database/migrate.ts up",
     "migrate:down": "tsx src/database/migrate.ts down",
     "seed": "tsx src/database/seed.ts",
-    "lint": "eslint . --max-warnings 391",
+    "lint": "eslint . --max-warnings 387",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.ts\"",
     "test": "vitest run",

--- a/server/services/productService.ts
+++ b/server/services/productService.ts
@@ -1,4 +1,5 @@
 import db from '../src/database/pool';
+import { PublicError } from '../src/http/errors';
 import { withTransaction, Queryable } from '../src/database/transaction';
 import { productSchema } from '../validators/productSchema';
 import { notifyLowStock } from './notifications';
@@ -295,7 +296,7 @@ export async function bulkUpdateProducts(
         'SELECT name FROM categories WHERE id = $1',
         [updates.category_id]
       );
-      if (cat.rows.length === 0) throw new Error('Category not found');
+      if (cat.rows.length === 0) throw new PublicError('NOT_FOUND', 'Category not found');
 
       const placeholders = ids.map((_, i) => `$${i + 3}`).join(',');
       const result = await client.query(
@@ -410,7 +411,7 @@ export async function adjustStock(
     const product = prodRes.rows[0];
 
     if (!product) {
-      throw new Error('Product not found');
+      throw new PublicError('NOT_FOUND', 'Product not found');
     }
 
     if (product.status === 'discontinued') {
@@ -456,7 +457,7 @@ export async function createVariant(
       [productId]
     );
     const product = prodRes.rows[0];
-    if (!product) throw new Error('Product not found');
+    if (!product) throw new PublicError('NOT_FOUND', 'Product not found');
     if (product.status === 'discontinued')
       throw new Error('Cannot add variants to a discontinued product');
 

--- a/server/src/database/constraintErrors.ts
+++ b/server/src/database/constraintErrors.ts
@@ -1,0 +1,58 @@
+/**
+ * Recognising a database constraint failure by its code rather than its prose.
+ *
+ * PostgreSQL reports these as SQLSTATE values, which node-postgres surfaces as `err.code`.
+ * Before this, a dozen controllers asked `err.message?.includes('UNIQUE')` — a test on
+ * wording that is not part of any contract. It depends on the server's `lc_messages`, on
+ * the driver, and on nobody rephrasing anything; and it matches too much, because a
+ * validation message that happens to contain the word "unique" reads as a duplicate-key
+ * failure and is answered with a 409.
+ *
+ * `'UNIQUE'` also came from the SQLite era — PostgreSQL's own text is
+ * `duplicate key value violates unique constraint "..."`, lowercase — so half of every
+ * one of those checks had been dead since the migration without anyone noticing, which is
+ * exactly what makes string-matching an error a bad way to know what happened.
+ *
+ * SQLSTATE values are defined by the standard and stable across versions and locales.
+ *
+ * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+
+export const UNIQUE_VIOLATION = '23505';
+export const FOREIGN_KEY_VIOLATION = '23503';
+export const NOT_NULL_VIOLATION = '23502';
+export const CHECK_VIOLATION = '23514';
+
+function sqlState(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+/** A row collided with a unique index — a duplicate SKU, barcode, email, code. */
+export function isUniqueViolation(error: unknown): boolean {
+  return sqlState(error) === UNIQUE_VIOLATION;
+}
+
+/** A referenced row does not exist, or a referencing row still does. */
+export function isForeignKeyViolation(error: unknown): boolean {
+  return sqlState(error) === FOREIGN_KEY_VIOLATION;
+}
+
+/** A CHECK constraint refused the value — a negative quantity, an unknown status. */
+export function isCheckViolation(error: unknown): boolean {
+  return sqlState(error) === CHECK_VIOLATION;
+}
+
+/**
+ * The constraint's name, when the database named one.
+ *
+ * Useful for telling *which* uniqueness failed when a table has several — `products_sku_key`
+ * versus `products_barcode_key` — without going back to the message text this module exists
+ * to stop reading.
+ */
+export function constraintName(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const name = (error as { constraint?: unknown }).constraint;
+  return typeof name === 'string' ? name : undefined;
+}

--- a/server/src/modules/commerce/coupons/service.ts
+++ b/server/src/modules/commerce/coupons/service.ts
@@ -10,6 +10,7 @@ import {
   ValidateCouponInput,
   ValidateCouponResult,
 } from './types';
+import { isUniqueViolation } from '../../../database/constraintErrors';
 
 export class CouponsService {
   constructor(private repo: ICouponsRepository = defaultRepo) {}
@@ -38,7 +39,7 @@ export class CouponsService {
     try {
       return await this.repo.create(data);
     } catch (err: any) {
-      if (err.message?.includes('UNIQUE') || err.message?.includes('duplicate key')) {
+      if (isUniqueViolation(err)) {
         throw new CouponError('Coupon code already exists', 409);
       }
       throw err;
@@ -69,7 +70,7 @@ export class CouponsService {
       return coupon;
     } catch (err: any) {
       if (err instanceof CouponError) throw err;
-      if (err.message?.includes('UNIQUE') || err.message?.includes('duplicate key')) {
+      if (isUniqueViolation(err)) {
         throw new CouponError('Coupon code already exists', 409);
       }
       throw err;

--- a/server/src/modules/commerce/giftCards/controller.ts
+++ b/server/src/modules/commerce/giftCards/controller.ts
@@ -13,6 +13,7 @@ import {
   toIdempotencyPublicError,
   withIdempotency,
 } from '../../../http/idempotency';
+import { isUniqueViolation } from '../../../database/constraintErrors';
 
 export const createGiftCardSchema = z.object({
   code: z.string().min(4).max(50).optional(),
@@ -62,7 +63,7 @@ export class GiftCardsController {
 
       res.status(201).json(success(card));
     } catch (err: any) {
-      if (err.message?.includes('UNIQUE') || err.message?.includes('duplicate key')) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'Gift card code or barcode already exists'));
         return;
       }
@@ -96,38 +97,24 @@ export class GiftCardsController {
       const authReq = req as AuthRequest;
       const code = req.params.code as string;
 
-      let outcome;
-      try {
-        outcome = await withIdempotency({
-          // Stable per endpoint: the card code is fingerprinted through the payload
-          // instead, so one key cannot straddle two different cards.
-          endpoint: 'POST /api/v1/gift-cards/:code/redeem',
-          key: readIdempotencyKey(req),
-          userId: authReq.user!.id,
-          payload: { ...parsed.data, code },
-          run: async (client) => {
-            const redeemed = await giftCardsService.redeem(
-              code,
-              amount,
-              sale_id,
-              authReq.user!.id,
-              client
-            );
-            return { status: 200, body: success(redeemed), result: redeemed };
-          },
-        });
-      } catch (err: any) {
-        if (
-          err.message === 'Gift card not found' ||
-          err.message === 'Gift card is not active' ||
-          err.message === 'Gift card has expired' ||
-          err.message.startsWith('Insufficient balance')
-        ) {
-          const code = err.message === 'Gift card not found' ? 'NOT_FOUND' : 'CONFLICT';
-          throw new PublicError(code, err.message);
-        }
-        throw err;
-      }
+      const outcome = await withIdempotency({
+        // Stable per endpoint: the card code is fingerprinted through the payload
+        // instead, so one key cannot straddle two different cards.
+        endpoint: 'POST /api/v1/gift-cards/:code/redeem',
+        key: readIdempotencyKey(req),
+        userId: authReq.user!.id,
+        payload: { ...parsed.data, code },
+        run: async (client) => {
+          const redeemed = await giftCardsService.redeem(
+            code,
+            amount,
+            sale_id,
+            authReq.user!.id,
+            client
+          );
+          return { status: 200, body: success(redeemed), result: redeemed };
+        },
+      });
 
       if (outcome.replayed) {
         // A replay must not write a second audit entry.

--- a/server/src/modules/commerce/giftCards/service.ts
+++ b/server/src/modules/commerce/giftCards/service.ts
@@ -1,4 +1,5 @@
 import { Queryable, withTransaction } from '../../../database/transaction';
+import { PublicError } from '../../../http/errors';
 import { IGiftCardsRepository, giftCardsRepository as defaultRepo } from './repository';
 import {
   CreateGiftCardInput,
@@ -137,26 +138,33 @@ export class GiftCardsService {
     const card = await this.repo.findByCode(code, client);
 
     if (!card) {
-      throw new Error('Gift card not found');
+      throw new PublicError('NOT_FOUND', 'Gift card not found');
     }
 
     const debited = await this.repo.redeemBalance(card.id, amount, client);
 
     if (!debited) {
       // The guarded UPDATE decided the card was ineligible but cannot say why. This
-      // read exists only to pick the message, in the same precedence as before.
+      // read exists only to pick the reason, in the same precedence as before.
+      //
+      // These carry their status as a typed code rather than a message the controller
+      // string-matches (#47). The wording is unchanged, but it is no longer load-bearing:
+      // renaming 'Gift card is not active' used to turn a 409 into a 500 silently.
       const current = await this.repo.findById(card.id, client);
 
       if (!current) {
-        throw new Error('Gift card not found');
+        throw new PublicError('NOT_FOUND', 'Gift card not found');
       }
       if (current.status !== 'active') {
-        throw new Error('Gift card is not active');
+        throw new PublicError('CONFLICT', 'Gift card is not active');
       }
       if (current.expires_at && new Date(current.expires_at) < new Date()) {
-        throw new Error('Gift card has expired');
+        throw new PublicError('CONFLICT', 'Gift card has expired');
       }
-      throw new Error(`Insufficient balance. Available: ${Number(current.balance)}`);
+      throw new PublicError(
+        'CONFLICT',
+        `Insufficient balance. Available: ${Number(current.balance)}`
+      );
     }
 
     const transaction = await this.repo.createTransaction(

--- a/server/src/modules/core/branches/controller.ts
+++ b/server/src/modules/core/branches/controller.ts
@@ -7,6 +7,7 @@ import { PublicError } from '../../../http/errors';
 import { paginationMeta } from '../../../http/pagination';
 import { success } from '../../../http/responses';
 import { parseTransferListQuery } from './types';
+import { isUniqueViolation } from '../../../database/constraintErrors';
 
 const branchSchema = z.object({
   name: z.string().min(1).max(100),
@@ -46,11 +47,7 @@ export class BranchesController {
         next(err);
         return;
       }
-      if (
-        err.code === '23505' ||
-        err.message?.includes('UNIQUE') ||
-        err.message?.includes('duplicate key')
-      ) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'Branch code already exists'));
         return;
       }
@@ -75,11 +72,7 @@ export class BranchesController {
         next(err);
         return;
       }
-      if (
-        err.code === '23505' ||
-        err.message?.includes('UNIQUE') ||
-        err.message?.includes('duplicate key')
-      ) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'Branch code already exists'));
         return;
       }

--- a/server/src/modules/core/users/controller.ts
+++ b/server/src/modules/core/users/controller.ts
@@ -8,6 +8,7 @@ import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
 import { z } from 'zod';
+import { isUniqueViolation } from '../../../database/constraintErrors';
 
 const favoritesSchema = z.object({ favorites: z.array(z.unknown()).max(100) }).strict();
 
@@ -51,11 +52,7 @@ export class UsersController {
 
       res.status(201).json(success(createdUser));
     } catch (err: any) {
-      if (
-        err.code === '23505' ||
-        err.message?.includes('UNIQUE') ||
-        err.message?.includes('duplicate key')
-      ) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'Email already exists'));
         return;
       }
@@ -79,11 +76,7 @@ export class UsersController {
       const updatedUser = await usersService.update(req.params.id as string, parsed.data);
       res.json(success(updatedUser));
     } catch (err: any) {
-      if (
-        err.code === '23505' ||
-        err.message?.includes('UNIQUE') ||
-        err.message?.includes('duplicate key')
-      ) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'Email already exists'));
         return;
       }

--- a/server/src/modules/fulfillment/delivery/controller.ts
+++ b/server/src/modules/fulfillment/delivery/controller.ts
@@ -50,15 +50,10 @@ export class DeliveryController {
         throw parsed.error;
       }
 
-      try {
-        const order = await deliveryService.createDeliveryOrder(parsed.data);
-        res.status(201).json(success(order));
-      } catch (err: any) {
-        if (err.message === 'Customer not found') {
-          throw new PublicError('VALIDATION_ERROR', 'Customer not found');
-        }
-        throw err;
-      }
+      // The service says what kind of refusal a failure was (#47), so there is nothing
+      // to catch and re-map here; the outer handler passes it to `next` as it is.
+      const order = await deliveryService.createDeliveryOrder(parsed.data);
+      res.status(201).json(success(order));
     } catch (err) {
       next(err);
     }
@@ -71,18 +66,8 @@ export class DeliveryController {
         throw parsed.error;
       }
 
-      try {
-        const order = await deliveryService.updateDeliveryOrder(
-          req.params.id as string,
-          parsed.data
-        );
-        res.json(success(order));
-      } catch (err: any) {
-        if (err.message === 'Order not found') {
-          throw new PublicError('NOT_FOUND', 'Order not found');
-        }
-        throw err;
-      }
+      const order = await deliveryService.updateDeliveryOrder(req.params.id as string, parsed.data);
+      res.json(success(order));
     } catch (err) {
       next(err);
     }

--- a/server/src/modules/fulfillment/delivery/service.ts
+++ b/server/src/modules/fulfillment/delivery/service.ts
@@ -8,6 +8,7 @@ import {
   DeliveryListResult,
   PerformanceResult,
 } from './types';
+import { PublicError } from '../../../http/errors';
 
 export function generateDeliveryOrderNumber(): string {
   const now = new Date();
@@ -42,7 +43,7 @@ export class DeliveryService {
     if (customer_id) {
       const existing = await this.repo.findCustomerById(customer_id, queryable);
       if (!existing) {
-        throw new Error('Customer not found');
+        throw new PublicError('VALIDATION_ERROR', 'Customer not found');
       }
       return customer_id;
     }
@@ -112,7 +113,7 @@ export class DeliveryService {
 
       const order = await this.repo.updateOrder(id, resolvedCustomerId, data, client);
       if (!order) {
-        throw new Error('Order not found');
+        throw new PublicError('NOT_FOUND', 'Order not found');
       }
 
       await this.repo.deleteOrderItems(id, client);

--- a/server/src/modules/fulfillment/purchaseOrders/controller.ts
+++ b/server/src/modules/fulfillment/purchaseOrders/controller.ts
@@ -83,23 +83,14 @@ export class PurchaseOrdersController {
       }
 
       const authReq = req as AuthRequest;
-      try {
-        const newStatus = await purchaseOrdersService.receiveItems(
-          req.params.id as string,
-          parsed.data,
-          authReq.user!.id
-        );
+      // Typed at the throw site now (#47), so no message inspection here.
+      const newStatus = await purchaseOrdersService.receiveItems(
+        req.params.id as string,
+        parsed.data,
+        authReq.user!.id
+      );
 
-        res.json(success({ id: Number(req.params.id), status: newStatus }));
-      } catch (err: any) {
-        if (err.message === 'Purchase order not found') {
-          throw new PublicError('NOT_FOUND', err.message);
-        }
-        if (err.message?.startsWith('Cannot receive items')) {
-          throw new PublicError('CONFLICT', err.message);
-        }
-        throw err;
-      }
+      res.json(success({ id: Number(req.params.id), status: newStatus }));
     } catch (err) {
       next(err);
     }

--- a/server/src/modules/fulfillment/purchaseOrders/service.ts
+++ b/server/src/modules/fulfillment/purchaseOrders/service.ts
@@ -1,14 +1,12 @@
 import { withTransaction } from '../../../database/transaction';
-import {
-  IPurchaseOrdersRepository,
-  purchaseOrdersRepository as defaultRepo,
-} from './repository';
+import { IPurchaseOrdersRepository, purchaseOrdersRepository as defaultRepo } from './repository';
 import {
   CreatePurchaseOrderDTO,
   ReceiveItemsDTO,
   PurchaseOrderFilters,
   PurchaseOrderListResult,
 } from './types';
+import { PublicError } from '../../../http/errors';
 
 export function generatePONumber(): string {
   const now = new Date();
@@ -54,10 +52,7 @@ export class PurchaseOrdersService {
     userId: number
   ): Promise<{ id: number; po_number: string }> {
     const poNumber = generatePONumber();
-    const total = data.items.reduce(
-      (sum, item) => sum + item.cost_price * item.quantity,
-      0
-    );
+    const total = data.items.reduce((sum, item) => sum + item.cost_price * item.quantity, 0);
 
     const poId = await withTransaction(async (client) => {
       const newPoId = await this.repo.create(
@@ -99,18 +94,14 @@ export class PurchaseOrdersService {
     return { id: Number(id), status };
   }
 
-  async receiveItems(
-    id: number | string,
-    data: ReceiveItemsDTO,
-    userId: number
-  ): Promise<string> {
+  async receiveItems(id: number | string, data: ReceiveItemsDTO, userId: number): Promise<string> {
     const existing = await this.repo.findById(id);
     if (!existing) {
-      throw new Error('Purchase order not found');
+      throw new PublicError('NOT_FOUND', 'Purchase order not found');
     }
 
     if (existing.status === 'Cancelled' || existing.status === 'Received') {
-      throw new Error(`Cannot receive items for ${existing.status} order`);
+      throw new PublicError('CONFLICT', `Cannot receive items for ${existing.status} order`);
     }
 
     return withTransaction(async (client) => {

--- a/server/src/modules/inventory/categories/controller.ts
+++ b/server/src/modules/inventory/categories/controller.ts
@@ -4,6 +4,7 @@ import { logAuditFromReq } from '../../../../middleware/auditLogger';
 import { categoriesService } from './service';
 import { success } from '../../../http/responses';
 import { PublicError } from '../../../http/errors';
+import { isUniqueViolation } from '../../../database/constraintErrors';
 
 export class CategoriesController {
   async getCategories(_req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -28,11 +29,7 @@ export class CategoriesController {
       logAuditFromReq(req, 'create', 'category', category.id, { name, code });
       res.status(201).json(success(category));
     } catch (err: any) {
-      if (
-        err.code === '23505' ||
-        err.message?.includes('UNIQUE') ||
-        err.message?.includes('duplicate key')
-      ) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'Category code already exists'));
         return;
       }
@@ -56,11 +53,7 @@ export class CategoriesController {
 
       res.json(success(category));
     } catch (err: any) {
-      if (
-        err.code === '23505' ||
-        err.message?.includes('UNIQUE') ||
-        err.message?.includes('duplicate key')
-      ) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'Category code already exists'));
         return;
       }

--- a/server/src/modules/inventory/products/controller.ts
+++ b/server/src/modules/inventory/products/controller.ts
@@ -15,6 +15,7 @@ import { paginationMeta } from '../../../http/pagination';
 import { PublicError } from '../../../http/errors';
 import { parseProductListQuery, parseProductLookupQuery } from './types';
 import { getStorage, productImageKey } from '../../../storage';
+import { isUniqueViolation } from '../../../database/constraintErrors';
 
 const bulkUpdateSchema = z.object({
   ids: z.array(z.number().int().positive()).min(1),
@@ -166,7 +167,7 @@ export class ProductsController {
       });
       res.status(201).json(success(product));
     } catch (err: any) {
-      if (err.message?.includes('UNIQUE') || err.message?.includes('duplicate key')) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'SKU or barcode already exists'));
         return;
       }
@@ -185,10 +186,7 @@ export class ProductsController {
       const updated = await productsService.bulkUpdateProducts(ids, updates);
       res.json(success({ updated }));
     } catch (err: any) {
-      if (err.message === 'Category not found') {
-        next(new PublicError('NOT_FOUND', err.message));
-        return;
-      }
+      // Typed at the throw site (#47).
       next(err);
     }
   }
@@ -218,7 +216,7 @@ export class ProductsController {
         next(new PublicError('FORBIDDEN', err.message));
         return;
       }
-      if (err.message?.includes('UNIQUE') || err.message?.includes('duplicate key')) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'SKU or barcode already exists'));
         return;
       }
@@ -439,11 +437,7 @@ export class ProductsController {
       const variant = await productsService.createVariant(productId, parsed.data);
       res.status(201).json(success(variant));
     } catch (err: any) {
-      if (err.message === 'Product not found') {
-        next(new PublicError('NOT_FOUND', err.message));
-        return;
-      }
-      if (err.message?.includes('UNIQUE') || err.message?.includes('duplicate key')) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'SKU or barcode already exists'));
         return;
       }
@@ -469,7 +463,7 @@ export class ProductsController {
 
       res.json(success(variant));
     } catch (err: any) {
-      if (err.message?.includes('UNIQUE') || err.message?.includes('duplicate key')) {
+      if (isUniqueViolation(err)) {
         next(new PublicError('CONFLICT', 'SKU or barcode already exists'));
         return;
       }

--- a/server/src/modules/pos/exchanges/controller.ts
+++ b/server/src/modules/pos/exchanges/controller.ts
@@ -97,13 +97,9 @@ export class ExchangesController {
         );
         return;
       }
-      next(
-        err instanceof z.ZodError || err instanceof PublicError
-          ? err
-          : err instanceof Error && err.message === 'Original sale not found'
-            ? new PublicError('NOT_FOUND', err.message)
-            : err
-      );
+      // 'Original sale not found' is thrown as a typed PublicError now (#47), so it takes
+      // the first branch like any other — no message comparison left to keep in sync.
+      next(err);
     }
   }
 

--- a/server/src/modules/pos/exchanges/service.ts
+++ b/server/src/modules/pos/exchanges/service.ts
@@ -3,6 +3,7 @@ import { IExchangesRepository, exchangesRepository as defaultRepo } from './repo
 import { CreateExchangeDTO, ExchangeFilters, ExchangeRow, ExchangeDetail } from './types';
 import { sortForStockWrites } from '../stockWriteOrder';
 import { INSUFFICIENT_STOCK_CODE, type StockConflict } from '../sales/types';
+import { PublicError } from '../../../http/errors';
 
 /**
  * A new exchange line could not be taken out of stock. Rolls the whole exchange back.
@@ -61,7 +62,7 @@ export class ExchangesService implements IExchangesService {
       // connections per request halves the pool's effective capacity under load.
       const originalSale = await this.repo.findSaleById(data.original_sale_id, client);
       if (!originalSale) {
-        throw new Error('Original sale not found');
+        throw new PublicError('NOT_FOUND', 'Original sale not found');
       }
       return this.writeExchange(data, cashierId, originalSale, client);
     }
@@ -69,7 +70,7 @@ export class ExchangesService implements IExchangesService {
     return withTransaction(async (tx) => {
       const originalSale = await this.repo.findSaleById(data.original_sale_id, tx);
       if (!originalSale) {
-        throw new Error('Original sale not found');
+        throw new PublicError('NOT_FOUND', 'Original sale not found');
       }
       return this.writeExchange(data, cashierId, originalSale, tx);
     });

--- a/server/src/modules/pos/layaway/controller.ts
+++ b/server/src/modules/pos/layaway/controller.ts
@@ -109,12 +109,16 @@ export class LayawayController {
     }
   }
 
+  /**
+   * The service now throws `PublicError` with the status it means (#47), so there is
+   * nothing here to map. This used to guess from the wording — `includes('not found')`
+   * chose 404, anything else 400 — which made every message string a load-bearing part of
+   * the API: rewording "Plan not found" to "No such plan" silently turned a 404 into a
+   * 400. Passing a PublicError through this now would double-wrap it and *lose* the code
+   * it already carries.
+   */
   private mapDomainError(error: unknown): unknown {
-    if (!(error instanceof Error)) return error;
-    return new PublicError(
-      error.message.includes('not found') ? 'NOT_FOUND' : 'VALIDATION_ERROR',
-      error.message
-    );
+    return error;
   }
 }
 

--- a/server/src/modules/pos/layaway/service.ts
+++ b/server/src/modules/pos/layaway/service.ts
@@ -7,6 +7,7 @@ import {
   LayawayPlanRow,
   LayawayPlanDetail,
 } from './types';
+import { PublicError } from '../../../http/errors';
 
 export function generatePlanNumber(): string {
   const now = new Date();
@@ -38,7 +39,7 @@ export class LayawayService implements ILayawayService {
 
   async createPlan(data: CreateLayawayDTO, userId: number): Promise<LayawayPlanRow> {
     if (data.deposit_amount >= data.total_amount) {
-      throw new Error('Deposit cannot equal or exceed total amount');
+      throw new PublicError('VALIDATION_ERROR', 'Deposit cannot equal or exceed total amount');
     }
 
     const planNumber = generatePlanNumber();
@@ -111,15 +112,18 @@ export class LayawayService implements ILayawayService {
   ): Promise<{ remaining_balance: number; status: string }> {
     const plan = await this.repo.findById(planId);
     if (!plan) {
-      throw new Error('Plan not found');
+      throw new PublicError('NOT_FOUND', 'Plan not found');
     }
     if (plan.status !== 'active') {
-      throw new Error('Plan is not active');
+      throw new PublicError('CONFLICT', 'Plan is not active');
     }
 
     const remaining = Number(plan.remaining_balance);
     if (data.amount > remaining) {
-      throw new Error(`Payment amount exceeds remaining balance of ${remaining}`);
+      throw new PublicError(
+        'VALIDATION_ERROR',
+        `Payment amount exceeds remaining balance of ${remaining}`
+      );
     }
 
     const newRemaining = remaining - data.amount;
@@ -150,10 +154,10 @@ export class LayawayService implements ILayawayService {
   async cancelPlan(planId: number): Promise<{ status: string }> {
     const plan = await this.repo.findById(planId);
     if (!plan) {
-      throw new Error('Plan not found');
+      throw new PublicError('NOT_FOUND', 'Plan not found');
     }
     if (plan.status !== 'active') {
-      throw new Error('Only active plans can be cancelled');
+      throw new PublicError('CONFLICT', 'Only active plans can be cancelled');
     }
 
     await withTransaction(async (client) => {

--- a/server/src/modules/pos/reservations/controller.ts
+++ b/server/src/modules/pos/reservations/controller.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { reservationsService, IReservationsService } from './service';
-import { PublicError } from '../../../http/errors';
 import { success } from '../../../http/responses';
 
 const reserveSchema = z.object({
@@ -25,11 +24,8 @@ export class ReservationsController {
       const reservation = await this.service.createReservation(parsed.data);
       res.status(201).json(success(reservation));
     } catch (err) {
-      next(
-        err instanceof Error && err.message === 'Insufficient available stock'
-          ? new PublicError('VALIDATION_ERROR', err.message)
-          : err
-      );
+      // Typed at the throw site (#47); the status is no longer derived from the wording.
+      next(err);
     }
   }
 
@@ -38,11 +34,8 @@ export class ReservationsController {
       await this.service.releaseReservation(req.params.id as string);
       res.sendStatus(204);
     } catch (err) {
-      next(
-        err instanceof Error && err.message === 'Reservation not found'
-          ? new PublicError('NOT_FOUND', err.message)
-          : err
-      );
+      // Typed at the throw site (#47); the status is no longer derived from the wording.
+      next(err);
     }
   }
 

--- a/server/src/modules/pos/reservations/service.ts
+++ b/server/src/modules/pos/reservations/service.ts
@@ -1,6 +1,7 @@
 import logger from '../../../../lib/logger';
 import { IReservationsRepository, reservationsRepository as defaultRepo } from './repository';
 import { CreateReservationDTO, ReservationRow } from './types';
+import { PublicError } from '../../../http/errors';
 
 export interface IReservationsService {
   createReservation(data: CreateReservationDTO): Promise<ReservationRow>;
@@ -30,7 +31,7 @@ export class ReservationsService implements IReservationsService {
     const reservedTotal = await this.repo.getReservedQuantity(product_id, variant_id);
     const available = currentStock - reservedTotal;
     if (available < quantity) {
-      throw new Error('Insufficient available stock');
+      throw new PublicError('VALIDATION_ERROR', 'Insufficient available stock');
     }
 
     return this.repo.createReservation({
@@ -46,7 +47,7 @@ export class ReservationsService implements IReservationsService {
   async releaseReservation(id: number | string): Promise<void> {
     const deleted = await this.repo.deleteById(id);
     if (!deleted) {
-      throw new Error('Reservation not found');
+      throw new PublicError('NOT_FOUND', 'Reservation not found');
     }
   }
 

--- a/server/src/modules/pos/sales/controller.ts
+++ b/server/src/modules/pos/sales/controller.ts
@@ -145,19 +145,10 @@ export class SalesController {
         next(new PublicError('VALIDATION_ERROR', err.message));
         return;
       }
-      if (
-        err.message?.includes('Insufficient stock') ||
-        err.message?.includes('Insufficient loyalty points') ||
-        err.message?.includes('Product not found') ||
-        err.message?.includes('Variant not found') ||
-        err.message?.includes('Customer not found') ||
-        err.message?.includes('A customer must be selected to redeem loyalty points') ||
-        err.message?.includes('Loyalty program is disabled') ||
-        err.message?.includes('Bundle')
-      ) {
-        next(new PublicError('VALIDATION_ERROR', err.message));
-        return;
-      }
+      // Each of these is now thrown as a typed PublicError by the checkout service (#47).
+      // The list they replace was eight substring tests, one of which was the bare word
+      // 'Bundle' — anything mentioning a bundle became a 400, and any rewording of the
+      // other seven quietly became a 500.
       next(err);
     }
   }
@@ -219,17 +210,10 @@ export class SalesController {
         next(conflict);
         return;
       }
-      if (
-        err.message === 'Sale not found' ||
-        err.message === 'Sale already fully refunded' ||
-        err.message?.includes('not in this sale') ||
-        err.message?.includes('exceeds sold quantity') ||
-        err.message === 'Refund amount exceeds sale total'
-      ) {
-        const code = err.message === 'Sale not found' ? 'NOT_FOUND' : 'VALIDATION_ERROR';
-        next(new PublicError(code, err.message));
-        return;
-      }
+      // The refund service says what kind of refusal each of these is (#47). This used to
+      // re-derive it from the wording — including two `includes()` checks on interpolated
+      // messages — which made every one of those strings part of the API contract without
+      // anyone declaring it so.
       next(err);
     }
   }

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -37,6 +37,7 @@ import {
   SPLIT_PAYMENT_MISMATCH_CODE,
   STRICT_SPLIT_PAYMENT_VALIDATION,
 } from './types';
+import { PublicError } from '../../../http/errors';
 
 /**
  * A single checkout line resolved to an authoritative, server-known price.
@@ -261,7 +262,8 @@ export class SalesService {
           item.product_id,
           queryable
         );
-        if (!variant) throw new Error(`Variant not found: ID ${item.variant_id}`);
+        if (!variant)
+          throw new PublicError('VALIDATION_ERROR', `Variant not found: ID ${item.variant_id}`);
         if (checkStock && Number(variant.stock) < item.quantity) {
           stockConflicts.push({
             productId: item.product_id,
@@ -283,7 +285,8 @@ export class SalesService {
         calcLines.push({ unitPriceMinor: toMinorUnits(unitPrice), quantity: item.quantity });
       } else {
         const product = await this.repo.getProductById(item.product_id, queryable);
-        if (!product) throw new Error(`Product not found: ID ${item.product_id}`);
+        if (!product)
+          throw new PublicError('VALIDATION_ERROR', `Product not found: ID ${item.product_id}`);
         if (checkStock && Number(product.stock) < item.quantity) {
           stockConflicts.push({
             productId: item.product_id,
@@ -352,12 +355,12 @@ export class SalesService {
   ): Promise<ResolvedLines> {
     const bundle = await this.bundles.findById(bundleId, queryable);
     if (!bundle || bundle.status !== 'active') {
-      throw new Error(`Bundle not found or inactive: ID ${bundleId}`);
+      throw new PublicError('VALIDATION_ERROR', `Bundle not found or inactive: ID ${bundleId}`);
     }
 
     const bundleItems = await this.bundles.findItemsByBundleId(bundleId, queryable);
     if (bundleItems.length === 0) {
-      throw new Error(`Bundle has no items: ID ${bundleId}`);
+      throw new PublicError('VALIDATION_ERROR', `Bundle has no items: ID ${bundleId}`);
     }
 
     const requestedByProduct = new Map<number, number>();
@@ -373,7 +376,10 @@ export class SalesService {
       bundleProductIds.size !== requestedByProduct.size ||
       ![...bundleProductIds].every((id) => requestedByProduct.has(id))
     ) {
-      throw new Error(`Bundle allocation does not match its definition: ID ${bundleId}`);
+      throw new PublicError(
+        'VALIDATION_ERROR',
+        `Bundle allocation does not match its definition: ID ${bundleId}`
+      );
     }
 
     let multiplier: number | null = null;
@@ -381,12 +387,18 @@ export class SalesService {
       const requestedQty = requestedByProduct.get(bi.product_id)!;
       const candidateMultiplier = requestedQty / bi.quantity;
       if (!Number.isInteger(candidateMultiplier) || candidateMultiplier <= 0) {
-        throw new Error(`Bundle allocation quantity mismatch: ID ${bundleId}`);
+        throw new PublicError(
+          'VALIDATION_ERROR',
+          `Bundle allocation quantity mismatch: ID ${bundleId}`
+        );
       }
       if (multiplier === null) {
         multiplier = candidateMultiplier;
       } else if (multiplier !== candidateMultiplier) {
-        throw new Error(`Bundle allocation quantity mismatch: ID ${bundleId}`);
+        throw new PublicError(
+          'VALIDATION_ERROR',
+          `Bundle allocation quantity mismatch: ID ${bundleId}`
+        );
       }
     }
 
@@ -428,7 +440,8 @@ export class SalesService {
       const bi = bundleItems[i];
       const requestedQty = requestedByProduct.get(bi.product_id)!;
       const product = await this.repo.getProductById(bi.product_id, queryable);
-      if (!product) throw new Error(`Product not found: ID ${bi.product_id}`);
+      if (!product)
+        throw new PublicError('VALIDATION_ERROR', `Product not found: ID ${bi.product_id}`);
       if (checkStock && Number(product.stock) < requestedQty) {
         stockConflicts.push({
           productId: bi.product_id,
@@ -521,20 +534,24 @@ export class SalesService {
     let customer: Record<string, any> | null = null;
     if (input.customer_id) {
       customer = await this.repo.getCustomerById(input.customer_id, queryable);
-      if (!customer) throw new Error(`Customer not found: ID ${input.customer_id}`);
+      if (!customer)
+        throw new PublicError('VALIDATION_ERROR', `Customer not found: ID ${input.customer_id}`);
     }
 
     const loyaltySettings = await this.getCanonicalLoyaltySettings(queryable);
     const pointsRequested = Math.max(0, input.points_redeemed || 0);
     if (pointsRequested > 0) {
       if (!input.customer_id || !customer) {
-        throw new Error('A customer must be selected to redeem loyalty points');
+        throw new PublicError(
+          'VALIDATION_ERROR',
+          'A customer must be selected to redeem loyalty points'
+        );
       }
       if (!loyaltySettings.enabled) {
-        throw new Error('Loyalty program is disabled');
+        throw new PublicError('VALIDATION_ERROR', 'Loyalty program is disabled');
       }
       if (Number(customer.loyalty_points) < pointsRequested) {
-        throw new Error('Insufficient loyalty points');
+        throw new PublicError('VALIDATION_ERROR', 'Insufficient loyalty points');
       }
     }
 
@@ -797,7 +814,7 @@ export class SalesService {
           if (remaining === null) {
             // The balance moved between the breakdown's read and this write. Same
             // wording the stale check produces, so the client sees no change.
-            throw new Error('Insufficient loyalty points');
+            throw new PublicError('VALIDATION_ERROR', 'Insufficient loyalty points');
           }
           await this.repo.createLoyaltyTransaction(
             input.customer_id,
@@ -896,16 +913,22 @@ export class SalesService {
       // the cumulative check below is only correct while no sibling refund can commit
       // between the read and the write.
       const sale = await this.repo.findByIdForUpdate(saleId, client);
-      if (!sale) throw new Error('Sale not found');
-      if (sale.refund_status === 'full') throw new Error('Sale already fully refunded');
+      if (!sale) throw new PublicError('NOT_FOUND', 'Sale not found');
+      if (sale.refund_status === 'full')
+        throw new PublicError('VALIDATION_ERROR', 'Sale already fully refunded');
 
       const saleItems = await this.repo.findItemsBySaleId(saleId, client);
 
       for (const refundItem of input.items) {
         const saleItem = saleItems.find((si) => si.product_id === refundItem.product_id);
-        if (!saleItem) throw new Error(`Product ${refundItem.product_id} not in this sale`);
+        if (!saleItem)
+          throw new PublicError(
+            'VALIDATION_ERROR',
+            `Product ${refundItem.product_id} not in this sale`
+          );
         if (refundItem.quantity > saleItem.quantity) {
-          throw new Error(
+          throw new PublicError(
+            'VALIDATION_ERROR',
             `Refund quantity exceeds sold quantity for product ${refundItem.product_id}`
           );
         }
@@ -918,7 +941,7 @@ export class SalesService {
 
       const previouslyRefunded = Number(sale.refunded_amount) || 0;
       if (previouslyRefunded + refundAmount > Number(sale.total)) {
-        throw new Error('Refund amount exceeds sale total');
+        throw new PublicError('VALIDATION_ERROR', 'Refund amount exceeds sale total');
       }
 
       const newRefundedTotal = previouslyRefunded + refundAmount;

--- a/server/tests/products.test.ts
+++ b/server/tests/products.test.ts
@@ -128,7 +128,10 @@ describe('product lookup contract', () => {
   it('passes duplicate conflicts to next instead of rejecting the async handler', async () => {
     const create = vi
       .spyOn(productsService, 'createProduct')
-      .mockRejectedValue(new Error('duplicate key value'));
+      // A real unique violation, as PostgreSQL reports it: SQLSTATE 23505. The controller
+      // reads the code now rather than the message (#47) — the old check also looked for
+      // 'UNIQUE', which is SQLite wording and had been dead since the migration.
+      .mockRejectedValue(Object.assign(new Error('duplicate key value'), { code: '23505' }));
     const req: any = {
       body: { name: 'Dress', sku: 'D-1', price: 100, cost_price: 50, stock: 1 },
       socket: {},

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -24,7 +24,7 @@ import {
 import { SalesRepository } from '../src/modules/pos/sales/repository';
 import { SalesController } from '../src/modules/pos/sales/controller';
 import { salesService, calculateSaleBreakdown } from '../src/modules/pos/sales/service';
-import { PublicError } from '../src/modules/http/errors';
+import { PublicError } from '../src/http/errors';
 import { paymentEntrySchema, saleSchema, MAX_PAYMENT_AMOUNT_MAJOR } from '../validators/saleSchema';
 import { openApiSpec } from '../src/docs/openapi';
 import {
@@ -56,9 +56,14 @@ describe('Sales - Mutation Contract', () => {
     expect(status).not.toHaveBeenCalled();
   });
 
-  it('maps known create failures to the canonical validation error', async () => {
+  /**
+   * The seam moved in #47: the service says what kind of refusal it is, and the controller
+   * passes it through. It used to arrive as a bare Error and be classified here by testing
+   * the message for eight substrings — one of which was the bare word 'Bundle'.
+   */
+  it('passes a typed create refusal through untouched', async () => {
     vi.spyOn(salesService, 'executeSale').mockRejectedValueOnce(
-      new Error('Insufficient stock for product')
+      new PublicError('VALIDATION_ERROR', 'Insufficient stock for product')
     );
     const next = vi.fn();
 
@@ -147,8 +152,10 @@ describe('Sales - Mutation Contract', () => {
     });
   });
 
-  it('maps a missing refund sale to the canonical not-found error', async () => {
-    vi.spyOn(salesService, 'executeRefund').mockRejectedValueOnce(new Error('Sale not found'));
+  it('passes a typed refund refusal through untouched', async () => {
+    vi.spyOn(salesService, 'executeRefund').mockRejectedValueOnce(
+      new PublicError('NOT_FOUND', 'Sale not found')
+    );
     const next = vi.fn();
 
     await new SalesController().refundSale(
@@ -165,6 +172,34 @@ describe('Sales - Mutation Contract', () => {
     expect(next).toHaveBeenCalledWith(
       expect.objectContaining<Partial<PublicError>>({ code: 'NOT_FOUND' })
     );
+  });
+
+  it('does not dress an unexpected failure up as a client error', async () => {
+    // The other half of removing the message matching. A bare Error used to be reported
+    // as VALIDATION_ERROR if its text happened to contain 'Bundle' or 'not found' — so a
+    // genuine server fault could reach the till as "fix your cart". It is a 500 now,
+    // which is the truth.
+    vi.spyOn(salesService, 'executeSale').mockRejectedValueOnce(
+      new Error('Bundle pricing service unreachable')
+    );
+    const next = vi.fn();
+
+    await new SalesController().createSale(
+      {
+        body: {
+          items: [{ product_id: 1, quantity: 1, unit_price: 10 }],
+          payment_method: 'Card',
+        },
+        user: { id: 1, name: 'Cashier' },
+        headers: {},
+      } as unknown as Request,
+      { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response,
+      next as NextFunction
+    );
+
+    const passed = next.mock.calls[0]?.[0];
+    expect(passed).toBeInstanceOf(Error);
+    expect(passed).not.toBeInstanceOf(PublicError);
   });
 });
 


### PR DESCRIPTION
Part of #47 — the error-contract half. Deliberately **not** `Closes`: the OpenAPI criterion is not met, and I would rather say so than imply otherwise. See *What is not done* below.

## The problem, stated precisely

Services said what went wrong in prose; controllers recovered the HTTP status by testing that prose. That makes every message string part of the API without anyone declaring it, and it fails in **both** directions:

- **Rewording breaks the contract silently.** `layaway` chose its status with `message.includes('not found')`. Renaming "Plan not found" to "No such plan" turns a 404 into a 400, and nothing fails.
- **Unrelated errors get misreported as user error.** The checkout path had **eight** substring tests, one of which was the bare word `'Bundle'`. A genuine server fault whose message happened to contain "Bundle" or "not found" reached the till as a 400 telling a cashier to fix their cart.

## The fix

Services throw `PublicError` with the code they mean; controllers pass it to `next` untouched. Applied across gift cards, delivery, purchase orders, layaway, exchanges, reservations, sales, and the legacy `services/productService.ts`.

An unexpected error is now a **500**, which is the truth. `tests/sales.test.ts` pins that as explicitly as the happy path — a bare `Error` must *not* come back as a `PublicError`.

There is precedent for this shape: `auth/service.ts` already threw `PublicError` directly, and the POS module already used typed domain errors (`InsufficientStockError`). This makes it the rule rather than the exception, and adds no new abstraction.

## Constraint failures read by SQLSTATE

New `src/database/constraintErrors.ts`, replacing a dozen `err.message?.includes('UNIQUE')` checks.

That test depends on the server's `lc_messages`, on the driver, and on nobody rephrasing anything. It also matches too much — a validation message containing the word "unique" reads as a duplicate key and is answered with a 409.

**And it was already half-dead:** `'UNIQUE'` is SQLite wording. PostgreSQL says `duplicate key value violates unique constraint`, lowercase, so that branch had matched nothing since the migration and no one noticed. Which is the argument against the technique, not just against that string. Some call sites already checked `err.code === '23505'` *alongside* it; now they all just do that.

## A defect the change surfaced

`tests/sales.test.ts` imported `PublicError` from `../src/modules/http/errors` — **a path that does not exist**. It never failed because the symbol was only used as a type, and type imports are erased at runtime. Using it as a value surfaced it immediately.

## Ratchet moved: 391 → 387

Removing the catch blocks let eslint's `no-useless-catch` find the now-empty `try { ... } catch (err) { throw err; }` wrappers I had left behind — a good catch by the linter, and worth noting that it only became visible once the string-matching was gone. Deleting them dropped four `any` annotations, so `--max-warnings` moves with it, which is what CLAUDE.md says this issue's job is.

## What is not done

**"Generate or verify OpenAPI from those contracts."** `src/docs/openapi.ts` is 11,865 hand-maintained lines and `scripts/generateOpenApi.ts` is a regex scraper over the manifest's *source text*, not anything derived from the Zod schemas that actually validate requests. This is not a small remainder, and the plan flagged it as the largest unstated cost in the issue.

CLAUDE.md now records the two routes and what each costs:

1. Derive the spec from the Zod schemas — makes them the single source and deletes most of that file, but changes the published spec's shape, so every consumer must be checked.
2. Keep the hand-written spec and add a drift check that fails when a registered route is missing from it — cheaper, catches the common omission, but a documented request's *shape* can still drift from the schema enforcing it.

Route 2 is the smaller step and the one to take first. Neither is in this diff. A generator nobody trusts would be worse than an honest note.

Also outstanding from the issue: typed repository/service interfaces for the high-risk modules, and the bulk of the `any` removal — the ratchet is the mechanism for that, and it now has somewhere to go.

## Testing

- Server suite **685 passed, 0 skipped** with a real PostgreSQL.
- Three contract tests updated rather than deleted: they pinned the *old* seam (controller derives status from message), and now pin the new one (service throws typed, controller passes through). Plus a new test that an unexpected failure is not dressed up as a client error.
- The products duplicate-conflict test now rejects with a real SQLSTATE `23505` rather than a message string, which is what the code path actually sees.
- `lint` 0 errors / 387 warnings; `typecheck` clean.

## Post-Deploy Monitoring & Validation

- **What could regress:** a refusal that used to be a 400/404 arriving as a 500, if some throw site was missed. Watch for a rise in `INTERNAL_ERROR` responses on `/sales`, `/gift-cards/:code/redeem`, `/layaway`, `/deliveries` and `/purchase-orders` in the first day.
- **Healthy signal:** the same 4xx codes for the same refusals as before — the wording is unchanged throughout, only where the status is decided has moved.
- **Rollback:** plain revert; no schema or config change.
- **Window / owner:** first 24h, whoever merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN