### PR TITLE
fix(database): upgrade legacy production schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,7 @@ duplicated Sidebar route strings, global i18n files), and slice split/merge crit
 ## Build Warnings
 
 Chunk size warning (>500KB) is expected for SPA bundle — safe to ignore.
+
+## Learnings
+
+- Baseline 001 was edited after deployment; applied filenames do not prove schema compatibility. Add forward migrations and test upgrades from the legacy schema, not only fresh databases. Migration 009 repairs the September production export. (2026-09-05)

--- a/README.md
+++ b/README.md
@@ -267,9 +267,27 @@ cd server && npm test
 
 The project includes a [`render.yaml`](render.yaml) for one-click deployment to [Render](https://render.com):
 
-- **API**: Node.js web service running migrations + seed on startup
+- **API**: Node.js web service running `npm run migrate && npm run start`; seed demo data only in development.
 - **Database**: Add a PostgreSQL instance on Render and set `DATABASE_URL`
 - **Client**: Deploy the `client/` build output to any static host (Vercel, Netlify, Render Static)
+
+For databases created before the baseline schema corrections, migration 009 upgrades
+the legacy tables and columns in a single transaction. Back up production before
+deploying and set the Render dashboard Start Command to match `render.yaml`.
+Stop application writes during this upgrade: old code cannot use renamed tables
+or columns after it commits. A failed deployment can leave the old instance running.
+Verify favorites, notifications, bundles, segments, layaway, distributors and
+collections after deployment. Do not clear `_migrations` or run production seeding.
+
+The repair retains legacy data, renames bundle/layaway tables in place (preserving
+foreign keys), and imports serialized layaway items with explicit product IDs,
+quantities and `unit_price` or `price`. Ambiguous tables or malformed items abort the
+transaction. Legacy notifications without an owner remain unassigned; the repair
+does not invent user ownership. Older exchange detail and transfer tables remain
+available for historical reconciliation. Migration 009 has no destructive rollback;
+restore the pre-upgrade backup with its matching release if rollback is required.
+The regression fixture reproduces production column metadata; it is not a complete
+production backup or a substitute for checking custom constraints and real data.
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     plan: free
     rootDir: server
     buildCommand: npm install --include=dev
-    startCommand: npm run migrate && (npm run seed || true) && npm run start
+    startCommand: npm run migrate && npm run start
     envVars:
       - key: NODE_ENV
         value: production

--- a/server/src/database/migrations/009_legacy_schema_alignment.down.sql
+++ b/server/src/database/migrations/009_legacy_schema_alignment.down.sql
@@ -1,0 +1,3 @@
+-- Intentionally a no-op: reversing this repair would orphan migrated production data.
+-- Restore a pre-upgrade database backup together with its matching release if necessary.
+SELECT 1;

--- a/server/src/database/migrations/009_legacy_schema_alignment.sql
+++ b/server/src/database/migrations/009_legacy_schema_alignment.sql
@@ -1,0 +1,513 @@
+-- Repairs baseline edits that never ran on databases already stamped with 001.
+-- The runner executes this whole migration in one transaction. Never seed or reset.
+DO $repair_009$
+DECLARE
+  legacy_layaway boolean := to_regclass('layaway') IS NOT NULL;
+BEGIN
+  IF to_regclass('bundles') IS NOT NULL THEN
+    IF to_regclass('product_bundles') IS NOT NULL THEN
+      RAISE EXCEPTION '009: both bundles and product_bundles exist; reconcile records before upgrading';
+    END IF;
+    ALTER TABLE bundles RENAME TO product_bundles;
+  END IF;
+  IF to_regclass('layaway') IS NOT NULL THEN
+    IF to_regclass('layaway_plans') IS NOT NULL THEN
+      RAISE EXCEPTION '009: both layaway and layaway_plans exist; reconcile records before upgrading';
+    END IF;
+    ALTER TABLE layaway RENAME TO layaway_plans;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_plans' AND column_name = 'balance_remaining') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_plans' AND column_name = 'remaining_balance') THEN
+      RAISE EXCEPTION '009: both layaway_plans.balance_remaining and remaining_balance exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE layaway_plans RENAME COLUMN balance_remaining TO remaining_balance;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_plans' AND column_name = 'expires_at') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_plans' AND column_name = 'due_date') THEN
+      RAISE EXCEPTION '009: both layaway_plans.expires_at and due_date exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE layaway_plans RENAME COLUMN expires_at TO due_date;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_payments' AND column_name = 'layaway_id') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_payments' AND column_name = 'plan_id') THEN
+      RAISE EXCEPTION '009: both layaway_payments.layaway_id and plan_id exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE layaway_payments RENAME COLUMN layaway_id TO plan_id;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_order_items' AND column_name = 'po_order_id') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_order_items' AND column_name = 'po_id') THEN
+      RAISE EXCEPTION '009: both purchase_order_items.po_order_id and po_id exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE purchase_order_items RENAME COLUMN po_order_id TO po_id;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_order_items' AND column_name = 'unit_cost') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_order_items' AND column_name = 'cost_price') THEN
+      RAISE EXCEPTION '009: both purchase_order_items.unit_cost and cost_price exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE purchase_order_items RENAME COLUMN unit_cost TO cost_price;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_count_items' AND column_name = 'stock_count_id') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_count_items' AND column_name = 'count_id') THEN
+      RAISE EXCEPTION '009: both stock_count_items.stock_count_id and count_id exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE stock_count_items RENAME COLUMN stock_count_id TO count_id;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_count_items' AND column_name = 'difference') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_count_items' AND column_name = 'variance') THEN
+      RAISE EXCEPTION '009: both stock_count_items.difference and variance exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE stock_count_items RENAME COLUMN difference TO variance;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_counts' AND column_name = 'counted_by') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_counts' AND column_name = 'created_by') THEN
+      RAISE EXCEPTION '009: both stock_counts.counted_by and created_by exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE stock_counts RENAME COLUMN counted_by TO created_by;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shifts' AND column_name = 'start_time') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shifts' AND column_name = 'clock_in') THEN
+      RAISE EXCEPTION '009: both shifts.start_time and clock_in exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE shifts RENAME COLUMN start_time TO clock_in;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shifts' AND column_name = 'end_time') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shifts' AND column_name = 'clock_out') THEN
+      RAISE EXCEPTION '009: both shifts.end_time and clock_out exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE shifts RENAME COLUMN end_time TO clock_out;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'notifications' AND column_name = 'is_read') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'notifications' AND column_name = 'read') THEN
+      RAISE EXCEPTION '009: both notifications.is_read and read exist; reconcile before upgrading';
+    END IF;
+    ALTER TABLE notifications RENAME COLUMN is_read TO read;
+  END IF;
+  CREATE TABLE IF NOT EXISTS branch_inventory (
+    id SERIAL PRIMARY KEY,
+    branch_id INTEGER NOT NULL REFERENCES branches(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    stock INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (branch_id, product_id)
+  );
+  CREATE TABLE IF NOT EXISTS layaway_plans (
+    id SERIAL PRIMARY KEY,
+    plan_number TEXT UNIQUE NOT NULL,
+    customer_id INTEGER NOT NULL REFERENCES customers(id),
+    total_amount NUMERIC NOT NULL,
+    deposit_amount NUMERIC NOT NULL,
+    remaining_balance NUMERIC NOT NULL,
+    due_date TIMESTAMPTZ NOT NULL,
+    status TEXT DEFAULT 'active' CHECK (status IN ('active', 'completed', 'cancelled')),
+    notes TEXT,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE TABLE IF NOT EXISTS layaway_items (
+    id SERIAL PRIMARY KEY,
+    plan_id INTEGER NOT NULL REFERENCES layaway_plans(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL,
+    quantity INTEGER NOT NULL,
+    price NUMERIC NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS exchange_returned_items (
+    id SERIAL PRIMARY KEY,
+    exchange_id INTEGER NOT NULL REFERENCES exchanges(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL,
+    quantity INTEGER NOT NULL,
+    price NUMERIC NOT NULL DEFAULT 0,
+    reason TEXT,
+    condition TEXT DEFAULT 'good'
+  );
+  CREATE TABLE IF NOT EXISTS exchange_new_items (
+    id SERIAL PRIMARY KEY,
+    exchange_id INTEGER NOT NULL REFERENCES exchanges(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL,
+    quantity INTEGER NOT NULL,
+    price NUMERIC NOT NULL DEFAULT 0
+  );
+  CREATE TABLE IF NOT EXISTS vendor_payouts (
+    id SERIAL PRIMARY KEY,
+    vendor_id INTEGER NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+    amount NUMERIC NOT NULL,
+    period_start TIMESTAMPTZ,
+    period_end TIMESTAMPTZ,
+    notes TEXT,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE TABLE IF NOT EXISTS storefront_banners (
+    id SERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    subtitle TEXT,
+    image_url TEXT NOT NULL,
+    link_url TEXT,
+    position INTEGER DEFAULT 0,
+    is_active INTEGER DEFAULT 1,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE TABLE IF NOT EXISTS product_bundles (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    price NUMERIC DEFAULT 0,
+    bundle_price NUMERIC DEFAULT 0,
+    discount_type TEXT DEFAULT 'fixed',
+    discount_value NUMERIC DEFAULT 0,
+    starts_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'active' CHECK (status IN ('active', 'inactive')),
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE TABLE IF NOT EXISTS branch_transfers (
+    id SERIAL PRIMARY KEY,
+    source_branch_id INTEGER NOT NULL REFERENCES branches(id),
+    target_branch_id INTEGER NOT NULL REFERENCES branches(id),
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL,
+    quantity INTEGER NOT NULL,
+    notes TEXT,
+    status TEXT DEFAULT 'pending',
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+  );
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'collections' AND column_name = 'image_url') THEN
+    ALTER TABLE collections ADD COLUMN image_url TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'collections' AND column_name = 'season') THEN
+    ALTER TABLE collections ADD COLUMN season TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'collections' AND column_name = 'is_featured') THEN
+    ALTER TABLE collections ADD COLUMN is_featured INTEGER DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'collections' AND column_name = 'status') THEN
+    ALTER TABLE collections ADD COLUMN status TEXT DEFAULT 'active';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'collections' AND column_name = 'updated_at') THEN
+    ALTER TABLE collections ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'coupons' AND column_name = 'updated_at') THEN
+    ALTER TABLE coupons ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'customer_feedback' AND column_name = 'category') THEN
+    ALTER TABLE customer_feedback ADD COLUMN category TEXT DEFAULT 'general';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'customer_feedback' AND column_name = 'comment') THEN
+    ALTER TABLE customer_feedback ADD COLUMN comment TEXT;
+    UPDATE customer_feedback SET comment = comments;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'customer_feedback' AND column_name = 'updated_at') THEN
+    ALTER TABLE customer_feedback ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'customer_segments' AND column_name = 'rules_json') THEN
+    ALTER TABLE customer_segments ADD COLUMN rules_json TEXT;
+    UPDATE customer_segments SET rules_json = criteria;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'customer_segments' AND column_name = 'updated_at') THEN
+    ALTER TABLE customer_segments ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'distributors' AND column_name = 'contact_info') THEN
+    ALTER TABLE distributors ADD COLUMN contact_info TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'exchange_number') THEN
+    ALTER TABLE exchanges ADD COLUMN exchange_number TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'customer_id') THEN
+    ALTER TABLE exchanges ADD COLUMN customer_id INTEGER REFERENCES customers(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'return_total') THEN
+    ALTER TABLE exchanges ADD COLUMN return_total NUMERIC DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'new_total') THEN
+    ALTER TABLE exchanges ADD COLUMN new_total NUMERIC DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'difference') THEN
+    ALTER TABLE exchanges ADD COLUMN difference NUMERIC DEFAULT 0;
+    UPDATE exchanges SET difference = price_difference;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'payment_method') THEN
+    ALTER TABLE exchanges ADD COLUMN payment_method TEXT DEFAULT 'Cash';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'notes') THEN
+    ALTER TABLE exchanges ADD COLUMN notes TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'exchanges' AND column_name = 'updated_at') THEN
+    ALTER TABLE exchanges ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'inventory_snapshots' AND column_name = 'snapshot_data') THEN
+    ALTER TABLE inventory_snapshots ADD COLUMN snapshot_data TEXT DEFAULT '[]';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'inventory_snapshots' AND column_name = 'updated_at') THEN
+    ALTER TABLE inventory_snapshots ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_payments' AND column_name = 'notes') THEN
+    ALTER TABLE layaway_payments ADD COLUMN notes TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_plans' AND column_name = 'plan_number') THEN
+    ALTER TABLE layaway_plans ADD COLUMN plan_number TEXT;
+    UPDATE layaway_plans SET plan_number = 'LEGACY-' || id::text;
+    ALTER TABLE layaway_plans ADD CONSTRAINT layaway_plans_plan_number_key UNIQUE (plan_number);
+    ALTER TABLE layaway_plans ALTER COLUMN plan_number SET NOT NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_plans' AND column_name = 'notes') THEN
+    ALTER TABLE layaway_plans ADD COLUMN notes TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'layaway_plans' AND column_name = 'created_by') THEN
+    ALTER TABLE layaway_plans ADD COLUMN created_by INTEGER REFERENCES users(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'notifications' AND column_name = 'user_id') THEN
+    ALTER TABLE notifications ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'notifications' AND column_name = 'entity_type') THEN
+    ALTER TABLE notifications ADD COLUMN entity_type TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'notifications' AND column_name = 'entity_id') THEN
+    ALTER TABLE notifications ADD COLUMN entity_id TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'notifications' AND column_name = 'link') THEN
+    ALTER TABLE notifications ADD COLUMN link TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_order_items' AND column_name = 'variant_id') THEN
+    ALTER TABLE online_order_items ADD COLUMN variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_order_items' AND column_name = 'price') THEN
+    ALTER TABLE online_order_items ADD COLUMN price NUMERIC;
+    UPDATE online_order_items SET price = unit_price;
+    ALTER TABLE online_order_items ALTER COLUMN price SET NOT NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'customer_id') THEN
+    ALTER TABLE online_orders ADD COLUMN customer_id INTEGER REFERENCES customers(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'customer_phone') THEN
+    ALTER TABLE online_orders ADD COLUMN customer_phone TEXT;
+    UPDATE online_orders SET customer_phone = phone;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'customer_email') THEN
+    ALTER TABLE online_orders ADD COLUMN customer_email TEXT;
+    UPDATE online_orders SET customer_email = email;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'shipping_address') THEN
+    ALTER TABLE online_orders ADD COLUMN shipping_address TEXT;
+    UPDATE online_orders SET shipping_address = address;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'city') THEN
+    ALTER TABLE online_orders ADD COLUMN city TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'subtotal') THEN
+    ALTER TABLE online_orders ADD COLUMN subtotal NUMERIC DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'shipping_fee') THEN
+    ALTER TABLE online_orders ADD COLUMN shipping_fee NUMERIC DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'online_orders' AND column_name = 'notes') THEN
+    ALTER TABLE online_orders ADD COLUMN notes TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'product_bundles' AND column_name = 'description') THEN
+    ALTER TABLE product_bundles ADD COLUMN description TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'product_bundles' AND column_name = 'bundle_price') THEN
+    ALTER TABLE product_bundles ADD COLUMN bundle_price NUMERIC DEFAULT 0;
+    UPDATE product_bundles SET bundle_price = price;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'product_bundles' AND column_name = 'discount_type') THEN
+    ALTER TABLE product_bundles ADD COLUMN discount_type TEXT DEFAULT 'fixed';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'product_bundles' AND column_name = 'discount_value') THEN
+    ALTER TABLE product_bundles ADD COLUMN discount_value NUMERIC DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'product_bundles' AND column_name = 'starts_at') THEN
+    ALTER TABLE product_bundles ADD COLUMN starts_at TIMESTAMPTZ;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'product_bundles' AND column_name = 'expires_at') THEN
+    ALTER TABLE product_bundles ADD COLUMN expires_at TIMESTAMPTZ;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'products' AND column_name = 'lead_time_days') THEN
+    ALTER TABLE products ADD COLUMN lead_time_days INTEGER DEFAULT 7;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'products' AND column_name = 'reorder_qty') THEN
+    ALTER TABLE products ADD COLUMN reorder_qty INTEGER DEFAULT 10;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'products' AND column_name = 'abc_class') THEN
+    ALTER TABLE products ADD COLUMN abc_class TEXT DEFAULT 'C';
+    UPDATE products SET abc_class = abc_classification;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_order_items' AND column_name = 'variant_id') THEN
+    ALTER TABLE purchase_order_items ADD COLUMN variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_orders' AND column_name = 'total') THEN
+    ALTER TABLE purchase_orders ADD COLUMN total NUMERIC DEFAULT 0;
+    UPDATE purchase_orders SET total = total_cost;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_orders' AND column_name = 'total_amount') THEN
+    ALTER TABLE purchase_orders ADD COLUMN total_amount NUMERIC DEFAULT 0;
+    UPDATE purchase_orders SET total_amount = total_cost;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'purchase_orders' AND column_name = 'expected_delivery') THEN
+    ALTER TABLE purchase_orders ADD COLUMN expected_delivery TIMESTAMPTZ;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sale_items' AND column_name = 'price') THEN
+    ALTER TABLE sale_items ADD COLUMN price NUMERIC;
+    UPDATE sale_items SET price = unit_price;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sale_items' AND column_name = 'discount') THEN
+    ALTER TABLE sale_items ADD COLUMN discount NUMERIC DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sale_items' AND column_name = 'subtotal') THEN
+    ALTER TABLE sale_items ADD COLUMN subtotal NUMERIC DEFAULT 0;
+    UPDATE sale_items SET subtotal = quantity * unit_price;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sales' AND column_name = 'receipt_number') THEN
+    ALTER TABLE sales ADD COLUMN receipt_number TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sales' AND column_name = 'subtotal') THEN
+    ALTER TABLE sales ADD COLUMN subtotal NUMERIC DEFAULT 0;
+    UPDATE sales s SET subtotal = COALESCE(
+      (SELECT SUM(i.quantity * i.unit_price) FROM sale_items i WHERE i.sale_id = s.id),
+      s.total + COALESCE(s.discount, 0) - COALESCE(s.tax_amount, 0)
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sales' AND column_name = 'tax') THEN
+    ALTER TABLE sales ADD COLUMN tax NUMERIC DEFAULT 0;
+    UPDATE sales SET tax = tax_amount;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sales' AND column_name = 'status') THEN
+    ALTER TABLE sales ADD COLUMN status TEXT DEFAULT 'completed';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'sales' AND column_name = 'updated_at') THEN
+    ALTER TABLE sales ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shifts' AND column_name = 'branch_id') THEN
+    ALTER TABLE shifts ADD COLUMN branch_id INTEGER REFERENCES branches(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shifts' AND column_name = 'break_start') THEN
+    ALTER TABLE shifts ADD COLUMN break_start TIMESTAMPTZ;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shifts' AND column_name = 'total_hours') THEN
+    ALTER TABLE shifts ADD COLUMN total_hours NUMERIC(5,2);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shipping_companies' AND column_name = 'phone') THEN
+    ALTER TABLE shipping_companies ADD COLUMN phone TEXT;
+    UPDATE shipping_companies SET phone = contact_phone;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shipping_companies' AND column_name = 'email') THEN
+    ALTER TABLE shipping_companies ADD COLUMN email TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shipping_companies' AND column_name = 'is_active') THEN
+    ALTER TABLE shipping_companies ADD COLUMN is_active INTEGER DEFAULT 1;
+    UPDATE shipping_companies SET is_active = active;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'shipping_companies' AND column_name = 'updated_at') THEN
+    ALTER TABLE shipping_companies ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_count_items' AND column_name = 'variant_id') THEN
+    ALTER TABLE stock_count_items ADD COLUMN variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_count_items' AND column_name = 'notes') THEN
+    ALTER TABLE stock_count_items ADD COLUMN notes TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_reservations' AND column_name = 'variant_id') THEN
+    ALTER TABLE stock_reservations ADD COLUMN variant_id INTEGER REFERENCES product_variants(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_reservations' AND column_name = 'source_type') THEN
+    ALTER TABLE stock_reservations ADD COLUMN source_type TEXT DEFAULT 'cart';
+    UPDATE stock_reservations SET source_type = reference_type;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_reservations' AND column_name = 'source_id') THEN
+    ALTER TABLE stock_reservations ADD COLUMN source_id TEXT;
+    UPDATE stock_reservations SET source_id = reference_id;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'stock_reservations' AND column_name = 'updated_at') THEN
+    ALTER TABLE stock_reservations ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'users' AND column_name = 'favorites') THEN
+    ALTER TABLE users ADD COLUMN favorites TEXT DEFAULT '[]';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'vendors' AND column_name = 'tax_number') THEN
+    ALTER TABLE vendors ADD COLUMN tax_number TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'vendors' AND column_name = 'updated_at') THEN
+    ALTER TABLE vendors ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'warranty_claims' AND column_name = 'product_id') THEN
+    ALTER TABLE warranty_claims ADD COLUMN product_id INTEGER REFERENCES products(id);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'warranty_claims' AND column_name = 'customer_name') THEN
+    ALTER TABLE warranty_claims ADD COLUMN customer_name TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'warranty_claims' AND column_name = 'customer_phone') THEN
+    ALTER TABLE warranty_claims ADD COLUMN customer_phone TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'warranty_claims' AND column_name = 'issue_description') THEN
+    ALTER TABLE warranty_claims ADD COLUMN issue_description TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'warranty_claims' AND column_name = 'resolution') THEN
+    ALTER TABLE warranty_claims ADD COLUMN resolution TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'warranty_claims' AND column_name = 'resolved_at') THEN
+    ALTER TABLE warranty_claims ADD COLUMN resolved_at TIMESTAMPTZ;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'warranty_claims' AND column_name = 'updated_at') THEN
+    ALTER TABLE warranty_claims ADD COLUMN updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'product_bundles' AND column_name = 'sku') THEN
+    ALTER TABLE product_bundles ALTER COLUMN sku DROP NOT NULL;
+  END IF;
+  IF legacy_layaway THEN
+    ALTER TABLE layaway_plans ALTER COLUMN items DROP NOT NULL;
+  END IF;
+  ALTER TABLE inventory_snapshots ALTER COLUMN snapshot_date DROP NOT NULL;
+  ALTER TABLE inventory_snapshots ALTER COLUMN snapshot_date SET DEFAULT CURRENT_DATE;
+  ALTER TABLE notifications ALTER COLUMN message DROP NOT NULL;
+  ALTER TABLE online_order_items ALTER COLUMN unit_price DROP NOT NULL;
+  ALTER TABLE online_orders ALTER COLUMN phone DROP NOT NULL;
+  ALTER TABLE online_orders ALTER COLUMN address DROP NOT NULL;
+  ALTER TABLE online_orders ALTER COLUMN status SET DEFAULT 'pending'::text;
+  ALTER TABLE online_orders ALTER COLUMN items DROP NOT NULL;
+  ALTER TABLE purchase_orders ALTER COLUMN status SET DEFAULT 'Draft'::text;
+  ALTER TABLE stock_counts ALTER COLUMN name DROP NOT NULL;
+  ALTER TABLE stock_counts ALTER COLUMN status SET DEFAULT 'in_progress'::text;
+  ALTER TABLE stock_reservations ALTER COLUMN reference_type DROP NOT NULL;
+  ALTER TABLE stock_reservations ALTER COLUMN reference_id DROP NOT NULL;
+  ALTER TABLE warranty_claims ALTER COLUMN warranty_id DROP NOT NULL;
+  ALTER TABLE warranty_claims ALTER COLUMN sale_id DROP NOT NULL;
+  ALTER TABLE shifts ALTER COLUMN clock_in SET DEFAULT CURRENT_TIMESTAMP;
+  ALTER TABLE stock_count_items ALTER COLUMN variance SET DEFAULT 0;
+  ALTER TABLE product_bundles ALTER COLUMN price SET DEFAULT 0;
+  ALTER TABLE shifts DROP CONSTRAINT IF EXISTS shifts_status_check;
+  ALTER TABLE shifts ADD CONSTRAINT shifts_status_check CHECK (status IN ('active', 'on_break', 'completed')) NOT VALID;
+  ALTER TABLE purchase_orders DROP CONSTRAINT IF EXISTS purchase_orders_status_check;
+  ALTER TABLE purchase_orders ADD CONSTRAINT purchase_orders_status_check CHECK (status IN ('Draft', 'Ordered', 'Partial', 'Received', 'Cancelled', 'pending', 'received', 'cancelled')) NOT VALID;
+  ALTER TABLE warranty_claims DROP CONSTRAINT IF EXISTS warranty_claims_status_check;
+  ALTER TABLE warranty_claims ADD CONSTRAINT warranty_claims_status_check CHECK (status IN ('pending', 'approved', 'rejected', 'completed', 'resolved', 'replaced', 'refunded')) NOT VALID;
+  -- Preserve serialized legacy items; malformed or ambiguous payloads abort atomically.
+  IF legacy_layaway THEN
+    IF EXISTS (SELECT 1 FROM layaway_plans WHERE items IS NOT NULL AND jsonb_typeof(items::jsonb) <> 'array') THEN
+      RAISE EXCEPTION '009: layaway.items must contain JSON arrays';
+    END IF;
+    IF EXISTS (SELECT 1 FROM layaway_items) AND EXISTS (SELECT 1 FROM layaway_plans WHERE items IS NOT NULL AND items::jsonb <> '[]'::jsonb) THEN
+      RAISE EXCEPTION '009: both serialized and normalized layaway items exist; reconcile before upgrading';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM layaway_plans p CROSS JOIN LATERAL jsonb_array_elements(p.items::jsonb) item
+      WHERE (item->>'quantity')::integer <= 0
+         OR COALESCE(item->>'unit_price', item->>'price')::numeric < 0
+         OR (item ? 'unit_price' AND item ? 'price' AND
+             (item->>'unit_price')::numeric <> (item->>'price')::numeric)
+    ) THEN
+      RAISE EXCEPTION '009: invalid quantity or ambiguous price in legacy layaway items';
+    END IF;
+    INSERT INTO layaway_items (plan_id, product_id, variant_id, quantity, price)
+    SELECT p.id, (item->>'product_id')::integer, (item->>'variant_id')::integer,
+           (item->>'quantity')::integer, COALESCE(item->>'unit_price', item->>'price')::numeric
+    FROM layaway_plans p CROSS JOIN LATERAL jsonb_array_elements(p.items::jsonb) item;
+  END IF;
+END
+$repair_009$;

--- a/server/tests/database/fixtures/production-schema-2026-09-05.json
+++ b/server/tests/database/fixtures/production-schema-2026-09-05.json
@@ -1,0 +1,4346 @@
+[
+  {
+    "table_schema": "public",
+    "table_name": "_migrations",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('_migrations_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "_migrations",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "_migrations",
+    "column_name": "applied_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_messages",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('ai_chat_messages_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_messages",
+    "column_name": "session_id",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_messages",
+    "column_name": "role",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_messages",
+    "column_name": "content",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_messages",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_sessions",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('ai_chat_sessions_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_sessions",
+    "column_name": "session_id",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_sessions",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "ai_chat_sessions",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('audit_log_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "user_name",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "action",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "entity_type",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "entity_id",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "details",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "ip_address",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "audit_log",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "auto_descriptions",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('auto_descriptions_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "auto_descriptions",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "auto_descriptions",
+    "column_name": "generated_description",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "auto_descriptions",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('branches_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "code",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "address",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "phone",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "currency",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'EGP'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "is_main",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "branches",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundle_items",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('bundle_items_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundle_items",
+    "column_name": "bundle_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundle_items",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundle_items",
+    "column_name": "quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "1"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundles",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('bundles_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundles",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundles",
+    "column_name": "sku",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundles",
+    "column_name": "price",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundles",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundles",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "bundles",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "categories",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('categories_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "categories",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "categories",
+    "column_name": "code",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "categories",
+    "column_name": "description",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "categories",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "categories",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collection_products",
+    "column_name": "collection_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collection_products",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collection_products",
+    "column_name": "position",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collections",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('collections_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collections",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collections",
+    "column_name": "description",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collections",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "collections",
+    "column_name": "year",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupon_usage",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('coupon_usage_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupon_usage",
+    "column_name": "coupon_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupon_usage",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupon_usage",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupon_usage",
+    "column_name": "discount_applied",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupon_usage",
+    "column_name": "used_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('coupons_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "code",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "type",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "value",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "min_purchase",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "max_discount",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "starts_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "expires_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "max_uses",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "max_uses_per_customer",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "scope",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'all'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "scope_ids",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "stackable",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "coupons",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_feedback",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('customer_feedback_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_feedback",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_feedback",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_feedback",
+    "column_name": "rating",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_feedback",
+    "column_name": "comments",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_feedback",
+    "column_name": "source",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'POS'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_feedback",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segment_members",
+    "column_name": "segment_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segment_members",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segment_members",
+    "column_name": "added_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segments",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('customer_segments_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segments",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segments",
+    "column_name": "description",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segments",
+    "column_name": "criteria",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "'{}'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customer_segments",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('customers_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "phone",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "email",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "address",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "loyalty_points",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "total_spent",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "tier",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'Bronze'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "customers",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "dashboard_widgets",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('dashboard_widgets_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "dashboard_widgets",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "dashboard_widgets",
+    "column_name": "widget_type",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "dashboard_widgets",
+    "column_name": "position",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "dashboard_widgets",
+    "column_name": "config",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "'{}'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "data_warehouse_sync",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('data_warehouse_sync_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "data_warehouse_sync",
+    "column_name": "last_synced_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "data_warehouse_sync",
+    "column_name": "record_count",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "data_warehouse_sync",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'idle'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_items",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('delivery_items_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_items",
+    "column_name": "order_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_items",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_items",
+    "column_name": "variant_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_items",
+    "column_name": "quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('delivery_orders_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "order_number",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "customer_name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "phone",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "address",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "items",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'[]'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'Pending'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "estimated_delivery",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "shipping_company_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "tracking_number",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "shipping_cost",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_orders",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_status_history",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('delivery_status_history_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_status_history",
+    "column_name": "order_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_status_history",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_status_history",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_status_history",
+    "column_name": "changed_by",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_status_history",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_tracking",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('delivery_tracking_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_tracking",
+    "column_name": "delivery_order_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_tracking",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_tracking",
+    "column_name": "note",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "delivery_tracking",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('distributors_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "contact_person",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "phone",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "email",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "address",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "distributors",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchange_items",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('exchange_items_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchange_items",
+    "column_name": "exchange_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchange_items",
+    "column_name": "returned_product_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchange_items",
+    "column_name": "returned_quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchange_items",
+    "column_name": "new_product_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchange_items",
+    "column_name": "new_quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchanges",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('exchanges_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchanges",
+    "column_name": "original_sale_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchanges",
+    "column_name": "new_sale_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchanges",
+    "column_name": "price_difference",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchanges",
+    "column_name": "cashier_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchanges",
+    "column_name": "reason",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "exchanges",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "expenses",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('expenses_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "expenses",
+    "column_name": "category",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "expenses",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "expenses",
+    "column_name": "description",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "expenses",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "expenses",
+    "column_name": "date",
+    "data_type": "date",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_DATE"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "expenses",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('gift_card_transactions_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "gift_card_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "balance_before",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "balance_after",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "performed_by",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_card_transactions",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('gift_cards_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "code",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "barcode",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "initial_value",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "balance",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "expires_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "created_by",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "gift_cards",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "key",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "endpoint",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "request_fingerprint",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "response_status",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "response_body",
+    "data_type": "json",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "resource_type",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "resource_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "NO",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "idempotency_keys",
+    "column_name": "expires_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('inter_store_transfers_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "from_branch_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "to_branch_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'pending'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "requested_by",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inter_store_transfers",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inventory_snapshots",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('inventory_snapshots_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inventory_snapshots",
+    "column_name": "snapshot_date",
+    "data_type": "date",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inventory_snapshots",
+    "column_name": "total_products",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inventory_snapshots",
+    "column_name": "total_units",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inventory_snapshots",
+    "column_name": "total_cost_value",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inventory_snapshots",
+    "column_name": "total_retail_value",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "inventory_snapshots",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "label_templates",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('label_templates_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "label_templates",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "label_templates",
+    "column_name": "config",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "label_templates",
+    "column_name": "is_default",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "label_templates",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "label_templates",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('layaway_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "total_amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "deposit_amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "balance_remaining",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "items",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "expires_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway_payments",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('layaway_payments_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway_payments",
+    "column_name": "layaway_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway_payments",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway_payments",
+    "column_name": "payment_method",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway_payments",
+    "column_name": "cashier_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "layaway_payments",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "loyalty_transactions",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('loyalty_transactions_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "loyalty_transactions",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "loyalty_transactions",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "loyalty_transactions",
+    "column_name": "points",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "loyalty_transactions",
+    "column_name": "type",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "loyalty_transactions",
+    "column_name": "note",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "loyalty_transactions",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "notifications",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('notifications_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "notifications",
+    "column_name": "title",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "notifications",
+    "column_name": "message",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "notifications",
+    "column_name": "type",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'info'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "notifications",
+    "column_name": "is_read",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "notifications",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "offline_sync_queue",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('offline_sync_queue_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "offline_sync_queue",
+    "column_name": "action",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "offline_sync_queue",
+    "column_name": "payload",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "offline_sync_queue",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'pending'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "offline_sync_queue",
+    "column_name": "retry_count",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "offline_sync_queue",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "offline_sync_queue",
+    "column_name": "synced_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_order_items",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('online_order_items_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_order_items",
+    "column_name": "order_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_order_items",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_order_items",
+    "column_name": "quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_order_items",
+    "column_name": "unit_price",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('online_orders_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "order_number",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "customer_name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "phone",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "email",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "address",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "total",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'Pending'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "items",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "online_orders",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "price_history",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('price_history_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "price_history",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "price_history",
+    "column_name": "field",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "price_history",
+    "column_name": "old_value",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "price_history",
+    "column_name": "new_value",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "price_history",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "price_history",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_reviews",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('product_reviews_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_reviews",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_reviews",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_reviews",
+    "column_name": "rating",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_reviews",
+    "column_name": "review",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_reviews",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('product_variants_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "sku",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "barcode",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "price",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "cost_price",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "stock",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "attributes",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "'{}'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "product_variants",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('products_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "sku",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "barcode",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "price",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "cost_price",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "stock",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "category",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "category_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "distributor_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "min_stock",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "5"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "image_url",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "has_variants",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "abc_classification",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'C'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "products",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_order_items",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('purchase_order_items_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_order_items",
+    "column_name": "po_order_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_order_items",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_order_items",
+    "column_name": "quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_order_items",
+    "column_name": "unit_cost",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_order_items",
+    "column_name": "received_quantity",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('purchase_orders_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "po_number",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "distributor_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'pending'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "total_cost",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "created_by",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "received_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "purchase_orders",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('refresh_tokens_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "expires_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "token_hash",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "family_id",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "revoked_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "revoked_reason",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refresh_tokens",
+    "column_name": "replaced_by_hash",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('refunds_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "reason",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "items",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "restock",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "1"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "cashier_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "refunds",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_movements",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('register_movements_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_movements",
+    "column_name": "session_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_movements",
+    "column_name": "type",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_movements",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_movements",
+    "column_name": "note",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_movements",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_movements",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('register_sessions_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "cashier_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "opening_float",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "expected_cash",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "counted_cash",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "variance",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "'open'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "opened_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "register_sessions",
+    "column_name": "closed_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "report_builder",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('report_builder_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "report_builder",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "report_builder",
+    "column_name": "config",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "report_builder",
+    "column_name": "created_by",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "report_builder",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "contract_version",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "subtotal",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "manual_discount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "coupon_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "coupon_discount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "points_redeemed",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "points_discount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "taxable_base",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "tax_mode",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "'exclusive'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "tax_rate_percent",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "tax_amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "tip_amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "amount_due",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "earned_points",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_calculations",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('sale_items_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "variant_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "unit_price",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "cost_price",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_items",
+    "column_name": "memo",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_payments",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('sale_payments_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_payments",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_payments",
+    "column_name": "method",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_payments",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sale_payments",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('sales_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "total",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "discount",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "discount_type",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'fixed'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "payment_method",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'Cash'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "cashier_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "tax_amount",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "points_redeemed",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "tip_amount",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "coupon_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "coupon_discount",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "refund_status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'none'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "refunded_amount",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "receipt_sent_via",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "register_session_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales_predictions",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('sales_predictions_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales_predictions",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales_predictions",
+    "column_name": "predicted_quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales_predictions",
+    "column_name": "prediction_date",
+    "data_type": "date",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales_predictions",
+    "column_name": "confidence",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "sales_predictions",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "saved_reports",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('saved_reports_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "saved_reports",
+    "column_name": "report_builder_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "saved_reports",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "saved_reports",
+    "column_name": "data",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "saved_reports",
+    "column_name": "generated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "scheduled_jobs",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "scheduled_jobs",
+    "column_name": "last_started_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "scheduled_jobs",
+    "column_name": "last_finished_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "scheduled_jobs",
+    "column_name": "last_status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "scheduled_jobs",
+    "column_name": "last_detail",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "scheduled_jobs",
+    "column_name": "run_count",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "scheduled_jobs",
+    "column_name": "failure_count",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "settings",
+    "column_name": "key",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "settings",
+    "column_name": "value",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "settings",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('shifts_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "start_time",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "end_time",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "break_minutes",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shifts",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shipping_companies",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('shipping_companies_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shipping_companies",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shipping_companies",
+    "column_name": "contact_phone",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shipping_companies",
+    "column_name": "tracking_url_template",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shipping_companies",
+    "column_name": "active",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "1"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "shipping_companies",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('stock_adjustments_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "previous_qty",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "new_qty",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "delta",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "reason",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "user_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_adjustments",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_count_items",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('stock_count_items_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_count_items",
+    "column_name": "stock_count_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_count_items",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_count_items",
+    "column_name": "expected_qty",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_count_items",
+    "column_name": "counted_qty",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_count_items",
+    "column_name": "difference",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_count_items",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('stock_counts_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'draft'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "category_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "counted_by",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "started_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "completed_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_counts",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_reservations",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('stock_reservations_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_reservations",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_reservations",
+    "column_name": "quantity",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_reservations",
+    "column_name": "reference_type",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_reservations",
+    "column_name": "reference_id",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_reservations",
+    "column_name": "expires_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "stock_reservations",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "store_performance",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('store_performance_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "store_performance",
+    "column_name": "branch_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "store_performance",
+    "column_name": "date",
+    "data_type": "date",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "store_performance",
+    "column_name": "revenue",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "store_performance",
+    "column_name": "sales_count",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "store_performance",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "storefront_config",
+    "column_name": "key",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "storefront_config",
+    "column_name": "value",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "storefront_config",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('users_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "email",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "password_hash",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "role",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "'Cashier'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "commission_rate",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "last_login",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "users",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_commissions",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('vendor_commissions_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_commissions",
+    "column_name": "vendor_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_commissions",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_commissions",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_commissions",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'pending'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_commissions",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_products",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('vendor_products_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_products",
+    "column_name": "vendor_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_products",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_products",
+    "column_name": "consignment_rate",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_products",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_reviews",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('vendor_reviews_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_reviews",
+    "column_name": "vendor_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_reviews",
+    "column_name": "rating",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_reviews",
+    "column_name": "review",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendor_reviews",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('vendors_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "contact_person",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "phone",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "email",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "address",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "commission_rate",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": "0"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'active'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "vendors",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranties",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('warranties_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranties",
+    "column_name": "product_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranties",
+    "column_name": "duration_months",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranties",
+    "column_name": "terms",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranties",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranty_claims",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('warranty_claims_id_seq'::regclass)"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranty_claims",
+    "column_name": "warranty_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranty_claims",
+    "column_name": "sale_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranty_claims",
+    "column_name": "customer_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranty_claims",
+    "column_name": "status",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "'pending'::text"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranty_claims",
+    "column_name": "notes",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": "NULL"
+  },
+  {
+    "table_schema": "public",
+    "table_name": "warranty_claims",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "CURRENT_TIMESTAMP"
+  }
+]

--- a/server/tests/database/migration009.test.ts
+++ b/server/tests/database/migration009.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { Pool } from 'pg';
+import fs from 'fs';
+import path from 'path';
+import { randomBytes } from 'crypto';
+import { describeWithPostgres, TEST_DATABASE_URL } from '../support/realPostgres';
+import { ensureMigrationTable, runMigrationsUp } from '../../src/database/migrate';
+import production from './fixtures/production-schema-2026-09-05.json';
+
+const dir = path.join(__dirname, '../../src/database/migrations');
+const migration = '009_legacy_schema_alignment.sql';
+const sql = fs.readFileSync(path.join(dir, migration), 'utf8');
+
+describeWithPostgres('009 legacy production schema repair', () => {
+  const prefix = `test_repair_${randomBytes(5).toString('hex')}`;
+  const admin = new Pool({ connectionString: TEST_DATABASE_URL });
+  const pools: Pool[] = [];
+  const schemas: string[] = [];
+
+  async function database(legacy: boolean): Promise<Pool> {
+    const schema = `${prefix}_${pools.length}`;
+    await admin.query(`CREATE SCHEMA ${schema}`);
+    schemas.push(schema);
+    const pool = new Pool({
+      connectionString: TEST_DATABASE_URL,
+      options: `-c search_path=${schema}`,
+    });
+    pools.push(pool);
+    if (!legacy) {
+      await runMigrationsUp(pool, dir);
+      return pool;
+    }
+    // Exact exported column types/defaults/nullability, with serial primary keys.
+    // The CSV does not contain constraints; representative legacy FKs/checks below
+    // exercise the dangerous rename and insert paths without claiming a full dump.
+    for (const table of new Set(production.map((r) => r.table_name))) {
+      const columns = production
+        .filter((r) => r.table_name === table)
+        .map((r) => {
+          if (r.column_default.startsWith('nextval('))
+            return `"${r.column_name}" SERIAL PRIMARY KEY`;
+          return `"${r.column_name}" ${r.data_type}${r.is_nullable === 'NO' ? ' NOT NULL' : ''}${r.column_default === 'NULL' ? '' : ` DEFAULT ${r.column_default}`}`;
+        });
+      await pool.query(`CREATE TABLE "${table}" (${columns.join(', ')})`);
+    }
+    await pool.query(`
+      ALTER TABLE bundle_items ADD FOREIGN KEY (bundle_id) REFERENCES bundles(id);
+      ALTER TABLE layaway_payments ADD FOREIGN KEY (layaway_id) REFERENCES layaway(id);
+      ALTER TABLE purchase_order_items ADD FOREIGN KEY (po_order_id) REFERENCES purchase_orders(id);
+      ALTER TABLE stock_count_items ADD FOREIGN KEY (stock_count_id) REFERENCES stock_counts(id);
+      ALTER TABLE purchase_orders ADD CONSTRAINT purchase_orders_status_check CHECK (status IN ('pending','received','cancelled'));
+      ALTER TABLE shifts ADD CONSTRAINT shifts_status_check CHECK (status IN ('active','completed'));
+      ALTER TABLE warranty_claims ADD CONSTRAINT warranty_claims_status_check CHECK (status IN ('pending','approved','rejected','completed'));
+    `);
+    await ensureMigrationTable(pool);
+    for (const name of fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.sql') && !f.includes('.down.') && f < migration)) {
+      await pool.query('INSERT INTO _migrations (name) VALUES ($1)', [name]);
+    }
+    return pool;
+  }
+
+  beforeAll(async () => {
+    await admin.query('SELECT 1');
+  });
+  afterAll(async () => {
+    await Promise.all(pools.map((p) => p.end()));
+    for (const schema of schemas) await admin.query(`DROP SCHEMA ${schema} CASCADE`);
+    await admin.end();
+  });
+
+  it('reproduces the reported errors, upgrades all exported columns and preserves legacy records and FKs', async () => {
+    const pool = await database(true);
+    await expect(pool.query('SELECT favorites FROM users')).rejects.toMatchObject({
+      code: '42703',
+    });
+    await expect(pool.query('SELECT * FROM product_bundles')).rejects.toMatchObject({
+      code: '42P01',
+    });
+    await pool.query(`
+      INSERT INTO users (id,name,email,password_hash,role) VALUES (21,'Migration test','migration@example.invalid','unused','Admin');
+      INSERT INTO customers (id,name,phone) VALUES (31,'Migration customer','migration-test');
+      INSERT INTO products (id,name,sku,price) VALUES (41,'Migration product','MIG-41',25);
+      INSERT INTO bundles (id,name,sku,price) VALUES (51,'Legacy bundle','B-51',40);
+      INSERT INTO bundle_items (bundle_id,product_id) VALUES (51,41);
+      INSERT INTO layaway (id,customer_id,total_amount,deposit_amount,balance_remaining,items,expires_at)
+      VALUES (61,31,50,10,40,'[{"product_id":41,"quantity":2,"unit_price":25}]','2030-01-01');
+      INSERT INTO layaway_payments (layaway_id,amount,payment_method) VALUES (61,10,'Cash');
+      INSERT INTO notifications (title,message,is_read) VALUES ('Legacy','Kept',1);
+      INSERT INTO purchase_orders (id,po_number,total_cost) VALUES (71,'PO-71',75);
+      INSERT INTO purchase_order_items (po_order_id,product_id,quantity,unit_cost) VALUES (71,41,3,25);
+      INSERT INTO shifts (user_id,start_time) VALUES (21,'2026-01-01');
+    `);
+    expect(await runMigrationsUp(pool, dir)).toEqual([migration]);
+    expect(await runMigrationsUp(pool, dir)).toEqual([]);
+    await pool.query(sql);
+    expect((await pool.query('SELECT favorites FROM users')).rows[0].favorites).toBe('[]');
+    expect(
+      (await pool.query('SELECT bundle_price FROM product_bundles WHERE id=51')).rows[0]
+        .bundle_price
+    ).toBe('40');
+    expect(
+      (await pool.query('SELECT remaining_balance FROM layaway_plans WHERE id=61')).rows[0]
+        .remaining_balance
+    ).toBe('40');
+    expect(
+      (await pool.query('SELECT quantity,price FROM layaway_items WHERE plan_id=61')).rows
+    ).toEqual([{ quantity: 2, price: '25' }]);
+    expect((await pool.query('SELECT plan_id FROM layaway_payments')).rows[0].plan_id).toBe(61);
+    expect((await pool.query('SELECT read,user_id FROM notifications')).rows[0]).toEqual({
+      read: 1,
+      user_id: null,
+    });
+    expect((await pool.query('SELECT po_id,cost_price FROM purchase_order_items')).rows[0]).toEqual(
+      { po_id: 71, cost_price: '25' }
+    );
+    await expect(
+      pool.query('INSERT INTO bundle_items (bundle_id,product_id) VALUES (9999,41)')
+    ).rejects.toMatchObject({ code: '23503' });
+    await pool.query(`INSERT INTO product_bundles (name,bundle_price) VALUES ('New bundle',30);
+      INSERT INTO shifts (user_id,status) VALUES (21,'on_break');
+      INSERT INTO purchase_orders (po_number,status) VALUES ('NEW-PO','Ordered');
+      SELECT user_id FROM notifications WHERE read=0;
+      SELECT contact_info FROM distributors;
+      SELECT image_url,season,is_featured,status,updated_at FROM collections;
+      SELECT rules_json FROM customer_segments;
+      SELECT * FROM storefront_banners;`);
+    const fresh = await database(false);
+    const columns = `SELECT table_name,column_name,data_type FROM information_schema.columns WHERE table_schema=current_schema() ORDER BY table_name,column_name`;
+    const actual = (await pool.query(columns)).rows;
+    for (const expected of (await fresh.query(columns)).rows)
+      expect(actual).toContainEqual(expected);
+  });
+
+  it('rolls back the entire repair on malformed legacy items', async () => {
+    const pool = await database(true);
+    await pool.query(`INSERT INTO layaway (customer_id,total_amount,deposit_amount,balance_remaining,items,expires_at)
+      VALUES (1,10,1,9,'invalid JSON','2030-01-01')`);
+    await expect(runMigrationsUp(pool, dir)).rejects.toMatchObject({ code: '22P02' });
+    expect(
+      (
+        await pool.query(
+          "SELECT to_regclass('layaway')::text AS old, to_regclass('layaway_plans')::text AS renamed"
+        )
+      ).rows[0]
+    ).toEqual({ old: 'layaway', renamed: null });
+    expect(
+      (await pool.query('SELECT name FROM _migrations WHERE name=$1', [migration])).rows
+    ).toHaveLength(0);
+  });
+
+  it('refuses ambiguous duplicate tables without discarding either copy', async () => {
+    const pool = await database(true);
+    await pool.query('CREATE TABLE product_bundles (id integer)');
+    await expect(pool.query(sql)).rejects.toThrow('both bundles and product_bundles exist');
+  });
+});

--- a/server/tests/support/pgMem.ts
+++ b/server/tests/support/pgMem.ts
@@ -26,6 +26,9 @@ import type { Pool as PgPool, PoolClient, QueryResult, QueryResultRow } from 'pg
 const TRAILING_NOT_VALID = /\s+NOT\s+VALID(?=\s*;|\s*$)/gi;
 
 export function toPgMemCompatibleSql(sql: string): string {
+  // 009 upgrades legacy schemas only. pg-mem fixtures start from the corrected 001;
+  // its catalog-driven PL/pgSQL repair is exercised on real PostgreSQL instead.
+  if (sql.includes('DO $repair_009$')) return 'SELECT 1;';
   return sql.replace(TRAILING_NOT_VALID, '');
 }
 


### PR DESCRIPTION
Production databases stamped with the original 001 migration never received later edits to that file, causing missing-table and missing-column errors across favorites, bundles, notifications, collections and other APIs. Add migration 009 to align the exported legacy schema, preserve renamed table IDs and foreign keys, backfill equivalent columns, and import serialized layaway items transactionally. Remove production seeding from the Render startup command.

Validation:
- Restored a full production backup into an isolated local PostgreSQL database. All seven reported routes returned 500 before migration and 200 afterward: favorites, bundles, segments, layaway, distributors, collections, notifications/unread-count.
- Existing table row counts matched before and after, including renamed tables. Production itself was not modified.
- 8 targeted tests passed, including real PostgreSQL upgrade, legacy data preservation, atomic failure and fresh-schema coverage.
- TypeScript and ESLint passed (387 existing lint warnings); all 9 migrations passed the repository round-trip verifier.
- PR CI is green, including server/client checks, migration checks and E2E smoke.

Deployment: preserve the full backup and stop application writes before upgrading. This is a forward repair with an intentionally non-destructive no-op down migration; old code cannot use renamed tables after commit. Confirm the Render dashboard Start Command is npm run migrate && npm run start. Merge and deploy, then verify the seven routes against production.

Unowned legacy notifications remain unassigned; legacy exchange detail and transfer tables remain available for reconciliation. The committed fixture includes schema metadata only, not production records or secrets. Ambiguous or invalid legacy data aborts the upgrade.
