### PR TITLE
fix: the Segments page, and the RFM endpoint it was written against

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Two numbers in this repo are ratchets, and they follow the same rule.
 | Ratchet | Where | Today |
 | --- | --- | --- |
 | ESLint warnings | `--max-warnings` in `server/package.json` | `385`, essentially all `@typescript-eslint/no-explicit-any` |
-| Operations with no request contract | `EXPECTED_UNCONVERTED` in `server/src/docs/requestContracts.ts` | `3` of 203 — the health probes |
+| Operations with no request contract | `EXPECTED_UNCONVERTED` in `server/src/docs/requestContracts.ts` | `3` of 204 — the health probes |
 | Operations accounted for by neither | `EXPECTED_UNCLASSIFIED`, same file | `0`, and it must stay there |
 
 **Never raise one. Lower it in the same commit that earns the reduction.** A ratchet left
@@ -167,6 +167,10 @@ Chunk size warning (>500KB) is expected for the SPA bundle — safe to ignore.
 Project-specific quirks and decisions worth not rediscovering. Keep under 20 entries and
 prune stale ones; anything cross-project belongs in the global instructions instead.
 
+- The Segments page was written against an RFM endpoint the server never had: it read
+  `GET /api/v1/segments`, which serves rule-authored segment records, and crashed on
+  `data.summary.map`. RFM now lives at `GET /api/v1/analytics/customer-segments`, and the
+  two features are unrelated despite the shared word (2026-09-09)
 - HeroUI's `Input`/`Textarea` hold their own controlled value, so react-hook-form's
   `setValue` never reaches the DOM. Any programmatically-filled field needs `Controller`;
   the delivery customer picker had been silently failing to populate since it was written

--- a/client/src/features/customers/index.ts
+++ b/client/src/features/customers/index.ts
@@ -10,3 +10,6 @@ export { default as Customers } from './pages/Customers';
 export { default as Feedback } from './pages/Feedback';
 export { default as Segments } from './pages/Segments';
 export { default as Warranty } from './pages/Warranty';
+
+// The route file validates `?segment=` against the same list the tiles render.
+export { CUSTOMER_SEGMENTS, type CustomerSegmentKey } from './types';

--- a/client/src/features/customers/pages/Segments.test.tsx
+++ b/client/src/features/customers/pages/Segments.test.tsx
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { renderWithRouter } from '../../../shared/tests/routerTestUtils';
+import { TransportProvider } from '../../../shared/lib/transport';
+import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
+import { useSettingsStore } from '../../../shared/store/settingsStore';
+import Segments from './Segments';
+
+const summary = [
+  { segment: 'champions', count: 2, total_revenue: 9000, avg_frequency: 8 },
+  { segment: 'loyal', count: 1, total_revenue: 3000, avg_frequency: 5 },
+  { segment: 'potential', count: 0, total_revenue: 0, avg_frequency: 0 },
+  { segment: 'at_risk', count: 0, total_revenue: 0, avg_frequency: 0 },
+  { segment: 'hibernating', count: 0, total_revenue: 0, avg_frequency: 0 },
+  { segment: 'lost', count: 1, total_revenue: 250, avg_frequency: 1 },
+  { segment: 'new', count: 0, total_revenue: 0, avg_frequency: 0 },
+];
+
+const customers = [
+  {
+    id: 1,
+    name: 'Nadia Kamal',
+    phone: '01000000001',
+    email: null,
+    recency_days: 3,
+    frequency: 9,
+    monetary: 6000,
+    segment: 'champions',
+    loyalty_points: 120,
+  },
+];
+
+function renderSegments(body: unknown = { customers, summary }, initialRoute = '/') {
+  const transport: MemoryTransport = createMemoryTransport(
+    {},
+    { reads: { 'analytics/customer-segments': body } }
+  );
+  const result = renderWithRouter(
+    <TransportProvider transport={transport}>
+      <Segments />
+    </TransportProvider>,
+    { initialRoute }
+  );
+  return { transport, ...result };
+}
+
+describe('Segments page', () => {
+  beforeEach(() => useSettingsStore.setState({ locale: 'en' }));
+
+  it('reads the RFM endpoint, not the rule-authored segments collection', async () => {
+    const { transport } = renderSegments();
+    await screen.findByRole('heading', { name: 'Customer Segments' });
+
+    await waitFor(() =>
+      expect(transport.calls()).toContainEqual(
+        expect.objectContaining({
+          method: 'GET',
+          path: 'analytics/customer-segments',
+          params: expect.objectContaining({ page: '1', pageSize: '25' }),
+        })
+      )
+    );
+    expect(transport.calls().some((call) => call.path === 'segments')).toBe(false);
+  });
+
+  it('renders every segment as a toggle, including the ones nobody is in', async () => {
+    renderSegments();
+
+    const champions = await screen.findByRole('button', { name: /Champions/ });
+    expect(champions).toHaveAttribute('aria-pressed', 'false');
+    expect(await screen.findByRole('button', { name: /Potential Loyalists/ })).toBeInTheDocument();
+    expect(await screen.findByText('Nadia Kamal')).toBeInTheDocument();
+  });
+
+  it('asks the server for one segment when a tile is pressed', async () => {
+    const { transport } = renderSegments();
+    const champions = await screen.findByRole('button', { name: /Champions/ });
+
+    fireEvent.click(champions);
+
+    await waitFor(() =>
+      expect(transport.calls()).toContainEqual(
+        expect.objectContaining({
+          path: 'analytics/customer-segments',
+          params: expect.objectContaining({ segment: 'champions', page: '1' }),
+        })
+      )
+    );
+    await waitFor(() =>
+      // Re-queried: the tile is re-rendered by the navigation, so the node held
+      // from before the click is no longer the one on screen.
+      expect(screen.getByRole('button', { name: /Champions/ })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      )
+    );
+  });
+
+  it('takes the selected segment from the URL, so the view is shareable', async () => {
+    const { transport } = renderSegments({ customers: [], summary }, '/?segment=lost');
+
+    await waitFor(() =>
+      expect(transport.calls()).toContainEqual(
+        expect.objectContaining({
+          path: 'analytics/customer-segments',
+          params: expect.objectContaining({ segment: 'lost' }),
+        })
+      )
+    );
+    expect(await screen.findByRole('button', { name: /^Lost/ })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  it('survives a response with no summary rather than blanking the page', async () => {
+    // What the page did against `GET /segments`, which answers with an array of
+    // rule-authored segments and no `summary` at all.
+    renderSegments([{ id: 1, name: 'VIP' }]);
+
+    expect(await screen.findByRole('heading', { name: 'Customer Segments' })).toBeInTheDocument();
+  });
+});

--- a/client/src/features/customers/pages/Segments.tsx
+++ b/client/src/features/customers/pages/Segments.tsx
@@ -1,23 +1,30 @@
-import { useState, useMemo } from 'react';
-import type { ColumnDef } from '@tanstack/react-table';
-import { Crown, Heart, Star, AlertTriangle, Moon, UserX, UserPlus } from 'lucide-react';
+import { useMemo } from 'react';
+import type { ColumnDef, PaginationState } from '@tanstack/react-table';
+import { Crown, Heart, Star, AlertTriangle, Moon, UserX, UserPlus, X } from 'lucide-react';
+import { Button } from '@heroui/react';
 import { Badge, type BadgeVariant, PageHeader, DataTable } from '../../../shared';
 import { useTranslation } from '../../../shared/i18n/index';
 import { formatCurrency } from '../../../shared/lib/utils';
 import { useApiQuery } from '../../../shared/lib/apiQuery';
-import type { SegmentsResponse, CustomerRFM } from '../types';
+import { useListRouteState, useLastPageRecovery } from '../../../shared/hooks/useListRouteState';
+import {
+  CUSTOMER_SEGMENTS,
+  type CustomerSegmentKey,
+  type SegmentsResponse,
+  type CustomerRFM,
+} from '../types';
 
-const segmentIcons: Record<string, React.ReactNode> = {
-  champions: <Crown className="h-5 w-5 text-amber-500" />,
-  loyal: <Heart className="h-5 w-5 text-rose-500" />,
-  potential: <Star className="h-5 w-5 text-blue-500" />,
-  at_risk: <AlertTriangle className="h-5 w-5 text-orange-500" />,
-  hibernating: <Moon className="h-5 w-5 text-purple-500" />,
-  lost: <UserX className="h-5 w-5 text-red-500" />,
-  new: <UserPlus className="h-5 w-5 text-emerald-500" />,
+const segmentIcons: Record<CustomerSegmentKey, React.ReactNode> = {
+  champions: <Crown className="h-5 w-5 text-amber-500" aria-hidden="true" />,
+  loyal: <Heart className="h-5 w-5 text-rose-500" aria-hidden="true" />,
+  potential: <Star className="h-5 w-5 text-blue-500" aria-hidden="true" />,
+  at_risk: <AlertTriangle className="h-5 w-5 text-orange-500" aria-hidden="true" />,
+  hibernating: <Moon className="h-5 w-5 text-purple-500" aria-hidden="true" />,
+  lost: <UserX className="h-5 w-5 text-red-500" aria-hidden="true" />,
+  new: <UserPlus className="h-5 w-5 text-emerald-500" aria-hidden="true" />,
 };
 
-const segmentColors: Record<string, string> = {
+const segmentColors: Record<CustomerSegmentKey, string> = {
   champions: 'bg-amber-500/10 border-amber-500/30',
   loyal: 'bg-rose-500/10 border-rose-500/30',
   potential: 'bg-blue-500/10 border-blue-500/30',
@@ -27,7 +34,7 @@ const segmentColors: Record<string, string> = {
   new: 'bg-emerald-500/10 border-emerald-500/30',
 };
 
-const segmentVariant: Record<string, BadgeVariant> = {
+const segmentVariant: Record<CustomerSegmentKey, BadgeVariant> = {
   champions: 'warning',
   loyal: 'danger',
   potential: 'secondary',
@@ -37,7 +44,7 @@ const segmentVariant: Record<string, BadgeVariant> = {
   new: 'success',
 };
 
-const segmentKeys: Record<string, string> = {
+const segmentKeys: Record<CustomerSegmentKey, string> = {
   champions: 'segments.champions',
   loyal: 'segments.loyal',
   potential: 'segments.potential',
@@ -49,98 +56,157 @@ const segmentKeys: Record<string, string> = {
 
 export default function SegmentsPage() {
   const { t } = useTranslation();
+  const { search: routeSearch, page, pageSize, update } = useListRouteState();
 
-  const { data, isLoading } = useApiQuery<SegmentsResponse>(['segments'], 'segments');
+  const selectedSegment = CUSTOMER_SEGMENTS.includes(routeSearch.segment as CustomerSegmentKey)
+    ? (routeSearch.segment as CustomerSegmentKey)
+    : null;
 
-  const [selectedSegment, setSelectedSegment] = useState<string | null>(null);
+  const params: Record<string, string> = {
+    page: String(page),
+    pageSize: String(pageSize),
+  };
+  if (selectedSegment) params.segment = selectedSegment;
 
-  const filteredCustomers = useMemo(() => {
-    if (!data?.customers) return [];
-    return selectedSegment
-      ? data.customers.filter((c) => c.segment === selectedSegment)
-      : data.customers;
-  }, [data?.customers, selectedSegment]);
+  const { data, meta, isLoading, isFetching, error, refetch } = useApiQuery<SegmentsResponse>(
+    ['analytics', 'customer-segments'],
+    'analytics/customer-segments',
+    params
+  );
 
-  const columns: ColumnDef<CustomerRFM>[] = [
-    {
-      accessorKey: 'name',
-      header: t('common.name'),
-      cell: ({ row }) => (
-        <div>
-          <span className="font-medium text-foreground">{row.original.name}</span>
-          {row.original.phone && (
-            <p className="text-xs text-muted-foreground">{row.original.phone}</p>
-          )}
-        </div>
-      ),
-    },
-    {
-      accessorKey: 'segment',
-      header: t('segments.segment'),
-      cell: ({ row }) => (
-        <Badge size="sm" variant={segmentVariant[row.original.segment] || 'default'}>
-          {t(segmentKeys[row.original.segment] as never)}
-        </Badge>
-      ),
-    },
-    {
-      accessorKey: 'recency_days',
-      header: t('segments.recency'),
-      cell: ({ getValue }) => {
-        const val = getValue() as number;
-        return (
-          <span className="font-data text-muted-foreground">{val >= 999 ? '—' : `${val}d`}</span>
-        );
+  useLastPageRecovery(page, meta?.pagination?.totalItems, meta?.pagination?.totalPages, update);
+
+  // The roll-up covers every scored customer, so the tiles keep their counts
+  // while a filter is on — which is what makes them a usable way back out.
+  const summary = data?.summary ?? [];
+  const pagination: PaginationState = { pageIndex: page - 1, pageSize };
+
+  const toggleSegment = (segment: CustomerSegmentKey) =>
+    update({ segment: selectedSegment === segment ? undefined : segment, page: 1 });
+
+  const columns: ColumnDef<CustomerRFM>[] = useMemo(
+    () => [
+      {
+        accessorKey: 'name',
+        header: t('common.name'),
+        cell: ({ row }) => (
+          <div>
+            <span className="font-medium text-foreground">{row.original.name}</span>
+            {row.original.phone && (
+              <p className="text-xs text-muted-foreground">{row.original.phone}</p>
+            )}
+          </div>
+        ),
       },
-    },
-    {
-      accessorKey: 'frequency',
-      header: t('segments.frequency'),
-      cell: ({ getValue }) => <span className="font-data">{getValue() as number}</span>,
-    },
-    {
-      accessorKey: 'monetary',
-      header: t('segments.monetary'),
-      cell: ({ getValue }) => (
-        <span className="font-data font-medium text-primary">
-          {formatCurrency(getValue() as number)}
-        </span>
-      ),
-    },
-  ];
+      {
+        accessorKey: 'segment',
+        header: t('segments.segment'),
+        cell: ({ row }) => (
+          <Badge size="sm" variant={segmentVariant[row.original.segment] || 'default'}>
+            {t(segmentKeys[row.original.segment] as never)}
+          </Badge>
+        ),
+      },
+      {
+        accessorKey: 'recency_days',
+        header: t('segments.recency'),
+        cell: ({ getValue }) => {
+          const val = getValue() as number;
+          return (
+            <span className="font-data text-muted-foreground">{val >= 999 ? '—' : `${val}d`}</span>
+          );
+        },
+      },
+      {
+        accessorKey: 'frequency',
+        header: t('segments.frequency'),
+        cell: ({ getValue }) => <span className="font-data">{getValue() as number}</span>,
+      },
+      {
+        accessorKey: 'monetary',
+        header: t('segments.monetary'),
+        cell: ({ getValue }) => (
+          <span className="font-data font-medium text-primary">
+            {formatCurrency(getValue() as number)}
+          </span>
+        ),
+      },
+    ],
+    [t]
+  );
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      <PageHeader title={t('segments.title')} />
+      <PageHeader
+        title={t('segments.title')}
+        actions={
+          selectedSegment && (
+            <Button
+              size="sm"
+              variant="flat"
+              startContent={<X className="h-4 w-4" aria-hidden="true" />}
+              onPress={() => update({ segment: undefined, page: 1 })}
+            >
+              {t('common.clearFilters')}
+            </Button>
+          )
+        }
+      />
 
-      {/* Segment cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3">
-        {data?.summary.map((seg) => (
-          <button
-            key={seg.segment}
-            onClick={() => setSelectedSegment(selectedSegment === seg.segment ? null : seg.segment)}
-            className={`p-3.5 rounded-lg border text-start transition-all shadow-sm ${
-              segmentColors[seg.segment] || 'bg-card border-border'
-            } ${selectedSegment === seg.segment ? 'ring-2 ring-primary' : ''}`}
-          >
-            <div className="flex items-center gap-2 mb-2">
-              {segmentIcons[seg.segment]}
-              <span className="text-xs font-semibold">{t(segmentKeys[seg.segment] as never)}</span>
-            </div>
-            <p className="text-xl font-data font-bold text-foreground">{seg.count}</p>
-            <p className="text-[11px] text-muted-foreground font-data mt-0.5">
-              {formatCurrency(seg.total_revenue)}
-            </p>
-          </button>
-        ))}
+      {/* The tiles are the filter control, so each one is a toggle rather than a card. */}
+      <div
+        role="group"
+        aria-label={t('segments.title')}
+        className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3"
+      >
+        {isLoading
+          ? CUSTOMER_SEGMENTS.map((segment) => (
+              <div
+                key={segment}
+                className="h-[104px] rounded-lg border border-border bg-card animate-pulse"
+              />
+            ))
+          : summary.map((seg) => (
+              <button
+                type="button"
+                key={seg.segment}
+                aria-pressed={selectedSegment === seg.segment}
+                onClick={() => toggleSegment(seg.segment)}
+                className={`p-3.5 rounded-lg border text-start transition-all shadow-sm cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                  segmentColors[seg.segment] || 'bg-card border-border'
+                } ${selectedSegment === seg.segment ? 'ring-2 ring-primary' : ''}`}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  {segmentIcons[seg.segment]}
+                  <span className="text-xs font-semibold">
+                    {t(segmentKeys[seg.segment] as never)}
+                  </span>
+                </div>
+                <p className="text-xl font-data font-bold text-foreground">{seg.count}</p>
+                <p className="text-[11px] text-muted-foreground font-data mt-0.5">
+                  {formatCurrency(seg.total_revenue)}
+                </p>
+              </button>
+            ))}
       </div>
 
-      {/* Customer table */}
       <DataTable
+        mode="server"
         columns={columns}
-        data={filteredCustomers}
+        data={data?.customers ?? []}
         isLoading={isLoading}
-        searchPlaceholder={t('common.search')}
+        isFetching={isFetching}
+        error={error instanceof Error ? error.message : undefined}
+        onRetry={() => void refetch()}
+        enableSearch={false}
+        isFiltered={selectedSegment !== null}
+        pagination={pagination}
+        onPaginationChange={(updater) => {
+          const next = typeof updater === 'function' ? updater(pagination) : updater;
+          update({ page: next.pageIndex + 1, pageSize: next.pageSize });
+        }}
+        pageCount={meta?.pagination?.totalPages ?? 0}
+        totalRows={meta?.pagination?.totalItems ?? 0}
       />
     </div>
   );

--- a/client/src/features/customers/types.ts
+++ b/client/src/features/customers/types.ts
@@ -1,15 +1,34 @@
 // Types owned by the customers slice. Cross-slice contracts (Customer,
 // AppSettings, ...) live in `shared/types` instead.
 
-/** One RFM segment's roll-up from GET /api/segments */
+/**
+ * The seven RFM segments the server can produce, in the order the tiles are
+ * drawn. Fixed labels, not the user-authored segments under `/api/v1/segments`.
+ */
+export const CUSTOMER_SEGMENTS = [
+  'champions',
+  'loyal',
+  'potential',
+  'at_risk',
+  'hibernating',
+  'lost',
+  'new',
+] as const;
+
+export type CustomerSegmentKey = (typeof CUSTOMER_SEGMENTS)[number];
+
+/** One RFM segment's roll-up from GET /api/v1/analytics/customer-segments */
 export interface SegmentSummary {
-  segment: string;
+  segment: CustomerSegmentKey;
   count: number;
   total_revenue: number;
   avg_frequency: number;
 }
 
-/** A customer scored on recency/frequency/monetary, from GET /api/segments */
+/**
+ * A customer scored on recency/frequency/monetary, from
+ * GET /api/v1/analytics/customer-segments.
+ */
 export interface CustomerRFM {
   id: number;
   name: string;
@@ -18,11 +37,16 @@ export interface CustomerRFM {
   recency_days: number;
   frequency: number;
   monetary: number;
-  segment: string;
+  segment: CustomerSegmentKey;
   loyalty_points: number;
 }
 
-/** Body of GET /api/segments */
+/**
+ * Body of GET /api/v1/analytics/customer-segments.
+ *
+ * `customers` is one page; `summary` always covers every scored customer, which
+ * is why the tiles keep their counts while paging or filtering.
+ */
 export interface SegmentsResponse {
   customers: CustomerRFM[];
   summary: SegmentSummary[];

--- a/client/src/routes/_authenticated/_admin/segments.tsx
+++ b/client/src/routes/_authenticated/_admin/segments.tsx
@@ -1,6 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { Segments } from '@/features/customers';
+import { z } from 'zod';
+import { Segments, CUSTOMER_SEGMENTS } from '@/features/customers';
+import { listSearchSchema } from '@/shared/lib/listSearch';
+
+/** The selected segment lives in the URL, so a filtered view can be shared. */
+export const segmentsSearchSchema = listSearchSchema.extend({
+  segment: z.enum(CUSTOMER_SEGMENTS).optional().catch(undefined),
+});
 
 export const Route = createFileRoute('/_authenticated/_admin/segments')({
+  validateSearch: segmentsSearchSchema,
   component: Segments,
 });

--- a/server/src/docs/openapi.ts
+++ b/server/src/docs/openapi.ts
@@ -10869,6 +10869,55 @@ export const openApiSpec = {
         },
       },
     },
+    '/api/v1/analytics/customer-segments': {
+      get: {
+        tags: ['Analytics'],
+        summary: 'List / Query Analytics (Admin)',
+        description:
+          'RFM segmentation of every customer who has purchased. Endpoint classification: P. Allowed Roles: Admin.',
+        security: [
+          {
+            BearerAuth: [],
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: {
+                      type: 'boolean',
+                      example: true,
+                    },
+                    data: {
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Validation error / Bad request',
+          },
+          '401': {
+            description: 'Unauthorized / Missing or invalid token',
+          },
+          '403': {
+            description: 'Forbidden / Insufficient role privileges',
+          },
+          '404': {
+            description: 'Resource not found',
+          },
+          '500': {
+            description: 'Internal server error',
+          },
+        },
+      },
+    },
     '/api/v1/analytics/hourly-heatmap': {
       get: {
         tags: ['Analytics'],

--- a/server/src/http/endpointManifest.ts
+++ b/server/src/http/endpointManifest.ts
@@ -940,6 +940,12 @@ export const endpointDetailsManifest: readonly DetailedEndpointEntry[] = [
   },
   {
     method: 'GET',
+    path: '/api/v1/analytics/customer-segments',
+    classification: 'P',
+    authorization: adminOnly,
+  },
+  {
+    method: 'GET',
     path: '/api/v1/analytics/hourly-heatmap',
     classification: 'B',
     authorization: adminOnly,

--- a/server/src/modules/intelligence/analytics/controller.ts
+++ b/server/src/modules/intelligence/analytics/controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { analyticsRequestContracts } from './schemas';
 import { analyticsService } from './service';
-import { withDefaultDays, type AnalyticsPageQuery } from './types';
+import { withDefaultDays, type AnalyticsPageQuery, type CustomerSegment } from './types';
 import { success } from '../../../http/responses';
 import { paginationMeta } from '../../../http/pagination';
 
@@ -176,6 +176,28 @@ export class AnalyticsController {
         query.pageSize,
         from,
         to
+      );
+      res.json(
+        success(result.data, {
+          pagination: paginationMeta(query.page, query.pageSize, result.totalItems),
+        })
+      );
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async getCustomerSegments(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const query = contracts.getCustomerSegments.parseQuery<{
+        page: number;
+        pageSize: number;
+        segment?: CustomerSegment;
+      }>(req.query);
+      const result = await analyticsService.getCustomerSegmentsPage(
+        query.page,
+        query.pageSize,
+        query.segment
       );
       res.json(
         success(result.data, {

--- a/server/src/modules/intelligence/analytics/repository.ts
+++ b/server/src/modules/intelligence/analytics/repository.ts
@@ -141,6 +141,18 @@ export interface IAnalyticsRepository {
       recency_days: string | number;
     }>
   >;
+  getCustomerRfmRaw(queryable?: Queryable): Promise<
+    Array<{
+      id: number;
+      name: string;
+      phone: string | null;
+      email: string | null;
+      loyalty_points: string | number | null;
+      recency_days: string | number;
+      frequency: string | number;
+      monetary: string | number;
+    }>
+  >;
   getHourlyHeatmapRaw(
     days: number,
     queryable?: Queryable
@@ -624,6 +636,40 @@ export class AnalyticsRepository implements IAnalyticsRepository {
        GROUP BY c.id
        ORDER BY lifetime_revenue DESC`,
       params
+    );
+    return result.rows;
+  }
+
+  async getCustomerRfmRaw(queryable?: Queryable): Promise<
+    Array<{
+      id: number;
+      name: string;
+      phone: string | null;
+      email: string | null;
+      loyalty_points: string | number | null;
+      recency_days: string | number;
+      frequency: string | number;
+      monetary: string | number;
+    }>
+  > {
+    const result = await this.q(queryable).query<{
+      id: number;
+      name: string;
+      phone: string | null;
+      email: string | null;
+      loyalty_points: string | number | null;
+      recency_days: string | number;
+      frequency: string | number;
+      monetary: string | number;
+    }>(
+      `SELECT c.id, c.name, c.phone, c.email, c.loyalty_points,
+              FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - MAX(s.created_at))) / 86400.0)::int AS recency_days,
+              COUNT(DISTINCT s.id)::int AS frequency,
+              COALESCE(SUM(s.total - COALESCE(s.refunded_amount, 0)), 0) AS monetary
+       FROM customers c
+       INNER JOIN sales s ON c.id = s.customer_id
+       GROUP BY c.id
+       ORDER BY monetary DESC, c.id ASC`
     );
     return result.rows;
   }

--- a/server/src/modules/intelligence/analytics/routes.ts
+++ b/server/src/modules/intelligence/analytics/routes.ts
@@ -59,6 +59,11 @@ router.get('/customer-ltv', verifyToken, requireRole('Admin'), (req, res, next) 
   analyticsController.getCustomerLtv(req, res, next)
 );
 
+// GET /api/analytics/customer-segments — RFM segmentation
+router.get('/customer-segments', verifyToken, requireRole('Admin'), (req, res, next) =>
+  analyticsController.getCustomerSegments(req, res, next)
+);
+
 // GET /api/analytics/hourly-heatmap — Sales by day-of-week and hour
 router.get('/hourly-heatmap', verifyToken, requireRole('Admin'), (req, res, next) =>
   analyticsController.getHourlyHeatmap(req, res, next)

--- a/server/src/modules/intelligence/analytics/schemas.ts
+++ b/server/src/modules/intelligence/analytics/schemas.ts
@@ -11,6 +11,7 @@ import {
   analyticsDaysPageQuerySchema,
   analyticsDaysQuerySchema,
   analyticsPageQuerySchema,
+  analyticsSegmentQuerySchema,
 } from './types';
 
 export const analyticsRequestContracts = {
@@ -102,6 +103,20 @@ export const analyticsRequestContracts = {
     beyondSchema: [
       '`days` is optional on the wire and defaults to 30 after parsing, so an omitted ' +
         'value is a 30-day window rather than an unbounded one.',
+    ],
+  }),
+
+  getCustomerSegments: defineRequestContract({
+    method: 'GET',
+    path: '/api/v1/analytics/customer-segments',
+    operation: 'getCustomerSegments',
+    query: analyticsSegmentQuerySchema,
+    beyondSchema: [
+      '`segment` filters the customer page only. The seven-row summary is always ' +
+        'computed over the whole scored population, because it is what the segment ' +
+        'tiles are drawn from.',
+      'Scores are quintiles of the whole customer base, so a customer can change ' +
+        'segment without buying anything — someone else buying moves the boundary.',
     ],
   }),
 

--- a/server/src/modules/intelligence/analytics/service.ts
+++ b/server/src/modules/intelligence/analytics/service.ts
@@ -17,6 +17,11 @@ import {
   HourlyHeatmapRow,
   DashboardAllData,
   AnalyticsPagedResult,
+  CUSTOMER_SEGMENTS,
+  CustomerSegment,
+  CustomerSegmentSummaryRow,
+  CustomerSegmentsResult,
+  CustomerRfmRow,
 } from './types';
 
 function buildDateFilter(
@@ -37,6 +42,58 @@ function buildDateFilter(
     params: [],
     nextIdx: startIdx,
   };
+}
+
+/**
+ * A customer's quintile by percentile rank: 5 is the best fifth, 1 the worst.
+ *
+ * The quintiles are relative to the whole customer base, so they cannot be
+ * computed on a page — which is why the scoring runs here, over every scored
+ * customer, rather than in the paging query.
+ *
+ * Percentile rank rather than `NTILE(5)`, which is what this would have been in
+ * SQL, because NTILE degrades badly on a small shop: over a single customer it
+ * returns bucket 1, and the only customer a boutique has would be labelled
+ * "Lost" on the day they bought something. Ranking says the top-ranked customer
+ * is in the top fifth however few of them there are, which is the claim the
+ * segment tiles actually make. On a population that divides evenly the two
+ * agree exactly.
+ */
+function quintile(rank: number, total: number): number {
+  if (total <= 0) return 1;
+  return Math.max(1, Math.min(5, Math.ceil(((rank + 1) / total) * 5)));
+}
+
+/**
+ * Rank ascending by "how good this number is", then bucket into quintiles.
+ * Ties are broken by customer id so the same population always scores the same
+ * way; NTILE makes no promise about ties either.
+ */
+function scoreBy<T extends { id: number }>(
+  rows: readonly T[],
+  goodness: (row: T) => number
+): Map<number, number> {
+  const ordered = [...rows].sort((a, b) => goodness(a) - goodness(b) || a.id - b.id);
+  const scores = new Map<number, number>();
+  ordered.forEach((row, index) => scores.set(row.id, quintile(index, ordered.length)));
+  return scores;
+}
+
+/**
+ * The segment ladder: first match wins, and the seven cases cover all 25
+ * (recency, frequency) score pairs, so every scored customer gets a label.
+ * Monetary is reported but does not decide the label — a high spender who has
+ * not returned in a year is at risk, and calling them a champion because of the
+ * money would hide exactly the customer this page exists to surface.
+ */
+function labelSegment(recencyScore: number, frequencyScore: number): CustomerSegment {
+  if (recencyScore >= 4 && frequencyScore >= 4) return 'champions';
+  if (frequencyScore >= 4) return 'loyal';
+  if (recencyScore === 5 && frequencyScore === 1) return 'new';
+  if (recencyScore >= 3) return 'potential';
+  if (recencyScore === 1 && frequencyScore <= 2) return 'lost';
+  if (frequencyScore >= 3) return 'at_risk';
+  return 'hibernating';
 }
 
 export class AnalyticsService {
@@ -707,6 +764,64 @@ export class AnalyticsService {
       },
       totalItems: result.totalItems,
     };
+  }
+
+  /**
+   * RFM segmentation over every customer who has ever bought something.
+   *
+   * The summary is built from the whole scored population and ignores the
+   * `segment` filter: it feeds the seven tiles, which are the control for that
+   * filter and would be nonsense if they only counted what the filter left.
+   */
+  async getCustomerSegmentsPage(
+    page: number,
+    pageSize: number,
+    segment?: CustomerSegment
+  ): Promise<{ data: CustomerSegmentsResult; totalItems: number }> {
+    const raw = await this.repo.getCustomerRfmRaw();
+    const metrics = raw.map((r) => ({
+      id: r.id,
+      name: r.name,
+      phone: r.phone,
+      email: r.email,
+      loyalty_points: Number(r.loyalty_points ?? 0),
+      recency_days: Number(r.recency_days),
+      frequency: Number(r.frequency),
+      monetary: Number(r.monetary),
+    }));
+
+    // Fewer days since the last purchase is better, so recency is scored on its negation.
+    const recencyScores = scoreBy(metrics, (m) => -m.recency_days);
+    const frequencyScores = scoreBy(metrics, (m) => m.frequency);
+
+    const scored: CustomerRfmRow[] = metrics.map((m) => ({
+      ...m,
+      segment: labelSegment(recencyScores.get(m.id) ?? 1, frequencyScores.get(m.id) ?? 1),
+    }));
+
+    const summary = this.rollUpSegments(scored);
+    const matching = segment ? scored.filter((c) => c.segment === segment) : scored;
+    const start = (page - 1) * pageSize;
+
+    return {
+      data: { customers: matching.slice(start, start + pageSize), summary },
+      totalItems: matching.length,
+    };
+  }
+
+  /** One row per segment, in a fixed order, including the segments nobody is in. */
+  private rollUpSegments(scored: readonly CustomerRfmRow[]): CustomerSegmentSummaryRow[] {
+    return CUSTOMER_SEGMENTS.map((segment) => {
+      const members = scored.filter((c) => c.segment === segment);
+      const revenue = members.reduce((sum, c) => sum + c.monetary, 0);
+      const frequency = members.reduce((sum, c) => sum + c.frequency, 0);
+      return {
+        segment,
+        count: members.length,
+        total_revenue: Math.round(revenue * 100) / 100,
+        avg_frequency: members.length ? Math.round((frequency / members.length) * 100) / 100 : 0,
+      };
+    });
   }
 
   async getHourlyHeatmap(days: number = 30): Promise<HourlyHeatmapRow[]> {

--- a/server/src/modules/intelligence/analytics/types.ts
+++ b/server/src/modules/intelligence/analytics/types.ts
@@ -1,5 +1,23 @@
 import { z } from 'zod';
 
+/**
+ * The seven RFM segments. Fixed, not user-defined: these are the labels the
+ * scoring rule can produce, and the client has an icon, a colour and a
+ * translation for each one. A rule-authored segment is a different feature and
+ * lives under `/api/v1/segments`.
+ */
+export const CUSTOMER_SEGMENTS = [
+  'champions',
+  'loyal',
+  'potential',
+  'at_risk',
+  'hibernating',
+  'lost',
+  'new',
+] as const;
+
+export type CustomerSegment = (typeof CUSTOMER_SEGMENTS)[number];
+
 export interface DashboardKpis {
   today_revenue: number;
   month_revenue: number;
@@ -32,6 +50,12 @@ export const analyticsPageQuerySchema = z
   .object({ ...pageFields, ...dateFilters })
   .strict()
   .superRefine(validateDateRange);
+export const analyticsSegmentQuerySchema = z
+  .object({
+    ...pageFields,
+    segment: z.enum(CUSTOMER_SEGMENTS).optional(),
+  })
+  .strict();
 export const analyticsDaysPageQuerySchema = z
   .object({
     ...pageFields,
@@ -227,6 +251,38 @@ export interface CustomerLtvResult {
     avg_ltv: number;
     top10_revenue_share: number;
   };
+}
+
+export interface CustomerRfmRow {
+  id: number;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  recency_days: number;
+  frequency: number;
+  monetary: number;
+  segment: CustomerSegment;
+  loyalty_points: number;
+}
+
+export interface CustomerSegmentSummaryRow {
+  segment: CustomerSegment;
+  count: number;
+  total_revenue: number;
+  avg_frequency: number;
+}
+
+/**
+ * The page of scored customers plus the roll-up.
+ *
+ * The summary is deliberately computed over every scored customer, not over the
+ * page and not through the `segment` filter: it is what the segment tiles are
+ * drawn from, and a tile that only counted the current page would change every
+ * time someone paged.
+ */
+export interface CustomerSegmentsResult {
+  customers: CustomerRfmRow[];
+  summary: CustomerSegmentSummaryRow[];
 }
 
 export interface HourlyHeatmapRow {

--- a/server/tests/customerSegments.test.ts
+++ b/server/tests/customerSegments.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { AnalyticsService } from '../src/modules/intelligence/analytics/service';
+import type { IAnalyticsRepository } from '../src/modules/intelligence/analytics/repository';
+import { CUSTOMER_SEGMENTS } from '../src/modules/intelligence/analytics/types';
+
+type RfmRow = Awaited<ReturnType<IAnalyticsRepository['getCustomerRfmRaw']>>[number];
+
+/**
+ * A repository that answers only the one question segmentation asks. The scoring
+ * is deliberately in the service rather than in SQL, which is what makes it
+ * provable without a database.
+ */
+function serviceOver(rows: RfmRow[]): AnalyticsService {
+  return new AnalyticsService({
+    getCustomerRfmRaw: async () => rows,
+  } as unknown as IAnalyticsRepository);
+}
+
+/** Ten customers spread evenly, so each quintile holds exactly two. */
+function population(): RfmRow[] {
+  return Array.from({ length: 10 }, (_, i) => ({
+    id: i + 1,
+    name: `Customer ${i + 1}`,
+    phone: `0100000000${i}`,
+    email: null,
+    loyalty_points: i * 10,
+    // Customer 1 bought yesterday and often; customer 10 long ago and once.
+    recency_days: i * 30,
+    frequency: 10 - i,
+    monetary: (10 - i) * 500,
+  }));
+}
+
+describe('RFM customer segmentation', () => {
+  it('labels the best and worst of a spread population as champions and lost', async () => {
+    const { data } = await serviceOver(population()).getCustomerSegmentsPage(1, 25);
+
+    const byId = new Map(data.customers.map((c) => [c.id, c.segment]));
+    expect(byId.get(1)).toBe('champions');
+    expect(byId.get(2)).toBe('champions');
+    expect(byId.get(10)).toBe('lost');
+  });
+
+  it('gives every scored customer exactly one of the seven segments', async () => {
+    const { data } = await serviceOver(population()).getCustomerSegmentsPage(1, 25);
+
+    expect(data.customers).toHaveLength(10);
+    for (const customer of data.customers) {
+      expect(CUSTOMER_SEGMENTS).toContain(customer.segment);
+    }
+    const summed = data.summary.reduce((total, row) => total + row.count, 0);
+    expect(summed).toBe(10);
+  });
+
+  it('rolls up all seven segments even when nobody is in them', async () => {
+    const { data } = await serviceOver(population()).getCustomerSegmentsPage(1, 25);
+
+    expect(data.summary.map((s) => s.segment)).toEqual([...CUSTOMER_SEGMENTS]);
+    for (const row of data.summary) {
+      if (row.count === 0) {
+        expect(row.total_revenue).toBe(0);
+        expect(row.avg_frequency).toBe(0);
+      }
+    }
+  });
+
+  it('summarises the whole population regardless of the page or the filter', async () => {
+    const service = serviceOver(population());
+
+    const unfiltered = await service.getCustomerSegmentsPage(1, 3);
+    const filtered = await service.getCustomerSegmentsPage(1, 3, 'champions');
+    const lastPage = await service.getCustomerSegmentsPage(4, 3);
+
+    expect(unfiltered.data.customers).toHaveLength(3);
+    expect(unfiltered.totalItems).toBe(10);
+    expect(lastPage.data.customers).toHaveLength(1);
+    // The tiles are the control for the filter; they must not move when it is applied.
+    expect(filtered.data.summary).toEqual(unfiltered.data.summary);
+    expect(lastPage.data.summary).toEqual(unfiltered.data.summary);
+  });
+
+  it('returns only the requested segment, and counts only that segment', async () => {
+    const service = serviceOver(population());
+    const all = await service.getCustomerSegmentsPage(1, 100);
+    const championCount = all.data.summary.find((s) => s.segment === 'champions')?.count ?? 0;
+
+    const filtered = await service.getCustomerSegmentsPage(1, 100, 'champions');
+
+    expect(filtered.totalItems).toBe(championCount);
+    expect(filtered.data.customers.every((c) => c.segment === 'champions')).toBe(true);
+  });
+
+  it('scores a single customer without dividing by zero', async () => {
+    const only = population().slice(0, 1);
+    const { data, totalItems } = await serviceOver(only).getCustomerSegmentsPage(1, 25);
+
+    expect(totalItems).toBe(1);
+    expect(data.customers[0].segment).toBe('champions');
+  });
+
+  it('returns an empty page and a zeroed roll-up when nobody has bought anything', async () => {
+    const { data, totalItems } = await serviceOver([]).getCustomerSegmentsPage(1, 25);
+
+    expect(totalItems).toBe(0);
+    expect(data.customers).toEqual([]);
+    expect(data.summary.every((row) => row.count === 0)).toBe(true);
+  });
+
+  it('coerces the numeric strings PostgreSQL returns for NUMERIC columns', async () => {
+    const rows: RfmRow[] = [
+      {
+        id: 1,
+        name: 'Numeric strings',
+        phone: null,
+        email: null,
+        loyalty_points: null,
+        recency_days: '12',
+        frequency: '3',
+        monetary: '1500.50',
+      },
+    ];
+
+    const { data } = await serviceOver(rows).getCustomerSegmentsPage(1, 25);
+
+    expect(data.customers[0]).toMatchObject({
+      recency_days: 12,
+      frequency: 3,
+      monetary: 1500.5,
+      loyalty_points: 0,
+    });
+  });
+});

--- a/server/tests/intelligence-contracts.test.ts
+++ b/server/tests/intelligence-contracts.test.ts
@@ -4,6 +4,7 @@ import {
   parseAnalyticsDaysPageQuery,
   parseAnalyticsDaysQuery,
   parseAnalyticsPageQuery,
+  analyticsSegmentQuerySchema,
 } from '../src/modules/intelligence/analytics/types';
 import {
   parseAiListQuery,
@@ -31,6 +32,17 @@ describe('intelligence collection contracts', () => {
     expect(parseAnalyticsDaysQuery({ days: '30' }, 90)).toEqual({ days: 30 });
     expect(parseAiListQuery({ page: '3', pageSize: '10' })).toEqual({ page: 3, pageSize: 10 });
     expect(parseRecommendationQuery({ productId: '7' })).toMatchObject({ productId: 7 });
+  });
+
+  it('parses the RFM segment filter and rejects a segment it cannot produce', () => {
+    expect(analyticsSegmentQuerySchema.parse({ page: '2', segment: 'at_risk' })).toEqual({
+      page: 2,
+      pageSize: 25,
+      segment: 'at_risk',
+    });
+    expect(analyticsSegmentQuerySchema.parse({})).toEqual({ page: 1, pageSize: 25 });
+    expect(() => analyticsSegmentQuerySchema.parse({ segment: 'vip' })).toThrow();
+    expect(() => analyticsSegmentQuerySchema.parse({ from: '2026-01-01' })).toThrow();
   });
 
   it('parses notifications and sales reports with canonical names', () => {


### PR DESCRIPTION
`/segments` threw `Cannot read properties of undefined (reading 'map')` for every admin who opened it, and had since it was written.

## What was wrong

The page read `GET /api/v1/segments` and destructured `{ customers, summary }` off the response. That route serves the **rule-authored** segments collection — an array of `{ id, name, rules_json, member_count }` — so `data.summary` was `undefined` and `data?.summary.map` threw. Nothing in the server computed RFM at all; `grep -i rfm server/src` returned nothing. Two unrelated features had been sharing one word.

## Server

New `GET /api/v1/analytics/customer-segments` — Admin, paged, optional `?segment=`.

- `getCustomerRfmRaw` is one `GROUP BY` over `customers ⋈ sales` for recency, frequency and monetary.
- **Scoring is in the service, not in SQL.** Quintiles are relative to the whole customer base, so they cannot be computed on a page — the population is scanned either way, and in TypeScript the seven-case segment ladder is provable without a database.
- **Percentile rank rather than `NTILE(5)`**, which is what this would have been in SQL. NTILE over a single row returns bucket 1, so a boutique's only customer would be labelled "Lost" on the day they bought something. The two agree exactly on a population that divides evenly.
- Monetary is reported but does not decide the label: a high spender who has not returned in a year is *at risk*, and letting the money override that would hide the customer this page exists to surface.
- **The summary ignores the `segment` filter** and always covers the whole scored population. The tiles are the control for that filter and are the way back out of it; tiles that counted only what the filter left would be unusable.

Manifest, OpenAPI and request contract are wired, so `check:api-docs` passes at 204 served routes. Both ratchets are untouched — `EXPECTED_UNCONVERTED` is still `3`, now of 204.

## Client

- The page reads the new endpoint. Filtering and paging moved to the server, so one segment can be shown without holding every scored customer in the browser.
- The selection lives in the URL (`?segment=lost`), so a filtered view is a link.
- The tiles are real toggles — `aria-pressed`, a visible focus ring, a Clear filters action — because they are the filter control rather than decoration. Loading skeletons reserve the row so the tiles do not shift the table on arrival.

## Verification

`server`: lint (385 warnings, exactly at the ratchet), typecheck, 608 tests, `check:api-docs`.
`client`: lint, typecheck, 594 tests — 5 new for this page, one of which pins the crash shape by feeding it a response with no `summary`.

Not run: the E2E suite and the real-PostgreSQL suites. There is no concurrency invariant here and neither needed a change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN