### PR TITLE
test(ci): fail on drift between served routes and the API docs (#47, #56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
         if: always()
         run: node scripts/assertRealPostgresSuitesRan.mjs vitest-report.json
 
+      - name: API documentation drift
+        # Walks the real Express router rather than comparing two hand-maintained lists,
+        # so a route added in code and forgotten in the spec and the manifest fails here.
+        run: npm run check:api-docs
+
   migrations:
     name: Migrations (up, down, re-apply)
     # Its own job rather than a step on `server`, so the report says which gate failed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Each gate is its own job, so the checks list says what broke without anyone open
 | --- | --- |
 | `Server (lint, typecheck, test)` | ESLint clean of errors and **not above the warning ratchet**, `tsc --noEmit`, the full suite with a real PostgreSQL, plus a guard that the real-PG suites were not silently skipped. |
 | `Migrations (up, down, re-apply)` | Every `.down.sql` actually reverses its `.sql`. |
+| API documentation drift (a step on the server job) | Every route the router serves is documented and manifested, and nothing is documented that is not served. |
 | `Client (lint, typecheck, test)` | ESLint, `tsc --noEmit`, vitest. |
 | `E2E smoke (pull requests)` | The money paths, under a ~3 minute budget. |
 | `E2E full (main)` / `E2E settings` | The sharded suite and the serial settings project. |
@@ -331,24 +332,32 @@ was answered with a 409. And `'UNIQUE'` is SQLite wording — PostgreSQL says
 those checks had been dead since the migration without anyone noticing. Which is the
 argument against the technique, not just against that string.
 
-### OpenAPI: not generated from contracts, and why
+### API documentation drift
 
-#47 asks to "generate or verify OpenAPI from those contracts". **That is not done, and it
-is not a small remainder.** `src/docs/openapi.ts` is 11,865 hand-maintained lines, and
-`scripts/generateOpenApi.ts` is a regex scraper over the manifest's source text rather
-than anything derived from the Zod schemas that actually validate requests.
+`npm run check:api-docs` walks the **real Express router** — `routeTable`, plus the three
+health probes mounted directly on the app — and compares that set against
+`src/docs/openapi.ts` and `endpointDetailsManifest`. It fails three ways: served but
+undocumented, documented but not served, and served but not in the manifest that drives
+`tests/verification/endpointHealth.test.ts` (a route missing there is a route nothing
+exercises).
 
-Closing it means picking one of two routes and paying for it:
+Walking the router is the point. Both other lists are hand-maintained, so comparing them
+to each other proves only that someone wrote the same thing down twice.
 
-1. Derive the spec from the Zod schemas (`zod-to-openapi` or equivalent), which makes the
-   schemas the single source and deletes most of that file — but changes the published
-   spec's shape, so every consumer of it has to be checked.
-2. Keep the hand-written spec and add a drift check that fails when a registered route is
-   missing from it. Cheaper, and catches the common omission, but the *shape* of a
-   documented request can still drift from the schema that enforces it.
+It found real drift on its first run: `POST /api/v1/auth/logout-all` was live, documented
+nowhere and exercised by nothing, and `GET /api/v1/customers/{id}` was documented while
+the router mounts only `PUT` and `DELETE` on that path — the spec promised an endpoint
+that answers 404.
 
-Route 2 is the smaller step and the one to take first. Neither is in #47's diff, and
-saying so is better than a generator nobody trusts.
+**What it does not claim.** That a documented request *shape* matches the Zod schema
+enforcing it. It compares `METHOD path` pairs and nothing else, so a documented body can
+still drift from its validator while this passes.
+
+Closing that gap means deriving the spec from the Zod schemas (`zod-to-openapi` or
+equivalent), which would make the schemas the single source and delete most of the
+11,865-line hand-maintained document — but it changes the published spec's shape, so every
+consumer has to be checked first. `scripts/generateOpenApi.ts` is *not* that: it is a regex
+scraper over the manifest's source text. Deleting or replacing it is the next step.
 
 ## Scheduled jobs
 

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "verify:migrations": "tsx scripts/verifyMigrations.ts"
+    "verify:migrations": "tsx scripts/verifyMigrations.ts",
+    "check:api-docs": "tsx scripts/checkApiDocDrift.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1127.0",

--- a/server/scripts/checkApiDocDrift.ts
+++ b/server/scripts/checkApiDocDrift.ts
@@ -1,0 +1,145 @@
+/**
+ * Fails when a route the server actually serves is missing from the OpenAPI document, or
+ * vice versa (#47, #56).
+ *
+ * ## Why it walks the router rather than reading a list
+ *
+ * `endpointManifest` and `src/docs/openapi.ts` are both hand-maintained, so comparing them
+ * to each other proves only that two people wrote the same thing down. The source of truth
+ * for what this server responds to is the Express router itself: `routeTable` mounts every
+ * feature router, and each router carries its own layer stack. That is what this reads.
+ *
+ * A route added in code and forgotten everywhere else is the failure this catches — the
+ * one that leaves an endpoint live, undocumented, and outside the health suite that drives
+ * itself from the manifest.
+ *
+ * ## What it does not claim
+ *
+ * That a documented request *shape* matches the Zod schema enforcing it. This compares the
+ * set of `METHOD path` pairs and nothing else. Deriving the spec from the schemas is the
+ * larger route recorded in CLAUDE.md; until then, a documented body can still drift from
+ * the validator while this passes. Saying that plainly is better than a green check that
+ * implies more than it tested.
+ *
+ * Usage: tsx scripts/checkApiDocDrift.ts
+ */
+import type { Router } from 'express';
+import { routeTable } from '../src/router';
+import { openApiSpec } from '../src/docs/openapi';
+import { endpointDetailsManifest } from '../src/http/endpointManifest';
+
+type Pair = string; // `GET /api/v1/products/:id`
+
+/** Express keeps its own regexp-encoded path; this is the readable form back out. */
+interface Layer {
+  route?: { path: string | string[]; methods: Record<string, boolean> };
+  handle?: { stack?: Layer[] };
+}
+
+function routesOf(router: Router, mount: string): Pair[] {
+  const stack = (router as unknown as { stack?: Layer[] }).stack ?? [];
+  const pairs: Pair[] = [];
+
+  for (const layer of stack) {
+    if (layer.route) {
+      const paths = Array.isArray(layer.route.path) ? layer.route.path : [layer.route.path];
+      for (const p of paths) {
+        for (const [method, enabled] of Object.entries(layer.route.methods)) {
+          if (!enabled || method === '_all') continue;
+          const full = `${mount}${p === '/' ? '' : p}`;
+          pairs.push(`${method.toUpperCase()} ${full}`);
+        }
+      }
+    } else if (layer.handle?.stack) {
+      // A nested router mounted inside a feature router.
+      pairs.push(...routesOf(layer.handle as unknown as Router, mount));
+    }
+  }
+  return pairs;
+}
+
+/** OpenAPI writes `{id}` where Express writes `:id`. */
+function toExpressStyle(path: string): string {
+  return path.replace(/\{([^}]+)\}/g, ':$1');
+}
+
+/**
+ * Mounted directly on the app in `index.ts` rather than through `routeTable`, because the
+ * probes must answer before and independently of the feature routers. They are served, so
+ * they are listed here; walking only `routeTable` would report them as documented-but-
+ * absent and teach everyone to ignore this gate's output.
+ */
+const MOUNTED_OUTSIDE_ROUTE_TABLE: readonly Pair[] = [
+  'GET /api/health',
+  'GET /api/health/live',
+  'GET /api/health/ready',
+];
+
+const served = new Set<Pair>(MOUNTED_OUTSIDE_ROUTE_TABLE);
+for (const [mount, router] of routeTable) {
+  for (const pair of routesOf(router, mount)) served.add(pair);
+}
+
+const documented = new Set<Pair>();
+const paths = (openApiSpec as { paths?: Record<string, Record<string, unknown>> }).paths ?? {};
+for (const [path, methods] of Object.entries(paths)) {
+  for (const method of Object.keys(methods)) {
+    if (!['get', 'post', 'put', 'delete', 'patch'].includes(method)) continue;
+    documented.add(`${method.toUpperCase()} ${toExpressStyle(path)}`);
+  }
+}
+
+const manifested = new Set<Pair>(
+  endpointDetailsManifest.map((e) => `${e.method} ${toExpressStyle(e.path)}`)
+);
+
+if (served.size === 0) {
+  console.error(
+    '\n✗ Walked the router and found no routes. This gate would pass while proving nothing.\n'
+  );
+  process.exit(1);
+}
+
+const undocumented = [...served].filter((p) => !documented.has(p)).sort();
+const phantom = [...documented].filter((p) => !served.has(p)).sort();
+const unmanifested = [...served]
+  .filter((p) => !manifested.has(p) && !MOUNTED_OUTSIDE_ROUTE_TABLE.includes(p))
+  .sort();
+
+function report(title: string, why: string, items: string[]): boolean {
+  if (items.length === 0) return false;
+  console.error(`\n✗ ${title} (${items.length})\n  ${why}\n`);
+  for (const item of items.slice(0, 40)) console.error(`    ${item}`);
+  if (items.length > 40) console.error(`    ... and ${items.length - 40} more`);
+  return true;
+}
+
+let failed = false;
+failed =
+  report(
+    'Served but not documented',
+    'These endpoints answer requests and appear in no OpenAPI path. Add them to src/docs/openapi.ts.',
+    undocumented
+  ) || failed;
+failed =
+  report(
+    'Documented but not served',
+    'The spec promises these and the router does not mount them. Remove them, or mount what was intended.',
+    phantom
+  ) || failed;
+failed =
+  report(
+    'Served but not in the endpoint manifest',
+    'endpointDetailsManifest drives tests/verification/endpointHealth.test.ts, so a route missing here is a route nothing exercises.',
+    unmanifested
+  ) || failed;
+
+if (failed) {
+  console.error('');
+  process.exit(1);
+}
+
+console.log(
+  `\n✓ ${served.size} served routes: all documented and manifested.\n` +
+    '  (Set membership only — a documented request shape can still drift from its Zod schema.)\n'
+);

--- a/server/src/docs/openapi.ts
+++ b/server/src/docs/openapi.ts
@@ -527,6 +527,66 @@ export const openApiSpec = {
         },
       },
     },
+    '/api/v1/auth/logout-all': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Log out every session (Admin, Cashier, Delivery)',
+        description:
+          'Ends every refresh-token family this user has, on every device. Cannot reach an access token already issued, which is why that lifetime is short and capped. Endpoint classification: M. Allowed Roles: Admin, Cashier, Delivery.',
+        security: [
+          {
+            BearerAuth: [],
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                additionalProperties: true,
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: {
+                      type: 'boolean',
+                      example: true,
+                    },
+                    data: {
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Validation error / Bad request',
+          },
+          '401': {
+            description: 'Unauthorized / Missing or invalid token',
+          },
+          '403': {
+            description: 'Forbidden / Insufficient role privileges',
+          },
+          '404': {
+            description: 'Resource not found',
+          },
+          '500': {
+            description: 'Internal server error',
+          },
+        },
+      },
+    },
     '/api/v1/auth/logout': {
       post: {
         tags: ['Auth'],
@@ -6638,63 +6698,6 @@ export const openApiSpec = {
       },
     },
     '/api/v1/customers/{id}': {
-      get: {
-        tags: ['Customers'],
-        summary: 'Get Customers by ID (Admin, Cashier, Delivery)',
-        description: 'Endpoint classification: S. Allowed Roles: Admin, Cashier, Delivery.',
-        security: [
-          {
-            BearerAuth: [],
-          },
-        ],
-        parameters: [
-          {
-            name: 'id',
-            in: 'path',
-            required: true,
-            schema: {
-              type: 'integer',
-            },
-            description: 'Target id',
-          },
-        ],
-        responses: {
-          '200': {
-            description: 'Successful operation',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    success: {
-                      type: 'boolean',
-                      example: true,
-                    },
-                    data: {
-                      type: 'object',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          '400': {
-            description: 'Validation error / Bad request',
-          },
-          '401': {
-            description: 'Unauthorized / Missing or invalid token',
-          },
-          '403': {
-            description: 'Forbidden / Insufficient role privileges',
-          },
-          '404': {
-            description: 'Resource not found',
-          },
-          '500': {
-            description: 'Internal server error',
-          },
-        },
-      },
       put: {
         tags: ['Customers'],
         summary: 'Update Customers (Admin, Cashier, Delivery)',

--- a/server/src/http/endpointManifest.ts
+++ b/server/src/http/endpointManifest.ts
@@ -111,6 +111,12 @@ export const endpointDetailsManifest: readonly DetailedEndpointEntry[] = [
     classification: 'M',
     authorization: allAuthenticated,
   },
+  {
+    method: 'POST',
+    path: '/api/v1/auth/logout-all',
+    classification: 'M',
+    authorization: allAuthenticated,
+  },
   { method: 'GET', path: '/api/v1/auth/me', classification: 'S', authorization: allAuthenticated },
 
   // Core / Users


### PR DESCRIPTION
Closes the last open acceptance criterion shared by **#47** ("CI detects drift between registered endpoints and API documentation") and **#56** ("CI detects contract drift and forbidden feature-boundary imports" — the boundary half landed in #94).

## It walks the router, not a list

`endpointManifest` and `src/docs/openapi.ts` are both hand-maintained. Comparing them to each other proves only that someone wrote the same thing down twice. The source of truth for what this server answers is the Express router, so that is what the check reads: `routeTable`'s mounted feature routers and each router's own layer stack.

Three failure modes, reported separately:

| Failure | Why it matters |
| --- | --- |
| Served but not documented | A live endpoint no consumer can discover |
| Documented but not served | The spec promises something that 404s |
| Served but not in the manifest | `endpointDetailsManifest` drives `endpointHealth.test.ts`, so a route missing there is a route **nothing exercises** |

## It found real drift immediately

**`POST /api/v1/auth/logout-all`** — live, in no OpenAPI path, in no manifest entry. CLAUDE.md documents the feature ("ends every session that user has, on every device") and *nothing tested it*, because the health suite builds itself from the manifest. Now documented and manifested; the health suite covers **201** endpoints instead of 200.

**`GET /api/v1/customers/{id}`** — documented, while the customers router mounts only `PUT /:id` and `DELETE /:id`. The spec promised an endpoint that answers 404. **Removed rather than implemented**: documentation should describe what exists, and adding an endpoint is a product decision, not a docs fix.

## What it does not claim

That a documented request *shape* matches the Zod schema enforcing it. It compares `METHOD path` pairs and nothing else, and says so in its own output and header. A documented body can still drift from its validator while this passes.

Closing that gap means deriving the spec from the Zod schemas, which would make the schemas the single source and delete most of the 11,865-line hand-maintained document — but it changes the published spec's shape, so every consumer has to be checked first. That is recorded in CLAUDE.md as the next step, along with the note that `scripts/generateOpenApi.ts` is *not* it (it is a regex scraper over the manifest's source text).

A green check that implied more than it tested would be worse than the gap.

## Testing

- Verified failing: removing a route from the manifest exits 1 and names it. The script also refuses to pass if the router walk yields zero routes — the same anti-vacuous-pass guard as the real-PostgreSQL and `@smoke` gates.
- One deliberate allowance, commented: the three `/api/health*` probes are mounted directly on the app rather than through `routeTable`. They *are* served, so listing them is correcting a blind spot in the walker — not an exception to the rule. Without it the gate would report three false positives and teach everyone to ignore its output.
- Server suite **685 passed, 0 skipped**; `lint` 0 errors / 387 warnings; `typecheck` clean.

## Post-Deploy Monitoring & Validation

No runtime impact — a CI step and two documentation corrections. The removed `GET /api/v1/customers/{id}` was never served, so nothing that worked stops working; a client calling it was already getting a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN