### PR TITLE
fix(a11y): HeroUI buttons ignore onClick from the keyboard (#111)

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -125,6 +125,31 @@ export default tseslint.config(
        * file-level disables would have hidden the locations. There is now nothing to
        * hide, and a warning gates nothing: `error` is what stops the next one landing.
        */
+      /**
+       * HeroUI's Button is react-aria based: it intercepts key events and dispatches
+       * `onPress`, suppressing the native click. A handler bound to `onClick` therefore
+       * fires for a mouse and never for a keyboard, which made 209 buttons pointer-only
+       * without a single gate noticing (#111).
+       *
+       * Nothing else can catch this. axe sees a `<button>` with a role and a name;
+       * `jsx-a11y` sees a real button, so `click-events-have-key-events` does not apply —
+       * that rule is for `<div onClick>`. It took an end-to-end test that used the
+       * keyboard the way a person does.
+       *
+       * The one legitimate exception is a handler that exists to stop a *pointer* event
+       * propagating, which has no keyboard equivalent to suppress; there is one, in
+       * SalesHistory, and it carries a comment saying so.
+       */
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'JSXOpeningElement[name.name="Button"] JSXAttribute[name.name="onClick"]',
+          message:
+            'HeroUI Button ignores onClick from the keyboard — use onPress. If this handler ' +
+            'exists only to stop pointer propagation, disable this rule on the line and say why.',
+        },
+      ],
+
       'jsx-a11y/click-events-have-key-events': 'error',
       'jsx-a11y/no-static-element-interactions': 'error',
       'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',

--- a/client/src/app/Layout.tsx
+++ b/client/src/app/Layout.tsx
@@ -28,7 +28,7 @@ export default function Layout(): React.JSX.Element {
               isIconOnly
               variant="light"
               className="lg:hidden h-9 w-9 text-muted-foreground hover:text-foreground"
-              onClick={() => setMobileOpen(true)}
+              onPress={() => setMobileOpen(true)}
               aria-label={t('nav.openNav') || 'Open navigation'}
             >
               <Menu className="h-5 w-5" />
@@ -49,7 +49,7 @@ export default function Layout(): React.JSX.Element {
             <Button
               isIconOnly
               variant="light"
-              onClick={toggleLocale}
+              onPress={toggleLocale}
               className="h-9 w-9 text-muted-foreground hover:text-foreground border border-border"
               title={locale === 'ar' ? 'English' : 'عربي'}
               aria-label={locale === 'ar' ? 'Switch to English' : 'التبديل إلى العربية'}
@@ -59,7 +59,7 @@ export default function Layout(): React.JSX.Element {
             <Button
               isIconOnly
               variant="light"
-              onClick={toggleTheme}
+              onPress={toggleTheme}
               className="h-9 w-9 text-muted-foreground hover:text-foreground border border-border"
               title={theme === 'dark' ? t('theme.light') : t('theme.dark')}
               aria-label={theme === 'dark' ? t('theme.light') : t('theme.dark')}
@@ -107,7 +107,7 @@ export default function Layout(): React.JSX.Element {
               <Button
                 size="sm"
                 variant="light"
-                onClick={retryFailed}
+                onPress={retryFailed}
                 className="h-7 min-w-0 px-3 text-warning underline"
               >
                 {t('offline.retry')}

--- a/client/src/app/Sidebar.tsx
+++ b/client/src/app/Sidebar.tsx
@@ -209,7 +209,7 @@ export default function Sidebar({
         <div className="p-3 border-t border-border">
           <Button
             variant="light"
-            onClick={handleLogout}
+            onPress={handleLogout}
             className="w-full justify-start gap-3 px-3 text-sm text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
           >
             <LogOut className="h-4 w-4" />
@@ -242,7 +242,7 @@ export default function Sidebar({
               <DrawerFooter>
                 <Button
                   variant="light"
-                  onClick={() => {
+                  onPress={() => {
                     onClose();
                     handleLogout();
                   }}

--- a/client/src/features/admin/pages/AuditLog.tsx
+++ b/client/src/features/admin/pages/AuditLog.tsx
@@ -321,7 +321,7 @@ export default function AuditLog() {
           <Button
             size="sm"
             variant="flat"
-            onClick={() => {
+            onPress={() => {
               setActionFilter('all');
               setEntityFilter('all');
               setUserFilter('all');

--- a/client/src/features/admin/pages/Backup.tsx
+++ b/client/src/features/admin/pages/Backup.tsx
@@ -50,7 +50,7 @@ export default function BackupPage() {
             <div className="pt-2">
               <Button
                 color="primary"
-                onClick={() => backupMutation.mutate()}
+                onPress={() => backupMutation.mutate()}
                 isLoading={backupMutation.isPending}
                 startContent={!backupMutation.isPending && <Download className="h-4 w-4" />}
                 className="w-full sm:w-auto"

--- a/client/src/features/admin/pages/Branches.tsx
+++ b/client/src/features/admin/pages/Branches.tsx
@@ -183,7 +183,7 @@ export default function BranchesPage() {
             variant={tab === 'branches' ? 'solid' : 'bordered'}
             color={tab === 'branches' ? 'primary' : 'default'}
             size="sm"
-            onClick={() => setTab('branches')}
+            onPress={() => setTab('branches')}
             startContent={<Building2 className="h-4 w-4" />}
           >
             {t('branches.list')}
@@ -192,7 +192,7 @@ export default function BranchesPage() {
             variant={tab === 'dashboard' ? 'solid' : 'bordered'}
             color={tab === 'dashboard' ? 'primary' : 'default'}
             size="sm"
-            onClick={() => setTab('dashboard')}
+            onPress={() => setTab('dashboard')}
             startContent={<BarChart3 className="h-4 w-4" />}
           >
             {t('branches.consolidated')}
@@ -201,7 +201,7 @@ export default function BranchesPage() {
             variant={tab === 'transfers' ? 'solid' : 'bordered'}
             color={tab === 'transfers' ? 'primary' : 'default'}
             size="sm"
-            onClick={() => setTab('transfers')}
+            onPress={() => setTab('transfers')}
             startContent={<ArrowRightLeft className="h-4 w-4" />}
           >
             {t('locations.transfers')}
@@ -209,7 +209,7 @@ export default function BranchesPage() {
           <Button
             color="primary"
             size="sm"
-            onClick={editor.openNew}
+            onPress={editor.openNew}
             startContent={<Plus className="h-4 w-4" />}
           >
             {t('branches.addBranch')}
@@ -314,7 +314,7 @@ export default function BranchesPage() {
                         variant="light"
                         size="sm"
                         className="h-8 w-8 text-muted-foreground"
-                        onClick={() => {
+                        onPress={() => {
                           setSelectedBranch(b.id);
                           setSettingsOpen(true);
                         }}
@@ -327,7 +327,7 @@ export default function BranchesPage() {
                         variant="light"
                         size="sm"
                         className="h-8 w-8 text-muted-foreground"
-                        onClick={() => editor.openEdit(b)}
+                        onPress={() => editor.openEdit(b)}
                         aria-label={t('common.edit')}
                       >
                         <Pencil className="h-4 w-4" />
@@ -339,7 +339,7 @@ export default function BranchesPage() {
                           color="danger"
                           size="sm"
                           className="h-8 w-8"
-                          onClick={() => {
+                          onPress={() => {
                             if (confirm(t('branches.deleteConfirm'))) deleteBranch.remove(b.id);
                           }}
                           aria-label={t('common.delete')}
@@ -411,7 +411,7 @@ export default function BranchesPage() {
             </Select>
             <Button
               variant="bordered"
-              onClick={() => setTransferDialogOpen(true)}
+              onPress={() => setTransferDialogOpen(true)}
               startContent={<ArrowRightLeft className="h-4 w-4" />}
             >
               {t('locations.newTransfer')}
@@ -582,7 +582,7 @@ export default function BranchesPage() {
                     type="button"
                     variant="flat"
                     size="sm"
-                    onClick={() =>
+                    onPress={() =>
                       setTransferForm({
                         ...transferForm,
                         items: [...transferForm.items, { product_id: 0, quantity: 1 }],
@@ -602,7 +602,7 @@ export default function BranchesPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setTransferDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setTransferDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
@@ -764,7 +764,7 @@ export default function BranchesPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saveBranch.isSaving}>
@@ -840,7 +840,7 @@ export default function BranchesPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setSettingsOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setSettingsOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saveSetting.isRunning}>

--- a/client/src/features/admin/pages/Settings.tsx
+++ b/client/src/features/admin/pages/Settings.tsx
@@ -225,7 +225,7 @@ export default function Settings() {
       </Card>
 
       <div className="max-w-xl">
-        <Button color="primary" onClick={handleSave} isLoading={saveMutation.isPending}>
+        <Button color="primary" onPress={handleSave} isLoading={saveMutation.isPending}>
           {t('common.save')}
         </Button>
       </div>

--- a/client/src/features/admin/pages/Users.tsx
+++ b/client/src/features/admin/pages/Users.tsx
@@ -212,7 +212,7 @@ export default function UsersPage() {
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground hover:text-foreground"
-              onClick={() => openEditDialog(user)}
+              onPress={() => openEditDialog(user)}
               title={t('common.edit')}
               aria-label={t('common.edit')}
             >
@@ -224,7 +224,7 @@ export default function UsersPage() {
               size="sm"
               className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40"
               isDisabled={isSelf}
-              onClick={() => setDeleteId(user.id)}
+              onPress={() => setDeleteId(user.id)}
               title={isSelf ? t('users.cannotDeleteSelf') : t('common.delete')}
               aria-label={isSelf ? t('users.cannotDeleteSelf') : t('common.delete')}
             >
@@ -245,7 +245,7 @@ export default function UsersPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={openCreateDialog}
+            onPress={openCreateDialog}
           >
             {t('users.addUser')}
           </Button>
@@ -367,7 +367,7 @@ export default function UsersPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button color="primary" size="sm" type="submit" isLoading={saver.isSaving}>

--- a/client/src/features/analytics/components/DashboardCharts.tsx
+++ b/client/src/features/analytics/components/DashboardCharts.tsx
@@ -80,7 +80,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('revenue')}
+              onPress={() => onExportCsv('revenue')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >
@@ -110,7 +110,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('top-products')}
+              onPress={() => onExportCsv('top-products')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >
@@ -142,7 +142,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('payment-methods')}
+              onPress={() => onExportCsv('payment-methods')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >
@@ -174,7 +174,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('orders-per-day')}
+              onPress={() => onExportCsv('orders-per-day')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >
@@ -209,7 +209,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('cashier-performance')}
+              onPress={() => onExportCsv('cashier-performance')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >
@@ -241,7 +241,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('cashier-performance')}
+              onPress={() => onExportCsv('cashier-performance')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >
@@ -324,7 +324,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('sales-by-category')}
+              onPress={() => onExportCsv('sales-by-category')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >
@@ -356,7 +356,7 @@ export default function DashboardCharts({
               variant="light"
               size="sm"
               className="h-8 w-8 text-muted-foreground"
-              onClick={() => onExportCsv('sales-by-distributor')}
+              onPress={() => onExportCsv('sales-by-distributor')}
               title={t('export.csv')}
               aria-label={t('export.csv')}
             >

--- a/client/src/features/analytics/pages/AdvancedAnalytics.tsx
+++ b/client/src/features/analytics/pages/AdvancedAnalytics.tsx
@@ -121,7 +121,7 @@ function DaysSelector({
           variant={value === d ? 'flat' : 'light'}
           color={value === d ? 'primary' : 'default'}
           className="h-7 min-w-8 text-xs font-data px-2"
-          onClick={() => onChange(d)}
+          onPress={() => onChange(d)}
         >
           {d}
         </Button>
@@ -575,7 +575,7 @@ export default function AdvancedAnalytics() {
             size="sm"
             variant={activeTab === tab.id ? 'flat' : 'light'}
             color={activeTab === tab.id ? 'primary' : 'default'}
-            onClick={() => setActiveTab(tab.id)}
+            onPress={() => setActiveTab(tab.id)}
             className="font-medium"
           >
             {tab.label}

--- a/client/src/features/analytics/pages/AiInsights.tsx
+++ b/client/src/features/analytics/pages/AiInsights.tsx
@@ -91,7 +91,7 @@ export default function AiInsightsPage() {
             variant={tab === 'predictions' ? 'flat' : 'light'}
             color={tab === 'predictions' ? 'primary' : 'default'}
             size="sm"
-            onClick={() => setTab('predictions')}
+            onPress={() => setTab('predictions')}
             startContent={<TrendingUp className="h-4 w-4" />}
           >
             {t('aiInsights.predictions')}
@@ -100,7 +100,7 @@ export default function AiInsightsPage() {
             variant={tab === 'knowledge' ? 'flat' : 'light'}
             color={tab === 'knowledge' ? 'primary' : 'default'}
             size="sm"
-            onClick={() => setTab('knowledge')}
+            onPress={() => setTab('knowledge')}
             startContent={<BookOpen className="h-4 w-4" />}
           >
             {t('aiInsights.knowledgeBase')}
@@ -113,7 +113,7 @@ export default function AiInsightsPage() {
           <Button
             color="primary"
             size="sm"
-            onClick={() => generatePredictions.mutate()}
+            onPress={() => generatePredictions.mutate()}
             isLoading={generatePredictions.isPending}
             startContent={!generatePredictions.isPending && <RefreshCw className="h-4 w-4" />}
           >
@@ -174,7 +174,7 @@ export default function AiInsightsPage() {
           <Button
             color="primary"
             size="sm"
-            onClick={() => setKbOpen(true)}
+            onPress={() => setKbOpen(true)}
             startContent={<Plus className="h-4 w-4" />}
           >
             {t('aiInsights.addEntry')}
@@ -264,7 +264,7 @@ export default function AiInsightsPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setKbOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setKbOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button color="primary" size="sm" type="submit" isLoading={addKbEntry.isPending}>

--- a/client/src/features/analytics/pages/Dashboard.tsx
+++ b/client/src/features/analytics/pages/Dashboard.tsx
@@ -196,7 +196,7 @@ export default function Dashboard() {
             variant="bordered"
             size="sm"
             startContent={<FileText className="h-4 w-4 text-muted-foreground" />}
-            onClick={handleExportPdf}
+            onPress={handleExportPdf}
             isLoading={exporting}
           >
             {exporting ? t('export.generating') : t('export.fullReport')}

--- a/client/src/features/analytics/pages/Exports.tsx
+++ b/client/src/features/analytics/pages/Exports.tsx
@@ -85,7 +85,7 @@ export default function ExportsPage() {
           </Select>
           <Button
             color="primary"
-            onClick={() => generateMutation.mutate()}
+            onPress={() => generateMutation.mutate()}
             isLoading={generateMutation.isPending}
             className="w-full"
             startContent={!generateMutation.isPending && <Download className="h-4 w-4" />}

--- a/client/src/features/analytics/pages/ReportBuilder.tsx
+++ b/client/src/features/analytics/pages/ReportBuilder.tsx
@@ -119,7 +119,7 @@ export default function ReportBuilderPage() {
               variant={tab === 'saved' ? 'flat' : 'light'}
               color={tab === 'saved' ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setTab('saved')}
+              onPress={() => setTab('saved')}
               startContent={<FileText className="h-4 w-4" />}
             >
               {t('reportBuilder.saved')}
@@ -128,7 +128,7 @@ export default function ReportBuilderPage() {
               variant={tab === 'quick' ? 'flat' : 'light'}
               color={tab === 'quick' ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setTab('quick')}
+              onPress={() => setTab('quick')}
               startContent={<Play className="h-4 w-4" />}
             >
               {t('reportBuilder.quickReport')}
@@ -136,7 +136,7 @@ export default function ReportBuilderPage() {
             <Button
               color="primary"
               size="sm"
-              onClick={() => setCreateOpen(true)}
+              onPress={() => setCreateOpen(true)}
               startContent={<Plus className="h-4 w-4" />}
             >
               {t('reportBuilder.create')}
@@ -168,7 +168,7 @@ export default function ReportBuilderPage() {
                         color="success"
                         size="sm"
                         className="h-7 w-7"
-                        onClick={() => runReport.mutate(r.id)}
+                        onPress={() => runReport.mutate(r.id)}
                         aria-label={t('reportBuilder.run')}
                       >
                         <Play className="h-3.5 w-3.5" />
@@ -179,7 +179,7 @@ export default function ReportBuilderPage() {
                         color="danger"
                         size="sm"
                         className="h-7 w-7"
-                        onClick={() => deleteReport.remove(r.id)}
+                        onPress={() => deleteReport.remove(r.id)}
                         aria-label={t('common.delete')}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
@@ -251,7 +251,7 @@ export default function ReportBuilderPage() {
             <Button
               color="primary"
               size="sm"
-              onClick={() => runQuick.mutate(quickForm)}
+              onPress={() => runQuick.mutate(quickForm)}
               isLoading={runQuick.isPending}
               startContent={!runQuick.isPending && <Play className="h-4 w-4" />}
             >
@@ -374,7 +374,7 @@ export default function ReportBuilderPage() {
                 </div>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setCreateOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setCreateOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button color="primary" size="sm" type="submit" isLoading={createReport.isSaving}>

--- a/client/src/features/customers/components/CustomerDetail.tsx
+++ b/client/src/features/customers/components/CustomerDetail.tsx
@@ -132,7 +132,7 @@ export default function CustomerDetail({ customerId, customerName, onBack }: Cus
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-4">
-        <Button isIconOnly variant="light" size="sm" onClick={onBack} aria-label="Back">
+        <Button isIconOnly variant="light" size="sm" onPress={onBack} aria-label="Back">
           <ArrowLeft className="h-5 w-5" />
         </Button>
         <div className="flex-1">
@@ -150,7 +150,7 @@ export default function CustomerDetail({ customerId, customerName, onBack }: Cus
                 {loyaltyData.points}
               </p>
             </div>
-            <Button variant="bordered" size="sm" onClick={() => setAdjustDialogOpen(true)}>
+            <Button variant="bordered" size="sm" onPress={() => setAdjustDialogOpen(true)}>
               {t('loyalty.adjustPoints')}
             </Button>
           </div>
@@ -388,7 +388,7 @@ export default function CustomerDetail({ customerId, customerName, onBack }: Cus
                       isIconOnly
                       variant="bordered"
                       size="sm"
-                      onClick={() => setAdjustPoints((p) => p - 10)}
+                      onPress={() => setAdjustPoints((p) => p - 10)}
                       aria-label={t('customers.decreasePoints')}
                     >
                       <Minus className="h-3 w-3" />
@@ -405,7 +405,7 @@ export default function CustomerDetail({ customerId, customerName, onBack }: Cus
                       isIconOnly
                       variant="bordered"
                       size="sm"
-                      onClick={() => setAdjustPoints((p) => p + 10)}
+                      onPress={() => setAdjustPoints((p) => p + 10)}
                       aria-label={t('customers.increasePoints')}
                     >
                       <Plus className="h-3 w-3" />
@@ -426,13 +426,13 @@ export default function CustomerDetail({ customerId, customerName, onBack }: Cus
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setAdjustDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setAdjustDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
                   color="primary"
                   size="sm"
-                  onClick={() =>
+                  onPress={() =>
                     adjustMutation.run({
                       id: customerId,
                       body: { points: adjustPoints, note: adjustNote },

--- a/client/src/features/customers/pages/Customers.tsx
+++ b/client/src/features/customers/pages/Customers.tsx
@@ -157,7 +157,7 @@ export default function CustomersPage() {
             variant="light"
             size="sm"
             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            onClick={() => setViewingCustomer(row.original)}
+            onPress={() => setViewingCustomer(row.original)}
             title={t('customers.viewHistory')}
             aria-label={t('customers.viewHistory')}
           >
@@ -168,7 +168,7 @@ export default function CustomersPage() {
             variant="light"
             size="sm"
             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            onClick={() => openEditDialog(row.original)}
+            onPress={() => openEditDialog(row.original)}
             title={t('common.edit')}
             aria-label={t('common.edit')}
           >
@@ -179,7 +179,7 @@ export default function CustomersPage() {
             variant="light"
             size="sm"
             className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-            onClick={() => setDeleteId(row.original.id)}
+            onPress={() => setDeleteId(row.original.id)}
             title={t('common.delete')}
             aria-label={t('common.delete')}
           >
@@ -211,7 +211,7 @@ export default function CustomersPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={openCreateDialog}
+            onPress={openCreateDialog}
           >
             {t('customers.addCustomer')}
           </Button>
@@ -305,7 +305,7 @@ export default function CustomersPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button

--- a/client/src/features/customers/pages/Warranty.tsx
+++ b/client/src/features/customers/pages/Warranty.tsx
@@ -181,7 +181,7 @@ export default function WarrantyPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={editor.openNew}
+            onPress={editor.openNew}
           >
             {t('warranty.create')}
           </Button>
@@ -288,7 +288,7 @@ export default function WarrantyPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button color="primary" size="sm" type="submit" isLoading={saver.isSaving}>

--- a/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.test.tsx
+++ b/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.test.tsx
@@ -124,6 +124,23 @@ describe('DeliveryFormDialog customer picker', () => {
     await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
   });
 
+  it('keeps its name when the list opens, which is when the name matters most', async () => {
+    /*
+     * Opening the popover marks everything outside it `aria-hidden`, including the visible
+     * label. A name computed from that label therefore disappears at exactly the moment a
+     * screen-reader user is choosing from the list — and jsdom will not tell you, because
+     * it computes the name from the DOM regardless. Playwright did (#111).
+     *
+     * So this asserts the *mechanism*: the name comes from an attribute on the element
+     * itself, which nothing can hide.
+     */
+    render(<Harness />);
+
+    const { input } = await openListbox();
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+    expect(input).toHaveAttribute('aria-label', 'Select Customer');
+  });
+
   it('selects an existing customer with the keyboard and fills the form', async () => {
     render(<Harness />);
 

--- a/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.test.tsx
+++ b/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.test.tsx
@@ -138,7 +138,20 @@ describe('DeliveryFormDialog customer picker', () => {
 
     const { input } = await openListbox();
     await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+
     expect(input).toHaveAttribute('aria-label', 'Select Customer');
+
+    /*
+     * And crucially, no `aria-labelledby` — which is what actually broke this.
+     *
+     * HeroUI's `label` prop emits both, and a reference wins the accessible-name
+     * algorithm over an attribute. Its reference pointed at the input itself and at an id
+     * that does not exist, so a browser computed no name at all while jsdom fell back to
+     * `aria-label` and reported success. Asserting only the presence of `aria-label`
+     * would therefore still pass against the broken markup; asserting the absence of the
+     * reference is what pins the fix.
+     */
+    expect(input).not.toHaveAttribute('aria-labelledby');
   });
 
   it('selects an existing customer with the keyboard and fills the form', async () => {

--- a/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.tsx
+++ b/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.tsx
@@ -384,7 +384,7 @@ export default function DeliveryFormDialog({
                     color="primary"
                     size="sm"
                     className="h-auto p-0 text-xs"
-                    onClick={onOpenCompaniesDialog}
+                    onPress={onOpenCompaniesDialog}
                   >
                     {t('deliveries.manageCompanies')}
                   </Button>
@@ -429,7 +429,7 @@ export default function DeliveryFormDialog({
                     variant="bordered"
                     size="sm"
                     startContent={<Plus className="h-3.5 w-3.5" />}
-                    onClick={() => append({ product_id: 0, quantity: 1 })}
+                    onPress={() => append({ product_id: 0, quantity: 1 })}
                   >
                     {t('deliveries.addItem')}
                   </Button>
@@ -479,7 +479,7 @@ export default function DeliveryFormDialog({
                           variant="light"
                           color="danger"
                           size="sm"
-                          onClick={() => remove(index)}
+                          onPress={() => remove(index)}
                           aria-label={t('common.remove')}
                         >
                           <Trash2 className="h-4 w-4" />
@@ -504,7 +504,7 @@ export default function DeliveryFormDialog({
               </div>
             </ModalBody>
             <ModalFooter className="border-t border-border/50">
-              <Button variant="flat" size="sm" onClick={() => onOpenChange(false)}>
+              <Button variant="flat" size="sm" onPress={() => onOpenChange(false)}>
                 {t('common.cancel')}
               </Button>
               <Button color="primary" size="sm" type="submit" isLoading={isSubmitting}>

--- a/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.tsx
+++ b/client/src/features/fulfillment/components/delivery/DeliveryFormDialog.tsx
@@ -235,62 +235,81 @@ export default function DeliveryFormDialog({
             </ModalHeader>
             <ModalBody className="py-4 space-y-4">
               {/* Customer selector */}
-              <Autocomplete
-                label={t('deliveries.selectCustomer')}
-                placeholder={t('deliveries.searchCustomer')}
-                size="sm"
-                variant="bordered"
-                startContent={<Search className="h-4 w-4 text-muted-foreground shrink-0" />}
-                inputValue={customerSearch}
-                onInputChange={onCustomerSearchChange}
-                selectedKey={selectedCustomerKey}
-                onSelectionChange={handleCustomerSelection}
-                // Results are already filtered by the server; filtering them again
-                // client-side would hide rows the query deliberately returned.
-                defaultFilter={() => true}
-                allowsEmptyCollection
-                isLoading={isLoadingCustomers}
-                isInvalid={hasCustomerLoadError}
-                errorMessage={hasCustomerLoadError ? t('common.error') : undefined}
-                description={
-                  !hasCustomerLoadError &&
-                  !isLoadingCustomers &&
-                  customerSearch.length > 0 &&
-                  customerOptions.length === 0
-                    ? t('deliveries.noCustomersFound')
-                    : undefined
-                }
-                data-testid="delivery-customer-picker"
-              >
-                {[
-                  <AutocompleteItem
-                    key={NEW_CUSTOMER_KEY}
-                    textValue={t('deliveries.newCustomer')}
-                    startContent={<UserPlus className="h-4 w-4 text-primary shrink-0" />}
-                    endContent={
-                      isNewCustomer ? <Check className="h-4 w-4 text-primary" /> : undefined
-                    }
-                  >
-                    <span className="font-medium">{t('deliveries.newCustomer')}</span>
-                  </AutocompleteItem>,
-                  ...customerOptions.map((c) => (
+              <div className="space-y-1.5">
+                {/*
+                 * The visible label is its own element, and the accessible name comes from
+                 * `aria-label` rather than HeroUI's `label` prop (#111).
+                 *
+                 * That prop emits `aria-labelledby` *as well as* `aria-label`, pointing at
+                 * the input itself and at an id that does not exist, so the name resolves
+                 * to nothing in a real browser — `aria-labelledby` wins the accessible-name
+                 * algorithm. jsdom's implementation quietly falls back to `aria-label`,
+                 * which is why the unit tests disagreed with Playwright.
+                 *
+                 * Naming the field with an attribute rather than a reference also survives
+                 * the popover: opening the list marks everything outside it `aria-hidden`,
+                 * which empties any name computed from a referenced element.
+                 */}
+                <p className="text-xs font-medium text-foreground" aria-hidden="true">
+                  {t('deliveries.selectCustomer')}
+                </p>
+                <Autocomplete
+                  aria-label={t('deliveries.selectCustomer')}
+                  placeholder={t('deliveries.searchCustomer')}
+                  size="sm"
+                  variant="bordered"
+                  startContent={<Search className="h-4 w-4 text-muted-foreground shrink-0" />}
+                  inputValue={customerSearch}
+                  onInputChange={onCustomerSearchChange}
+                  selectedKey={selectedCustomerKey}
+                  onSelectionChange={handleCustomerSelection}
+                  // Results are already filtered by the server; filtering them again
+                  // client-side would hide rows the query deliberately returned.
+                  defaultFilter={() => true}
+                  allowsEmptyCollection
+                  isLoading={isLoadingCustomers}
+                  isInvalid={hasCustomerLoadError}
+                  errorMessage={hasCustomerLoadError ? t('common.error') : undefined}
+                  description={
+                    !hasCustomerLoadError &&
+                    !isLoadingCustomers &&
+                    customerSearch.length > 0 &&
+                    customerOptions.length === 0
+                      ? t('deliveries.noCustomersFound')
+                      : undefined
+                  }
+                  data-testid="delivery-customer-picker"
+                >
+                  {[
                     <AutocompleteItem
-                      key={customerOptionKey(c.id)}
-                      textValue={c.name}
+                      key={NEW_CUSTOMER_KEY}
+                      textValue={t('deliveries.newCustomer')}
+                      startContent={<UserPlus className="h-4 w-4 text-primary shrink-0" />}
                       endContent={
-                        selectedCustomer?.id === c.id ? (
-                          <Check className="h-4 w-4 text-primary" />
-                        ) : undefined
+                        isNewCustomer ? <Check className="h-4 w-4 text-primary" /> : undefined
                       }
                     >
-                      <div className="min-w-0">
-                        <div className="font-medium text-foreground truncate">{c.name}</div>
-                        <div className="text-xs text-muted-foreground font-data">{c.phone}</div>
-                      </div>
-                    </AutocompleteItem>
-                  )),
-                ]}
-              </Autocomplete>
+                      <span className="font-medium">{t('deliveries.newCustomer')}</span>
+                    </AutocompleteItem>,
+                    ...customerOptions.map((c) => (
+                      <AutocompleteItem
+                        key={customerOptionKey(c.id)}
+                        textValue={c.name}
+                        endContent={
+                          selectedCustomer?.id === c.id ? (
+                            <Check className="h-4 w-4 text-primary" />
+                          ) : undefined
+                        }
+                      >
+                        <div className="min-w-0">
+                          <div className="font-medium text-foreground truncate">{c.name}</div>
+                          <div className="text-xs text-muted-foreground font-data">{c.phone}</div>
+                        </div>
+                      </AutocompleteItem>
+                    )),
+                  ]}
+                </Autocomplete>
+              </div>
 
               {/*
                 HeroUI's Input keeps its own controlled value, so an imperative

--- a/client/src/features/fulfillment/components/delivery/ShippingCompaniesDialog.tsx
+++ b/client/src/features/fulfillment/components/delivery/ShippingCompaniesDialog.tsx
@@ -105,7 +105,7 @@ export default function ShippingCompaniesDialog({
                     onValueChange={(val) => editor.set('website', val)}
                   />
                   <div className="flex gap-2 justify-end pt-2">
-                    <Button type="button" variant="flat" size="sm" onClick={editor.close}>
+                    <Button type="button" variant="flat" size="sm" onPress={editor.close}>
                       {t('common.cancel')}
                     </Button>
                     <Button color="primary" type="submit" size="sm" isLoading={saver.isSaving}>
@@ -120,7 +120,7 @@ export default function ShippingCompaniesDialog({
                     size="sm"
                     startContent={<Plus className="h-4 w-4" />}
                     className="w-full"
-                    onClick={editor.openNew}
+                    onPress={editor.openNew}
                   >
                     {t('deliveries.addCompany')}
                   </Button>
@@ -151,7 +151,7 @@ export default function ShippingCompaniesDialog({
                             variant="light"
                             size="sm"
                             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                            onClick={() => editor.openEdit(sc)}
+                            onPress={() => editor.openEdit(sc)}
                             aria-label={t('common.edit')}
                           >
                             <Pencil className="h-4 w-4" />
@@ -162,7 +162,7 @@ export default function ShippingCompaniesDialog({
                             color="danger"
                             size="sm"
                             className="h-8 w-8"
-                            onClick={() => remover.remove(sc.id)}
+                            onPress={() => remover.remove(sc.id)}
                             aria-label={t('common.delete')}
                           >
                             <Trash2 className="h-4 w-4" />

--- a/client/src/features/fulfillment/pages/Deliveries.tsx
+++ b/client/src/features/fulfillment/pages/Deliveries.tsx
@@ -345,7 +345,7 @@ export default function Deliveries() {
               color="primary"
               size="sm"
               startContent={<Plus className="h-4 w-4" />}
-              onClick={openCreateDialog}
+              onPress={openCreateDialog}
             >
               {t('deliveries.newOrder')}
             </Button>
@@ -432,7 +432,7 @@ export default function Deliveries() {
             variant={statusFilter === s ? 'solid' : 'bordered'}
             color={statusFilter === s ? 'primary' : 'default'}
             size="sm"
-            onClick={() => {
+            onPress={() => {
               updateListSearch({ status: s === 'All' ? undefined : s, page: 1 });
             }}
           >

--- a/client/src/features/fulfillment/pages/OnlineOrders.tsx
+++ b/client/src/features/fulfillment/pages/OnlineOrders.tsx
@@ -115,7 +115,7 @@ export default function OnlineOrdersPage() {
           variant="light"
           size="sm"
           className="h-8 w-8 text-muted-foreground hover:text-foreground"
-          onClick={() => viewOrder(row.original.id)}
+          onPress={() => viewOrder(row.original.id)}
           aria-label="View order"
         >
           <Eye className="w-4 h-4" />
@@ -135,7 +135,7 @@ export default function OnlineOrdersPage() {
             variant={statusFilter === s ? 'solid' : 'bordered'}
             color={statusFilter === s ? 'primary' : 'default'}
             size="sm"
-            onClick={() => {
+            onPress={() => {
               update({ status: s || undefined, page: 1 });
             }}
           >
@@ -223,7 +223,7 @@ export default function OnlineOrdersPage() {
                           size="sm"
                           color="primary"
                           startContent={<CheckCircle className="w-4 h-4" />}
-                          onClick={() =>
+                          onPress={() =>
                             updateStatus.run({
                               id: selectedOrder.id,
                               body: { status: 'confirmed' },
@@ -238,7 +238,7 @@ export default function OnlineOrdersPage() {
                           size="sm"
                           color="primary"
                           startContent={<CheckCircle className="w-4 h-4" />}
-                          onClick={() =>
+                          onPress={() =>
                             updateStatus.run({
                               id: selectedOrder.id,
                               body: { status: 'processing' },
@@ -253,7 +253,7 @@ export default function OnlineOrdersPage() {
                           size="sm"
                           color="primary"
                           startContent={<Truck className="w-4 h-4" />}
-                          onClick={() =>
+                          onPress={() =>
                             updateStatus.run({ id: selectedOrder.id, body: { status: 'shipped' } })
                           }
                         >
@@ -265,7 +265,7 @@ export default function OnlineOrdersPage() {
                           size="sm"
                           color="success"
                           startContent={<CheckCircle className="w-4 h-4" />}
-                          onClick={() =>
+                          onPress={() =>
                             updateStatus.run({
                               id: selectedOrder.id,
                               body: { status: 'delivered' },
@@ -280,7 +280,7 @@ export default function OnlineOrdersPage() {
                           size="sm"
                           variant="bordered"
                           startContent={<XCircle className="w-4 h-4" />}
-                          onClick={() =>
+                          onPress={() =>
                             updateStatus.run({
                               id: selectedOrder.id,
                               body: { status: 'cancelled' },

--- a/client/src/features/fulfillment/pages/Storefront.tsx
+++ b/client/src/features/fulfillment/pages/Storefront.tsx
@@ -68,7 +68,7 @@ export default function StorefrontPage() {
               variant={tab === 'config' ? 'solid' : 'bordered'}
               color={tab === 'config' ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setTab('config')}
+              onPress={() => setTab('config')}
               startContent={<Settings2 className="h-4 w-4" />}
             >
               {t('storefront.config')}
@@ -77,7 +77,7 @@ export default function StorefrontPage() {
               variant={tab === 'banners' ? 'solid' : 'bordered'}
               color={tab === 'banners' ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setTab('banners')}
+              onPress={() => setTab('banners')}
               startContent={<Image className="h-4 w-4" />}
             >
               {t('storefront.banners')}
@@ -86,7 +86,7 @@ export default function StorefrontPage() {
               variant={tab === 'preview' ? 'solid' : 'bordered'}
               color={tab === 'preview' ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setTab('preview')}
+              onPress={() => setTab('preview')}
               startContent={<Eye className="h-4 w-4" />}
             >
               {t('storefront.preview')}
@@ -122,7 +122,7 @@ export default function StorefrontPage() {
               <Button
                 color="primary"
                 size="sm"
-                onClick={() => saveConfig.mutate(configForm)}
+                onPress={() => saveConfig.mutate(configForm)}
                 isLoading={saveConfig.isPending}
                 startContent={<Save className="h-4 w-4" />}
               >

--- a/client/src/features/inventory/components/AdjustStockDialog.tsx
+++ b/client/src/features/inventory/components/AdjustStockDialog.tsx
@@ -138,7 +138,7 @@ export default function AdjustStockDialog({
               <Button
                 variant="flat"
                 size="sm"
-                onClick={() => {
+                onPress={() => {
                   onOpenChange(false);
                   resetForm();
                 }}
@@ -148,7 +148,7 @@ export default function AdjustStockDialog({
               <Button
                 color="primary"
                 size="sm"
-                onClick={handleSubmit}
+                onPress={handleSubmit}
                 disabled={delta === 0 || newStock < 0}
                 isLoading={adjuster.isRunning}
               >

--- a/client/src/features/inventory/components/inventory/BulkOperationDialogs.tsx
+++ b/client/src/features/inventory/components/inventory/BulkOperationDialogs.tsx
@@ -138,7 +138,7 @@ export default function BulkOperationDialogs({
                 </Select>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setBulkCategoryOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setBulkCategoryOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
@@ -146,7 +146,7 @@ export default function BulkOperationDialogs({
                   size="sm"
                   disabled={!bulkCategory}
                   isLoading={bulkUpdatePending}
-                  onClick={() => onBulkCategoryUpdate(selectedIds, Number(bulkCategory))}
+                  onPress={() => onBulkCategoryUpdate(selectedIds, Number(bulkCategory))}
                 >
                   {t('common.update')}
                 </Button>
@@ -200,7 +200,7 @@ export default function BulkOperationDialogs({
                 </Select>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setBulkDistributorOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setBulkDistributorOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
@@ -208,7 +208,7 @@ export default function BulkOperationDialogs({
                   size="sm"
                   disabled={!bulkDistributor}
                   isLoading={bulkUpdatePending}
-                  onClick={() =>
+                  onPress={() =>
                     onBulkDistributorUpdate(
                       selectedIds,
                       bulkDistributor === 'null' ? null : Number(bulkDistributor)
@@ -259,7 +259,7 @@ export default function BulkOperationDialogs({
                 <p className="text-xs text-muted-foreground">{t('bulk.pricePercentHint')}</p>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setBulkPriceOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setBulkPriceOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
@@ -267,7 +267,7 @@ export default function BulkOperationDialogs({
                   size="sm"
                   disabled={!bulkPricePercent}
                   isLoading={bulkUpdatePending}
-                  onClick={() => onBulkPriceUpdate(selectedIds, Number(bulkPricePercent))}
+                  onPress={() => onBulkPriceUpdate(selectedIds, Number(bulkPricePercent))}
                 >
                   {t('common.update')}
                 </Button>
@@ -320,7 +320,7 @@ export default function BulkOperationDialogs({
                 </Select>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setBulkStatusOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setBulkStatusOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
@@ -328,7 +328,7 @@ export default function BulkOperationDialogs({
                   size="sm"
                   disabled={!bulkStatusValue}
                   isLoading={bulkUpdatePending}
-                  onClick={() => {
+                  onPress={() => {
                     onBulkStatusUpdate(selectedIds, bulkStatusValue);
                     setBulkStatusOpen(false);
                   }}

--- a/client/src/features/inventory/components/inventory/ProductFormDialog.tsx
+++ b/client/src/features/inventory/components/inventory/ProductFormDialog.tsx
@@ -307,7 +307,7 @@ export default function ProductFormDialog({
                         variant="bordered"
                         size="sm"
                         startContent={<Upload className="h-3.5 w-3.5" />}
-                        onClick={() => imageInputRef.current?.click()}
+                        onPress={() => imageInputRef.current?.click()}
                       >
                         {t('inventory.uploadImage')}
                       </Button>
@@ -318,7 +318,7 @@ export default function ProductFormDialog({
                           color="danger"
                           size="sm"
                           startContent={<Trash2 className="h-3.5 w-3.5" />}
-                          onClick={() => onImageRemove(editingProduct.id)}
+                          onPress={() => onImageRemove(editingProduct.id)}
                         >
                           {t('inventory.removeImage')}
                         </Button>
@@ -329,7 +329,7 @@ export default function ProductFormDialog({
               )}
             </ModalBody>
             <ModalFooter className="border-t border-border/50">
-              <Button variant="flat" size="sm" onClick={() => handleOpenChange(false)}>
+              <Button variant="flat" size="sm" onPress={() => handleOpenChange(false)}>
                 {t('common.cancel')}
               </Button>
               <Button color="primary" size="sm" type="submit" isLoading={isSubmitting}>

--- a/client/src/features/inventory/components/inventory/VariantManagerDialog.tsx
+++ b/client/src/features/inventory/components/inventory/VariantManagerDialog.tsx
@@ -150,7 +150,7 @@ export default function VariantManagerDialog({
                             variant="light"
                             size="sm"
                             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                            onClick={() => onOpenEditVariant(variant)}
+                            onPress={() => onOpenEditVariant(variant)}
                             aria-label={t('common.edit')}
                           >
                             <Pencil className="h-3.5 w-3.5" />
@@ -161,7 +161,7 @@ export default function VariantManagerDialog({
                             color="danger"
                             size="sm"
                             className="h-8 w-8"
-                            onClick={() => setVariantDeleteId(variant.id)}
+                            onPress={() => setVariantDeleteId(variant.id)}
                             aria-label={t('common.delete')}
                           >
                             <Trash2 className="h-3.5 w-3.5" />
@@ -265,7 +265,7 @@ export default function VariantManagerDialog({
                               color="danger"
                               size="sm"
                               className="h-8 w-8 shrink-0"
-                              onClick={() =>
+                              onPress={() =>
                                 setVariantAttrs(variantAttrs.filter((_, j) => j !== i))
                               }
                               aria-label={t('common.remove')}
@@ -279,19 +279,19 @@ export default function VariantManagerDialog({
                         variant="bordered"
                         size="sm"
                         startContent={<Plus className="h-3.5 w-3.5" />}
-                        onClick={() => setVariantAttrs([...variantAttrs, { key: '', value: '' }])}
+                        onPress={() => setVariantAttrs([...variantAttrs, { key: '', value: '' }])}
                       >
                         {t('variants.addAttribute')}
                       </Button>
                     </div>
                     <div className="flex gap-2 justify-end pt-2">
-                      <Button variant="flat" size="sm" onClick={onResetVariantForm}>
+                      <Button variant="flat" size="sm" onPress={onResetVariantForm}>
                         {t('common.cancel')}
                       </Button>
                       <Button
                         color="primary"
                         size="sm"
-                        onClick={onVariantSubmit}
+                        onPress={onVariantSubmit}
                         isLoading={createVariantPending || updateVariantPending}
                       >
                         {editingVariant ? t('common.update') : t('common.create')}
@@ -305,7 +305,7 @@ export default function VariantManagerDialog({
                     size="sm"
                     className="w-full"
                     startContent={<Plus className="h-4 w-4" />}
-                    onClick={() => setVariantFormOpen(true)}
+                    onPress={() => setVariantFormOpen(true)}
                   >
                     {t('variants.addVariant')}
                   </Button>

--- a/client/src/features/inventory/pages/Bundles.tsx
+++ b/client/src/features/inventory/pages/Bundles.tsx
@@ -158,7 +158,7 @@ export default function BundlesPage() {
             isIconOnly
             variant="flat"
             size="sm"
-            onClick={() => setSelectedBundle(null)}
+            onPress={() => setSelectedBundle(null)}
             aria-label={t('common.back')}
           >
             <ArrowRight className="h-4 w-4 rtl:rotate-180" />
@@ -169,7 +169,7 @@ export default function BundlesPage() {
               size="sm"
               variant="bordered"
               startContent={<Pencil className="h-4 w-4" />}
-              onClick={() => openEditDialog(detail)}
+              onPress={() => openEditDialog(detail)}
             >
               {t('common.edit')}
             </Button>
@@ -178,7 +178,7 @@ export default function BundlesPage() {
               color="danger"
               variant="flat"
               startContent={<Trash2 className="h-4 w-4" />}
-              onClick={() => remover.remove(detail.id)}
+              onPress={() => remover.remove(detail.id)}
             >
               {t('common.delete')}
             </Button>
@@ -300,7 +300,7 @@ export default function BundlesPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={openCreateDialog}
+            onPress={openCreateDialog}
           >
             {t('bundles.create')}
           </Button>
@@ -372,7 +372,7 @@ export default function BundlesPage() {
                   variant="light"
                   size="sm"
                   className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                  onClick={() => openEditDialog(bundle)}
+                  onPress={() => openEditDialog(bundle)}
                   aria-label={`${bundle.name}: ${t('common.edit')}`}
                 >
                   <Pencil className="h-3.5 w-3.5" />
@@ -383,7 +383,7 @@ export default function BundlesPage() {
                   color="danger"
                   size="sm"
                   className="h-8 w-8"
-                  onClick={() => remover.remove(bundle.id)}
+                  onPress={() => remover.remove(bundle.id)}
                   aria-label={`${bundle.name}: ${t('common.delete')}`}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
@@ -511,7 +511,7 @@ export default function BundlesPage() {
                       variant="bordered"
                       size="sm"
                       startContent={<Plus className="h-3.5 w-3.5" />}
-                      onClick={() => {
+                      onPress={() => {
                         setAddProductOpen(true);
                         setProductSearch('');
                       }}
@@ -556,7 +556,7 @@ export default function BundlesPage() {
                             color="danger"
                             size="sm"
                             className="h-8 w-8 shrink-0"
-                            onClick={() => removeItemFromBundle(item.product_id)}
+                            onPress={() => removeItemFromBundle(item.product_id)}
                             aria-label={t('common.remove')}
                           >
                             <X className="h-4 w-4" />
@@ -568,7 +568,7 @@ export default function BundlesPage() {
                 </div>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button

--- a/client/src/features/inventory/pages/Categories.tsx
+++ b/client/src/features/inventory/pages/Categories.tsx
@@ -96,7 +96,7 @@ export default function CategoriesPage() {
             variant="light"
             size="sm"
             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            onClick={() => openEditDialog(row.original)}
+            onPress={() => openEditDialog(row.original)}
             title={t('common.edit')}
             aria-label={t('common.edit')}
           >
@@ -107,7 +107,7 @@ export default function CategoriesPage() {
             variant="light"
             size="sm"
             className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-            onClick={() => setDeleteId(row.original.id)}
+            onPress={() => setDeleteId(row.original.id)}
             title={t('common.delete')}
             aria-label={t('common.delete')}
           >
@@ -127,7 +127,7 @@ export default function CategoriesPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={openCreateDialog}
+            onPress={openCreateDialog}
           >
             {t('categories.addCategory')}
           </Button>
@@ -188,7 +188,7 @@ export default function CategoriesPage() {
                 </div>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saver.isSaving}>

--- a/client/src/features/inventory/pages/Collections.tsx
+++ b/client/src/features/inventory/pages/Collections.tsx
@@ -130,7 +130,7 @@ export default function CollectionsPage() {
             isIconOnly
             variant="flat"
             size="sm"
-            onClick={() => setSelectedCol(null)}
+            onPress={() => setSelectedCol(null)}
             aria-label={t('common.back')}
           >
             <ArrowRight className="h-4 w-4 rotate-180 rtl:rotate-0" />
@@ -141,7 +141,7 @@ export default function CollectionsPage() {
                 color="primary"
                 size="sm"
                 startContent={<Plus className="h-4 w-4" />}
-                onClick={() => setAddProductOpen(true)}
+                onPress={() => setAddProductOpen(true)}
               >
                 {t('collections.addProduct')}
               </Button>
@@ -186,7 +186,7 @@ export default function CollectionsPage() {
                       size="sm"
                       className="h-6 w-6 text-muted-foreground hover:text-danger"
                       isDisabled={productEditsBlocked}
-                      onClick={() =>
+                      onPress={() =>
                         removeProduct.save(
                           withProducts(
                             detail,
@@ -299,7 +299,7 @@ export default function CollectionsPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={editor.openNew}
+            onPress={editor.openNew}
           >
             {t('collections.create')}
           </Button>
@@ -380,7 +380,7 @@ export default function CollectionsPage() {
                   variant="light"
                   size="sm"
                   className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                  onClick={() => editor.openEdit(col)}
+                  onPress={() => editor.openEdit(col)}
                   aria-label={`${col.name}: ${t('common.edit')}`}
                 >
                   <Pencil className="h-3.5 w-3.5" />
@@ -391,7 +391,7 @@ export default function CollectionsPage() {
                   color="danger"
                   size="sm"
                   className="h-8 w-8"
-                  onClick={() => remover.remove(col.id)}
+                  onPress={() => remover.remove(col.id)}
                   aria-label={`${col.name}: ${t('common.delete')}`}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
@@ -500,7 +500,7 @@ export default function CollectionsPage() {
                 </div>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saver.isSaving}>

--- a/client/src/features/inventory/pages/Inventory.tsx
+++ b/client/src/features/inventory/pages/Inventory.tsx
@@ -672,7 +672,7 @@ export default function Inventory() {
                 variant="bordered"
                 size="sm"
                 startContent={<Upload className="h-4 w-4" />}
-                onClick={() => fileInputRef.current?.click()}
+                onPress={() => fileInputRef.current?.click()}
               >
                 {t('inventory.importCsv')}
               </Button>
@@ -680,7 +680,7 @@ export default function Inventory() {
                 color="primary"
                 size="sm"
                 startContent={<Plus className="h-4 w-4" />}
-                onClick={openCreateDialog}
+                onPress={openCreateDialog}
               >
                 {t('inventory.addProduct')}
               </Button>
@@ -753,7 +753,7 @@ export default function Inventory() {
             variant={lowStockFilter ? 'solid' : 'bordered'}
             color={lowStockFilter ? 'warning' : 'default'}
             startContent={<AlertTriangle className="h-3.5 w-3.5" />}
-            onClick={() => toggleLowStock(!lowStockFilter)}
+            onPress={() => toggleLowStock(!lowStockFilter)}
           >
             {t('inventory.lowStockFilter')}
           </Button>
@@ -771,7 +771,7 @@ export default function Inventory() {
             size="sm"
             variant="light"
             endContent={<X className="h-3.5 w-3.5" />}
-            onClick={() => toggleLowStock(false)}
+            onPress={() => toggleLowStock(false)}
           >
             {t('inventory.viewAll')}
           </Button>
@@ -833,28 +833,28 @@ export default function Inventory() {
           getRowId={(row: Product) => String(row.id)}
           bulkActions={(_selected, clearSelection) => (
             <>
-              <Button variant="bordered" size="sm" onClick={() => setBulkCategoryOpen(true)}>
+              <Button variant="bordered" size="sm" onPress={() => setBulkCategoryOpen(true)}>
                 {t('bulk.changeCategory')}
               </Button>
-              <Button variant="bordered" size="sm" onClick={() => setBulkDistributorOpen(true)}>
+              <Button variant="bordered" size="sm" onPress={() => setBulkDistributorOpen(true)}>
                 {t('bulk.changeDistributor')}
               </Button>
               <Button
                 variant="bordered"
                 size="sm"
                 startContent={<Percent className="h-3.5 w-3.5" />}
-                onClick={() => setBulkPriceOpen(true)}
+                onPress={() => setBulkPriceOpen(true)}
               >
                 {t('bulk.adjustPrice')}
               </Button>
-              <Button variant="bordered" size="sm" onClick={() => setBulkStatusOpen(true)}>
+              <Button variant="bordered" size="sm" onPress={() => setBulkStatusOpen(true)}>
                 {t('bulk.changeStatus')}
               </Button>
               <Button
                 variant="bordered"
                 size="sm"
                 startContent={<Download className="h-3.5 w-3.5" />}
-                onClick={handleBulkExport}
+                onPress={handleBulkExport}
               >
                 {t('bulk.export')}
               </Button>
@@ -863,11 +863,11 @@ export default function Inventory() {
                 color="danger"
                 size="sm"
                 startContent={<Archive className="h-3.5 w-3.5" />}
-                onClick={() => setBulkDeleteOpen(true)}
+                onPress={() => setBulkDeleteOpen(true)}
               >
                 {t('bulk.discontinueSelected')}
               </Button>
-              <Button variant="light" size="sm" onClick={clearSelection}>
+              <Button variant="light" size="sm" onPress={clearSelection}>
                 {t('bulk.clearSelection')}
               </Button>
             </>

--- a/client/src/features/inventory/pages/SmartPricing.tsx
+++ b/client/src/features/inventory/pages/SmartPricing.tsx
@@ -145,7 +145,7 @@ export default function SmartPricingPage() {
             size="sm"
             variant="flat"
             color="success"
-            onClick={() => handleSuggestion.save({ id: row.original.id, status: 'applied' })}
+            onPress={() => handleSuggestion.save({ id: row.original.id, status: 'applied' })}
             title={t('smartPricing.apply')}
             aria-label={t('smartPricing.apply')}
           >
@@ -155,7 +155,7 @@ export default function SmartPricingPage() {
             isIconOnly
             size="sm"
             variant="light"
-            onClick={() => handleSuggestion.save({ id: row.original.id, status: 'dismissed' })}
+            onPress={() => handleSuggestion.save({ id: row.original.id, status: 'dismissed' })}
             title={t('smartPricing.dismiss')}
             aria-label={t('smartPricing.dismiss')}
             className="text-muted-foreground hover:text-destructive hover:bg-destructive/10"
@@ -177,7 +177,7 @@ export default function SmartPricingPage() {
               variant={tab === 'suggestions' ? 'solid' : 'bordered'}
               color={tab === 'suggestions' ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setTab('suggestions')}
+              onPress={() => setTab('suggestions')}
               startContent={<Zap className="h-4 w-4" />}
             >
               {t('smartPricing.suggestions')}
@@ -186,7 +186,7 @@ export default function SmartPricingPage() {
               variant={tab === 'rules' ? 'solid' : 'bordered'}
               color={tab === 'rules' ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setTab('rules')}
+              onPress={() => setTab('rules')}
               startContent={<TrendingUp className="h-4 w-4" />}
             >
               {t('smartPricing.rules')}
@@ -194,7 +194,7 @@ export default function SmartPricingPage() {
             <Button
               color="primary"
               size="sm"
-              onClick={() => generate.mutate()}
+              onPress={() => generate.mutate()}
               isLoading={generate.isPending}
               startContent={
                 <RefreshCw className={`h-4 w-4 ${generate.isPending ? 'animate-spin' : ''}`} />
@@ -221,7 +221,7 @@ export default function SmartPricingPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={() => setRuleOpen(true)}
+            onPress={() => setRuleOpen(true)}
           >
             {t('smartPricing.addRule')}
           </Button>
@@ -321,7 +321,7 @@ export default function SmartPricingPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setRuleOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setRuleOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button color="primary" size="sm" type="submit" isLoading={createRule.isSaving}>

--- a/client/src/features/inventory/pages/StockCount.tsx
+++ b/client/src/features/inventory/pages/StockCount.tsx
@@ -122,7 +122,7 @@ export default function StockCountPage() {
             isIconOnly
             variant="flat"
             size="sm"
-            onClick={() => setSelectedCount(null)}
+            onPress={() => setSelectedCount(null)}
             aria-label={t('common.back')}
           >
             {isRtl ? <ArrowRight className="h-4 w-4" /> : <ArrowLeft className="h-4 w-4" />}
@@ -212,7 +212,7 @@ export default function StockCountPage() {
                           variant={item.approved ? 'solid' : 'bordered'}
                           color={item.approved ? 'primary' : 'default'}
                           className="h-8 w-8 mx-auto"
-                          onClick={() => toggleApproveMutation.mutate(item.id)}
+                          onPress={() => toggleApproveMutation.mutate(item.id)}
                           aria-label={t('common.confirm')}
                         >
                           {item.approved ? <Check className="h-4 w-4" /> : null}
@@ -236,7 +236,7 @@ export default function StockCountPage() {
               color="primary"
               size="sm"
               startContent={<Check className="h-4 w-4" />}
-              onClick={() => selectedCount && approveCountMutation.run({ id: selectedCount })}
+              onPress={() => selectedCount && approveCountMutation.run({ id: selectedCount })}
               isLoading={approveCountMutation.isRunning}
             >
               {t('stockCount.approveCount')}
@@ -246,7 +246,7 @@ export default function StockCountPage() {
               color="danger"
               size="sm"
               startContent={<X className="h-4 w-4" />}
-              onClick={() => selectedCount && cancelMutation.remove(selectedCount)}
+              onPress={() => selectedCount && cancelMutation.remove(selectedCount)}
             >
               {t('stockCount.cancel')}
             </Button>
@@ -264,7 +264,7 @@ export default function StockCountPage() {
           color="primary"
           size="sm"
           startContent={<Plus className="h-4 w-4" />}
-          onClick={() => setCreateOpen(true)}
+          onPress={() => setCreateOpen(true)}
         >
           {t('stockCount.startCount')}
         </Button>
@@ -364,13 +364,13 @@ export default function StockCountPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setCreateOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setCreateOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
                   color="primary"
                   size="sm"
-                  onClick={() => createMutation.mutate()}
+                  onPress={() => createMutation.mutate()}
                   isLoading={createMutation.isPending}
                 >
                   {t('stockCount.startCount')}

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -166,7 +166,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
             variant="light"
             size="sm"
             className="h-8 w-8"
-            onClick={handleHoldCart}
+            onPress={handleHoldCart}
             isDisabled={items.length === 0}
             title={t('cart.hold')}
             aria-label={t('cart.hold')}
@@ -178,7 +178,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
             variant="light"
             size="sm"
             className="h-8 w-8 relative"
-            onClick={() => setHeldCartsOpen(true)}
+            onPress={() => setHeldCartsOpen(true)}
             title={t('cart.heldCarts')}
             aria-label={t('cart.heldCarts')}
           >
@@ -195,7 +195,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
               color="danger"
               size="sm"
               className="h-8 text-xs ms-1"
-              onClick={clearCart}
+              onPress={clearCart}
             >
               {t('cart.clearAll')}
             </Button>
@@ -211,7 +211,7 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
       {needsReview && (
         <div className="mx-4 mt-3 p-3 rounded-lg border border-warning/40 bg-warning/10 flex items-start gap-2">
           <p className="text-xs text-foreground flex-1">{t('cart.needsReviewWarning')}</p>
-          <Button size="sm" variant="flat" color="warning" onClick={acknowledgeReview}>
+          <Button size="sm" variant="flat" color="warning" onPress={acknowledgeReview}>
             {t('cart.needsReviewAcknowledge')}
           </Button>
         </div>

--- a/client/src/features/pos/components/HeldCartsDialog.tsx
+++ b/client/src/features/pos/components/HeldCartsDialog.tsx
@@ -124,7 +124,7 @@ export default function HeldCartsDialog({ open, onOpenChange }: HeldCartsDialogP
                               color="primary"
                               size="sm"
                               className="h-8 w-8"
-                              onClick={() => handleRetrieve(cart.id)}
+                              onPress={() => handleRetrieve(cart.id)}
                               title={t('cart.retrieve')}
                               aria-label={t('cart.retrieve')}
                             >
@@ -136,7 +136,7 @@ export default function HeldCartsDialog({ open, onOpenChange }: HeldCartsDialogP
                               color="danger"
                               size="sm"
                               className="h-8 w-8"
-                              onClick={() => handleDelete(cart.id)}
+                              onPress={() => handleDelete(cart.id)}
                               title={t('cart.deleteHeld')}
                               aria-label={t('cart.deleteHeld')}
                             >

--- a/client/src/features/pos/components/StartupPrompt.tsx
+++ b/client/src/features/pos/components/StartupPrompt.tsx
@@ -117,7 +117,7 @@ export default function StartupPrompt() {
                     <Button
                       color="primary"
                       size="sm"
-                      onClick={handleClockIn}
+                      onPress={handleClockIn}
                       isLoading={clockInMutation.isPending}
                     >
                       {t('startup.clockIn')}
@@ -150,7 +150,7 @@ export default function StartupPrompt() {
                     <Button
                       color="primary"
                       size="sm"
-                      onClick={handleOpenRegister}
+                      onPress={handleOpenRegister}
                       isLoading={openRegisterMutation.isPending}
                     >
                       {t('startup.openRegister')}
@@ -161,7 +161,7 @@ export default function StartupPrompt() {
             </ModalBody>
 
             <ModalFooter className="border-t border-border/50">
-              <Button variant="light" size="sm" onClick={handleSkip}>
+              <Button variant="light" size="sm" onPress={handleSkip}>
                 {t('startup.skip')}
               </Button>
             </ModalFooter>

--- a/client/src/features/pos/components/checkout/CartFooter.tsx
+++ b/client/src/features/pos/components/checkout/CartFooter.tsx
@@ -119,7 +119,7 @@ export default function CartFooter({
                   variant={discount === pct ? 'solid' : 'bordered'}
                   color={discount === pct ? 'primary' : 'default'}
                   className="flex-1 h-7 min-w-0 px-1 text-[11px] font-data font-medium"
-                  onClick={() => setDiscount(pct)}
+                  onPress={() => setDiscount(pct)}
                 >
                   {pct}%
                 </Button>
@@ -131,7 +131,7 @@ export default function CartFooter({
                   variant={discount === amt ? 'solid' : 'bordered'}
                   color={discount === amt ? 'primary' : 'default'}
                   className="flex-1 h-7 min-w-0 px-1 text-[11px] font-data font-medium"
-                  onClick={() => setDiscount(amt)}
+                  onPress={() => setDiscount(amt)}
                 >
                   ${amt}
                 </Button>
@@ -188,7 +188,7 @@ export default function CartFooter({
         color="primary"
         size="md"
         className="w-full font-semibold shadow-sm"
-        onClick={onCheckout}
+        onPress={onCheckout}
         isDisabled={checkoutDisabled}
       >
         {t('cart.checkout')}

--- a/client/src/features/pos/components/checkout/CartLineItem.tsx
+++ b/client/src/features/pos/components/checkout/CartLineItem.tsx
@@ -70,7 +70,7 @@ export default function CartLineItem({
           variant="light"
           size="sm"
           className="h-7 w-7"
-          onClick={() => onQuantityChange(item.quantity - 1)}
+          onPress={() => onQuantityChange(item.quantity - 1)}
           aria-label="Decrease quantity"
         >
           <Minus className="h-3.5 w-3.5 text-primary" />
@@ -88,7 +88,7 @@ export default function CartLineItem({
           variant="light"
           size="sm"
           className="h-7 w-7"
-          onClick={() => onQuantityChange(item.quantity + 1)}
+          onPress={() => onQuantityChange(item.quantity + 1)}
           isDisabled={item.quantity >= item.stock}
           aria-label="Increase quantity"
         >
@@ -104,7 +104,7 @@ export default function CartLineItem({
         color="danger"
         size="sm"
         className="h-7 w-7"
-        onClick={onRemove}
+        onPress={onRemove}
         aria-label="Remove item"
       >
         <X className="h-3.5 w-3.5" />

--- a/client/src/features/pos/components/checkout/CheckoutDrawer.tsx
+++ b/client/src/features/pos/components/checkout/CheckoutDrawer.tsx
@@ -170,7 +170,7 @@ export default function CheckoutDrawer({
                       variant="light"
                       size="sm"
                       className="h-7 w-7"
-                      onClick={coupon.remove}
+                      onPress={coupon.remove}
                       aria-label="Remove coupon"
                     >
                       <X className="h-3.5 w-3.5" />
@@ -186,7 +186,7 @@ export default function CheckoutDrawer({
                       onValueChange={coupon.setInput}
                       className="flex-1"
                     />
-                    <Button variant="bordered" size="sm" onClick={coupon.apply}>
+                    <Button variant="bordered" size="sm" onPress={coupon.apply}>
                       {t('cart.applyCoupon')}
                     </Button>
                   </div>
@@ -216,7 +216,7 @@ export default function CheckoutDrawer({
                         discountType === 'percentage' && discount === pct ? 'primary' : 'default'
                       }
                       className="flex-1 h-7 min-w-0 text-[11px] font-data font-medium"
-                      onClick={() => {
+                      onPress={() => {
                         setDiscountType('percentage');
                         setDiscount(pct);
                       }}
@@ -309,7 +309,7 @@ export default function CheckoutDrawer({
                 color="primary"
                 size="md"
                 className="w-full shrink-0 font-semibold shadow-sm"
-                onClick={onConfirm}
+                onPress={onConfirm}
                 isDisabled={isPending || needsReview || (splitPayment && !split.isBalanced)}
                 isLoading={isPending}
               >

--- a/client/src/features/pos/components/checkout/CustomerSection.tsx
+++ b/client/src/features/pos/components/checkout/CustomerSection.tsx
@@ -46,7 +46,7 @@ export default function CustomerSection({
             variant="light"
             size="sm"
             className="h-7 w-7 shrink-0"
-            onClick={onRemoveSelected}
+            onPress={onRemoveSelected}
             aria-label="Remove selected customer"
           >
             <X className="h-3.5 w-3.5" />
@@ -77,11 +77,11 @@ export default function CustomerSection({
                 !customer.newName.trim() || !customer.newPhone.trim() || customer.isSaving
               }
               isLoading={customer.isSaving}
-              onClick={customer.createAndSelect}
+              onPress={customer.createAndSelect}
             >
               {t('cart.saveCustomer')}
             </Button>
-            <Button variant="flat" size="sm" className="text-xs" onClick={customer.cancelCreating}>
+            <Button variant="flat" size="sm" className="text-xs" onPress={customer.cancelCreating}>
               {t('common.cancel')}
             </Button>
           </div>
@@ -127,7 +127,7 @@ export default function CustomerSection({
             size="sm"
             className="w-full text-xs"
             startContent={<Plus className="h-3 w-3" />}
-            onClick={customer.startCreating}
+            onPress={customer.startCreating}
           >
             {t('cart.addNewCustomer')}
           </Button>

--- a/client/src/features/pos/components/checkout/PaymentSection.tsx
+++ b/client/src/features/pos/components/checkout/PaymentSection.tsx
@@ -129,7 +129,7 @@ export default function PaymentSection({
                   variant="light"
                   size="sm"
                   className="h-7 w-7"
-                  onClick={() => setPayments(payments.filter((_, i) => i !== idx))}
+                  onPress={() => setPayments(payments.filter((_, i) => i !== idx))}
                   aria-label="Remove payment split"
                 >
                   <X className="h-3.5 w-3.5" />
@@ -142,7 +142,7 @@ export default function PaymentSection({
               variant="light"
               size="sm"
               startContent={<Plus className="h-3 w-3" />}
-              onClick={() => setPayments([...payments, { method: 'Cash', amount: 0 }])}
+              onPress={() => setPayments([...payments, { method: 'Cash', amount: 0 }])}
             >
               {t('cart.addPayment')}
             </Button>

--- a/client/src/features/pos/components/checkout/StockConflictNotice.tsx
+++ b/client/src/features/pos/components/checkout/StockConflictNotice.tsx
@@ -50,7 +50,7 @@ export default function StockConflictNotice({
           </li>
         ))}
       </ul>
-      <Button size="sm" variant="flat" color="warning" onClick={conflict.resolve}>
+      <Button size="sm" variant="flat" color="warning" onPress={conflict.resolve}>
         {t('cart.stockConflictAdjust')}
       </Button>
     </div>

--- a/client/src/features/pos/components/register/CashMovementDialog.tsx
+++ b/client/src/features/pos/components/register/CashMovementDialog.tsx
@@ -89,7 +89,7 @@ export default function CashMovementDialog({
               />
             </ModalBody>
             <ModalFooter className="border-t border-border/50">
-              <Button variant="flat" size="sm" onClick={() => handleOpenChange(false)}>
+              <Button variant="flat" size="sm" onPress={() => handleOpenChange(false)}>
                 {t('common.cancel')}
               </Button>
               <Button type="submit" color="primary" size="sm" isLoading={isSubmitting}>

--- a/client/src/features/pos/pages/BarcodeTools.tsx
+++ b/client/src/features/pos/pages/BarcodeTools.tsx
@@ -152,14 +152,14 @@ export default function BarcodeTools() {
                           <Button
                             color="primary"
                             size="sm"
-                            onClick={() => handleAddToCart(scannedProduct)}
+                            onPress={() => handleAddToCart(scannedProduct)}
                           >
                             {t('barcode.addToCart')}
                           </Button>
                           <Button
                             size="sm"
                             variant="bordered"
-                            onClick={() => navigate({ to: '/inventory' })}
+                            onPress={() => navigate({ to: '/inventory' })}
                           >
                             {t('barcode.viewProduct')}
                           </Button>
@@ -230,7 +230,7 @@ export default function BarcodeTools() {
                       color="primary"
                       size="sm"
                       startContent={<Printer className="h-4 w-4" />}
-                      onClick={() => {
+                      onPress={() => {
                         const printWindow = window.open('', '_blank');
                         if (!printWindow) return;
                         printWindow.document.write(`
@@ -271,7 +271,7 @@ export default function BarcodeTools() {
                 color="primary"
                 size="sm"
                 startContent={<Printer className="h-4 w-4" />}
-                onClick={handleBulkPrint}
+                onPress={handleBulkPrint}
                 isDisabled={selectedForPrint.size === 0}
               >
                 {t('barcode.generatePrint', { count: selectedForPrint.size })}

--- a/client/src/features/pos/pages/POS.tsx
+++ b/client/src/features/pos/pages/POS.tsx
@@ -250,7 +250,7 @@ export default function POS() {
               variant={showScanner ? 'solid' : 'bordered'}
               color={showScanner ? 'primary' : 'default'}
               size="sm"
-              onClick={() => setShowScanner(!showScanner)}
+              onPress={() => setShowScanner(!showScanner)}
               startContent={<Camera className="h-4 w-4" />}
             >
               {t('pos.scan')}
@@ -259,7 +259,7 @@ export default function POS() {
               isIconOnly
               variant="light"
               size="sm"
-              onClick={() => setShowShortcuts(true)}
+              onPress={() => setShowShortcuts(true)}
               title={t('pos.shortcuts')}
               aria-label={t('pos.shortcuts')}
               className="hidden lg:flex"
@@ -276,7 +276,7 @@ export default function POS() {
                 variant={selectedCategory === null ? 'solid' : 'bordered'}
                 color={selectedCategory === null ? 'primary' : 'default'}
                 className="rounded-full text-xs h-7 px-3 min-w-0"
-                onClick={() => setSelectedCategory(null)}
+                onPress={() => setSelectedCategory(null)}
               >
                 {t('pos.allCategories')}
               </Button>
@@ -287,7 +287,7 @@ export default function POS() {
                   variant={selectedCategory === cat.id ? 'solid' : 'bordered'}
                   color={selectedCategory === cat.id ? 'primary' : 'default'}
                   className="rounded-full text-xs h-7 px-3 min-w-0"
-                  onClick={() => setSelectedCategory(selectedCategory === cat.id ? null : cat.id)}
+                  onPress={() => setSelectedCategory(selectedCategory === cat.id ? null : cat.id)}
                 >
                   {cat.name}
                 </Button>
@@ -300,14 +300,14 @@ export default function POS() {
             <div className="flex items-center gap-3 p-3 rounded-xl border border-primary/30 bg-primary/5">
               <AlertCircle className="h-5 w-5 text-primary shrink-0" />
               <p className="text-sm text-foreground flex-1">{t('cart.recoveredCart')}</p>
-              <Button size="sm" variant="bordered" onClick={() => setShowRecoveryBanner(false)}>
+              <Button size="sm" variant="bordered" onPress={() => setShowRecoveryBanner(false)}>
                 {t('cart.keepCart')}
               </Button>
               <Button
                 size="sm"
                 variant="light"
                 color="danger"
-                onClick={() => {
+                onPress={() => {
                   clearCart();
                   setShowRecoveryBanner(false);
                 }}

--- a/client/src/features/pos/pages/Register.tsx
+++ b/client/src/features/pos/pages/Register.tsx
@@ -159,7 +159,7 @@ export default function RegisterPage() {
             <Button
               variant="bordered"
               size="sm"
-              onClick={() => setHistoryDialogOpen(true)}
+              onPress={() => setHistoryDialogOpen(true)}
               startContent={<Clock className="h-4 w-4" />}
             >
               {t('register.history')}
@@ -168,7 +168,7 @@ export default function RegisterPage() {
               <Button
                 color="primary"
                 size="sm"
-                onClick={() => setOpenDialogOpen(true)}
+                onPress={() => setOpenDialogOpen(true)}
                 startContent={<Vault className="h-4 w-4" />}
               >
                 {t('register.openRegister')}
@@ -177,7 +177,7 @@ export default function RegisterPage() {
               <Button
                 variant="bordered"
                 size="sm"
-                onClick={() => setCloseDialogOpen(true)}
+                onPress={() => setCloseDialogOpen(true)}
                 startContent={<X className="h-4 w-4" />}
                 className="border-destructive/40 text-destructive hover:bg-destructive/10"
               >
@@ -197,7 +197,7 @@ export default function RegisterPage() {
           <Button
             color="primary"
             size="sm"
-            onClick={() => setOpenDialogOpen(true)}
+            onPress={() => setOpenDialogOpen(true)}
             startContent={<Vault className="h-4 w-4" />}
           >
             {t('register.openRegister')}
@@ -234,7 +234,7 @@ export default function RegisterPage() {
             <Button
               variant="bordered"
               className="h-20 flex-col gap-2 rounded-xl"
-              onClick={() => {
+              onPress={() => {
                 setMovementType('cash_in');
                 setMovementDialogOpen(true);
               }}
@@ -245,7 +245,7 @@ export default function RegisterPage() {
             <Button
               variant="bordered"
               className="h-20 flex-col gap-2 rounded-xl"
-              onClick={() => {
+              onPress={() => {
                 setMovementType('cash_out');
                 setMovementDialogOpen(true);
               }}
@@ -256,7 +256,7 @@ export default function RegisterPage() {
             <Button
               variant="bordered"
               className="h-20 flex-col gap-2 rounded-xl"
-              onClick={() => setReportSessionId(currentSession.id)}
+              onPress={() => setReportSessionId(currentSession.id)}
             >
               <FileText className="h-6 w-6 text-primary" />
               <span className="text-sm font-medium">{t('register.xReport')}</span>
@@ -313,7 +313,7 @@ export default function RegisterPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setOpenDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setOpenDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={openRegister.isPending}>
@@ -380,7 +380,7 @@ export default function RegisterPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setCloseDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setCloseDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="danger" size="sm" isLoading={closeRegister.isPending}>
@@ -477,7 +477,7 @@ export default function RegisterPage() {
                                   variant="light"
                                   size="sm"
                                   className="h-7 w-7"
-                                  onClick={() => setReportSessionId(s.id)}
+                                  onPress={() => setReportSessionId(s.id)}
                                   aria-label="View report"
                                 >
                                   <FileText className="h-3.5 w-3.5" />
@@ -489,7 +489,7 @@ export default function RegisterPage() {
                                     color="danger"
                                     size="sm"
                                     className="h-7 w-7"
-                                    onClick={() => {
+                                    onPress={() => {
                                       if (window.confirm(t('register.forceCloseConfirm'))) {
                                         forceClose.run({ id: s.id });
                                       }

--- a/client/src/features/pos/pages/Shifts.tsx
+++ b/client/src/features/pos/pages/Shifts.tsx
@@ -100,7 +100,7 @@ export default function ShiftsPage() {
                 <Button
                   color="primary"
                   size="sm"
-                  onClick={() => clockIn.mutate()}
+                  onPress={() => clockIn.mutate()}
                   isLoading={clockIn.isPending}
                   startContent={<LogIn className="h-4 w-4" />}
                 >
@@ -112,7 +112,7 @@ export default function ShiftsPage() {
                     <Button
                       variant="bordered"
                       size="sm"
-                      onClick={() => startBreak.mutate()}
+                      onPress={() => startBreak.mutate()}
                       isLoading={startBreak.isPending}
                       startContent={<Coffee className="h-4 w-4" />}
                     >
@@ -122,7 +122,7 @@ export default function ShiftsPage() {
                     <Button
                       variant="bordered"
                       size="sm"
-                      onClick={() => endBreak.mutate()}
+                      onPress={() => endBreak.mutate()}
                       isLoading={endBreak.isPending}
                       startContent={<Play className="h-4 w-4" />}
                     >
@@ -132,7 +132,7 @@ export default function ShiftsPage() {
                   <Button
                     color="danger"
                     size="sm"
-                    onClick={() => clockOut.mutate()}
+                    onPress={() => clockOut.mutate()}
                     isLoading={clockOut.isPending}
                     startContent={<LogOut className="h-4 w-4" />}
                   >

--- a/client/src/features/purchasing/components/purchase-orders/PODetailDialog.tsx
+++ b/client/src/features/purchasing/components/purchase-orders/PODetailDialog.tsx
@@ -194,7 +194,7 @@ export default function PODetailDialog({
                 <Button
                   color="primary"
                   size="sm"
-                  onClick={handleReceive}
+                  onPress={handleReceive}
                   isLoading={isReceiving}
                   startContent={<PackageCheck className="h-4 w-4" />}
                 >
@@ -207,7 +207,7 @@ export default function PODetailDialog({
                     variant="bordered"
                     size="sm"
                     startContent={<PackageCheck className="h-4 w-4" />}
-                    onClick={() => {
+                    onPress={() => {
                       setReceiveMode(true);
                       setReceiveQtys({});
                     }}

--- a/client/src/features/purchasing/components/purchase-orders/POFormDialog.tsx
+++ b/client/src/features/purchasing/components/purchase-orders/POFormDialog.tsx
@@ -187,7 +187,7 @@ export default function POFormDialog({
                     variant="bordered"
                     size="sm"
                     className="h-10 w-10"
-                    onClick={handleAddLineItem}
+                    onPress={handleAddLineItem}
                     isDisabled={!addProductId}
                     aria-label={t('common.add')}
                   >
@@ -261,7 +261,7 @@ export default function POFormDialog({
                           color="danger"
                           size="sm"
                           className="col-span-1 h-7 w-7"
-                          onClick={() => setLineItems(lineItems.filter((_, j) => j !== i))}
+                          onPress={() => setLineItems(lineItems.filter((_, j) => j !== i))}
                           aria-label={t('common.remove')}
                         >
                           <X className="h-3.5 w-3.5" />
@@ -283,13 +283,13 @@ export default function POFormDialog({
               )}
             </ModalBody>
             <ModalFooter className="border-t border-border/50">
-              <Button variant="flat" size="sm" onClick={() => handleOpenChange(false)}>
+              <Button variant="flat" size="sm" onPress={() => handleOpenChange(false)}>
                 {t('common.cancel')}
               </Button>
               <Button
                 color="primary"
                 size="sm"
-                onClick={handleSubmit}
+                onPress={handleSubmit}
                 isLoading={isSubmitting}
                 isDisabled={!distributorId || lineItems.length === 0 || isSubmitting}
               >

--- a/client/src/features/purchasing/pages/Distributors.tsx
+++ b/client/src/features/purchasing/pages/Distributors.tsx
@@ -125,7 +125,7 @@ export default function DistributorsPage() {
             variant="light"
             size="sm"
             className="h-8 w-8"
-            onClick={() => openEditDialog(row.original)}
+            onPress={() => openEditDialog(row.original)}
             aria-label={t('common.edit')}
           >
             <Pencil className="h-3.5 w-3.5 text-primary" />
@@ -136,7 +136,7 @@ export default function DistributorsPage() {
             color="danger"
             size="sm"
             className="h-8 w-8"
-            onClick={() => setDeleteId(row.original.id)}
+            onPress={() => setDeleteId(row.original.id)}
             aria-label={t('common.delete')}
           >
             <Trash2 className="h-3.5 w-3.5" />
@@ -153,7 +153,7 @@ export default function DistributorsPage() {
           color="primary"
           size="sm"
           startContent={<Plus className="h-4 w-4" />}
-          onClick={openCreateDialog}
+          onPress={openCreateDialog}
         >
           {t('distributors.addDistributor')}
         </Button>
@@ -239,7 +239,7 @@ export default function DistributorsPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saver.isSaving}>

--- a/client/src/features/purchasing/pages/Expenses.tsx
+++ b/client/src/features/purchasing/pages/Expenses.tsx
@@ -96,7 +96,7 @@ export default function ExpensesPage() {
           color="primary"
           size="sm"
           startContent={<Plus className="h-4 w-4" />}
-          onClick={editor.openNew}
+          onPress={editor.openNew}
         >
           {t('expenses.addExpense')}
         </Button>
@@ -186,7 +186,7 @@ export default function ExpensesPage() {
                             variant="light"
                             size="sm"
                             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                            onClick={() => editor.openEdit(exp)}
+                            onPress={() => editor.openEdit(exp)}
                             aria-label={t('common.edit')}
                           >
                             <Pencil className="h-3.5 w-3.5" />
@@ -197,7 +197,7 @@ export default function ExpensesPage() {
                             color="danger"
                             size="sm"
                             className="h-8 w-8"
-                            onClick={() => remover.remove(exp.id)}
+                            onPress={() => remover.remove(exp.id)}
                             aria-label={t('common.delete')}
                           >
                             <Trash2 className="h-3.5 w-3.5" />
@@ -408,7 +408,7 @@ export default function ExpensesPage() {
                 </div>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saver.isSaving}>

--- a/client/src/features/purchasing/pages/PurchaseOrders.tsx
+++ b/client/src/features/purchasing/pages/PurchaseOrders.tsx
@@ -246,7 +246,7 @@ export default function PurchaseOrders() {
               size="sm"
               className="h-8 w-8"
               title={t('po.viewDetails')}
-              onClick={() => {
+              onPress={() => {
                 setDetailId(po.id);
                 setDetailOpen(true);
                 setInitialReceiveMode(false);
@@ -262,7 +262,7 @@ export default function PurchaseOrders() {
                 size="sm"
                 className="h-8 w-8"
                 title={t('po.markSent')}
-                onClick={() => changeStatus.run({ id: po.id, body: { status: 'Sent' } })}
+                onPress={() => changeStatus.run({ id: po.id, body: { status: 'Sent' } })}
                 aria-label={t('po.markSent')}
               >
                 <Send className="h-3.5 w-3.5 text-primary" />
@@ -275,7 +275,7 @@ export default function PurchaseOrders() {
                 size="sm"
                 className="h-8 w-8"
                 title={t('po.receive')}
-                onClick={() => {
+                onPress={() => {
                   setDetailId(po.id);
                   setDetailOpen(true);
                   setInitialReceiveMode(true);
@@ -292,7 +292,7 @@ export default function PurchaseOrders() {
                 size="sm"
                 className="h-8 w-8"
                 title={t('po.cancel')}
-                onClick={() => setCancelId(po.id)}
+                onPress={() => setCancelId(po.id)}
                 aria-label={t('po.cancel')}
               >
                 <X className="h-3.5 w-3.5 text-warning" />
@@ -306,7 +306,7 @@ export default function PurchaseOrders() {
                 size="sm"
                 className="h-8 w-8"
                 title={t('po.delete')}
-                onClick={() => setDeleteId(po.id)}
+                onPress={() => setDeleteId(po.id)}
                 aria-label={t('po.delete')}
               >
                 <Trash2 className="h-3.5 w-3.5" />
@@ -328,7 +328,7 @@ export default function PurchaseOrders() {
               variant="bordered"
               size="sm"
               className="gap-2"
-              onClick={handleAutoGenerate}
+              onPress={handleAutoGenerate}
               startContent={<Wand2 className="h-4 w-4 text-primary" />}
             >
               {t('po.autoGenerate')}
@@ -337,7 +337,7 @@ export default function PurchaseOrders() {
               color="primary"
               size="sm"
               className="gap-2"
-              onClick={handleCreateOpen}
+              onPress={handleCreateOpen}
               startContent={<Plus className="h-4 w-4" />}
             >
               {t('po.create')}

--- a/client/src/features/purchasing/pages/Vendors.tsx
+++ b/client/src/features/purchasing/pages/Vendors.tsx
@@ -143,7 +143,7 @@ export default function VendorsPage() {
           color="primary"
           size="sm"
           startContent={<Plus className="h-4 w-4" />}
-          onClick={editor.openNew}
+          onPress={editor.openNew}
         >
           {t('vendors.addVendor')}
         </Button>
@@ -193,7 +193,7 @@ export default function VendorsPage() {
             variant={statusFilter === s ? 'solid' : 'bordered'}
             color={statusFilter === s ? 'primary' : 'default'}
             size="sm"
-            onClick={() => {
+            onPress={() => {
               update({ status: s || undefined, page: 1 });
             }}
           >
@@ -238,7 +238,7 @@ export default function VendorsPage() {
                         variant="light"
                         size="sm"
                         className="h-7 w-7"
-                        onClick={() => editor.openEdit(v)}
+                        onPress={() => editor.openEdit(v)}
                         aria-label={t('common.edit')}
                       >
                         <Pencil className="h-3.5 w-3.5 text-primary" />
@@ -249,7 +249,7 @@ export default function VendorsPage() {
                           variant="light"
                           size="sm"
                           className="h-7 w-7 text-success"
-                          onClick={() => updateStatus.run({ id: v.id, body: { status: 'active' } })}
+                          onPress={() => updateStatus.run({ id: v.id, body: { status: 'active' } })}
                           aria-label={t('common.confirm')}
                         >
                           <CheckCircle className="h-3.5 w-3.5" />
@@ -261,7 +261,7 @@ export default function VendorsPage() {
                           variant="light"
                           size="sm"
                           className="h-7 w-7 text-primary"
-                          onClick={() => {
+                          onPress={() => {
                             setSelectedVendor(v);
                             setPayoutOpen(true);
                           }}
@@ -277,7 +277,7 @@ export default function VendorsPage() {
                           color="danger"
                           size="sm"
                           className="h-7 w-7"
-                          onClick={() =>
+                          onPress={() =>
                             updateStatus.run({ id: v.id, body: { status: 'suspended' } })
                           }
                           aria-label={t('common.delete')}
@@ -408,7 +408,7 @@ export default function VendorsPage() {
                 </div>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saveVendor.isSaving}>
@@ -482,7 +482,7 @@ export default function VendorsPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setPayoutOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setPayoutOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={createPayout.isRunning}>

--- a/client/src/features/sales/components/RefundDialog.tsx
+++ b/client/src/features/sales/components/RefundDialog.tsx
@@ -259,7 +259,7 @@ export default function RefundDialog({
               {/* Submit */}
               <Button
                 color="primary"
-                onClick={handleSubmit}
+                onPress={handleSubmit}
                 isDisabled={
                   !hasSelection ||
                   refunder.isRunning ||

--- a/client/src/features/sales/pages/GiftCards.tsx
+++ b/client/src/features/sales/pages/GiftCards.tsx
@@ -244,7 +244,7 @@ export default function GiftCards() {
           color="primary"
           size="sm"
           startContent={<Plus className="h-4 w-4" />}
-          onClick={editor.openNew}
+          onPress={editor.openNew}
         >
           {t('giftCards.create')}
         </Button>
@@ -326,13 +326,13 @@ export default function GiftCards() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button
                   color="primary"
                   size="sm"
-                  onClick={handleCreate}
+                  onPress={handleCreate}
                   isLoading={creator.isSaving}
                   isDisabled={!form.initial_value}
                   startContent={<CreditCard className="h-4 w-4" />}

--- a/client/src/features/sales/pages/Layaway.tsx
+++ b/client/src/features/sales/pages/Layaway.tsx
@@ -232,7 +232,7 @@ export default function LayawayPage() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={() => {
+            onPress={() => {
               resetCreateForm();
               setCreateOpen(true);
             }}
@@ -288,7 +288,7 @@ export default function LayawayPage() {
                         variant="light"
                         size="sm"
                         className="h-7 w-7"
-                        onClick={() => {
+                        onPress={() => {
                           setSelectedId(lo.id);
                           setDetailDialogOpen(true);
                         }}
@@ -303,7 +303,7 @@ export default function LayawayPage() {
                             variant="light"
                             size="sm"
                             className="h-7 w-7 text-success"
-                            onClick={() => {
+                            onPress={() => {
                               setSelectedId(lo.id);
                               setPaymentAmount('');
                               setPaymentDialogOpen(true);
@@ -318,7 +318,7 @@ export default function LayawayPage() {
                             color="danger"
                             size="sm"
                             className="h-7 w-7"
-                            onClick={() => {
+                            onPress={() => {
                               if (window.confirm(t('layaway.cancel') + '?'))
                                 cancelMutation.run({ id: lo.id });
                             }}
@@ -389,7 +389,7 @@ export default function LayawayPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setPaymentDialogOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setPaymentDialogOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={payMutation.isRunning}>
@@ -466,7 +466,7 @@ export default function LayawayPage() {
                         className="w-full"
                         isDisabled={!newCustName.trim() || createCustomerMutation.isPending}
                         isLoading={createCustomerMutation.isPending}
-                        onClick={() =>
+                        onPress={() =>
                           createCustomerMutation.mutate({
                             name: newCustName.trim(),
                             phone: newCustPhone.trim(),
@@ -535,7 +535,7 @@ export default function LayawayPage() {
                       variant="bordered"
                       size="sm"
                       className="h-10 w-10"
-                      onClick={addProduct}
+                      onPress={addProduct}
                       isDisabled={!selectedProductId}
                       aria-label={t('common.add')}
                     >
@@ -589,7 +589,7 @@ export default function LayawayPage() {
                           color="danger"
                           size="sm"
                           className="h-7 w-7"
-                          onClick={() => setCreateItems((prev) => prev.filter((_, i) => i !== idx))}
+                          onPress={() => setCreateItems((prev) => prev.filter((_, i) => i !== idx))}
                           aria-label={t('common.remove')}
                         >
                           <Trash2 className="h-3.5 w-3.5" />
@@ -631,13 +631,13 @@ export default function LayawayPage() {
                 />
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={() => setCreateOpen(false)}>
+                <Button variant="flat" size="sm" onPress={() => setCreateOpen(false)}>
                   {t('common.cancel')}
                 </Button>
                 <Button
                   color="primary"
                   size="sm"
-                  onClick={handleCreate}
+                  onPress={handleCreate}
                   isLoading={createMutation.isSaving}
                   isDisabled={
                     createMutation.isSaving || !customerId || createItems.length === 0 || !dueDate

--- a/client/src/features/sales/pages/Promotions.tsx
+++ b/client/src/features/sales/pages/Promotions.tsx
@@ -95,7 +95,7 @@ export default function Promotions() {
             color="primary"
             size="sm"
             startContent={<Plus className="h-4 w-4" />}
-            onClick={editor.openNew}
+            onPress={editor.openNew}
           >
             {t('promotions.addCoupon')}
           </Button>
@@ -351,7 +351,7 @@ export default function Promotions() {
                 </div>
               </ModalBody>
               <ModalFooter className="border-t border-border/50">
-                <Button variant="flat" size="sm" onClick={editor.close}>
+                <Button variant="flat" size="sm" onPress={editor.close}>
                   {t('common.cancel')}
                 </Button>
                 <Button type="submit" color="primary" size="sm" isLoading={saver.isSaving}>

--- a/client/src/features/sales/pages/SalesHistory.tsx
+++ b/client/src/features/sales/pages/SalesHistory.tsx
@@ -305,6 +305,16 @@ export default function SalesHistory() {
               isIconOnly
               variant="light"
               size="sm"
+              /*
+               * Deliberately `onClick`, unlike every other Button in the app (#111).
+               *
+               * This is not an action; it stops a pointer event reaching the clickable
+               * row underneath. `onPress` would receive a react-aria PressEvent, which
+               * has no `stopPropagation` — and the dropdown's own keyboard activation
+               * does not bubble to the row, so there is nothing for a keyboard path to
+               * suppress here.
+               */
+              // eslint-disable-next-line no-restricted-syntax -- pointer-only by design
               onClick={(e) => e.stopPropagation()}
               aria-label={t('common.actions')}
             >
@@ -342,7 +352,7 @@ export default function SalesHistory() {
             variant="bordered"
             size="sm"
             startContent={<Download className="w-4 h-4" />}
-            onClick={handleExportCSV}
+            onPress={handleExportCSV}
           >
             {t('sales.exportCsv')}
           </Button>
@@ -413,7 +423,7 @@ export default function SalesHistory() {
           <Button
             variant="light"
             size="sm"
-            onClick={() => {
+            onPress={() => {
               update({
                 dateFrom: undefined,
                 dateTo: undefined,

--- a/client/src/shared/components/EmptyState.tsx
+++ b/client/src/shared/components/EmptyState.tsx
@@ -37,7 +37,7 @@ export default function EmptyState({
       <p className="text-sm font-semibold text-foreground mb-1">{title}</p>
       {description && <p className="text-xs text-muted-foreground mb-4 max-w-sm">{description}</p>}
       {actionLabel && onAction && (
-        <Button variant="flat" size="sm" onClick={onAction}>
+        <Button variant="flat" size="sm" onPress={onAction}>
           {actionLabel}
         </Button>
       )}

--- a/client/src/shared/components/ErrorBoundary.tsx
+++ b/client/src/shared/components/ErrorBoundary.tsx
@@ -40,7 +40,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
           <div className="flex gap-3">
             <Button
               variant="bordered"
-              onClick={() => {
+              onPress={() => {
                 this.setState({ hasError: false, error: null });
                 window.location.href = '/';
               }}
@@ -48,7 +48,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
               {t('error.goHome')}
             </Button>
             <Button
-              onClick={() => {
+              onPress={() => {
                 this.setState({ hasError: false, error: null });
                 window.location.reload();
               }}

--- a/client/src/shared/components/PWAInstallPrompt.tsx
+++ b/client/src/shared/components/PWAInstallPrompt.tsx
@@ -66,10 +66,10 @@ export default function PWAInstallPrompt() {
             </p>
             <p className="text-xs text-muted-foreground mt-1">{t('pwa.installDesc')}</p>
             <div className="flex gap-2 mt-3">
-              <Button size="sm" onClick={handleInstall}>
+              <Button size="sm" onPress={handleInstall}>
                 {t('common.install')}
               </Button>
-              <Button size="sm" variant="ghost" onClick={() => setShowPrompt(false)}>
+              <Button size="sm" variant="ghost" onPress={() => setShowPrompt(false)}>
                 {t('common.later')}
               </Button>
             </div>

--- a/client/src/shared/components/ReceiptDialog.tsx
+++ b/client/src/shared/components/ReceiptDialog.tsx
@@ -40,12 +40,12 @@ export default function ReceiptDialog({ open, onOpenChange, data }: ReceiptDialo
               <Receipt data={data} />
             </ModalBody>
             <ModalFooter className="flex gap-2 justify-end no-print border-t border-border/50">
-              <Button variant="flat" size="sm" onClick={() => onOpenChange(false)}>
+              <Button variant="flat" size="sm" onPress={() => onOpenChange(false)}>
                 {t('common.close')}
               </Button>
               <Button
                 size="sm"
-                onClick={handlePrint}
+                onPress={handlePrint}
                 startContent={<Printer className="h-4 w-4" />}
               >
                 {t('common.print')}

--- a/client/src/shared/components/__tests__/heroUiButtonKeyboard.test.tsx
+++ b/client/src/shared/components/__tests__/heroUiButtonKeyboard.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from '@heroui/react';
+
+/**
+ * The behaviour behind #111, pinned so nobody has to rediscover it.
+ *
+ * HeroUI's Button is react-aria based: it intercepts key events and dispatches `onPress`,
+ * suppressing the native click. A handler on `onClick` therefore fires for a mouse and
+ * never for a keyboard — which left 209 buttons pointer-only with every gate green.
+ *
+ * The lint rule is what stops a new one landing. This is what stops the lint rule from
+ * looking like superstition after someone upgrades HeroUI: if a future version makes
+ * `onClick` fire from the keyboard, the first test here fails and the rule can go.
+ */
+describe('HeroUI Button keyboard activation', () => {
+  function pressEnter(name: string) {
+    const button = screen.getByRole('button', { name });
+    button.focus();
+    fireEvent.keyDown(button, { key: 'Enter', code: 'Enter' });
+    fireEvent.keyUp(button, { key: 'Enter', code: 'Enter' });
+  }
+
+  it('does not fire onClick from the keyboard — the reason for the rule', () => {
+    const onClick = vi.fn();
+    // eslint-disable-next-line no-restricted-syntax -- demonstrating the defect the rule prevents
+    render(<Button onClick={onClick}>Legacy</Button>);
+
+    pressEnter('Legacy');
+    expect(onClick).not.toHaveBeenCalled();
+
+    // ...while a pointer works, which is exactly why this was invisible.
+    fireEvent.click(screen.getByRole('button', { name: 'Legacy' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onPress from the keyboard', () => {
+    const onPress = vi.fn();
+    render(<Button onPress={onPress}>Correct</Button>);
+
+    pressEnter('Correct');
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * The pointer half is deliberately not asserted here.
+   *
+   * `usePress` is built on real pointer input, and jsdom reaches none of it: a bare
+   * `fireEvent.click` never gets there, and synthesised `pointerDown`/`pointerUp` do not
+   * either, because jsdom's PointerEvent support is not what react-aria listens for.
+   * Asserting it would mean writing a test that passes for a reason unrelated to the app.
+   *
+   * A real mouse and Playwright both produce the input react-aria wants, so the pointer
+   * path is covered where it can actually be exercised: `e2e/specs`, where every existing
+   * `.click()` on these buttons keeps passing.
+   */
+
+  it('fires onPress from Space as well, which is the other button key', () => {
+    const onPress = vi.fn();
+    render(<Button onPress={onPress}>Spacebar</Button>);
+
+    const button = screen.getByRole('button', { name: 'Spacebar' });
+    button.focus();
+    fireEvent.keyDown(button, { key: ' ', code: 'Space' });
+    fireEvent.keyUp(button, { key: ' ', code: 'Space' });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -21,21 +21,35 @@ sense. That is why both exist, and why the list below exists as well.
 
 ## Known gaps
 
-None outstanding. #103 (pointer-only customer picker), #104 (controls nested inside
-pressable cards) and #105 (`role="status"` on a `<td>`) were the three, and all three are
-fixed. `jsx-a11y/click-events-have-key-events`, `no-static-element-interactions` and
-`no-interactive-element-to-noninteractive-role` were held at `warn` while this list had
-entries, so the count and the locations stayed visible; they are now `error` in
-`client/eslint.config.mjs`.
+**#111 — HeroUI buttons wired with `onClick` were pointer-only.** Fixed, and recorded here
+because the way it hid is the useful part. HeroUI's `Button` is react-aria based: it
+intercepts key events and dispatches `onPress`, suppressing the native click, so a handler
+on `onClick` fires for a mouse and never for a keyboard. 209 buttons across 59 files were
+in that state — roughly two thirds of the app's actions — while every gate was green.
 
-Record the next one here **with an issue** rather than only in a comment or a commit
-message — a gap that lives in a document nobody opens is a gap nobody picks up — and drop
-the rule that catches it back to `warn` only if the fix genuinely cannot land with it.
+Nothing here could have caught it. axe sees a `<button>` with a correct role and name.
+`jsx-a11y` sees a real button, so `click-events-have-key-events` does not apply — that rule
+exists for `<div onClick>`. The unit tests drove dialogs directly rather than opening them.
+It took the keyboard-only delivery spec added for #103, and that spec only ran after the
+change had merged, at which point it turned `main` red.
+
+The lesson is not "add a rule" — the rule exists now
+(`no-restricted-syntax` in `client/eslint.config.mjs`, with
+`heroUiButtonKeyboard.test.tsx` pinning the behaviour so the rule cannot become
+superstition after a HeroUI upgrade). It is that **a component library can take a
+keyboard away from valid markup**, and no static check will tell you. Only driving the
+interface the way a person does will.
+
+#103 (pointer-only customer picker), #104 (controls nested inside pressable cards) and
+#105 (`role="status"` on a `<td>`) are the earlier three, all fixed.
+
+Record the next gap here **with an issue** rather than only in a comment or a commit
+message, and drop the rule that catches it back to `warn` only if the fix genuinely cannot
+land with it.
 
 The delivery dialog, `/collections` and `/bundles` are all axe-scanned surfaces now, and
-`e2e/specs/a11y.spec.ts` also creates a delivery order keyboard-only — the half axe
-cannot score. None of them was scanned when this list was written, which is why the scan
-did not find #103 or #104 itself; both came from `jsx-a11y` and from reading.
+`e2e/specs/a11y.spec.ts` also creates a delivery order keyboard-only — the half axe cannot
+score, and the half that found #111.
 
 ### What is still not proven
 

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -43,13 +43,20 @@ interface the way a person does will.
 #103 (pointer-only customer picker), #104 (controls nested inside pressable cards) and
 #105 (`role="status"` on a `<td>`) are the earlier three, all fixed.
 
-**#113 — a combobox loses its accessible name while its listbox is open.** Open. Split
-out of #111 rather than absorbed into it, because a finding folded into another change is
-a finding nobody measures. `e2e/specs/a11y.spec.ts` asserts the picker's name once while
-it is closed and drives the rest by `data-testid`; removing that indirection is the signal
-the issue is fixed. Every input in that dialog looks the same in a browser's accessibility
-tree, so this is probably HeroUI's label handling generally rather than one component —
-worth establishing rather than assuming.
+**#113 — does a combobox keep its accessible name while its listbox is open?** Open, and
+narrower than it first looked.
+
+The symptom that produced it — a locator resolving on one line and timing out on the next
+— turned out to be about *scope*, not naming. Opening the listbox makes its popover the
+top layer, and react-aria marks everything outside it `aria-hidden`, including the modal
+dialog. `getByRole('dialog')` resolves against the accessibility tree, so it stops
+matching, and every locator chained through it goes with it. **Locate from the page, not
+through the dialog, once a popover is open.** That is the practical rule; it cost four CI
+runs to see, because a vanishing ancestor reads exactly like a changing element.
+
+What is still genuinely open is only whether the field keeps its name while expanded. The
+aria snapshot suggested not, and every sibling input looked the same — but that snapshot
+was taken of a page where most of the tree was hidden, so it is not clean evidence.
 
 Record the next gap here **with an issue** rather than only in a comment or a commit
 message, and drop the rule that catches it back to `warn` only if the fix genuinely cannot

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -43,6 +43,14 @@ interface the way a person does will.
 #103 (pointer-only customer picker), #104 (controls nested inside pressable cards) and
 #105 (`role="status"` on a `<td>`) are the earlier three, all fixed.
 
+**#113 — a combobox loses its accessible name while its listbox is open.** Open. Split
+out of #111 rather than absorbed into it, because a finding folded into another change is
+a finding nobody measures. `e2e/specs/a11y.spec.ts` asserts the picker's name once while
+it is closed and drives the rest by `data-testid`; removing that indirection is the signal
+the issue is fixed. Every input in that dialog looks the same in a browser's accessibility
+tree, so this is probably HeroUI's label handling generally rather than one component —
+worth establishing rather than assuming.
+
 Record the next gap here **with an issue** rather than only in a comment or a commit
 message, and drop the rule that catches it back to `warn` only if the fix genuinely cannot
 land with it.

--- a/docs/plans/2026-09-04-001-refactor-parallel-issue-execution-map-plan.md
+++ b/docs/plans/2026-09-04-001-refactor-parallel-issue-execution-map-plan.md
@@ -1,0 +1,408 @@
+---
+title: "Parallel execution map for the nine open issues"
+type: refactor
+status: active
+date: 2026-09-04
+---
+
+# Parallel execution map for the nine open issues
+
+## Overview
+
+Nine actionable issues are open (`#83`, `#82`, `#81`, `#56`, `#55`, `#54`, `#53`, `#47`, `#43`).
+`#57` and `#48` are epics — trackers, not work. This plan decides **which of the nine can be
+worked at the same time without collision**, in what order the rest must land, and what small
+enabling work has to happen first to make the parallelism real rather than optimistic.
+
+The output is a wave schedule with explicit **file ownership per wave**. The rule the whole plan
+rests on: *within a wave, exactly one lane may write any given file.* Where two issues need the
+same file, either one waits, or a prep unit splits the file so they no longer share it.
+
+## Problem Frame
+
+Running these issues concurrently is attractive — several are independent in intent — but four of
+them converge on the same handful of shared configuration and shared-component files. Discovered
+collision points, ranked by how much rework a conflict costs:
+
+| Rank | File | Issues that want it | Why it hurts |
+|---|---|---|---|
+| 1 | `client/src/shared/components/{DataTable,PageHeader,ConfirmDialog,StatusBadge}.tsx` + canonical targets | #54, #55, #56 | #56 rewrites 45 import lines across ~30 files while #54 edits the same components' internals |
+| 2 | `client/eslint.config.mjs` | #54, #55, #56 | All three add to the same `rules` object |
+| 3 | `client/vite.config.ts` | #53, #55 | #53 edits `VitePWA`/`workbox`, #55 edits `build.rollupOptions` — adjacent keys of one exported object |
+| 4 | `.github/workflows/ci.yml` | #43, #47, #53, #54, #55, #82 | Six issues want to add or tighten a gate in one 300-line file |
+| 5 | `server/src/modules/inventory/collections/*` | #83, #81 | Same Zod schema, same `service.update` transaction, same `repository.update` call |
+| 6 | `client/src/shared/index.ts` | #55, #56 | **Opposing intents** — #55 wants to break the barrel's pull-through of `xlsx`; #56 wants the barrel to *be* the canonical path |
+
+## Requirements Trace
+
+- R1. Every one of the nine issues is placed in exactly one wave with a named lane.
+- R2. No two lanes in the same wave write the same file.
+- R3. Sequencing dependencies (not merely file overlaps) are stated with their reason.
+- R4. Where a shared file blocks parallelism and can be cheaply split, a prep unit splits it.
+- R5. Where two issues have opposing intent on one file, the plan resolves the intent, not just the merge.
+- R6. The schedule survives a lane slipping — a delayed lane must not strand another wave.
+
+## Scope Boundaries
+
+- **Not** an implementation plan for any individual issue. Each lane still needs its own plan or
+  is executed straight from its issue body. This plan says *when* and *alongside what*.
+- Does not re-scope, re-prioritize, or close any issue. Priority labels stay as they are.
+- Does not decide staffing or wall-clock estimates. Lanes are units of isolation, not of effort.
+- The two epics (#57, #48) are updated only as trackers, never worked directly.
+
+## Context & Research
+
+### Already landed, so several acceptance criteria are met before work starts
+
+- **Client typecheck is gated.** `origin/main` commit `4202598` (PR #89) added the client
+  `tsc --noEmit` step and cleared the 35 errors behind it. #43's "TypeScript compilation passes
+  with no errors" criterion is satisfied for both halves. *(The local branch
+  `zhamdy/sales-insufficient-stock-code` is 2 commits behind `origin/main` and still shows the old
+  `ci.yml` — rebase before quoting CI state.)*
+- **Real-PostgreSQL CI exists.** `.github/workflows/ci.yml` already provisions `postgres:16`, sets
+  `TEST_DATABASE_URL`, and runs `server/scripts/assertRealPostgresSuitesRan.mjs` as an
+  anti-silent-skip guard. The e2e suite is sharded with per-shard "ran nothing" guards.
+- **The `StorageDriver` abstraction exists.** `server/src/storage/` already defines the full
+  interface including the `ownsUrl` / `keyFromUrl` distinction. #82 is a new file plus a
+  `createStorageDriver` case, not an architecture change.
+- **ESLint boundary enforcement exists.** `client/eslint.config.mjs` runs `eslint-plugin-boundaries`
+  with element-type policies and a `no-restricted-imports` block. #56 adds one entry to an existing
+  mechanism rather than introducing one.
+- **`server/tests/concurrency/collections.concurrency.test.ts` already proves #81** and documents
+  the drop as accepted current behaviour. Fixing #81 means rewriting that test's assertions.
+
+### What is genuinely still missing
+
+- `.github/workflows/` contains **only** `ci.yml`. No migration up/down verification job, no
+  coverage threshold, no dependency audit, no bundle-size check.
+- `npm run lint --prefix server` exits 0 with **391 warnings**, essentially all
+  `@typescript-eslint/no-explicit-any`. No `--max-warnings` flag, so warnings gate nothing.
+- `collections` has a `status` column that no `UPDATE` has ever written, and **no `year` column at all**.
+- `client/public/` holds only `_redirects` and `moon-logo.svg`; the PWA manifest references two
+  PNGs that **do not exist**.
+- No a11y tooling anywhere (`axe`, `@axe-core/playwright`, `eslint-plugin-jsx-a11y` all absent).
+- No virtualization anywhere; `DataTable` paginates at 10 rows, the POS grid is a plain `.map()`.
+- `contracts/` holds exactly one file (`checkout-totals.v1.json`). There is no generated OpenAPI —
+  `server/scripts/generateOpenApi.ts` is a **regex scraper over the manifest source text**, and
+  `server/src/docs/openapi.ts` is 11,865 hand-maintained lines.
+
+### Incidental findings worth a ticket, not a lane
+
+- `xlsx@0.18.5` is a known-CVE version, and it is re-exported through `client/src/shared/index.ts`,
+  so anything importing `@/shared` pulls it into its chunk. Belongs to #55's lane as a finding.
+- `@tanstack/router-devtools` sits in `dependencies`, not `devDependencies`.
+- Locale and text direction are **not linked**: `settingsStore` drives `isRtl` while
+  `DirectionProvider` uses a separate `moon-store-direction` key, and nothing sets
+  `documentElement.lang`. This is #54's problem and is larger than "audit the markup".
+- `docs/CONVENTIONS.md` still carries a **"SQLite Gotchas"** section after the PostgreSQL migration.
+- A stray `nul` file sits at the repo root (a Windows redirection artifact).
+
+## Key Technical Decisions
+
+- **#56 lands before #54 and before any #55 virtualization.** #56 is a mechanical rewrite of 45
+  import lines across ~30 files — the single worst thing in this backlog to rebase. Everything that
+  edits shared components waits for it. *Cost:* #54 and #55's second half are pushed a wave.
+  *Alternative rejected:* running #56 last, which converts every other lane's diff into a conflict.
+
+- **The `client/src/shared/index.ts` intent conflict resolves in #56's favour, with #55's
+  constraint written into #56's acceptance criteria.** The barrel stays the canonical path, and
+  #56 additionally must not re-export anything that statically pulls a heavy dependency —
+  `exportUtils` (and therefore `xlsx`) moves behind a lazy accessor. One decision, made once,
+  instead of two lanes pulling the file in opposite directions.
+
+- **#83 before #81.** Both rewrite `collectionUpdateSchema`, `service.update` and the same
+  `buildPartialUpdate` call; they cannot be concurrent. #83 is smaller, carries the migration, and
+  #81's precondition check rebases cleanly on top of it. The reverse order does not hold.
+
+- **#81 takes optimistic concurrency on `updated_at`, not the partial API and not a row lock.**
+  `collections.updated_at` already exists and is bumped unconditionally by `buildPartialUpdate`'s
+  `alwaysSet`, so no migration is needed. The row lock is rejected for the reason the issue gives:
+  the loser still writes a set computed from stale data, so it only *looks* like a fix. The genuine
+  partial add/remove/reorder API is the better end state but is a separate, larger issue —
+  optimistic concurrency stops the silent loss now and does not block that later.
+
+- **#43 ships a lint ratchet at the current count rather than waiting for #47.** `--max-warnings 391`
+  gates regression immediately; #47 lowers the number as it goes. This converts what looked like a
+  hard #47 → #43 dependency into two independent lanes, which is what #43's own acceptance criterion
+  ("establish a ratchet ... rather than an unsafe big-bang cleanup") already asks for.
+
+- **#55 splits at the measurement boundary.** Phase 1 — measure, baseline, budgets, CI check — has
+  zero overlap with #54. Phase 2 — virtualization of `DataTable` and the POS grid — collides with
+  #54 head-on and waits for it. The issue itself says to virtualize "only where measurements
+  justify it", so the split follows its own logic and may end with phase 2 unnecessary.
+
+- **`ci.yml` gets an owner per wave rather than being split into reusable workflows.** Extraction
+  into `workflow_call` files was considered and rejected: six issues touch it but each adds only a
+  few lines, and reusable-workflow indirection would make the one file every contributor reads
+  harder to read for the life of the repo. Cheaper to name an owner. *Revisit if a wave produces
+  more than two `ci.yml` conflicts.*
+
+## Open Questions
+
+### Resolved during planning
+
+- *Does #43 depend on #47?* No — the ratchet decouples them. They share only `ci.yml`, and #43 owns it.
+- *Is #43's client-typecheck criterion still open?* No, PR #89 closed it.
+- *Which direction does #83 take (real fields vs. remove them from the modal)?* Real fields. `status`
+  is already a column and already flows out on reads, the client type already declares
+  `year: number | null`, and the i18n catalogue carries `collections.season/year/spring/...`.
+  Removing them would delete working data plumbing on three sides.
+- *Should #83 also add `.strict()` repo-wide?* No. Scope it to the collections update schema; the
+  repo-wide sweep is a separate issue with its own blast radius.
+
+### Deferred to implementation
+
+- Whether `status` and `is_featured` overlap in meaning — the issue flags it, and it is answerable
+  only by reading how each is consumed. #83's lane resolves it before adding a second flag.
+- Which S3 SDK #82 picks, and whether CI gets a MinIO service or the driver is tested against a
+  fake. Determines whether #82 touches `ci.yml` at all.
+- Whether #55 phase 2 is needed. Depends entirely on phase 1's measurements.
+- Whether #54's locale/direction unification is in scope or spins out — it is a real architectural
+  defect discovered during research, not something the issue anticipated.
+
+## Wave schedule
+
+```mermaid
+graph TD
+  P0["Prep: split vite.config.ts"] --> E1
+  P0 --> D2
+  A1["#83 collections status+year"] --> A2["#81 optimistic concurrency"]
+  C1["#43 CI gates + ratchet"] --> B2["#47 type contracts"]
+  D1["#56 import consolidation"] --> A3["#54 WCAG 2.2 AA"]
+  D1 --> D2["#55p1 measure + budgets"]
+  A3 --> D3["#55p2 virtualization (conditional)"]
+  B1["#82 S3 storage driver"]
+  E1["#53 PWA + offline"]
+```
+
+| Wave | Lane | Issue | Owns exclusively | Must not touch |
+|---|---|---|---|---|
+| 0 | prep | — | `client/vite.config.ts`, `client/config/*` | everything else |
+| 1 | A | #83 | `server/src/modules/inventory/collections/*`, migration `008_*`, `client/src/features/inventory/pages/Collections.tsx` | `ci.yml` |
+| 1 | B | #82 | `server/src/storage/*`, `render.yaml`, `server/src/config/env.ts` | `ci.yml`, `openapi.ts` |
+| 1 | C | #43 | `.github/workflows/*`, `server/tests/support/*`, `server/package.json` scripts | `server/src/**` |
+| 1 | D | #56 | the 4 compat shims + canonical dirs, `client/src/shared/index.ts`, `client/eslint.config.mjs` | `client/vite.config.ts`, `ci.yml` |
+| 1 | E | #53 | `client/config/pwa.ts`, `client/public/*`, `client/src/shared/hooks/useOffline.ts`, `client/src/shared/lib/queryClient.ts` | `client/config/build.ts`, `client/eslint.config.mjs` |
+| 2 | A | #81 | collections module, `server/tests/concurrency/collections.concurrency.test.ts`, `server/src/http/errors.ts` | `ci.yml` |
+| 2 | B | #47 | `server/src/modules/*/repository.ts`, module `types.ts`, `server/src/docs/openapi.ts` | `ci.yml`, collections module |
+| 2 | D | #55p1 | `client/config/build.ts`, a new bundle-budget workflow, `client/package.json` | shared components |
+| 3 | A | #54 | shared components, `client/eslint.config.mjs`, i18n/direction | `client/config/*` |
+| 3 | D | #55p2 | `DataTable.tsx`, the POS grid in `POS.tsx` | — (runs only after #54 merges) |
+
+**Wave 1 lanes A and D both touch `client/src/features/inventory/Collections.tsx`** — #56 rewrites
+its import lines while #83 edits its submit payload. This is the one accepted overlap in the
+schedule: both diffs are small and in different regions of the file. Lane D merges first and lane A
+rebases; if this proves noisy, move #83 to wave 2 alongside #81 and lose nothing.
+
+## Implementation Units
+
+- [ ] **Unit 1: Split `client/vite.config.ts` so #53 and #55 stop sharing a file**
+
+**Goal:** `client/vite.config.ts` becomes a thin composition that imports its PWA block and its
+build/chunking block from two separate files, so wave 1 lane E and wave 2 lane D never write the
+same file.
+
+**Requirements:** R2, R4
+
+**Dependencies:** None. This is the only thing that must land before wave 1 opens.
+
+**Files:**
+- Create: `client/config/pwa.ts` (the `VitePWA({...})` options object, including `manifest` and `workbox`)
+- Create: `client/config/build.ts` (the `build.rollupOptions` object, including `manualChunks`)
+- Modify: `client/vite.config.ts`
+
+**Approach:**
+- Pure move. The exported Vite config must be equivalent in effect — no chunk regrouping, no
+  workbox rule changes, no manifest edits. Those are #55's and #53's work, not this unit's.
+- Export plain objects or factories, not a plugin wrapper, so each lane edits data rather than
+  indirection.
+
+**Patterns to follow:** `client/eslint.config.mjs` already composes from multiple config objects;
+match that shape rather than inventing a new one.
+
+**Test scenarios:**
+- Happy path: `npm run build --prefix client` emits the same chunk names and count as before the
+  split — capture the pre-split output first and diff the two lists.
+- Happy path: the generated service-worker precache manifest lists the same entries pre- and post-split.
+- Edge case: `npm run dev --prefix client` starts and the PWA plugin registers in dev mode as before.
+
+**Verification:** The build-output diff is empty apart from content hashes, and the e2e `@smoke`
+suite still passes against the production build.
+
+- [ ] **Unit 2: Open wave 1 — five isolated lanes**
+
+**Goal:** #83, #82, #43, #56 and #53 proceed concurrently, each on a branch from `main`, each
+respecting its ownership row in the wave table.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** Unit 1, for lane E only — the other four lanes can start immediately.
+
+**Files:** Per the wave-1 rows of the ownership table. No lane may write a file owned by another.
+
+**Approach:**
+- Lane C (#43) is the sole writer of `.github/workflows/`. Any other lane that wants a CI gate opens
+  a follow-up against lane C's branch rather than editing `ci.yml` itself.
+- Lane D (#56) carries the extra acceptance criterion from the intent-conflict decision: after
+  consolidation, importing `@/shared` must not statically pull `xlsx`. Prove it from the build
+  output, not by reading the code.
+- Lane C's ratchet lands as `--max-warnings 391` on the server lint step, with the number in a
+  comment naming #47 as the thing that lowers it.
+- Lane A (#83) resolves the `status` vs `is_featured` semantic question before writing the
+  migration, and adds `.strict()` to the collections update schema only.
+- #43's remaining real gap is **migration up/down verification** — no job runs `migrate` or
+  `migrate:down` standalone today; migrations run only implicitly inside `realPostgres.ts`.
+
+**Execution note:** Lanes A and B are both behaviour changes with a data-loss or data-destruction
+failure mode (#83 writes new columns; #82's `ownsUrl` bug class deletes images). Both benefit from a
+failing test written first — for #82 specifically, a test that a legacy relative URL under an
+absolute `MEDIA_PUBLIC_BASE_URL` is classified "mine but unresolvable" and **aborts the sweep**,
+not "not mine".
+
+**Patterns to follow:**
+- #82: `server/src/storage/localDriver.ts`'s private `ownedPrefixes()` is the reference for getting
+  the ownership distinction right.
+- #43: `server/scripts/assertRealPostgresSuitesRan.mjs` and `e2e/scripts/assertSmokeTestsRan.mjs`
+  are the established "this gate did not silently skip" pattern — a migration-verification job
+  should carry the same guard.
+
+**Test scenarios:** Each lane carries its own issue's scenarios. This unit's own scenarios are the
+integration checks:
+- Integration: each lane's branch, rebased onto the previous lane's merge, produces zero conflicts
+  outside the one accepted `Collections.tsx` overlap.
+- Integration: after all five merge, the full CI suite (all six jobs) is green on `main`.
+- Error path: if lane C's ratchet number is stale when it merges — another lane changed the warning
+  count — CI fails loudly on the lint gate rather than passing with a wrong ceiling.
+
+**Verification:** Five PRs merged, `main` green, and the wave-2 lanes rebase cleanly.
+
+- [ ] **Unit 3: Wave 2 — #81, #47, #55 phase 1**
+
+**Goal:** The three lanes that were blocked on a wave-1 predecessor proceed concurrently.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** #81 needs #83 merged (same files). #47 needs #43's ratchet in place, so its
+progress is measured. #55p1 needs Unit 1 and #56 merged.
+
+**Files:** Per the wave-2 rows of the ownership table.
+
+**Approach:**
+- #81 implements optimistic concurrency on `collections.updated_at` — the client round-trips the
+  value it read, the server refuses a mismatch with a typed `409`. Follow the shape of the
+  `INSUFFICIENT_STOCK` code that landed in PR #90: a typed code carrying the numbers behind it, not
+  a message string.
+- #81 must rewrite the `'survives a reorder racing an append'` case in
+  `server/tests/concurrency/collections.concurrency.test.ts`, which currently *documents* the drop
+  as accepted. Its comment becomes wrong the moment the fix lands.
+- #47 works repositories first — `pos/sales/repository.ts` (31 `any` lines),
+  `inventory/products/repository.ts` (28), `fulfillment/delivery/repository.ts` (17) — and lowers
+  the ratchet in `ci.yml` via a one-line PR to lane C's file, per wave 1's ownership rule.
+- #47 should record explicitly whether the regex-scraper `generateOpenApi.ts` is being replaced or
+  kept. "Generate or verify OpenAPI from those contracts" is not currently possible against an
+  11,865-line hand-maintained spec, and that gap is the largest unstated cost in the issue.
+
+**Execution note:** #81 is a concurrency fix and belongs in the `describeWithPostgres` suites —
+pg-mem cannot prove it. Write the failing interleaving first; the harness for it already exists.
+
+**Test scenarios:**
+- Happy path (#81): an update carrying the current `updated_at` succeeds and bumps it.
+- Error path (#81): an update carrying a stale `updated_at` returns `409` with a typed code, and the
+  collection's product set is unchanged.
+- Integration (#81): the three-interleaving concurrency test now asserts *membership* — the appended
+  product survives, or the reorder is refused, and it is never silently dropped.
+- Happy path (#47): a known unique-constraint violation surfaces as a stable public error code with
+  no error-message string parsing anywhere on the path.
+- Happy path (#55p1): a documented, reproducible bundle baseline exists and the CI check fails on a
+  deliberate size regression.
+- Edge case (#55p1): the POS route's initial chunk contains none of `recharts`, `xlsx`, or
+  `@ericblade/quagga2`.
+
+**Verification:** Wave-2 PRs merged, the ratchet number strictly lower than 391, and the bundle
+baseline committed and enforced.
+
+- [ ] **Unit 4: Wave 3 — #54, then #55 phase 2**
+
+**Goal:** The accessibility audit lands against stable canonical component paths, and virtualization
+— if measurements justified it — follows it rather than racing it.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** #54 needs #56 merged. #55p2 needs #54 merged **and** a phase-1 measurement that
+justifies it; if the measurements do not, this half does not happen.
+
+**Files:** Per the wave-3 rows of the ownership table.
+
+**Approach:**
+- #54's first decision is whether the locale/direction split (`settingsStore.isRtl` versus
+  `DirectionProvider`'s separate `moon-store-direction` key, with nothing setting
+  `documentElement.lang`) is in scope. It is a real defect the issue did not anticipate and it
+  underlies the RTL acceptance criterion, so it probably is — but it should be an explicit call.
+- The eight chart files under `client/src/features/analytics/components/charts/` hard-code
+  `dir="ltr"`. #54 must decide whether that is correct by intent (numeric axes) or a workaround.
+- #55p2, if it happens, must not regress the row and grid semantics #54 just established.
+  Virtualization and naive `role`/row-count a11y are directly at odds; #54's assertions are the
+  regression net.
+
+**Test scenarios:**
+- Happy path (#54): POS checkout, inventory edit, and the login flow are each completable
+  keyboard-only, with visible focus at every step.
+- Edge case (#54): a dialog traps focus and restores it to the trigger on close, in both LTR and RTL.
+- Integration (#54): an async mutation result, the offline banner state change, and a validation
+  error are each announced to a screen reader.
+- Error path (#54): CI fails on a deliberately introduced high-impact axe violation.
+- Integration (#55p2, if it runs): the #54 keyboard and announcement assertions still pass against
+  the virtualized `DataTable` and POS grid.
+
+**Verification:** `main` green with the a11y gate active; if #55p2 ran, the a11y suite is green
+against the virtualized components.
+
+## System-Wide Impact
+
+- **Interaction graph:** `ci.yml` is the single point every lane eventually touches; the ownership
+  rule is what keeps it from becoming the bottleneck. `client/eslint.config.mjs` is second, owned by
+  #56 in wave 1 and #54 in wave 3 — never both at once.
+- **Error propagation:** #81 and #47 both introduce typed error codes. They should agree on the
+  shape before either ships, or the API grows two conventions in one wave. #47's lane owns the
+  convention; #81's lane consumes it.
+- **State lifecycle risks:** #83 adds a migration (`008_*`) while #82 changes where bytes live. If
+  both are in flight and a rollback is needed, the migration is reversible and the storage config is
+  a config flip — neither depends on the other, which is why they are the safest wave-1 pairing.
+- **API surface parity:** `server/src/docs/openapi.ts` is hand-maintained across 11,865 lines and is
+  touched by #83, #81 and #47. It is the one server file where merge conflicts are likely despite
+  the ownership rule, because all three append to different endpoint sections of one document.
+- **Unchanged invariants:** No lane changes the checkout total calculation, the idempotency window,
+  the refresh-token rotation contract, or the rate-limit bucketing. Those landed recently and are
+  explicitly out of every lane's scope.
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| #56's 45-line import rewrite lands mid-wave and conflicts with lane A's `Collections.tsx` edit | Med | Low | Accepted overlap; lane D merges first, lane A rebases. Escalation is moving #83 to wave 2. |
+| `ci.yml` conflicts despite the ownership rule | Med | Low | One owner per wave; other lanes PR into the owner's branch. Revisit reusable workflows if it happens twice. |
+| `server/src/docs/openapi.ts` conflicts between #83, #81 and #47 | High | Low | Three-way append conflicts in one 11k-line file are noisy but mechanical. #47's lane should say early whether it is replacing the file wholesale — if so, the other two append minimally and let #47 absorb it. |
+| #47's OpenAPI criterion is unachievable against a hand-maintained spec | High | Med | Surface it in wave 2 as an explicit scope call rather than discovering it at review. |
+| #55 phase 1 measurements justify nothing, and phase 2 is built anyway | Low | Med | Phase 2 is conditional by construction; the plan permits it to be dropped. |
+| #82 reintroduces the `ownsUrl` data-destruction bug in a new driver | Low | **High** | Test-first on the "mine but unresolvable → abort" case, per the execution note. Verify a key-preserving copy end to end before pointing production at a bucket. |
+| A lane slips and strands its dependents | Med | Low | Only #81, #54 and #55p2 have hard predecessors. The other six proceed regardless. |
+
+## Documentation / Operational Notes
+
+- `docs/CONVENTIONS.md` still has a **"SQLite Gotchas"** section (`ALTER TABLE` limitations, the
+  SQLite transaction pattern) after the PostgreSQL migration. Any lane touching that file should
+  remove it; #47's lane is the natural owner.
+- The user-level `CLAUDE.md` at the home directory describes the pre-migration SQLite/Radix
+  architecture entirely and contradicts the repo's own `CLAUDE.md`. Worth correcting outside any
+  lane — it is actively misleading to every session.
+- A stray `nul` file sits at the repo root and should be removed.
+- The two epics (#57, #48) should have their checkbox lists updated as lanes close, and #57's
+  remaining P2/P3 items reordered to match this schedule.
+
+## Sources & References
+
+- Issues: #83, #82, #81, #57, #56, #55, #54, #53, #48, #47, #43
+- Recently merged, which changes several stated preconditions: PR #89 (`4202598`, the client
+  typecheck gate), PR #90 (`b383bc2`, typed `INSUFFICIENT_STOCK`), PR #87 (the partial-update contract)
+- Existing plans in `docs/plans/` covering the already-landed backend hardening
+- `docs/CONVENTIONS.md`, `AGENTS.md`, `CLAUDE.md`

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -297,21 +297,23 @@ test.describe('keyboard and focus @smoke', () => {
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
-    /*
-     * Named while closed, driven by test id while open.
-     *
-     * The accessible name is asserted here, once, in the state a user meets the field in.
-     * Everything after this addresses it by `data-testid`, because focusing the combobox
-     * opens its listbox, and while the listbox is open the name is not resolvable in
-     * Chromium — a role+name locator that worked a line earlier stops matching, so the
-     * test would fail for a naming reason in the middle of measuring the keyboard path.
-     *
-     * That is a real finding and it has its own issue; conflating it with this test means
-     * neither gets measured. This one is about whether a delivery order can be created
-     * without a pointer.
-     */
-    const picker = dialog.getByTestId('delivery-customer-picker');
+    // Named, and scoped to the dialog while the dialog is still the top layer.
     await expect(dialog.getByRole('combobox', { name: /select customer/i })).toBeVisible();
+
+    /*
+     * From here on, locate from the page rather than through `dialog`.
+     *
+     * Opening the listbox makes its popover the top layer, and react-aria marks everything
+     * outside it `aria-hidden` — including the modal dialog. `getByRole('dialog')` is
+     * resolved against the accessibility tree, so it stops matching, and every locator
+     * chained through it stops matching with it. The combobox is still there and still
+     * named; its *ancestor* is what disappears.
+     *
+     * That cost three CI runs to see, because the symptom is a locator that resolves on
+     * one line and times out on the next, which reads like the element changing rather
+     * than the scope changing.
+     */
+    const picker = page.getByTestId('delivery-customer-picker');
 
     await picker.focus();
     expect(await picker.evaluate((el) => el === document.activeElement)).toBe(true);
@@ -319,7 +321,7 @@ test.describe('keyboard and focus @smoke', () => {
     await page.keyboard.type(customer.name.slice(0, 12));
     await expect(picker).toHaveAttribute('aria-expanded', 'true');
 
-    const option = dialog.getByRole('option', { name: customer.name });
+    const option = page.getByRole('option', { name: customer.name });
     await expect(option).toBeVisible();
     // Arrow to the option and commit it: the combobox tracks the active option through
     // aria-activedescendant, so DOM focus never leaves the input.
@@ -338,8 +340,8 @@ test.describe('keyboard and focus @smoke', () => {
     await page.keyboard.press('Enter');
 
     // Selecting a customer must actually populate the form the submit reads.
-    await expect(dialog.getByLabel(/customer name/i)).toHaveValue(customer.name);
-    await expect(dialog.getByLabel(/^phone$/i)).toHaveValue(customer.phone);
+    await expect(page.getByLabel(/customer name/i)).toHaveValue(customer.name);
+    await expect(page.getByLabel(/^phone$/i)).toHaveValue(customer.phone);
     await expect(option).toHaveCount(0);
 
     const address = dialog.getByLabel(/address/i);

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -297,10 +297,24 @@ test.describe('keyboard and focus @smoke', () => {
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 
-    const picker = dialog.getByRole('combobox', { name: /select customer/i });
+    /*
+     * Named while closed, driven by test id while open.
+     *
+     * The accessible name is asserted here, once, in the state a user meets the field in.
+     * Everything after this addresses it by `data-testid`, because focusing the combobox
+     * opens its listbox, and while the listbox is open the name is not resolvable in
+     * Chromium — a role+name locator that worked a line earlier stops matching, so the
+     * test would fail for a naming reason in the middle of measuring the keyboard path.
+     *
+     * That is a real finding and it has its own issue; conflating it with this test means
+     * neither gets measured. This one is about whether a delivery order can be created
+     * without a pointer.
+     */
+    const picker = dialog.getByTestId('delivery-customer-picker');
+    await expect(dialog.getByRole('combobox', { name: /select customer/i })).toBeVisible();
+
     await picker.focus();
     expect(await picker.evaluate((el) => el === document.activeElement)).toBe(true);
-    await expect(picker).toHaveAttribute('aria-expanded', 'false');
 
     await page.keyboard.type(customer.name.slice(0, 12));
     await expect(picker).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
Closes #111. **Fixes `main`**, which has been red since #109 merged.

## The defect

HeroUI's `Button` is react-aria based: it intercepts key events and dispatches `onPress`, suppressing the native click. A handler bound to `onClick` therefore fires for a mouse and **never** for a keyboard.

Measured, not inferred:

```
KEYBOARD -> onClick calls: 0   onPress calls: 1
POINTER  -> onClick calls: 1
```

**254 buttons across 60 files** were in that state — roughly two thirds of the actions in the app, every one of them mouse-only, with every gate green.

## Why nothing caught it

- **axe** sees a `<button>` with a correct role and an accessible name. There is nothing to flag.
- **`jsx-a11y`** sees a real button, so `click-events-have-key-events` does not apply — that rule exists for `<div onClick>`.
- **The unit tests** drove dialogs directly rather than opening them through their trigger.

It took the keyboard-only delivery spec added for #103 — and that spec first ran *after* merging, which is why `main` went red and stayed there. It also means **#103 fixed one level too deep**: the delivery dialog became keyboard-operable while the New Order button that opens it stayed unreachable.

## The change

- `onClick` → `onPress` on 254 HeroUI Buttons.
- **One `onClick` stays**, in `SalesHistory`, with a comment: it exists to stop a pointer event reaching the row underneath, and a `PressEvent` has no `stopPropagation` — there is no keyboard propagation to suppress.
- **An AST lint rule** (`no-restricted-syntax`) fails on any HeroUI `Button` given an `onClick`. It earned itself immediately, finding a button in `AdjustStockDialog` my regex had missed because an arrow function's `=>` inside an attribute broke the pattern.
- **`heroUiButtonKeyboard.test.tsx`** pins the behaviour so the rule cannot become superstition: if a future HeroUI makes `onClick` work from the keyboard, that test fails and the rule can go.

## What is deliberately not asserted

The pointer path in jsdom. `usePress` listens for real pointer input, and neither `fireEvent.click` nor synthesised `pointerDown`/`pointerUp` reaches it — a test there would pass for a reason unrelated to the app. A real mouse and Playwright both produce what react-aria wants, so that half is covered in `e2e/specs`, where every existing `.click()` on these buttons keeps passing.

## Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `eslint` | 0 errors, 16 warnings (unchanged) |
| `vitest` | **581 passed, 0 failed** — unchanged, which is the evidence that converting 254 handlers changed nothing a test was watching |
| `npm run build` | succeeds |

The one that matters is **E2E smoke**, which is what found this. It should go green on this PR, and with it `main`.

## The lesson, recorded in `docs/ACCESSIBILITY.md`

Not "add a rule" — the rule exists now. It is that **a component library can take a keyboard away from valid markup, and no static check will tell you.** Only driving the interface the way a person does will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN