### PR TITLE
fix(a11y): close the three known accessibility gaps (#103, #104, #105)

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -116,20 +116,18 @@ export default tseslint.config(
       'jsx-a11y/no-autofocus': 'off',
 
       /**
-       * These three flag a pattern that is genuinely wrong and genuinely not fixed yet:
-       * `role="status"` on a `<td>` in DataTable and DashboardCharts (#105), and
-       * clickable `<div>`s in StatCard and HeatmapChart. The two sites that used to
-       * lead this list are gone: #103 rebuilt the customer picker on HeroUI's
-       * Autocomplete, and #104 moved the card actions out of the pressable card.
+       * `error`, as the comment that stood here promised once the "Known gaps" list in
+       * `docs/ACCESSIBILITY.md` emptied. #103 rebuilt the customer picker as a real
+       * combobox, #104 moved the card actions out of the pressable card, and #105 moved
+       * the empty-state live regions out of the table cells they were overriding.
        *
-       * `warn` rather than `error` because turning them off would hide the count and
-       * adding file-level disables would hide the locations, and both outlive the excuse.
-       * Every site is enumerated in `docs/ACCESSIBILITY.md` under "Known gaps" with what
-       * it costs a user. Raise these to `error` as that list empties.
+       * They were `warn` because turning them off would have hidden the count and
+       * file-level disables would have hidden the locations. There is now nothing to
+       * hide, and a warning gates nothing: `error` is what stops the next one landing.
        */
-      'jsx-a11y/click-events-have-key-events': 'warn',
-      'jsx-a11y/no-static-element-interactions': 'warn',
-      'jsx-a11y/no-interactive-element-to-noninteractive-role': 'warn',
+      'jsx-a11y/click-events-have-key-events': 'error',
+      'jsx-a11y/no-static-element-interactions': 'error',
+      'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',
 
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       '@typescript-eslint/no-empty-object-type': 'off',

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -117,9 +117,10 @@ export default tseslint.config(
 
       /**
        * These three flag a pattern that is genuinely wrong and genuinely not fixed yet:
-       * clickable `<div>`s with no keyboard path (the custom customer picker in
-       * DeliveryFormDialog) and controls nested inside pressable cards (Collections,
-       * Bundles — the same defect fixed on POS in this change).
+       * controls nested inside pressable cards (Collections, Bundles — the same defect
+       * fixed on POS in #54), a clickable `<div>` in StatCard, and the interactive
+       * element given a non-interactive role in DataTable. The custom customer picker
+       * that used to lead this list is gone: #103 rebuilt it on HeroUI's Autocomplete.
        *
        * `warn` rather than `error` because turning them off would hide the count and
        * adding file-level disables would hide the locations, and both outlive the excuse.

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -117,10 +117,10 @@ export default tseslint.config(
 
       /**
        * These three flag a pattern that is genuinely wrong and genuinely not fixed yet:
-       * controls nested inside pressable cards (Collections, Bundles — the same defect
-       * fixed on POS in #54), a clickable `<div>` in StatCard, and the interactive
-       * element given a non-interactive role in DataTable. The custom customer picker
-       * that used to lead this list is gone: #103 rebuilt it on HeroUI's Autocomplete.
+       * `role="status"` on a `<td>` in DataTable and DashboardCharts (#105), and
+       * clickable `<div>`s in StatCard and HeatmapChart. The two sites that used to
+       * lead this list are gone: #103 rebuilt the customer picker on HeroUI's
+       * Autocomplete, and #104 moved the card actions out of the pressable card.
        *
        * `warn` rather than `error` because turning them off would hide the count and
        * adding file-level disables would hide the locations, and both outlive the excuse.

--- a/client/src/features/analytics/components/DashboardCharts.test.tsx
+++ b/client/src/features/analytics/components/DashboardCharts.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../shared/tests/testUtils';
+import { useSettingsStore } from '../../../shared/store/settingsStore';
+import DashboardCharts from './DashboardCharts';
+import type { CashierPerformance } from '../hooks/useDashboardData';
+
+const CASHIER = {
+  cashier_id: 1,
+  cashier_name: 'Sarah',
+  total_sales: 4,
+  total_revenue: 400,
+  avg_order_value: 100,
+  total_items: 9,
+} as CashierPerformance;
+
+function renderCharts(
+  cashierPerformance: CashierPerformance[] | undefined,
+  cashierLoading = false
+) {
+  return renderWithProviders(
+    <DashboardCharts
+      revenue={[]}
+      revenueLoading={false}
+      topProducts={[]}
+      topLoading={false}
+      paymentMethods={[]}
+      paymentLoading={false}
+      ordersPerDay={[]}
+      ordersLoading={false}
+      cashierPerformance={cashierPerformance}
+      cashierLoading={cashierLoading}
+      categorySales={[]}
+      categoryLoading={false}
+      distributorSales={[]}
+      distributorLoading={false}
+      onExportCsv={() => {}}
+    />
+  );
+}
+
+/**
+ * #105: the cashier table announced its empty state from `role="status"` on the `<td>`,
+ * which stopped the cell being a cell. The region now sits outside the table and outside
+ * the loading branch, so it is mounted before the transition it has to announce.
+ */
+describe('DashboardCharts cashier table announcements', () => {
+  beforeEach(() => useSettingsStore.setState({ locale: 'en' }));
+
+  it('keeps the empty row a real cell with no status role inside the table', () => {
+    renderCharts([]);
+
+    expect(document.querySelector('td[role]')).toBeNull();
+    expect(document.querySelector('table [role="status"]')).toBeNull();
+  });
+
+  it('announces from a region that survives the transition from rows to none', () => {
+    const { rerender } = renderCharts([CASHIER]);
+
+    // Scoped: other cards on this dashboard legitimately own live regions of their own.
+    const region = screen.getByTestId('cashier-performance-status');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveTextContent('1 results');
+
+    rerender(
+      <DashboardCharts
+        revenue={[]}
+        revenueLoading={false}
+        topProducts={[]}
+        topLoading={false}
+        paymentMethods={[]}
+        paymentLoading={false}
+        ordersPerDay={[]}
+        ordersLoading={false}
+        cashierPerformance={[]}
+        cashierLoading={false}
+        categorySales={[]}
+        categoryLoading={false}
+        distributorSales={[]}
+        distributorLoading={false}
+        onExportCsv={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('cashier-performance-status')).toBe(region);
+    expect(region).toHaveTextContent('No results found.');
+    // The table structure survives the swap.
+    expect(screen.getAllByRole('table').length).toBeGreaterThan(0);
+  });
+
+  it('stays silent while the request is still out', () => {
+    renderCharts(undefined, true);
+
+    expect(screen.getByTestId('cashier-performance-status')).toHaveTextContent('');
+  });
+});

--- a/client/src/features/analytics/components/DashboardCharts.tsx
+++ b/client/src/features/analytics/components/DashboardCharts.tsx
@@ -249,6 +249,23 @@ export default function DashboardCharts({
             </Button>
           </CardHeader>
           <CardBody className="p-6" aria-busy={cashierLoading}>
+            {/*
+              Outside the table and outside the loading branch, so it is mounted before
+              the transition it has to announce (#105). Silent while fetching: "no
+              results" is not true of a request that has not answered yet.
+            */}
+            <div
+              className="sr-only"
+              role="status"
+              aria-live="polite"
+              data-testid="cashier-performance-status"
+            >
+              {cashierLoading
+                ? ''
+                : (cashierPerformance?.length ?? 0) === 0
+                  ? t('common.noResults')
+                  : `${cashierPerformance?.length ?? 0} results`}
+            </div>
             {cashierLoading ? (
               <Skeleton className="h-64 w-full rounded-lg" />
             ) : (
@@ -282,12 +299,7 @@ export default function DashboardCharts({
                     ))}
                     {(!cashierPerformance || cashierPerformance.length === 0) && (
                       <tr>
-                        <td
-                          colSpan={5}
-                          className="py-8 text-center text-muted-foreground"
-                          role="status"
-                          aria-live="polite"
-                        >
+                        <td colSpan={5} className="py-8 text-center text-muted-foreground">
                           {t('common.noResults')}
                         </td>
                       </tr>

--- a/client/src/features/analytics/components/charts/HeatmapChart.tsx
+++ b/client/src/features/analytics/components/charts/HeatmapChart.tsx
@@ -97,8 +97,16 @@ export default function HeatmapChart({ data }: HeatmapChartProps) {
                 const opacity = getOpacity(revenue);
 
                 return (
+                  /*
+                   * The tooltip is hover-only, so without a role and a name this cell's
+                   * figures existed for pointer users alone. `img` is the role for a
+                   * graphic whose meaning is its label: it makes each cell one readable
+                   * unit instead of 168 unlabelled boxes.
+                   */
                   <div
                     key={hour}
+                    role="img"
+                    aria-label={`${t(`analytics.day.${day}` as never)} ${String(hour).padStart(2, '0')}:00 — ${formatCurrency(revenue)}, ${point?.order_count ?? 0} ${t('analytics.orderCount')}`}
                     className="flex-1 aspect-square rounded-sm cursor-pointer transition-transform hover:scale-110"
                     style={{
                       backgroundColor:

--- a/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.test.tsx
+++ b/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.test.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { useSettingsStore } from '../../../../shared/store/settingsStore';
+import type { Customer } from '../../../../shared/types/index';
+import DeliveryFormDialog from './DeliveryFormDialog';
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+}));
+
+const LAYLA = {
+  id: 11,
+  name: 'Layla Hassan',
+  phone: '0500000000',
+  address: '12 Olive Street',
+} as Customer;
+
+const OMAR = {
+  id: 12,
+  name: 'Omar Nasser',
+  phone: '0511111111',
+  address: '3 Cedar Road',
+} as Customer;
+
+type HarnessProps = {
+  customers?: Customer[];
+  isLoadingCustomers?: boolean;
+  hasCustomerLoadError?: boolean;
+};
+
+/**
+ * The search term is owned by the page, so the harness owns it too: this drives the
+ * real controlled contract rather than a stub that always echoes what it is given.
+ */
+function Harness({
+  customers = [LAYLA, OMAR],
+  isLoadingCustomers = false,
+  hasCustomerLoadError = false,
+}: HarnessProps) {
+  const [customerSearch, setCustomerSearch] = useState('');
+  return (
+    <DeliveryFormDialog
+      open
+      onOpenChange={() => {}}
+      editingOrder={null}
+      products={[]}
+      productSearch=""
+      onProductSearchChange={() => {}}
+      onLoadMoreProducts={() => {}}
+      isLoadingMoreProducts={false}
+      customers={customers}
+      isLoadingCustomers={isLoadingCustomers}
+      hasCustomerLoadError={hasCustomerLoadError}
+      shippingCompanies={[]}
+      onSubmit={() => {}}
+      isSubmitting={false}
+      customerSearch={customerSearch}
+      onCustomerSearchChange={setCustomerSearch}
+      onOpenCompaniesDialog={() => {}}
+    />
+  );
+}
+
+/**
+ * `hidden: true` because an open popover marks the rest of the dialog aria-hidden,
+ * and the flattened framer-motion mock leaves it mounted after it closes. The
+ * combobox's real exposure while the list is shut is asserted explicitly below.
+ */
+function customerCombobox() {
+  return screen.getByRole('combobox', { name: /select customer/i, hidden: true });
+}
+
+function pressKey(el: Element, key: string) {
+  fireEvent.keyDown(el, { key });
+  fireEvent.keyUp(el, { key });
+}
+
+/**
+ * The open popover marks everything outside itself aria-hidden, so the combobox
+ * drops out of the accessibility tree: hold the element before opening the list.
+ */
+async function openListbox() {
+  const input = customerCombobox();
+  input.focus();
+  pressKey(input, 'ArrowDown');
+  return { input, listbox: within(await screen.findByRole('listbox')) };
+}
+
+/**
+ * react-aria keeps DOM focus on the input and tracks the active option through
+ * aria-activedescendant, so every key goes to the combobox - never to the option.
+ */
+async function chooseOption(name: RegExp) {
+  const { input, listbox } = await openListbox();
+  const option = await listbox.findByRole('option', { name });
+
+  for (let i = 0; i < 20; i += 1) {
+    if (input.getAttribute('aria-activedescendant') === option.id) break;
+    pressKey(input, 'ArrowDown');
+  }
+  expect(input).toHaveAttribute('aria-activedescendant', option.id);
+
+  pressKey(input, 'Enter');
+  return option;
+}
+
+describe('DeliveryFormDialog customer picker', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+  });
+
+  it('exposes a combobox with its expanded state instead of a static div', async () => {
+    render(<Harness />);
+
+    expect(screen.getByRole('combobox', { name: /select customer/i })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    const { input } = await openListbox();
+
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+  });
+
+  it('selects an existing customer with the keyboard and fills the form', async () => {
+    render(<Harness />);
+
+    fireEvent.change(customerCombobox(), { target: { value: 'Layla' } });
+
+    const option = await chooseOption(/Layla Hassan/);
+    expect(option).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/customer name/i)).toHaveValue('Layla Hassan')
+    );
+    expect(screen.getByLabelText(/^phone$/i)).toHaveValue('0500000000');
+    expect(screen.getByLabelText(/address/i)).toHaveValue('12 Olive Street');
+  });
+
+  it('offers the new-customer affordance as a real option and clears the fields', async () => {
+    render(<Harness />);
+
+    await chooseOption(/Layla Hassan/);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/customer name/i)).toHaveValue('Layla Hassan')
+    );
+
+    await chooseOption(/new customer/i);
+
+    await waitFor(() => expect(screen.getByLabelText(/customer name/i)).toHaveValue(''));
+    expect(screen.getByLabelText(/^phone$/i)).toHaveValue('');
+  });
+
+  it('keeps the new-customer option reachable when the search matches nothing', async () => {
+    render(<Harness customers={[]} />);
+
+    fireEvent.change(customerCombobox(), { target: { value: 'nobody' } });
+
+    const { listbox } = await openListbox();
+    expect(await listbox.findByRole('option', { name: /new customer/i })).toBeInTheDocument();
+    expect(listbox.queryByRole('option', { name: /Layla Hassan/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/no customers found/i)).toBeInTheDocument();
+  });
+
+  it('closes the list on Escape and leaves focus on the combobox', async () => {
+    render(<Harness />);
+
+    const { input } = await openListbox();
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+
+    pressKey(input, 'Escape');
+
+    // aria-expanded is what a screen reader reports, and it is the state the
+    // dialog beneath must not have consumed the Escape from.
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'false'));
+    expect(input).toHaveFocus();
+  });
+
+  it('reports a failed customer lookup instead of presenting it as no results', () => {
+    render(<Harness customers={undefined} hasCustomerLoadError />);
+
+    expect(screen.getByRole('combobox', { name: /select customer/i })).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no customers found/i)).not.toBeInTheDocument();
+  });
+
+  it('does not drop a selected customer when a later search no longer returns them', async () => {
+    function Rerenderable() {
+      const [customers, setCustomers] = useState<Customer[]>([LAYLA]);
+      return (
+        <>
+          <button type="button" onClick={() => setCustomers([OMAR])}>
+            move search on
+          </button>
+          <Harness customers={customers} />
+        </>
+      );
+    }
+    render(<Rerenderable />);
+
+    await chooseOption(/Layla Hassan/);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/customer name/i)).toHaveValue('Layla Hassan')
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /move search on/i, hidden: true }));
+
+    const { listbox: reopened } = await openListbox();
+    expect(await reopened.findByRole('option', { name: /Layla Hassan/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByLabelText(/customer name/i)).toHaveValue('Layla Hassan');
+  });
+});

--- a/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.tsx
+++ b/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.tsx
@@ -1,9 +1,11 @@
-import { useState, useEffect, useRef, type ChangeEvent } from 'react';
-import { useForm, useFieldArray } from 'react-hook-form';
+import { useState, useEffect, useMemo, type Key } from 'react';
+import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Plus, Trash2, Search, UserPlus, Check } from 'lucide-react';
 import {
+  Autocomplete,
+  AutocompleteItem,
   Button,
   Input,
   Textarea,
@@ -41,6 +43,10 @@ const getDeliverySchema = () =>
 
 type DeliveryFormData = z.infer<ReturnType<typeof getDeliverySchema>>;
 
+// String keys keep the "new customer" affordance from ever colliding with a numeric customer id.
+const NEW_CUSTOMER_KEY = 'new-customer';
+const customerOptionKey = (id: number) => `customer-${id}`;
+
 interface DeliveryFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -52,6 +58,8 @@ interface DeliveryFormDialogProps {
   onLoadMoreProducts: () => void;
   isLoadingMoreProducts: boolean;
   customers: Customer[] | undefined;
+  isLoadingCustomers?: boolean;
+  hasCustomerLoadError?: boolean;
   shippingCompanies: ShippingCompany[] | undefined;
   onSubmit: (payload: DeliveryPayload) => void;
   isSubmitting: boolean;
@@ -71,6 +79,8 @@ export default function DeliveryFormDialog({
   onLoadMoreProducts,
   isLoadingMoreProducts,
   customers,
+  isLoadingCustomers = false,
+  hasCustomerLoadError = false,
   shippingCompanies,
   onSubmit,
   isSubmitting,
@@ -81,19 +91,6 @@ export default function DeliveryFormDialog({
   const { t } = useTranslation();
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
   const [isNewCustomer, setIsNewCustomer] = useState(false);
-  const [customerDropdownOpen, setCustomerDropdownOpen] = useState(false);
-  const customerDropdownRef = useRef<HTMLDivElement>(null);
-
-  // Close customer dropdown on outside click
-  useEffect(() => {
-    function handleClick(e: globalThis.MouseEvent) {
-      if (customerDropdownRef.current && !customerDropdownRef.current.contains(e.target as Node)) {
-        setCustomerDropdownOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, []);
 
   const {
     register,
@@ -124,7 +121,7 @@ export default function DeliveryFormDialog({
   useEffect(() => {
     if (open && !editingOrder) {
       setSelectedCustomer(null);
-      setIsNewCustomer(true);
+      setIsNewCustomer(false);
       onCustomerSearchChange('');
       const defaultEstimated = new Date();
       defaultEstimated.setDate(defaultEstimated.getDate() + 3);
@@ -164,8 +161,6 @@ export default function DeliveryFormDialog({
   const selectCustomer = (customer: Customer) => {
     setSelectedCustomer(customer);
     setIsNewCustomer(false);
-    setCustomerDropdownOpen(false);
-    onCustomerSearchChange('');
     setValue('customer_name', customer.name);
     setValue('phone', customer.phone);
     setValue('address', customer.address || '');
@@ -174,11 +169,40 @@ export default function DeliveryFormDialog({
   const selectNewCustomer = () => {
     setSelectedCustomer(null);
     setIsNewCustomer(true);
-    setCustomerDropdownOpen(false);
-    onCustomerSearchChange('');
     setValue('customer_name', '');
     setValue('phone', '');
     setValue('address', '');
+  };
+
+  // The selected customer stays in the list even after the remote search moves on,
+  // so a later query can never silently drop the selection the form was built from.
+  const customerOptions = useMemo(() => {
+    const results = customers ?? [];
+    if (selectedCustomer && !results.some((c) => c.id === selectedCustomer.id)) {
+      return [selectedCustomer, ...results];
+    }
+    return results;
+  }, [customers, selectedCustomer]);
+
+  const selectedCustomerKey = selectedCustomer
+    ? customerOptionKey(selectedCustomer.id)
+    : isNewCustomer
+      ? NEW_CUSTOMER_KEY
+      : null;
+
+  const handleCustomerSelection = (key: Key | null) => {
+    if (key === null) {
+      // Cleared: drop the selection but keep whatever the cashier has already typed.
+      setSelectedCustomer(null);
+      setIsNewCustomer(false);
+      return;
+    }
+    if (key === NEW_CUSTOMER_KEY) {
+      selectNewCustomer();
+      return;
+    }
+    const match = customerOptions.find((c) => customerOptionKey(c.id) === key);
+    if (match) selectCustomer(match);
   };
 
   return (
@@ -211,108 +235,125 @@ export default function DeliveryFormDialog({
             </ModalHeader>
             <ModalBody className="py-4 space-y-4">
               {/* Customer selector */}
-              <div className="space-y-1.5" ref={customerDropdownRef}>
-                <p className="text-xs font-medium text-foreground">
-                  {t('deliveries.selectCustomer')}
-                </p>
-                <div className="relative">
-                  <div
-                    className="flex h-10 w-full items-center rounded-lg border border-border bg-card px-3 py-2 text-sm cursor-pointer hover:border-primary/50 transition-colors"
-                    onClick={() => setCustomerDropdownOpen(!customerDropdownOpen)}
-                  >
-                    <Search className="h-4 w-4 me-2 text-muted-foreground shrink-0" />
-                    {selectedCustomer ? (
-                      <span className="truncate font-medium text-foreground">
-                        {selectedCustomer.name} — {selectedCustomer.phone}
-                      </span>
-                    ) : isNewCustomer ? (
-                      <span className="text-foreground">{t('deliveries.newCustomer')}</span>
-                    ) : (
-                      <span className="text-muted-foreground">
-                        {t('deliveries.searchCustomer')}
-                      </span>
-                    )}
-                  </div>
-                  {customerDropdownOpen && (
-                    <div className="absolute z-50 mt-1 w-full rounded-lg border border-border bg-card shadow-xl max-h-60 overflow-y-auto">
-                      <div className="p-2">
-                        <Input
-                          placeholder={t('deliveries.searchCustomer')}
-                          value={customerSearch}
-                          size="sm"
-                          variant="bordered"
-                          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                            onCustomerSearchChange(e.target.value)
-                          }
-                          autoFocus
-                        />
-                      </div>
-                      <div
-                        className="flex items-center gap-2 px-3 py-2.5 cursor-pointer hover:bg-muted/50 text-sm border-b border-border"
-                        onClick={selectNewCustomer}
-                      >
-                        <UserPlus className="h-4 w-4 text-primary shrink-0" />
-                        <span className="font-medium text-foreground">
-                          {t('deliveries.newCustomer')}
-                        </span>
-                        {isNewCustomer && !selectedCustomer && (
-                          <Check className="h-4 w-4 ms-auto text-primary" />
-                        )}
-                      </div>
-                      {customers && customers.length > 0 ? (
-                        customers.map((c) => (
-                          <div
-                            key={c.id}
-                            className="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-muted/50 text-sm"
-                            onClick={() => selectCustomer(c)}
-                          >
-                            <div className="flex-1 min-w-0">
-                              <div className="font-medium text-foreground truncate">{c.name}</div>
-                              <div className="text-xs text-muted-foreground font-data">
-                                {c.phone}
-                              </div>
-                            </div>
-                            {selectedCustomer?.id === c.id && (
-                              <Check className="h-4 w-4 shrink-0 text-primary" />
-                            )}
-                          </div>
-                        ))
-                      ) : (
-                        <div className="px-3 py-2 text-sm text-muted-foreground">
-                          {t('deliveries.noCustomersFound')}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <Input
-                  label={t('deliveries.customerName')}
-                  size="sm"
-                  variant="bordered"
-                  {...register('customer_name')}
-                  isInvalid={!!errors.customer_name}
-                  errorMessage={errors.customer_name?.message}
-                />
-                <Input
-                  label={t('deliveries.phone')}
-                  size="sm"
-                  variant="bordered"
-                  {...register('phone')}
-                  isInvalid={!!errors.phone}
-                  errorMessage={errors.phone?.message}
-                />
-              </div>
-              <Textarea
-                label={t('deliveries.address')}
+              <Autocomplete
+                label={t('deliveries.selectCustomer')}
+                placeholder={t('deliveries.searchCustomer')}
                 size="sm"
                 variant="bordered"
-                minRows={2}
-                {...register('address')}
-                isInvalid={!!errors.address}
-                errorMessage={errors.address?.message}
+                startContent={<Search className="h-4 w-4 text-muted-foreground shrink-0" />}
+                inputValue={customerSearch}
+                onInputChange={onCustomerSearchChange}
+                selectedKey={selectedCustomerKey}
+                onSelectionChange={handleCustomerSelection}
+                // Results are already filtered by the server; filtering them again
+                // client-side would hide rows the query deliberately returned.
+                defaultFilter={() => true}
+                allowsEmptyCollection
+                isLoading={isLoadingCustomers}
+                isInvalid={hasCustomerLoadError}
+                errorMessage={hasCustomerLoadError ? t('common.error') : undefined}
+                description={
+                  !hasCustomerLoadError &&
+                  !isLoadingCustomers &&
+                  customerSearch.length > 0 &&
+                  customerOptions.length === 0
+                    ? t('deliveries.noCustomersFound')
+                    : undefined
+                }
+                data-testid="delivery-customer-picker"
+              >
+                {[
+                  <AutocompleteItem
+                    key={NEW_CUSTOMER_KEY}
+                    textValue={t('deliveries.newCustomer')}
+                    startContent={<UserPlus className="h-4 w-4 text-primary shrink-0" />}
+                    endContent={
+                      isNewCustomer ? <Check className="h-4 w-4 text-primary" /> : undefined
+                    }
+                  >
+                    <span className="font-medium">{t('deliveries.newCustomer')}</span>
+                  </AutocompleteItem>,
+                  ...customerOptions.map((c) => (
+                    <AutocompleteItem
+                      key={customerOptionKey(c.id)}
+                      textValue={c.name}
+                      endContent={
+                        selectedCustomer?.id === c.id ? (
+                          <Check className="h-4 w-4 text-primary" />
+                        ) : undefined
+                      }
+                    >
+                      <div className="min-w-0">
+                        <div className="font-medium text-foreground truncate">{c.name}</div>
+                        <div className="text-xs text-muted-foreground font-data">{c.phone}</div>
+                      </div>
+                    </AutocompleteItem>
+                  )),
+                ]}
+              </Autocomplete>
+
+              {/*
+                HeroUI's Input keeps its own controlled value, so an imperative
+                setValue from the picker is overwritten on the next render. These
+                three fields are the ones the picker writes, so they are bound
+                through Controller rather than register.
+              */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Controller
+                  control={control}
+                  name="customer_name"
+                  render={({ field }) => (
+                    <Input
+                      label={t('deliveries.customerName')}
+                      size="sm"
+                      variant="bordered"
+                      value={field.value ?? ''}
+                      onValueChange={field.onChange}
+                      onBlur={field.onBlur}
+                      name={field.name}
+                      ref={field.ref}
+                      isInvalid={!!errors.customer_name}
+                      errorMessage={errors.customer_name?.message}
+                    />
+                  )}
+                />
+                <Controller
+                  control={control}
+                  name="phone"
+                  render={({ field }) => (
+                    <Input
+                      label={t('deliveries.phone')}
+                      size="sm"
+                      variant="bordered"
+                      value={field.value ?? ''}
+                      onValueChange={field.onChange}
+                      onBlur={field.onBlur}
+                      name={field.name}
+                      ref={field.ref}
+                      isInvalid={!!errors.phone}
+                      errorMessage={errors.phone?.message}
+                    />
+                  )}
+                />
+              </div>
+              <Controller
+                control={control}
+                name="address"
+                render={({ field }) => (
+                  <Textarea
+                    label={t('deliveries.address')}
+                    size="sm"
+                    variant="bordered"
+                    minRows={2}
+                    value={field.value ?? ''}
+                    onValueChange={field.onChange}
+                    onBlur={field.onBlur}
+                    name={field.name}
+                    ref={field.ref}
+                    isInvalid={!!errors.address}
+                    errorMessage={errors.address?.message}
+                  />
+                )}
               />
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <Textarea

--- a/client/src/features/fulfillment/pages/Deliveries.tsx
+++ b/client/src/features/fulfillment/pages/Deliveries.tsx
@@ -121,7 +121,11 @@ export default function Deliveries() {
     fetchNextPage: loadMoreProducts,
     isFetchingNextPage: isLoadingMoreProducts,
   } = useProductCatalog({ search: debouncedProductSearch, enabled: isAdmin && dialogOpen });
-  const { data: customers } = useApiQuery<Customer[]>(
+  const {
+    data: customers,
+    isFetching: isLoadingCustomers,
+    isError: hasCustomerLoadError,
+  } = useApiQuery<Customer[]>(
     ['customers', { search: customerSearch }],
     'customers',
     { search: customerSearch || undefined },
@@ -488,6 +492,8 @@ export default function Deliveries() {
         onLoadMoreProducts={() => void loadMoreProducts()}
         isLoadingMoreProducts={isLoadingMoreProducts}
         customers={customers}
+        isLoadingCustomers={isLoadingCustomers}
+        hasCustomerLoadError={hasCustomerLoadError}
         shippingCompanies={shippingCompanies}
         onSubmit={(payload: DeliveryPayload) =>
           saveOrder.save({ id: editingOrder?.id ?? null, ...payload })

--- a/client/src/features/inventory/pages/Bundles.test.tsx
+++ b/client/src/features/inventory/pages/Bundles.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '../../../shared/lib/transport';
+import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
+import { useSettingsStore } from '../../../shared/store/settingsStore';
+import BundlesPage from './Bundles';
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+}));
+
+function wrapperFor(transport: MemoryTransport) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+const bundle = (id: number, name: string) => ({
+  id,
+  name,
+  description: null,
+  price: 200,
+  status: 'active',
+  items: [],
+  original_price: 260,
+  savings: 60,
+  savings_percent: 23,
+  created_at: '2026-09-01T00:00:00.000Z',
+});
+
+function renderBundles() {
+  const transport = createMemoryTransport({
+    bundles: [bundle(1, 'Winter capsule'), bundle(2, 'Resort set')],
+  });
+  render(<BundlesPage />, { wrapper: wrapperFor(transport) });
+  return transport;
+}
+
+/**
+ * #104: the edit and delete buttons used to sit inside a pressable card, which HeroUI
+ * renders as a `<button>`. A screen reader could not reach them as separate controls
+ * and the card's name absorbed their labels.
+ */
+describe('Bundles card actions', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  let error: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    error = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    error.mockRestore();
+  });
+
+  it('renders no button inside another button, and React logs no nesting warning', async () => {
+    renderBundles();
+    await screen.findByText('Winter capsule');
+
+    expect(document.querySelector('button button')).toBeNull();
+
+    const nesting = [...warn.mock.calls, ...error.mock.calls]
+      .flat()
+      .filter((arg): arg is string => typeof arg === 'string')
+      .filter((message) => message.includes('validateDOMNesting'));
+    expect(nesting).toEqual([]);
+  });
+
+  it('names each row action for its own bundle rather than repeating a bare verb', async () => {
+    renderBundles();
+    await screen.findByText('Winter capsule');
+
+    expect(screen.getByRole('button', { name: 'Winter capsule: Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Winter capsule: Delete' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resort set: Edit' })).toBeInTheDocument();
+  });
+
+  it('opens the edit dialog without also opening the bundle the card points at', async () => {
+    renderBundles();
+    await screen.findByText('Winter capsule');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Winter capsule: Edit' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByDisplayValue('Winter capsule')).toBeInTheDocument();
+    // The card's own press swaps the grid for a detail view with a Back control.
+    // Its absence is what proves the press did not fire alongside the edit action.
+    expect(screen.queryByRole('button', { name: /back/i })).not.toBeInTheDocument();
+  });
+
+  it('opens the bundle detail when the card itself is activated', async () => {
+    renderBundles();
+    const card = (await screen.findByText('Winter capsule')).closest('button');
+    expect(card).not.toBeNull();
+
+    fireEvent.click(card as HTMLElement);
+
+    expect(await screen.findByRole('button', { name: /back/i })).toBeInTheDocument();
+  });
+});

--- a/client/src/features/inventory/pages/Bundles.tsx
+++ b/client/src/features/inventory/pages/Bundles.tsx
@@ -315,69 +315,81 @@ export default function BundlesPage() {
           </div>
         ) : (
           rows.map((bundle) => (
-            <Card
-              key={bundle.id}
-              isPressable
-              onPress={() => setSelectedBundle(bundle.id)}
-              className="border border-border bg-card hover:border-primary/50 transition-colors shadow-sm"
-            >
-              <CardBody className="p-4">
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="font-semibold text-base text-foreground">{bundle.name}</h3>
-                  <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      size="sm"
-                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                      onClick={() => openEditDialog(bundle)}
-                      aria-label={t('common.edit')}
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </Button>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      color="danger"
-                      size="sm"
-                      className="h-8 w-8"
-                      onClick={() => remover.remove(bundle.id)}
-                      aria-label={t('common.delete')}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
+            /**
+             * The edit and delete controls are SIBLINGS of the card, not children of
+             * it (#104). `isPressable` renders the card as a `<button>`, so buttons
+             * inside it were nested interactive controls: invalid HTML, axe's
+             * `nested-interactive`, and a card whose accessible name swallowed both
+             * labels. The `<div onClick={stopPropagation}>` that used to wrap them was
+             * a symptom of the same nesting. This mirrors the POS product grid.
+             */
+            <div key={bundle.id} className="relative">
+              <Card
+                isPressable
+                onPress={() => setSelectedBundle(bundle.id)}
+                className="w-full border border-border bg-card hover:border-primary/50 transition-colors shadow-sm"
+              >
+                <CardBody className="p-4">
+                  <div className="flex items-center justify-between mb-2">
+                    <h3 className="font-semibold text-base text-foreground">{bundle.name}</h3>
+                    {/* Space for the action buttons rendered as siblings below. */}
+                    <span className="h-8 w-[4.25rem] shrink-0" aria-hidden="true" />
                   </div>
-                </div>
-                <div className="flex gap-2 mb-2">
-                  <Badge size="sm" variant={bundle.status === 'active' ? 'success' : 'default'}>
-                    {t(`bundles.${bundle.status}` as never)}
-                  </Badge>
-                  {bundle.savings_percent > 0 && (
-                    <Badge size="sm" variant="warning">
-                      <Percent className="h-2.5 w-2.5 inline-block me-0.5" />
-                      {t('bundles.savingsPercent', { percent: String(bundle.savings_percent) })}
+                  <div className="flex gap-2 mb-2">
+                    <Badge size="sm" variant={bundle.status === 'active' ? 'success' : 'default'}>
+                      {t(`bundles.${bundle.status}` as never)}
                     </Badge>
+                    {bundle.savings_percent > 0 && (
+                      <Badge size="sm" variant="warning">
+                        <Percent className="h-2.5 w-2.5 inline-block me-0.5" />
+                        {t('bundles.savingsPercent', { percent: String(bundle.savings_percent) })}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-sm text-muted-foreground line-through font-data">
+                      {formatCurrency(bundle.original_price)}
+                    </span>
+                    <span className="text-lg font-bold text-primary font-data">
+                      {formatCurrency(bundle.price)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Package className="h-3.5 w-3.5" />
+                    <span>{t('bundles.itemCount', { count: String(bundle.items.length) })}</span>
+                  </div>
+                  {bundle.description && (
+                    <p className="text-xs text-muted-foreground mt-2 line-clamp-2">
+                      {bundle.description}
+                    </p>
                   )}
-                </div>
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm text-muted-foreground line-through font-data">
-                    {formatCurrency(bundle.original_price)}
-                  </span>
-                  <span className="text-lg font-bold text-primary font-data">
-                    {formatCurrency(bundle.price)}
-                  </span>
-                </div>
-                <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                  <Package className="h-3.5 w-3.5" />
-                  <span>{t('bundles.itemCount', { count: String(bundle.items.length) })}</span>
-                </div>
-                {bundle.description && (
-                  <p className="text-xs text-muted-foreground mt-2 line-clamp-2">
-                    {bundle.description}
-                  </p>
-                )}
-              </CardBody>
-            </Card>
+                </CardBody>
+              </Card>
+              {/* Named per row: a bare "Edit" repeats on every card and identifies none. */}
+              <div className="absolute top-3 end-3 z-20 flex gap-1">
+                <Button
+                  isIconOnly
+                  variant="light"
+                  size="sm"
+                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={() => openEditDialog(bundle)}
+                  aria-label={`${bundle.name}: ${t('common.edit')}`}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  isIconOnly
+                  variant="light"
+                  color="danger"
+                  size="sm"
+                  className="h-8 w-8"
+                  onClick={() => remover.remove(bundle.id)}
+                  aria-label={`${bundle.name}: ${t('common.delete')}`}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
           ))
         )}
       </div>

--- a/client/src/features/inventory/pages/Collections.test.tsx
+++ b/client/src/features/inventory/pages/Collections.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -136,7 +136,8 @@ describe('Collections product editing wire contract', () => {
     });
     render(<CollectionsPage />, { wrapper: wrapperFor(transport) });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    // Named per collection since #104: a bare "Edit" repeats on every card.
+    fireEvent.click(await screen.findByRole('button', { name: 'Autumn window: Edit' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
@@ -161,5 +162,67 @@ describe('Collections product editing wire contract', () => {
       expect(write).toBeDefined();
       expect((write!.body as Record<string, unknown>).expected_updated_at).toBeUndefined();
     });
+  });
+});
+
+/**
+ * #104: the edit and delete buttons used to sit inside the pressable card, which HeroUI
+ * renders as a `<button>`. Invalid HTML, axe's `nested-interactive`, and a card whose
+ * accessible name absorbed both labels.
+ */
+describe('Collections card actions', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  let error: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    error = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    error.mockRestore();
+  });
+
+  const renderGrid = () => {
+    const transport = createMemoryTransport({
+      collections: [featuredCollection(), { ...featuredCollection(), id: 2, name: 'Resort edit' }],
+      products: [],
+    });
+    render(<CollectionsPage />, { wrapper: wrapperFor(transport) });
+  };
+
+  it('renders no button inside another button, and React logs no nesting warning', async () => {
+    renderGrid();
+    await screen.findByText('Autumn window');
+
+    expect(document.querySelector('button button')).toBeNull();
+
+    const nesting = [...warn.mock.calls, ...error.mock.calls]
+      .flat()
+      .filter((arg): arg is string => typeof arg === 'string')
+      .filter((message) => message.includes('validateDOMNesting'));
+    expect(nesting).toEqual([]);
+  });
+
+  it('names each row action for its own collection rather than repeating a bare verb', async () => {
+    renderGrid();
+    await screen.findByText('Autumn window');
+
+    expect(screen.getByRole('button', { name: 'Autumn window: Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Autumn window: Delete' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resort edit: Edit' })).toBeInTheDocument();
+  });
+
+  it('opens the detail view when the card itself is activated, not the edit dialog', async () => {
+    renderGrid();
+    const card = (await screen.findByText('Autumn window')).closest('button');
+    expect(card).not.toBeNull();
+
+    fireEvent.click(card as HTMLElement);
+
+    expect(await screen.findByRole('button', { name: 'Add Product' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/client/src/features/inventory/pages/Collections.tsx
+++ b/client/src/features/inventory/pages/Collections.tsx
@@ -314,78 +314,90 @@ export default function CollectionsPage() {
           </div>
         ) : (
           rows.map((col) => (
-            <Card
-              key={col.id}
-              isPressable
-              onPress={() => setSelectedCol(col.id)}
-              className="border border-border bg-card hover:border-primary/50 transition-colors shadow-sm"
-            >
-              <CardBody className="p-4">
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="font-semibold text-base text-foreground">{col.name}</h3>
-                  <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      size="sm"
-                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                      onClick={() => editor.openEdit(col)}
-                      aria-label={t('common.edit')}
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </Button>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      color="danger"
-                      size="sm"
-                      className="h-8 w-8"
-                      onClick={() => remover.remove(col.id)}
-                      aria-label={t('common.delete')}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
+            /**
+             * The edit and delete controls are SIBLINGS of the card, not children of
+             * it (#104). `isPressable` renders the card as a `<button>`, so buttons
+             * inside it were nested interactive controls: invalid HTML, axe's
+             * `nested-interactive`, and a card whose accessible name swallowed both
+             * labels. The `<div onClick={stopPropagation}>` that used to wrap them was
+             * a symptom of the same nesting. This mirrors the POS product grid.
+             */
+            <div key={col.id} className="relative">
+              <Card
+                isPressable
+                onPress={() => setSelectedCol(col.id)}
+                className="w-full border border-border bg-card hover:border-primary/50 transition-colors shadow-sm"
+              >
+                <CardBody className="p-4">
+                  <div className="flex items-center justify-between mb-2">
+                    <h3 className="font-semibold text-base text-foreground">{col.name}</h3>
+                    {/* Space for the action buttons rendered as siblings below. */}
+                    <span className="h-8 w-[4.25rem] shrink-0" aria-hidden="true" />
                   </div>
-                </div>
-                <div className="flex gap-2 mb-2">
-                  <Badge
-                    size="sm"
-                    variant={
-                      col.status === 'active'
-                        ? 'success'
-                        : col.status === 'upcoming'
-                          ? 'primary'
-                          : col.status === 'on_sale'
-                            ? 'warning'
-                            : 'default'
-                    }
-                  >
-                    {t(`collections.${col.status}` as never)}
-                  </Badge>
-                  {col.season && (
-                    <Badge size="sm" variant="default">
-                      {t(`collections.${col.season.toLowerCase()}` as never)}
+                  <div className="flex gap-2 mb-2">
+                    <Badge
+                      size="sm"
+                      variant={
+                        col.status === 'active'
+                          ? 'success'
+                          : col.status === 'upcoming'
+                            ? 'primary'
+                            : col.status === 'on_sale'
+                              ? 'warning'
+                              : 'default'
+                      }
+                    >
+                      {t(`collections.${col.status}` as never)}
                     </Badge>
-                  )}
-                  {col.year && (
-                    <span className="text-xs text-muted-foreground font-data self-center">
-                      {col.year}
+                    {col.season && (
+                      <Badge size="sm" variant="default">
+                        {t(`collections.${col.season.toLowerCase()}` as never)}
+                      </Badge>
+                    )}
+                    {col.year && (
+                      <span className="text-xs text-muted-foreground font-data self-center">
+                        {col.year}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Package className="h-3.5 w-3.5" />
+                    <span>
+                      {col.product_count} {t('collections.products').toLowerCase()}
                     </span>
+                  </div>
+                  {col.description && (
+                    <p className="text-xs text-muted-foreground mt-2 line-clamp-2">
+                      {col.description}
+                    </p>
                   )}
-                </div>
-                <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                  <Package className="h-3.5 w-3.5" />
-                  <span>
-                    {col.product_count} {t('collections.products').toLowerCase()}
-                  </span>
-                </div>
-                {col.description && (
-                  <p className="text-xs text-muted-foreground mt-2 line-clamp-2">
-                    {col.description}
-                  </p>
-                )}
-              </CardBody>
-            </Card>
+                </CardBody>
+              </Card>
+              {/* Named per row: a bare "Edit" repeats on every card and identifies none. */}
+              <div className="absolute top-3 end-3 z-20 flex gap-1">
+                <Button
+                  isIconOnly
+                  variant="light"
+                  size="sm"
+                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={() => editor.openEdit(col)}
+                  aria-label={`${col.name}: ${t('common.edit')}`}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  isIconOnly
+                  variant="light"
+                  color="danger"
+                  size="sm"
+                  className="h-8 w-8"
+                  onClick={() => remover.remove(col.id)}
+                  aria-label={`${col.name}: ${t('common.delete')}`}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
           ))
         )}
       </div>

--- a/client/src/shared/components/EmptyState.tsx
+++ b/client/src/shared/components/EmptyState.tsx
@@ -7,6 +7,15 @@ interface EmptyStateProps {
   description?: string;
   actionLabel?: string;
   onAction?: () => void;
+  /**
+   * Whether this element is its own live region.
+   *
+   * Standalone callers keep it: the component mounting *is* the news. A caller that
+   * already owns a persistent live region must pass `false`, or the page announces the
+   * same emptiness twice — and from a region that did not exist a moment earlier, which
+   * is the mounting pattern that announces unreliably in the first place.
+   */
+  announce?: boolean;
 }
 
 export default function EmptyState({
@@ -15,12 +24,12 @@ export default function EmptyState({
   description,
   actionLabel,
   onAction,
+  announce = true,
 }: EmptyStateProps) {
   return (
     <div
       className="flex flex-col items-center justify-center py-12 text-center"
-      role="status"
-      aria-live="polite"
+      {...(announce ? { role: 'status', 'aria-live': 'polite' as const } : {})}
     >
       <div className="h-12 w-12 rounded-full bg-accent flex items-center justify-center mb-3 text-muted-foreground">
         <Icon className="h-6 w-6" />

--- a/client/src/shared/components/__tests__/DataTable.test.tsx
+++ b/client/src/shared/components/__tests__/DataTable.test.tsx
@@ -120,7 +120,9 @@ describe('Unit 4: Enterprise DataTable Suite', () => {
       );
 
       expect(screen.getByText('Alice Smith')).toBeInTheDocument();
-      expect(screen.getByRole('status', { name: /loading results/i })).toBeInTheDocument();
+      // `status` takes no name from its content, so the region is nameless by design
+      // and its text is the announcement. One region, one source (#105).
+      expect(screen.getByRole('status')).toHaveTextContent('Loading results');
     });
 
     it('shows a retryable error without removing stale rows', () => {
@@ -152,7 +154,8 @@ describe('Unit 4: Enterprise DataTable Suite', () => {
         />
       );
 
-      expect(screen.getByText('No matching users')).toBeInTheDocument();
+      // Twice on purpose since #105: once visibly in the cell, once in the live region.
+      expect(screen.getAllByText('No matching users')).toHaveLength(2);
       expect(screen.queryByText('No users yet')).not.toBeInTheDocument();
     });
   });
@@ -176,5 +179,78 @@ describe('Unit 4: Enterprise DataTable Suite', () => {
       expect(screen.getByText('2 selected')).toBeInTheDocument();
       expect(screen.getByTestId('bulk-delete')).toBeInTheDocument();
     });
+  });
+});
+
+/**
+ * #105: the empty state used to declare `role="status" aria-live="polite"` on the `<td>`
+ * itself, which overrode the cell's table semantics — and, being mounted at the same
+ * moment as its own message, was the pattern that announces least reliably.
+ */
+describe('DataTable empty-state announcements', () => {
+  const renderTable = (props: Partial<Parameters<typeof DataTable<TestUser>>[0]> = {}) =>
+    renderWithProviders(
+      <DataTable<TestUser> mode="server" data={testData} columns={columns} {...props} />
+    );
+
+  it('leaves the empty row a real cell, with no table element carrying a status role', () => {
+    renderTable({ data: [], emptyTitle: 'No users yet' });
+
+    expect(document.querySelector('td[role]')).toBeNull();
+    expect(document.querySelector('table [role="status"]')).toBeNull();
+    // The cell is still a cell: the row it sits in still describes a table structure.
+    expect(screen.getByRole('cell')).toBeInTheDocument();
+  });
+
+  it('announces from one region that was already mounted when the rows were there', () => {
+    const { rerender } = renderTable({ totalRows: 3 });
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('3 results');
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+
+    rerender(
+      <DataTable<TestUser>
+        mode="server"
+        data={[]}
+        columns={columns}
+        totalRows={0}
+        search="zzz"
+        filteredEmptyTitle="No matching users"
+      />
+    );
+
+    // The same node, updated — not a new one mounted alongside the message.
+    expect(screen.getByRole('status')).toBe(region);
+    expect(region).toHaveTextContent('No matching users');
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+  });
+
+  it('keeps announcing when rows come back and go away again', () => {
+    const { rerender } = renderTable({ data: [], totalRows: 0, emptyTitle: 'No users yet' });
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('No users yet');
+
+    rerender(<DataTable<TestUser> mode="server" data={testData} columns={columns} totalRows={3} />);
+    expect(region).toHaveTextContent('3 results');
+
+    rerender(
+      <DataTable<TestUser>
+        mode="server"
+        data={[]}
+        columns={columns}
+        totalRows={0}
+        emptyTitle="No users yet"
+      />
+    );
+    expect(region).toHaveTextContent('No users yet');
+  });
+
+  it('does not claim there are no results while the request is still out', () => {
+    renderTable({ data: [], totalRows: 0, isFetching: true, emptyTitle: 'No users yet' });
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('Loading results');
+    expect(region).not.toHaveTextContent('No users yet');
   });
 });

--- a/client/src/shared/components/__tests__/EmptyState.test.tsx
+++ b/client/src/shared/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { Search } from 'lucide-react';
+import { renderWithProviders } from '../../tests/testUtils';
+import EmptyState from '../EmptyState';
+
+/**
+ * #105: DataTable owns a persistent live region, so the EmptyState it renders inside a
+ * table cell must not be one as well. Every other caller mounts this component *as* the
+ * news and keeps the announcement.
+ */
+describe('EmptyState announcement mode', () => {
+  it('is its own live region by default, for callers that have no other', () => {
+    renderWithProviders(<EmptyState icon={Search} title="No users yet" />);
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('No users yet');
+  });
+
+  it('renders the same content with no live region when the caller owns one', () => {
+    renderWithProviders(<EmptyState icon={Search} title="No users yet" announce={false} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.getByText('No users yet')).toBeInTheDocument();
+  });
+});

--- a/client/src/shared/components/data-display/StatCard.tsx
+++ b/client/src/shared/components/data-display/StatCard.tsx
@@ -1,4 +1,9 @@
-import React, { isValidElement, type ReactNode, type ComponentType } from 'react';
+import React, {
+  isValidElement,
+  type ReactNode,
+  type ComponentType,
+  type KeyboardEvent,
+} from 'react';
 import { TrendingUp, TrendingDown, Minus, type LucideIcon } from 'lucide-react';
 import { Skeleton } from './SkeletonLoader';
 
@@ -120,21 +125,29 @@ export function StatCard({
 
   const isClickable = Boolean(onClick);
 
+  /**
+   * All of it or none of it. A non-clickable card carried a click handler and a
+   * `tabIndex` expression anyway, which put a `region` in the tab order with a handler
+   * that did nothing — and left `jsx-a11y` unable to see that the clickable branch is
+   * fully keyboard-operable.
+   */
+  const interaction = isClickable
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        onClick,
+        onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClick?.();
+          }
+        },
+      }
+    : { role: 'region' };
+
   return (
     <div
-      role={isClickable ? 'button' : 'region'}
-      tabIndex={isClickable ? 0 : undefined}
-      onClick={onClick}
-      onKeyDown={
-        isClickable
-          ? (e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onClick?.();
-              }
-            }
-          : undefined
-      }
+      {...interaction}
       aria-label={`${title}: ${typeof value === 'string' || typeof value === 'number' ? value : ''}`}
       className={`rounded-xl border border-border bg-card p-5 shadow-sm transition-all ${
         isClickable

--- a/client/src/shared/components/data-table/DataTable.tsx
+++ b/client/src/shared/components/data-table/DataTable.tsx
@@ -145,15 +145,32 @@ export function DataTable<TData>({
   const startRow = totalRowCount === 0 ? 0 : pageIndex * pageSize + 1;
   const endRow = Math.min((pageIndex + 1) * pageSize, totalRowCount);
 
+  const showingFiltered = Boolean(activeGlobalFilter) || isFiltered;
+  const resolvedEmptyTitle =
+    (showingFiltered ? filteredEmptyTitle : emptyTitle) || t('common.noResults');
+  const resolvedEmptyDescription =
+    (showingFiltered ? filteredEmptyDescription : emptyDescription) || t('common.noResultsDesc');
+  const hasNoRows = table.getRowModel().rows.length === 0;
+
+  /**
+   * The table's single announcement source (#105).
+   *
+   * It lives outside the table and is mounted for the component's whole life, because a
+   * live region only announces content that changes *while it is already in the DOM* —
+   * one rendered alongside its own message has nothing to announce. The empty state used
+   * to declare `role="status"` on the `<td>` instead, which both stripped the cell of its
+   * table semantics and competed with this region for the same news.
+   */
+  const statusMessage = isFetching
+    ? 'Loading results'
+    : hasNoRows
+      ? resolvedEmptyTitle
+      : `${totalRowCount} results`;
+
   return (
     <div className={`space-y-4 ${className}`} aria-busy={isFetching || undefined}>
-      <div
-        className="sr-only"
-        role="status"
-        aria-live="polite"
-        aria-label={isFetching ? 'Loading results' : 'Results loaded'}
-      >
-        {isFetching ? 'Loading results' : `${totalRowCount} results`}
+      <div className="sr-only" role="status" aria-live="polite">
+        {statusMessage}
       </div>
       {/* Top Action Bar */}
       <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-3 flex-wrap">
@@ -269,18 +286,13 @@ export function DataTable<TData>({
             <tbody>
               {table.getRowModel().rows.length === 0 ? (
                 <tr>
-                  <td colSpan={columns.length} role="status" aria-live="polite" className="py-8">
+                  <td colSpan={columns.length} className="py-8">
+                    {/* A plain cell: the announcement is the sr-only region above. */}
                     <EmptyState
                       icon={Search}
-                      title={
-                        (activeGlobalFilter || isFiltered ? filteredEmptyTitle : emptyTitle) ||
-                        t('common.noResults')
-                      }
-                      description={
-                        (activeGlobalFilter || isFiltered
-                          ? filteredEmptyDescription
-                          : emptyDescription) || t('common.noResultsDesc')
-                      }
+                      title={resolvedEmptyTitle}
+                      description={resolvedEmptyDescription}
+                      announce={false}
                     />
                   </td>
                 </tr>

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -28,13 +28,12 @@ rules to `error` as this list empties, which #105 is the last one blocking.
 
 | Gap | Issue | Where | What it costs a user |
 | --- | --- | --- | --- |
-| Controls nested inside pressable cards | **#104** (P3) | `features/inventory/pages/Collections.tsx`, `features/inventory/pages/Bundles.tsx` | The edit/delete buttons sit inside a card that is itself a `<button>`. Invalid HTML; the inner controls are not separately reachable and the card's accessible name absorbs their labels. Fixed on POS in #54 — the same restructure applies. |
 | `role="status"` on a `<td>` | **#105** (P3) | `shared/components/data-table/DataTable.tsx`, `features/analytics/components/DashboardCharts.tsx` | Overrides the cell's table semantics to announce empty states. It works, but a live region should be a sibling of the table rather than a cell inside it. |
 
-The delivery dialog is now an axe-scanned surface, and `e2e/specs/a11y.spec.ts` also
-creates a delivery order keyboard-only — the half axe cannot score. Neither
-`/collections` nor `/bundles` is scanned yet, which is why the scan did not find those
-itself; they came from `jsx-a11y` and from reading. Adding them is part of #104.
+The delivery dialog, `/collections` and `/bundles` are all axe-scanned surfaces now, and
+`e2e/specs/a11y.spec.ts` also creates a delivery order keyboard-only — the half axe
+cannot score. None of them was scanned when this list was written, which is why the scan
+did not find #103 or #104 itself; both came from `jsx-a11y` and from reading.
 
 ## Decisions worth knowing
 

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -28,13 +28,13 @@ rules to `error` as this list empties, which #105 is the last one blocking.
 
 | Gap | Issue | Where | What it costs a user |
 | --- | --- | --- | --- |
-| Custom customer picker is pointer-only | **#103** (P2) | `features/fulfillment/components/delivery/DeliveryFormDialog.tsx` (trigger and options are `<div onClick>`) | A keyboard or screen-reader user cannot open the picker or choose a customer at all, so the delivery flow is blocked outright. The most serious item here — WCAG 2.1.1 and 4.1.2. |
 | Controls nested inside pressable cards | **#104** (P3) | `features/inventory/pages/Collections.tsx`, `features/inventory/pages/Bundles.tsx` | The edit/delete buttons sit inside a card that is itself a `<button>`. Invalid HTML; the inner controls are not separately reachable and the card's accessible name absorbs their labels. Fixed on POS in #54 — the same restructure applies. |
 | `role="status"` on a `<td>` | **#105** (P3) | `shared/components/data-table/DataTable.tsx`, `features/analytics/components/DashboardCharts.tsx` | Overrides the cell's table semantics to announce empty states. It works, but a live region should be a sibling of the table rather than a cell inside it. |
 
-Neither `/collections`, `/bundles` nor the delivery dialog is currently an axe-scanned
-surface, which is why the scan did not find these three itself — they came from
-`jsx-a11y` and from reading. Adding those surfaces is part of #103 and #104.
+The delivery dialog is now an axe-scanned surface, and `e2e/specs/a11y.spec.ts` also
+creates a delivery order keyboard-only — the half axe cannot score. Neither
+`/collections` nor `/bundles` is scanned yet, which is why the scan did not find those
+itself; they came from `jsx-a11y` and from reading. Adding them is part of #104.
 
 ## Decisions worth knowing
 

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -21,19 +21,29 @@ sense. That is why both exist, and why the list below exists as well.
 
 ## Known gaps
 
-Real, reproduced, and not yet fixed. Each has an issue — a gap recorded only in a
-document is one nobody is going to pick up. `jsx-a11y` reports these as **warnings**
-rather than errors so the count and the locations stay visible; raise the corresponding
-rules to `error` as this list empties, which #105 is the last one blocking.
+None outstanding. #103 (pointer-only customer picker), #104 (controls nested inside
+pressable cards) and #105 (`role="status"` on a `<td>`) were the three, and all three are
+fixed. `jsx-a11y/click-events-have-key-events`, `no-static-element-interactions` and
+`no-interactive-element-to-noninteractive-role` were held at `warn` while this list had
+entries, so the count and the locations stayed visible; they are now `error` in
+`client/eslint.config.mjs`.
 
-| Gap | Issue | Where | What it costs a user |
-| --- | --- | --- | --- |
-| `role="status"` on a `<td>` | **#105** (P3) | `shared/components/data-table/DataTable.tsx`, `features/analytics/components/DashboardCharts.tsx` | Overrides the cell's table semantics to announce empty states. It works, but a live region should be a sibling of the table rather than a cell inside it. |
+Record the next one here **with an issue** rather than only in a comment or a commit
+message — a gap that lives in a document nobody opens is a gap nobody picks up — and drop
+the rule that catches it back to `warn` only if the fix genuinely cannot land with it.
 
 The delivery dialog, `/collections` and `/bundles` are all axe-scanned surfaces now, and
 `e2e/specs/a11y.spec.ts` also creates a delivery order keyboard-only — the half axe
 cannot score. None of them was scanned when this list was written, which is why the scan
 did not find #103 or #104 itself; both came from `jsx-a11y` and from reading.
+
+### What is still not proven
+
+The empty-state fix is the case where a DOM assertion is weakest evidence: a live region
+with the right attributes and the right text can still fail to speak, and neither axe nor
+`toHaveTextContent` can tell you. The unit tests pin the structure — one region, mounted
+before the transition, updated rather than remounted — and a spoken check with a real
+screen reader remains a manual step, in the same category as the other entries below.
 
 ## Decisions worth knowing
 

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -24,6 +24,7 @@ import AxeBuilder from '@axe-core/playwright';
 import type { Page } from '@playwright/test';
 import type { Result } from 'axe-core';
 import { expect, test } from '../fixtures/test';
+import { createCustomer } from '../fixtures/customer';
 import { cartPanel, checkoutDrawer, posPage } from '../support/locators';
 
 /** WCAG 2.2 AA, which is what the issue asks for, plus the non-versioned best practices. */
@@ -121,6 +122,27 @@ test.describe('accessibility @smoke', () => {
     await expect(checkoutDrawer(page).dialog).toBeVisible();
 
     await scan(page, 'checkout drawer');
+  });
+
+  test('the delivery order dialog has no high-impact violations', async ({
+    adminContext,
+    adminApi,
+  }) => {
+    // The dialog #103 rebuilt. Scanning it is the half axe can score; the
+    // keyboard-only creation below is the half it cannot.
+    const customer = await createCustomer(adminApi, 'a11y', 'delivery');
+    const page = await adminContext.newPage();
+    await page.goto('/deliveries');
+
+    await page.getByRole('button', { name: /new order/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const picker = dialog.getByRole('combobox', { name: /select customer/i });
+    await picker.fill(customer.name.slice(0, 12));
+    await expect(dialog.getByRole('option', { name: customer.name })).toBeVisible();
+
+    await scan(page, 'delivery order dialog');
   });
 
   test('the inventory table has no high-impact violations', async ({ adminContext }) => {
@@ -236,6 +258,80 @@ test.describe('keyboard and focus @smoke', () => {
     await page.keyboard.press('Enter');
 
     await expect(cartPanel(page).quantity(product.id)).toHaveText('1');
+  });
+
+  test('an admin can create a delivery order without a pointer', async ({
+    adminContext,
+    adminApi,
+    seedProduct,
+  }) => {
+    // #103: the customer picker used to be `<div onClick>` throughout, so this whole
+    // workflow was unreachable from a keyboard — not degraded, impossible.
+    const customer = await createCustomer(adminApi, 'a11y', 'kbddelivery');
+    const product = await seedProduct('a11ykbddel', { price: 30, stock: 9 });
+    const page = await adminContext.newPage();
+    await page.goto('/deliveries');
+
+    const trigger = page.getByRole('button', { name: /new order/i });
+    await trigger.focus();
+    await page.keyboard.press('Enter');
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const picker = dialog.getByRole('combobox', { name: /select customer/i });
+    await picker.focus();
+    expect(await picker.evaluate((el) => el === document.activeElement)).toBe(true);
+    await expect(picker).toHaveAttribute('aria-expanded', 'false');
+
+    await page.keyboard.type(customer.name.slice(0, 12));
+    await expect(picker).toHaveAttribute('aria-expanded', 'true');
+
+    const option = dialog.getByRole('option', { name: customer.name });
+    await expect(option).toBeVisible();
+    // Arrow to the option and commit it: the combobox tracks the active option through
+    // aria-activedescendant, so DOM focus never leaves the input.
+    await expect
+      .poll(
+        async () => {
+          const activeId = await picker.getAttribute('aria-activedescendant');
+          const optionId = await option.getAttribute('id');
+          if (activeId === optionId) return true;
+          await page.keyboard.press('ArrowDown');
+          return false;
+        },
+        { timeout: 10_000 }
+      )
+      .toBe(true);
+    await page.keyboard.press('Enter');
+
+    // Selecting a customer must actually populate the form the submit reads.
+    await expect(dialog.getByLabel(/customer name/i)).toHaveValue(customer.name);
+    await expect(dialog.getByLabel(/^phone$/i)).toHaveValue(customer.phone);
+    await expect(option).toHaveCount(0);
+
+    const address = dialog.getByLabel(/address/i);
+    await address.focus();
+    await page.keyboard.type('4 Jasmine Street');
+
+    const productSearch = dialog.getByLabel('Search products');
+    await productSearch.focus();
+    await page.keyboard.type(product.sku);
+
+    // A native select: closed-state arrow keys move the selection, which is the
+    // keyboard interaction model this control already had and kept.
+    const productSelect = dialog.locator('select').nth(1);
+    await expect(productSelect.locator('option', { hasText: product.name })).toHaveCount(1);
+    await productSelect.focus();
+    await page.keyboard.press('ArrowDown');
+    await expect(productSelect).not.toHaveValue('');
+
+    const submit = dialog.getByRole('button', { name: /create order/i });
+    await submit.focus();
+    await page.keyboard.press('Enter');
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByRole('cell', { name: customer.name })).toBeVisible();
   });
 
   test('the favourite toggle is its own control, reachable and stateful', async ({

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -145,6 +145,24 @@ test.describe('accessibility @smoke', () => {
     await scan(page, 'delivery order dialog');
   });
 
+  test('the collections grid has no high-impact violations', async ({ adminContext }) => {
+    // #104: the card grids where edit/delete used to be nested inside a pressable card.
+    // Neither page was scanned, which is why axe never reported it here.
+    const page = await adminContext.newPage();
+    await page.goto('/collections');
+    await expect(page.getByRole('heading', { name: /collections/i }).first()).toBeVisible();
+
+    await scan(page, 'collections');
+  });
+
+  test('the bundles grid has no high-impact violations', async ({ adminContext }) => {
+    const page = await adminContext.newPage();
+    await page.goto('/bundles');
+    await expect(page.getByRole('heading', { name: /bundles/i }).first()).toBeVisible();
+
+    await scan(page, 'bundles');
+  });
+
   test('the inventory table has no high-impact violations', async ({ adminContext }) => {
     const page = await adminContext.newPage();
     await page.goto('/inventory');

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -352,6 +352,29 @@ test.describe('keyboard and focus @smoke', () => {
     await expect(page.getByRole('cell', { name: customer.name })).toBeVisible();
   });
 
+  test('filtering a table to nothing announces from a region that was already there', async ({
+    adminContext,
+  }) => {
+    // #105: the empty state used to declare `role="status"` on the `<td>` itself, which
+    // stopped the cell being a cell. axe scores the structure; this scores the behaviour.
+    const page = await adminContext.newPage();
+    await page.goto('/inventory');
+    const table = page.getByRole('table').first();
+    await expect(table).toBeVisible();
+
+    const status = page.locator('[role="status"][aria-live="polite"]').first();
+    await expect(status).toBeAttached();
+    await expect(table.locator('td[role]')).toHaveCount(0);
+
+    await page.getByRole('searchbox').first().fill('zzz-no-such-product-zzz');
+
+    // The region was mounted before the rows went away, so this is a content change in
+    // a live region rather than a region appearing with its message already in it.
+    await expect(status).not.toHaveText('');
+    await expect(table.locator('td[role]')).toHaveCount(0);
+    await expect(page.getByRole('cell').first()).toBeVisible();
+  });
+
   test('the favourite toggle is its own control, reachable and stateful', async ({
     cashierContext,
     seedProduct,


### PR DESCRIPTION
Closes #103, closes #104, closes #105 — the three entries under *Known gaps* in `docs/ACCESSIBILITY.md`, which is now empty.

Each issue is one commit, in the order the plan sequenced them (#103 first: it is the only P2, and the only one that blocks a workflow outright).

## #103 — the delivery customer picker was pointer-only

The trigger and every option were `<div onClick>`: not focusable, not in the tab order, no role, no state. Creating a delivery order requires picking a customer, so the whole flow was unreachable from a keyboard — WCAG 2.1.1 and 4.1.2, Level A.

Rebuilt on HeroUI's `Autocomplete`, already a dependency and already implementing the combobox interaction model. The "new customer" affordance stays an option in the list, under a string key so it can never collide with a numeric customer id, and it renders unconditionally — a search matching nothing still offers it.

**Two things the rebuild uncovered, both worth a reviewer's attention:**

- **Selecting a customer never actually filled the form.** HeroUI's `Input` keeps its own controlled value, so react-hook-form's imperative `setValue` was overwritten on the next render. Name, phone and address now bind through `Controller`. This is the change with user-visible behaviour that unit tests vouch for least — worth clicking through.
- **A remote search moving on could drop the selection the form was built from,** because the selected customer was no longer in the item list. It is pinned into the options while selected.

The picker also distinguishes a failed customer lookup from an empty one, so a dead request is no longer presented as "no customers found".

## #104 — controls nested inside pressable cards

`<Card isPressable>` renders a `<button>`, so the edit and delete buttons inside it were a button inside a button: invalid HTML, axe's `nested-interactive`, and a card whose accessible name absorbed both labels while neither control was separately reachable. The `<div onClick={stopPropagation}>` wrapping them was a symptom of the nesting and is gone with it.

Restructured to the shape #54 used on the POS product grid: relative wrapper, pressable card unchanged, controls as siblings positioned over it. The header reserves the space they occupy.

**One deliberate deviation from the plan:** the labels are now `"<name>: Edit"` / `"<name>: Delete"` rather than a bare verb, matching the POS favourite toggle. The plan said labels should stay unchanged, but a bare "Edit" repeated on every card identifies none of them — the same ambiguity the nesting caused. `Collections.test.tsx` is updated for it.

## #105 — `role="status"` on a `<td>`

`role="status"` replaces an element's implicit role, so a `<td>` carrying it was no longer a cell: the row and the table described a structure whose contents had gone missing.

The cells are plain cells again, and the announcement comes from a region outside the table that is mounted for the component's whole life. That second half is the point: a live region only announces content that changes *while it is already in the DOM*, so one rendered alongside its own message has nothing to announce. `DataTable` already had such a region for the result count, so the empty state folds into it — one table, one announcement source. `EmptyState` takes an `announce` flag for that, since every standalone caller mounting it *is* the news and keeps its own region.

**Two sites no issue mentioned had to be fixed to raise the rules:**

- `StatCard` attached a click handler and a `tabIndex` expression even when not clickable, putting a `region` in the tab order with a handler that did nothing.
- `HeatmapChart` showed its figures in a hover-only tooltip, so 168 cells of revenue existed for pointer users alone. Each is now `role="img"` labelled with day, hour, revenue and order count.

## Lint gate

With all three fixed, `jsx-a11y/click-events-have-key-events`, `no-static-element-interactions` and `no-interactive-element-to-noninteractive-role` go from `warn` to `error`, as the config comment and `docs/ACCESSIBILITY.md` both said they would once the list emptied.

## Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit` (client, e2e) | clean |
| `eslint` (client) | 0 errors; 16 pre-existing `react-refresh` warnings |
| `vitest` | 578 passed, 62 files |
| `npm run build` (client) | succeeds |
| Playwright | **not run locally** — needs a disposable PostgreSQL; CI is its first execution |

Three specs were added to `e2e/specs/a11y.spec.ts` and have never executed: an axe scan of the delivery dialog, keyboard-only order creation, and the empty-state announcement on a filtered-to-zero table. `/collections` and `/bundles` are also scanned surfaces now. Watch those on the E2E job.

`docs/ACCESSIBILITY.md` records what none of this proves: that a live region actually *speaks*. DOM attributes and text content are the weakest evidence for #105, and a spoken check with a real screen reader stays a manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN