### PR TITLE
fix(pos): let a product card fill its grid cell

### DIFF
--- a/client/src/features/pos/pages/POS.tsx
+++ b/client/src/features/pos/pages/POS.tsx
@@ -481,13 +481,20 @@ export default function POS() {
                  * it over the card keeps the appearance and makes it a real, separately
                  * focusable button.
                  */
-                <div key={product.id} className="relative">
+                <div key={product.id} className="relative h-full">
                   <Card
                     /* E2E: the card's accessible name concatenates stock badge, category,
                      name and SKU, so an exact role+name query is not usable. */
                     data-testid={`product-card-${product.sku}`}
                     isPressable={getEffectiveStock(product) > 0}
-                    className={`relative transition-all border border-border bg-card shadow-sm ${
+                    /* `w-full h-full` is load-bearing, not tidying: HeroUI's Card defaults
+                     `fullWidth` to false, and `isPressable` renders it as a <button>, which
+                     shrinks to its content. The card then stopped short of its grid cell
+                     while the favourite star — positioned on the wrapper, because it has to
+                     be a sibling — stayed out at the cell edge, detached from the card it
+                     belongs to. An out-of-stock card is not pressable, so it renders as a
+                     <div> and stretched anyway: the row's cards were different widths. */
+                    className={`relative w-full h-full transition-all border border-border bg-card shadow-sm ${
                       getEffectiveStock(product) === 0
                         ? 'opacity-60 cursor-not-allowed'
                         : 'hover:border-primary/50'


### PR DESCRIPTION
The POS product cards did not fill their grid cells: each card was as wide as its own text, right-aligned in RTL, with the favourite star stranded out at the cell's edge.

## Cause

HeroUI's `Card` defaults `fullWidth` to **false**, and `isPressable` renders the card as a `<button>` — which shrinks to fit its content. So every in-stock card was sized by its product name rather than by its cell. The star could not follow it, because the star is positioned on the wrapper: it has to be a *sibling* of the card, not a child, or `isPressable` makes it a nested interactive control (#54).

An out-of-stock card is not pressable, renders as a `<div>`, and stretched normally — so one row could show cards at three different widths.

`w-full h-full` on the card fixes both the width and the ragged row heights. Collections and Bundles already pass `w-full` for exactly this reason; the POS grid was the one that did not.

## Verification

`client`: typecheck, lint, 167 POS tests. The change is a class on one element — no behaviour to test beyond what already runs. Please confirm visually.

## Noticed, not changed

`StockCount.tsx:285` has the same missing `w-full` on a pressable card in a full-width list. Say the word and I will fix it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN