### PR TITLE
fix(prod): API base URL, migration recovery, and crash-on-partial-response

### DIFF
--- a/client/src/features/admin/pages/AuditLog.tsx
+++ b/client/src/features/admin/pages/AuditLog.tsx
@@ -171,7 +171,7 @@ export default function AuditLog() {
   });
   const users = usersQuery.data?.pages.flatMap((response) => response.data) ?? [];
 
-  const totalPages = meta?.pagination.totalPages ?? 0;
+  const totalPages = meta?.pagination?.totalPages ?? 0;
 
   const getActionConfig = (action: string) =>
     ACTION_CONFIG[action] || { color: 'default' as const, icon: Activity };

--- a/client/src/features/admin/pages/Settings.tsx
+++ b/client/src/features/admin/pages/Settings.tsx
@@ -16,6 +16,7 @@ import { useApiQuery } from '../../../shared/lib/apiQuery';
 import { useTransport } from '../../../shared/lib/transport/index';
 import { PageHeader } from '../../../shared';
 import type { AppSettings } from '../../../shared/types/index';
+import { API_BASE_URL } from '../../../shared/lib/apiBase';
 
 export default function Settings() {
   const { t } = useTranslation();
@@ -202,7 +203,7 @@ export default function Settings() {
           <div className="flex gap-3">
             <Button
               as="a"
-              href="http://localhost:3001/reference"
+              href={`${API_BASE_URL}/reference`}
               target="_blank"
               rel="noopener noreferrer"
               variant="flat"
@@ -212,7 +213,7 @@ export default function Settings() {
             </Button>
             <Button
               as="a"
-              href="http://localhost:3001/openapi.json"
+              href={`${API_BASE_URL}/openapi.json`}
               target="_blank"
               rel="noopener noreferrer"
               variant="bordered"

--- a/client/src/features/admin/pages/Users.tsx
+++ b/client/src/features/admin/pages/Users.tsx
@@ -265,8 +265,8 @@ export default function UsersPage() {
           const next = typeof updater === 'function' ? updater(pagination) : updater;
           update({ page: next.pageIndex + 1, pageSize: next.pageSize });
         }}
-        pageCount={meta?.pagination.totalPages ?? 0}
-        totalRows={meta?.pagination.totalItems ?? 0}
+        pageCount={meta?.pagination?.totalPages ?? 0}
+        totalRows={meta?.pagination?.totalItems ?? 0}
         sorting={sorting}
         onSortingChange={(updater) => {
           const next = typeof updater === 'function' ? updater(sorting) : updater;

--- a/client/src/features/fulfillment/pages/Storefront.tsx
+++ b/client/src/features/fulfillment/pages/Storefront.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from '../../../shared/i18n/index';
 import { useApiQuery } from '../../../shared/lib/apiQuery';
 import { useTransport } from '../../../shared/lib/transport/index';
 import type { StorefrontBanner, StorefrontConfig, StorefrontProduct } from '../types';
+import { assetUrl } from '../../../shared/lib/apiBase';
 
 export default function StorefrontPage() {
   const { t } = useTranslation();
@@ -175,7 +176,7 @@ export default function StorefrontPage() {
                 <div className="h-40 bg-muted/30 flex items-center justify-center">
                   {p.image_url ? (
                     <img
-                      src={`http://localhost:3001${p.image_url}`}
+                      src={assetUrl(p.image_url)}
                       alt={p.name}
                       className="h-full w-full object-cover"
                     />

--- a/client/src/features/inventory/components/inventory/ProductFormDialog.tsx
+++ b/client/src/features/inventory/components/inventory/ProductFormDialog.tsx
@@ -18,9 +18,9 @@ import { useTranslation } from '../../../../shared/i18n/index';
 import type { Product, Category, Distributor } from '../../../../shared/types/index';
 import type { ProductFormData } from '../../types';
 import type { z } from 'zod';
+import { assetUrl } from '../../../../shared/lib/apiBase';
 
 /** Where the server serves uploaded product images from. */
-const assetBase = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 interface ProductFormDialogProps {
   open: boolean;
@@ -279,7 +279,7 @@ export default function ProductFormDialog({
                   <div className="flex items-center gap-3">
                     {editingProduct.image_url ? (
                       <img
-                        src={`${assetBase}${editingProduct.image_url}`}
+                        src={assetUrl(editingProduct.image_url)}
                         alt={editingProduct.name}
                         className="h-16 w-16 rounded-lg object-cover border border-border"
                       />

--- a/client/src/features/inventory/pages/Inventory.tsx
+++ b/client/src/features/inventory/pages/Inventory.tsx
@@ -56,12 +56,12 @@ import type {
   ProductFormData,
   ProductImportResult,
 } from '../types';
+import { assetUrl } from '../../../shared/lib/apiBase';
 
 const products = resource<Product>('products');
 const distributors = resource<Distributor>('distributors');
 
 /** Where the server serves uploaded product images from. */
-const assetBase = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 /**
  * Bulk update, bulk discontinue and CSV import address the whole collection, not
@@ -431,7 +431,7 @@ export default function Inventory() {
         <div className="flex items-center gap-2">
           {row.original.image_url ? (
             <img
-              src={`${assetBase}${row.original.image_url}`}
+              src={assetUrl(row.original.image_url)}
               alt={row.original.name}
               className="h-8 w-8 rounded-lg object-cover shrink-0 border border-border"
               loading="lazy"

--- a/client/src/features/pos/pages/POS.tsx
+++ b/client/src/features/pos/pages/POS.tsx
@@ -27,12 +27,12 @@ import { usePosData, type PosBundle } from '../hooks/usePosData';
 import { useTransport } from '../../../shared/lib/transport/index';
 import { useTranslation } from '../../../shared/i18n/index';
 import type { Product, ProductVariant } from '../../../shared/types/index';
+import { assetUrl } from '../../../shared/lib/apiBase';
 
 /**
  * Where uploaded product images are served from. The transport owns request
  * paths, not `<img src>`, so this reads the same env var the HTTP client does.
  */
-const ASSET_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 export default function POS() {
   const [searchInput, setSearchInput] = useState('');
@@ -444,7 +444,7 @@ export default function POS() {
                       <div className="flex items-start justify-between mb-2">
                         {product.image_url ? (
                           <img
-                            src={`${ASSET_BASE_URL}${product.image_url}`}
+                            src={assetUrl(product.image_url)}
                             alt={product.name}
                             className="h-10 w-10 rounded-lg object-cover border border-border"
                             loading="lazy"

--- a/client/src/features/purchasing/pages/Expenses.tsx
+++ b/client/src/features/purchasing/pages/Expenses.tsx
@@ -210,11 +210,11 @@ export default function ExpensesPage() {
               </tbody>
             </table>
           </div>
-          {(meta?.pagination.totalPages ?? 0) > 1 && (
+          {(meta?.pagination?.totalPages ?? 0) > 1 && (
             <div className="flex justify-center">
               <Pagination
                 page={page}
-                total={meta?.pagination.totalPages ?? 1}
+                total={meta?.pagination?.totalPages ?? 1}
                 onChange={(newPage) => update({ page: newPage })}
                 showControls
               />

--- a/client/src/features/sales/pages/SalesHistory.tsx
+++ b/client/src/features/sales/pages/SalesHistory.tsx
@@ -353,13 +353,13 @@ export default function SalesHistory() {
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           title={t('sales.totalRevenue')}
-          value={formatCurrency(meta?.aggregates.totalRevenue || 0)}
+          value={formatCurrency(meta?.aggregates?.totalRevenue || 0)}
           icon={DollarSign}
           isLoading={isLoading}
         />
         <StatCard
           title={t('sales.totalSales')}
-          value={meta?.aggregates.totalSales || 0}
+          value={meta?.aggregates?.totalSales || 0}
           icon={ShoppingCart}
           isLoading={isLoading}
         />
@@ -440,8 +440,8 @@ export default function SalesHistory() {
           const next = typeof updater === 'function' ? updater(pagination) : updater;
           update({ page: next.pageIndex + 1, pageSize: next.pageSize });
         }}
-        pageCount={meta?.pagination.totalPages ?? 0}
-        totalRows={meta?.pagination.totalItems ?? 0}
+        pageCount={meta?.pagination?.totalPages ?? 0}
+        totalRows={meta?.pagination?.totalItems ?? 0}
         sorting={sorting}
         onSortingChange={(updater) => {
           const next = typeof updater === 'function' ? updater(sorting) : updater;

--- a/client/src/shared/lib/apiBase.ts
+++ b/client/src/shared/lib/apiBase.ts
@@ -1,0 +1,75 @@
+/**
+ * Where the API lives, resolved once.
+ *
+ * `VITE_API_URL` is baked in at **build** time, not read at runtime — Vite substitutes
+ * `import.meta.env.*` into the bundle — so this is decided by the deploy that produced the
+ * JavaScript, and cannot be corrected by changing configuration afterwards.
+ *
+ * ## Why a production build never falls back to localhost
+ *
+ * Five call sites used to spell this as `import.meta.env.VITE_API_URL ||
+ * 'http://localhost:3001'`, and three more hardcoded that URL outright. A deploy that
+ * forgot to set `VITE_API_URL` therefore shipped a bundle asking every visitor's browser
+ * to call **its own machine**. Every request fails, every page that touches data throws,
+ * and nothing in the build or the logs says why — the app looks broken rather than
+ * misconfigured, which is a much more expensive thing to debug.
+ *
+ * So the fallback is split by build mode:
+ *
+ * - **dev**: `http://localhost:3001`, which is where `npm run dev` serves the API.
+ * - **production**: same origin, plus a loud console error naming the missing variable.
+ *   Same origin is not a working default — the SPA rewrite (`vercel.json` /
+ *   `public/_redirects`) answers `/api/*` with `index.html` — but it fails *locally and
+ *   visibly* instead of pointing at a machine that has nothing to do with this
+ *   deployment. It also cannot silently succeed against a developer who happens to have
+ *   the server running, which is the failure mode that hides this bug the longest.
+ *
+ * Deliberately not a throw: taking a running app down over a bad base URL is a worse
+ * outcome than degrading with an explanation in the console, and the pages already render
+ * an error state for a failed request.
+ */
+
+const configured = import.meta.env.VITE_API_URL;
+
+function resolveApiBaseUrl(): string {
+  if (configured) return configured.replace(/\/+$/, '');
+
+  if (import.meta.env.PROD) {
+    console.error(
+      '[config] VITE_API_URL was not set when this bundle was built, so the app does not ' +
+        'know where its API is. Set it in the deploy environment and rebuild — it is baked ' +
+        'in at build time and cannot be changed after the fact. Falling back to this origin, ' +
+        'which will not serve the API.'
+    );
+    return '';
+  }
+
+  return 'http://localhost:3001';
+}
+
+/** Base URL for API calls. No trailing slash. Empty string means "this origin". */
+export const API_BASE_URL = resolveApiBaseUrl();
+
+/**
+ * Base URL for files the API serves (product images under `/uploads`).
+ *
+ * The same origin as the API today. It is named separately because it does not have to
+ * stay that way: `MEDIA_PUBLIC_BASE_URL` on the server can point image URLs at a CDN, and
+ * when it does those rows already carry absolute URLs, so nothing should be prefixed at
+ * all. Callers must therefore only prefix a *relative* `image_url` — see `assetUrl`.
+ */
+export const ASSET_BASE_URL = API_BASE_URL;
+
+/**
+ * Resolves a stored `image_url` to something loadable.
+ *
+ * Handles the case the media migration creates: rows written before a CDN move hold
+ * `/uploads/...` and need the API origin in front, while rows written after hold an
+ * absolute URL and must be left exactly as they are. Prefixing an absolute URL produces
+ * `https://cdn.example.com` glued onto the API host, which 404s.
+ */
+export function assetUrl(imageUrl: string | null | undefined): string | undefined {
+  if (!imageUrl) return undefined;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(imageUrl) || imageUrl.startsWith('//')) return imageUrl;
+  return `${ASSET_BASE_URL}${imageUrl}`;
+}

--- a/client/src/shared/lib/transport/client.ts
+++ b/client/src/shared/lib/transport/client.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { getAccessToken, onAuthFailure, onTokenRefreshed } from './authPort';
+import { API_BASE_URL } from '../apiBase';
 import type { AuthResponseData } from '../../types/index';
 
 interface QueueItem {
@@ -8,7 +9,7 @@ interface QueueItem {
 }
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3001',
+  baseURL: API_BASE_URL,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
@@ -66,7 +67,7 @@ const setupRefreshInterceptor = () => {
 
         try {
           const response = await axios.post<AuthResponseData>(
-            `${import.meta.env.VITE_API_URL || 'http://localhost:3001'}/api/v1/auth/refresh`,
+            `${API_BASE_URL}/api/v1/auth/refresh`,
             {},
             { withCredentials: true }
           );

--- a/server/src/database/migrate.ts
+++ b/server/src/database/migrate.ts
@@ -15,6 +15,37 @@ export async function ensureMigrationTable(pool: Pool): Promise<void> {
       applied_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
     )
   `);
+
+  /**
+   * Realign the id sequence with the rows that are actually there.
+   *
+   * `_migrations.id` is a SERIAL, so the next insert takes its value from a sequence
+   * rather than from the table. Anything that writes rows without advancing that
+   * sequence — a `pg_dump`/restore, a `TRUNCATE ... RESTART IDENTITY`, a schema copied
+   * between databases — leaves the sequence behind the data. The next migration then
+   * fails with `duplicate key value violates unique constraint "_migrations_pkey"`,
+   * which names the bookkeeping table and says nothing about the migration being
+   * applied or how to recover. It reads like a corrupt migration; it is a stale counter.
+   *
+   * Observed on a developer database that had been restored: every migration after 001
+   * refused to apply, so the API answered 500 on login (`refresh_tokens.token_hash`
+   * missing) and the app looked broken from the frontend down.
+   *
+   * `setval(..., false)` sets the *next* value, so it is correct on an empty table too.
+   *
+   * Not wrapped in a catch. pg-mem has no sequence object, so `tests/support/pgMem.ts`
+   * registers `pg_get_serial_sequence`/`setval` as a no-op pair — there is nothing there
+   * to fall out of step, so doing nothing is correct rather than degraded. Swallowing the
+   * error here instead would mean a repair that hides its own failure, which is how the
+   * original problem stayed invisible.
+   */
+  await pool.query(`
+    SELECT setval(
+      pg_get_serial_sequence('_migrations', 'id'),
+      COALESCE((SELECT MAX(id) FROM _migrations), 0) + 1,
+      false
+    )
+  `);
 }
 
 export async function getAppliedMigrations(pool: Pool): Promise<string[]> {

--- a/server/tests/concurrency/migrations.sequence.test.ts
+++ b/server/tests/concurrency/migrations.sequence.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The migration runner against a real sequence.
+ *
+ * `_migrations.id` is a SERIAL, so the next insert takes its value from a sequence rather
+ * than from the table. Anything that writes rows without advancing that sequence — a
+ * `pg_dump`/restore, a `TRUNCATE ... RESTART IDENTITY`, a schema copied between databases
+ * — leaves the counter behind the data, and the next migration dies on
+ * `duplicate key value violates unique constraint "_migrations_pkey"`. That message names
+ * the bookkeeping table and says nothing about which migration or how to recover; it
+ * reads like corruption and is a stale counter.
+ *
+ * Seen on a developer database restored from a dump: every migration after 001 refused to
+ * apply, so `refresh_tokens.token_hash` was missing, `POST /auth/login` answered 500, and
+ * the app looked broken from the frontend down — pages crashing on undefined data because
+ * every request was failing.
+ *
+ * This lives here rather than beside the other migration tests because pg-mem implements
+ * SERIAL without exposing a sequence object: `tests/support/pgMem.ts` registers
+ * `setval` as a no-op, so the desync being guarded against cannot be created there. A
+ * test that cannot reproduce the fault cannot prove the fix.
+ */
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import path from 'path';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { ensureMigrationTable, runMigrationsUp } from '../../src/database/migrate';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/database/migrations');
+
+describeWithPostgres('migration bookkeeping against a real sequence', () => {
+  let harness: RealPostgresHarness;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('migrations-sequence', { maxConnections: 3 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  it('applies a migration when the id sequence has been left behind the rows', async () => {
+    // The harness already migrated this schema. Reproduce a restored dump: the rows are
+    // there, the counter is not.
+    await harness.pool.query(
+      `SELECT setval(pg_get_serial_sequence('_migrations', 'id'), 1, false)`
+    );
+
+    // Make one migration pending again so an INSERT actually has to happen.
+    await harness.pool.query(`DELETE FROM _migrations WHERE name = '008_collection_year.sql'`);
+    await harness.pool.query('ALTER TABLE collections DROP COLUMN IF EXISTS year');
+
+    const applied = await runMigrationsUp(harness.pool, MIGRATIONS_DIR);
+
+    expect(applied).toEqual(['008_collection_year.sql']);
+    const { rows } = await harness.pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+          WHERE table_schema = current_schema() AND table_name = 'collections' AND column_name = 'year'
+       ) AS exists`
+    );
+    expect(rows[0].exists, 'the migration actually ran, not just its bookkeeping').toBe(true);
+  });
+
+  it('realigns the sequence rather than leaving it for the next caller', async () => {
+    await harness.pool.query(
+      `SELECT setval(pg_get_serial_sequence('_migrations', 'id'), 1, false)`
+    );
+
+    await ensureMigrationTable(harness.pool);
+
+    // The repair is idempotent and does not depend on a migration being pending, so a
+    // plain insert succeeds immediately afterwards.
+    await expect(
+      harness.pool.query(`INSERT INTO _migrations (name) VALUES ('sequence-probe.sql')`)
+    ).resolves.toBeTruthy();
+    await harness.pool.query(`DELETE FROM _migrations WHERE name = 'sequence-probe.sql'`);
+  });
+});

--- a/server/tests/support/pgMem.ts
+++ b/server/tests/support/pgMem.ts
@@ -76,6 +76,33 @@ export function registerPgMemFunctions(memDb: IMemoryDb): void {
     impure: true,
     implementation: () => new Date(),
   });
+
+  /**
+   * pg-mem implements SERIAL without exposing a sequence object, so neither
+   * `pg_get_serial_sequence` nor `setval` exists. `ensureMigrationTable` realigns the
+   * `_migrations` id sequence with its rows on every run — a repair for a database
+   * restored from a dump, where the counter is left behind the data and the next
+   * migration dies on a duplicate primary key.
+   *
+   * Registered as a no-op pair rather than removed from the production SQL, and rather
+   * than caught by the caller: pg-mem raises this without a SQLSTATE, so a caller could
+   * only recognise it by reading the message — the exact technique #47 removed from this
+   * codebase. There is no sequence here to fall out of step, so doing nothing is the
+   * correct behaviour, not a degradation.
+   */
+  memDb.public.registerFunction({
+    name: 'pg_get_serial_sequence',
+    args: [DataType.text, DataType.text],
+    returns: DataType.text,
+    implementation: (table: string, column: string) => `${table}_${column}_seq`,
+  });
+  memDb.public.registerFunction({
+    name: 'setval',
+    args: [DataType.text, DataType.integer, DataType.bool],
+    returns: DataType.integer,
+    impure: true,
+    implementation: (_name: string, value: number) => value,
+  });
 }
 
 /**


### PR DESCRIPTION
Reported as `Cannot read properties of undefined` on many pages **in production**. Three independent causes; the first is the one I would check first.

---

## 1. A production build can silently point at `localhost:3001`

`VITE_API_URL` is baked in at **build** time. Five call sites spelled its fallback as `import.meta.env.VITE_API_URL || 'http://localhost:3001'`, and three more hardcoded that URL outright. **A deploy that did not set the variable shipped a bundle asking every visitor's browser to call its own machine.**

Every request then fails, every page that touches data throws, and the root route's `errorComponent` renders `{error.message}` — which is exactly the reports, on many pages at once. `client/.env` (which carries the localhost value locally) is **untracked**, so a deploy never sees it and the hardcoded fallback is what ships.

### Check this first — it takes five seconds and may need no code at all

Open the production site → DevTools → **Network** → any `/api/v1/...` request. **If the host is `localhost:3001`,** that is the whole bug: set `VITE_API_URL` in the Vercel/Cloudflare project settings and redeploy.

### The fix

One source of truth (`shared/lib/apiBase.ts`), split by build mode:

- **dev** — `http://localhost:3001`, unchanged.
- **production with no `VITE_API_URL`** — falls back to the current origin *and logs a console error naming the missing variable*.

Same origin does not work either (the SPA rewrite answers `/api/*` with `index.html`), but it fails **locally and visibly** instead of pointing at an unrelated machine — and it cannot silently succeed against a developer who happens to be running the server, which is the failure mode that hides this longest.

Deliberately **not a throw**: taking a running app down over a base URL is worse than degrading with an explanation, and pages already render an error state for a failed request.

**Three of the hardcoded URLs were product images.** `Storefront.tsx` rendered every image from `localhost:3001` unconditionally, in every environment — broken in prod regardless of configuration. `assetUrl()` also leaves an *absolute* `image_url` alone, so rows written after a `MEDIA_PUBLIC_BASE_URL` move to a CDN are not prefixed with the API host.

**Verified both ways:** a prod build with no `VITE_API_URL` now contains **zero** occurrences of `localhost:3001` and carries the diagnostic; with it set, the configured host is baked in.

---

## 2. The migration runner cannot recover a restored database

`_migrations.id` is a `SERIAL`. Anything that writes rows without advancing the sequence — a `pg_dump`/restore, `TRUNCATE ... RESTART IDENTITY`, a schema copied between databases — leaves the counter behind the data, and the next `npm run migrate` dies on:

```
duplicate key value violates unique constraint "_migrations_pkey"
```

That names the *bookkeeping* table, not the migration, and reads like corruption when it is a stale counter. **Reproduced here:** every migration after `001` refused to apply, `refresh_tokens.token_hash` did not exist, `POST /auth/login` returned **500**, and every authenticated request failed.

`ensureMigrationTable` now realigns the sequence on every run. Not wrapped in a catch — pg-mem has no sequence object, so the shim registers `pg_get_serial_sequence`/`setval` as a no-op pair instead; a repair that swallows its own failure is how this stayed invisible.

> Note for prod: `render.yaml` runs `npm run migrate` on deploy and the chain is `&&`, so a database in this state fails the **whole start command** — the API would not come up at all, rather than come up broken.

## 3. Nine unguarded accesses turn a partial response into a whole-page crash

```ts
meta?.pagination.totalPages ?? 0   // throws — the chain stops at `meta`
meta?.pagination?.totalPages ?? 0  // renders 0
```

`SalesHistory.tsx` is the tell: line 93 was already written `meta?.pagination?.` while 356/362/443/444 were not — someone hit this and patched one site. All nine now guard both hops, so a partial or failed response renders an empty state instead of taking the page down.

---

## Testing

- Migration regression test lives in `tests/concurrency/` because pg-mem **cannot create the desync it guards against**; both cases fail with the exact production error when the fix is removed.
- Server **687 passed, 0 skipped**. Client **555 passed**, lint 0 errors, within bundle budget.

## Still needs a decision, not a patch

**The Segments page is wired to an endpoint that has never returned what it needs** — an independent third reproduction of the `.map` error, and unfixable by guarding:

| | |
|---|---|
| `GET /api/v1/segments` returns | `SegmentRecord[]` — saved segment definitions |
| `Segments.tsx` expects | `{ customers: CustomerRFM[]; summary: SegmentSummary[] }` |

Verified against a running server: it returns `{"data":[]}`, so `data?.summary` is undefined. There is **no RFM endpoint anywhere on the server**. Guarding it yields a permanently empty page that looks like "no data" rather than "never built"; building RFM is a feature. Tell me which and I will do it.

This is also the class of drift #101's endpoint check **cannot** catch — the route exists and is documented, so the *set* matches. Only deriving the spec from the schemas (#102) closes it.

## Post-Deploy Monitoring & Validation

- **Confirm the API host first** (Network tab). If it was `localhost`, set `VITE_API_URL` and redeploy — that alone may resolve the reports.
- **Healthy signal:** `/api/v1/...` requests going to the real API host and returning 200; no `[config] VITE_API_URL was not set` in the browser console.
- **Failure signal:** that console error appearing after deploy means the deploy environment still lacks the variable.
- **Rollback:** plain revert; the sequence realignment is idempotent and leaves nothing to undo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN