### PR TITLE
fix(sales): refund integrity — per-line caps, variant restock, cash-only drawer (#120, #121, #126)

### DIFF
--- a/client/src/features/sales/components/RefundDialog.test.tsx
+++ b/client/src/features/sales/components/RefundDialog.test.tsx
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '../../../shared/lib/transport';
+import { createMemoryTransport, type MemoryTransport } from '../../../shared/lib/transport/memory';
+import { useSettingsStore } from '../../../shared/store/settingsStore';
+import RefundDialog from './RefundDialog';
+import type { SaleItem, SaleRefund } from '../types';
+
+function wrapperFor(transport: MemoryTransport) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <TransportProvider transport={transport}>{children}</TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+const dress: SaleItem = {
+  product_id: 1,
+  product_name: 'Silk Dress',
+  quantity: 3,
+  unit_price: 500,
+};
+
+function renderDialog(items: SaleItem[], refunds: SaleRefund[] = []) {
+  const transport = createMemoryTransport({ sales: [] });
+  render(
+    <RefundDialog
+      open
+      onOpenChange={() => {}}
+      saleId={42}
+      saleTotal={items.reduce((sum, i) => sum + i.unit_price * i.quantity, 0)}
+      refundedAmount={refunds.reduce((sum, r) => sum + r.amount, 0)}
+      items={items}
+      refunds={refunds}
+    />,
+    { wrapper: wrapperFor(transport) }
+  );
+  return transport;
+}
+
+const refundOf = (items: SaleItem[], amount: number): SaleRefund => ({
+  id: 1,
+  amount,
+  reason: 'Customer Return',
+  cashier_name: 'Sarah',
+  created_at: '2026-09-09T00:00:00.000Z',
+  items,
+});
+
+describe('RefundDialog line accounting (#120, #121)', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ locale: 'en' });
+  });
+
+  it('offers the whole sold quantity when nothing has been refunded', () => {
+    renderDialog([dress]);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Silk Dress' }));
+
+    const qty = screen.getByRole('spinbutton', { name: 'Qty to refund' });
+    expect(qty).toHaveValue(3);
+    expect(qty).toHaveAttribute('max', '3');
+  });
+
+  it('offers only what is left after a partial refund', () => {
+    renderDialog([dress], [refundOf([{ ...dress, quantity: 1 }], 500)]);
+
+    expect(screen.getByText(/2 of 3 left to refund/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Silk Dress' }));
+
+    const qty = screen.getByRole('spinbutton', { name: 'Qty to refund' });
+    expect(qty).toHaveValue(2);
+    expect(qty).toHaveAttribute('max', '2');
+  });
+
+  it('disables a fully refunded line and says so in words, not only by dimming it', () => {
+    renderDialog([dress], [refundOf([{ ...dress, quantity: 3 }], 1500)]);
+
+    expect(screen.getByRole('checkbox', { name: 'Select Silk Dress' })).toBeDisabled();
+    expect(screen.getByText('Fully refunded')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /process refund/i })).toBeDisabled();
+  });
+
+  it('renders two variants of one product as two independently selectable lines', () => {
+    const red: SaleItem = {
+      product_id: 1,
+      variant_id: 10,
+      variant_sku: 'DRESS-RED',
+      product_name: 'Silk Dress',
+      quantity: 1,
+      unit_price: 500,
+    };
+    const blue: SaleItem = { ...red, variant_id: 11, variant_sku: 'DRESS-BLUE' };
+
+    // The red variant is spent; the blue one is untouched. Keyed on product_id alone
+    // these would be one row, and the blue line would be unreachable.
+    renderDialog([red, blue], [refundOf([{ ...red, quantity: 1 }], 500)]);
+
+    expect(screen.getByRole('checkbox', { name: 'Select Silk Dress (DRESS-RED)' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'Select Silk Dress (DRESS-BLUE)' })).toBeEnabled();
+  });
+
+  it('submits variant_id for a variant line and omits it for a plain one', async () => {
+    const variant: SaleItem = {
+      product_id: 1,
+      variant_id: 10,
+      variant_sku: 'DRESS-RED',
+      product_name: 'Silk Dress',
+      quantity: 1,
+      unit_price: 500,
+    };
+    const plain: SaleItem = {
+      product_id: 2,
+      product_name: 'Cotton Shirt',
+      quantity: 1,
+      unit_price: 200,
+    };
+    const transport = renderDialog([variant, plain]);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Silk Dress (DRESS-RED)' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Cotton Shirt' }));
+    fireEvent.click(screen.getByRole('button', { name: /process refund/i }));
+
+    await screen.findByRole('dialog');
+    const refundCall = transport.calls().find((c) => c.path.includes('refund'));
+    expect(refundCall).toBeDefined();
+    expect((refundCall?.body as { items: unknown[] }).items).toEqual([
+      { product_id: 1, variant_id: 10, quantity: 1, unit_price: 500 },
+      { product_id: 2, quantity: 1, unit_price: 200 },
+    ]);
+  });
+
+  it('prices the refund from the sale line, per selected quantity', () => {
+    renderDialog([dress]);
+
+    // The summary row, scoped by its own label -- '500' also appears in each line's
+    // "500 x 3" caption, so an unscoped text match would be ambiguous.
+    const summary = () => screen.getByText('Refund Amount').parentElement as HTMLElement;
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Silk Dress' }));
+    expect(summary().textContent).toMatch(/1,500/);
+
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Qty to refund' }), {
+      target: { value: '1' },
+    });
+    expect(summary().textContent).toMatch(/(^|[^,\d])500/);
+  });
+});

--- a/client/src/features/sales/components/RefundDialog.tsx
+++ b/client/src/features/sales/components/RefundDialog.tsx
@@ -14,10 +14,19 @@ import {
 import { formatCurrency } from '../../../shared/lib/utils';
 import { resource } from '../../../shared/lib/resource';
 import { useTranslation } from '../../../shared/i18n/index';
-import type { SaleItem } from '../types';
+import type { SaleItem, SaleRefund } from '../types';
 
 /** Only the refund sub-action is reached from here, so no row shape surfaces. */
 const sales = resource<{ id: number }>('sales');
+
+/**
+ * The key a sale line is identified by, matching the server's own composite key: two
+ * variants of one product are distinct lines, and a plain line normalizes to the empty
+ * variant. `product_id` alone would collapse them onto one row and let the cashier
+ * request a refund the server has to reject (#120, #121).
+ */
+const lineKey = (item: { product_id: number; variant_id?: number | null }): string =>
+  `${item.product_id}:${item.variant_id ?? ''}`;
 
 interface RefundDialogProps {
   open: boolean;
@@ -26,6 +35,8 @@ interface RefundDialogProps {
   saleTotal: number;
   refundedAmount: number;
   items: SaleItem[];
+  /** Prior refunds against this sale; each line's remaining quantity is derived from them. */
+  refunds?: SaleRefund[];
 }
 
 type RefundReason = 'Customer Return' | 'Cashier Error' | 'Defective' | 'Other';
@@ -37,12 +48,13 @@ export default function RefundDialog({
   saleTotal,
   refundedAmount,
   items,
+  refunds = [],
 }: RefundDialogProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
   const [selectedItems, setSelectedItems] = useState<
-    Record<number, { selected: boolean; quantity: number }>
+    Record<string, { selected: boolean; quantity: number }>
   >({});
   const [reason, setReason] = useState<RefundReason>('Customer Return');
   const [restock, setRestock] = useState(true);
@@ -53,9 +65,24 @@ export default function RefundDialog({
     setRestock(true);
   };
 
+  /** How much of each line prior refunds have already taken, keyed the server's way. */
+  const alreadyRefunded = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const refund of refunds) {
+      for (const item of refund.items ?? []) {
+        counts[lineKey(item)] = (counts[lineKey(item)] ?? 0) + item.quantity;
+      }
+    }
+    return counts;
+  }, [refunds]);
+
+  /** Sold minus already refunded: the most this line can still be refunded for. */
+  const remainingFor = (item: SaleItem): number =>
+    Math.max(0, item.quantity - (alreadyRefunded[lineKey(item)] ?? 0));
+
   const refundAmount = useMemo(() => {
     return items.reduce((sum, item) => {
-      const sel = selectedItems[item.product_id];
+      const sel = selectedItems[lineKey(item)];
       if (sel?.selected && sel.quantity > 0) {
         return sum + item.unit_price * sel.quantity;
       }
@@ -80,12 +107,14 @@ export default function RefundDialog({
 
     const refundItems = items
       .filter((item) => {
-        const sel = selectedItems[item.product_id];
+        const sel = selectedItems[lineKey(item)];
         return sel?.selected && sel.quantity > 0;
       })
       .map((item) => ({
         product_id: item.product_id,
-        quantity: selectedItems[item.product_id].quantity,
+        // Sent only for a variant line, so a plain line's payload is unchanged.
+        ...(item.variant_id ? { variant_id: item.variant_id } : {}),
+        quantity: selectedItems[lineKey(item)].quantity,
         unit_price: item.unit_price,
       }));
 
@@ -94,20 +123,20 @@ export default function RefundDialog({
     refunder.run({ id: saleId, body: { items: refundItems, reason, restock } });
   };
 
-  const toggleItem = (productId: number, maxQty: number) => {
+  const toggleItem = (key: string, maxQty: number) => {
     setSelectedItems((prev) => {
-      const current = prev[productId];
+      const current = prev[key];
       if (current?.selected) {
-        return { ...prev, [productId]: { selected: false, quantity: 0 } };
+        return { ...prev, [key]: { selected: false, quantity: 0 } };
       }
-      return { ...prev, [productId]: { selected: true, quantity: maxQty } };
+      return { ...prev, [key]: { selected: true, quantity: maxQty } };
     });
   };
 
-  const updateQuantity = (productId: number, qty: number) => {
+  const updateQuantity = (key: string, qty: number) => {
     setSelectedItems((prev) => ({
       ...prev,
-      [productId]: { selected: qty > 0, quantity: qty },
+      [key]: { selected: qty > 0, quantity: qty },
     }));
   };
 
@@ -152,40 +181,68 @@ export default function RefundDialog({
                 </label>
                 <div className="space-y-2 max-h-48 overflow-y-auto">
                   {items.map((item) => {
-                    const sel = selectedItems[item.product_id];
+                    const key = lineKey(item);
+                    const sel = selectedItems[key];
+                    const remaining = remainingFor(item);
+                    const exhausted = remaining === 0;
                     return (
                       <div
-                        key={item.product_id}
-                        className="flex items-center gap-3 p-2.5 rounded-xl border border-border bg-muted/10 hover:border-primary/40 transition-colors"
+                        key={key}
+                        className={`flex items-center gap-3 p-2.5 rounded-xl border border-border bg-muted/10 transition-colors ${
+                          exhausted ? 'opacity-60' : 'hover:border-primary/40'
+                        }`}
                       >
                         <Checkbox
                           isSelected={sel?.selected || false}
-                          onValueChange={() => toggleItem(item.product_id, item.quantity)}
+                          isDisabled={exhausted}
+                          onValueChange={() => toggleItem(key, remaining)}
                           size="sm"
-                          aria-label={`Select ${item.product_name}`}
+                          aria-label={`Select ${item.product_name}${
+                            item.variant_sku ? ` (${item.variant_sku})` : ''
+                          }`}
                         />
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium text-foreground truncate">
                             {item.product_name}
+                            {item.variant_sku && (
+                              <span className="text-muted-foreground font-normal">
+                                {' '}
+                                · {item.variant_sku}
+                              </span>
+                            )}
                           </p>
                           <p className="text-xs text-muted-foreground font-data">
                             {formatCurrency(item.unit_price)} x {item.quantity}
+                            {remaining < item.quantity && !exhausted && (
+                              <span>
+                                {' · '}
+                                {t('sales.refundRemaining', { remaining, sold: item.quantity })}
+                              </span>
+                            )}
                           </p>
                         </div>
-                        {sel?.selected && (
+                        {/* Stated in words, not only by the dimmed row: a disabled control
+                            that does not say why reads as a broken one. */}
+                        {exhausted && (
+                          <span className="text-xs text-muted-foreground">
+                            {t('sales.alreadyFullyRefunded')}
+                          </span>
+                        )}
+                        {!exhausted && sel?.selected && (
                           <div className="flex items-center gap-1.5">
-                            <span className="text-xs text-muted-foreground">
+                            <span className="text-xs text-muted-foreground" id={`qty-label-${key}`}>
                               {t('sales.qtyToRefund')}
                             </span>
                             <input
                               type="number"
                               min={1}
-                              max={item.quantity}
+                              max={remaining}
                               value={sel.quantity}
+                              aria-labelledby={`qty-label-${key}`}
                               onChange={(e) =>
                                 updateQuantity(
-                                  item.product_id,
-                                  Math.min(item.quantity, Math.max(1, Number(e.target.value)))
+                                  key,
+                                  Math.min(remaining, Math.max(1, Number(e.target.value)))
                                 )
                               }
                               className="w-14 h-8 text-center text-sm border border-border rounded-lg bg-card text-foreground font-data focus:outline-none focus:border-primary"

--- a/client/src/features/sales/pages/SalesHistory.tsx
+++ b/client/src/features/sales/pages/SalesHistory.tsx
@@ -34,7 +34,6 @@ import { formatCurrency, formatDateTime } from '../../../shared/lib/utils';
 import { exportToExcel } from '../../../shared/lib/exportUtils';
 import { useTranslation } from '../../../shared/i18n/index';
 import { resource } from '../../../shared/lib/resource';
-import { useApiQuery } from '../../../shared/lib/apiQuery';
 import { useTransport } from '../../../shared/lib/transport/index';
 import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue';
 import { useListRouteState, useLastPageRecovery } from '../../../shared/hooks/useListRouteState';
@@ -95,12 +94,10 @@ export default function SalesHistory() {
 
   const { data: saleDetail } = saleDetails.useOne(expandedRow);
 
-  const { data: saleRefunds } = useApiQuery<SaleRefund[]>(
-    ['sale-refunds', expandedRow],
-    `sales/${expandedRow}/refunds`,
-    undefined,
-    { enabled: !!expandedRow }
-  );
+  // Refunds ride along on the sale detail. This used to be a second query against
+  // `sales/:id/refunds`, a route the server has never mounted, so the expanded row's
+  // refund history was permanently empty.
+  const saleRefunds = saleDetail?.refunds;
 
   const handleExportCSV = () => {
     const exported = rows || [];
@@ -129,9 +126,6 @@ export default function SalesHistory() {
 
   const readSale = (saleId: number) =>
     transport.request<SaleDetail>({ method: 'GET', path: `sales/${saleId}` });
-
-  const readSaleRefunds = (saleId: number) =>
-    transport.request<SaleRefund[]>({ method: 'GET', path: `sales/${saleId}/refunds` });
 
   const handlePrintReceipt = async (saleId: number) => {
     try {
@@ -181,18 +175,16 @@ export default function SalesHistory() {
 
   const handleRefund = async (sale: Sale) => {
     try {
-      // Prior refunds come along so the dialog can cap each line at what is left of it,
-      // rather than offering a quantity the server will reject (#120).
-      const [{ data: detail }, { data: priorRefunds }] = await Promise.all([
-        readSale(sale.id),
-        readSaleRefunds(sale.id),
-      ]);
+      // The sale detail already carries every prior refund, so the dialog can cap each
+      // line at what is left of it rather than offering a quantity the server will
+      // reject (#120). No second request: there is no /sales/:id/refunds endpoint.
+      const { data: detail } = await readSale(sale.id);
       setRefundSale({
         id: sale.id,
         total: sale.total,
         refundedAmount: sale.refunded_amount || 0,
         items: detail.items || [],
-        refunds: priorRefunds || [],
+        refunds: detail.refunds || [],
       });
       setRefundOpen(true);
     } catch {

--- a/client/src/features/sales/pages/SalesHistory.tsx
+++ b/client/src/features/sales/pages/SalesHistory.tsx
@@ -40,7 +40,7 @@ import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue';
 import { useListRouteState, useLastPageRecovery } from '../../../shared/hooks/useListRouteState';
 import type { ColumnDef, PaginationState, SortingState } from '@tanstack/react-table';
 import type { ReceiptData } from '../../../shared/components/Receipt';
-import type { Sale, SaleDetail, SaleRefund, SalesMeta } from '../types';
+import type { Sale, SaleDetail, SaleItem, SaleRefund, SalesMeta } from '../types';
 
 const sales = resource<Sale, SalesMeta>('sales');
 const saleDetails = resource<SaleDetail>('sales');
@@ -75,7 +75,8 @@ export default function SalesHistory() {
     id: number;
     total: number;
     refundedAmount: number;
-    items: { product_id: number; product_name: string; quantity: number; unit_price: number }[];
+    items: SaleItem[];
+    refunds: SaleRefund[];
   } | null>(null);
 
   const params: Record<string, string> = {};
@@ -129,6 +130,9 @@ export default function SalesHistory() {
   const readSale = (saleId: number) =>
     transport.request<SaleDetail>({ method: 'GET', path: `sales/${saleId}` });
 
+  const readSaleRefunds = (saleId: number) =>
+    transport.request<SaleRefund[]>({ method: 'GET', path: `sales/${saleId}/refunds` });
+
   const handlePrintReceipt = async (saleId: number) => {
     try {
       const { data: sale } = await readSale(saleId);
@@ -177,12 +181,18 @@ export default function SalesHistory() {
 
   const handleRefund = async (sale: Sale) => {
     try {
-      const { data: detail } = await readSale(sale.id);
+      // Prior refunds come along so the dialog can cap each line at what is left of it,
+      // rather than offering a quantity the server will reject (#120).
+      const [{ data: detail }, { data: priorRefunds }] = await Promise.all([
+        readSale(sale.id),
+        readSaleRefunds(sale.id),
+      ]);
       setRefundSale({
         id: sale.id,
         total: sale.total,
         refundedAmount: sale.refunded_amount || 0,
         items: detail.items || [],
+        refunds: priorRefunds || [],
       });
       setRefundOpen(true);
     } catch {
@@ -552,6 +562,7 @@ export default function SalesHistory() {
           saleTotal={refundSale.total}
           refundedAmount={refundSale.refundedAmount}
           items={refundSale.items}
+          refunds={refundSale.refunds}
         />
       )}
     </div>

--- a/client/src/features/sales/types.ts
+++ b/client/src/features/sales/types.ts
@@ -4,6 +4,9 @@
 /** Sale line item from GET /api/sales/:id (read shape, not the write payload) */
 export interface SaleItem {
   product_id: number;
+  /** Present on a variant line; two variants of one product are two distinct lines. */
+  variant_id?: number | null;
+  variant_sku?: string | null;
   product_name: string;
   quantity: number;
   unit_price: number;

--- a/client/src/features/sales/types.ts
+++ b/client/src/features/sales/types.ts
@@ -158,14 +158,17 @@ export interface SaleDetail {
   calculation?: SaleCalculationSnapshotDTO;
   /** Additive since Unit 4 -- present only when the sale used split-tender payments. */
   payments?: SalePaymentEntry[];
+  /** Every refund already taken against this sale; empty when there are none. */
+  refunds?: SaleRefund[];
 }
 
-/** One refund against a sale, from GET /api/v1/sales/:id/refunds. */
+/** One refund against a sale, carried on GET /api/v1/sales/:id alongside its items. */
 export interface SaleRefund {
   id: number;
   amount: number;
   reason: string;
   cashier_name: string | null;
   created_at: string;
+  /** Refunded lines. Stored as a JSON blob server-side and parsed there, not here. */
   items: SaleItem[];
 }

--- a/client/src/shared/i18n/ar.json
+++ b/client/src/shared/i18n/ar.json
@@ -370,6 +370,7 @@
   "sales.selectItems": "اختر العناصر للاسترجاع",
   "sales.qtyToRefund": "الكمية للاسترجاع",
   "sales.alreadyFullyRefunded": "تم الاسترجاع بالكامل",
+  "sales.refundRemaining": "متبقٍ للاسترجاع {remaining} من {sold}",
   "sales.customer": "العميل",
   "sales.walkIn": "عميل عابر",
   "users.title": "المستخدمون",

--- a/client/src/shared/i18n/en.json
+++ b/client/src/shared/i18n/en.json
@@ -370,6 +370,7 @@
   "sales.selectItems": "Select items to refund",
   "sales.qtyToRefund": "Qty to refund",
   "sales.alreadyFullyRefunded": "Fully refunded",
+  "sales.refundRemaining": "{remaining} of {sold} left to refund",
   "sales.customer": "Customer",
   "sales.walkIn": "Walk-in",
   "users.title": "Users",

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -173,6 +173,16 @@ export class SalesRepository implements ISalesRepository {
     return res.rows;
   }
 
+  /**
+   * `refunds.items` is a `TEXT` column holding JSON, not a normalized table, so it is
+   * parsed here -- once, at the boundary -- rather than by each caller. Leaving it a
+   * string reached the refund dialog as something iterable character by character, which
+   * silently produced "nothing has been refunded yet" for every line (#120).
+   *
+   * An unparseable row throws rather than degrading to `[]`: this JSON is the only record
+   * of how much of a line has already gone back, and reading a damaged one as zero is
+   * exactly the double-refund the cumulative cap exists to prevent.
+   */
   async findRefundsBySaleId(
     saleId: number | string,
     queryable?: Queryable
@@ -185,7 +195,10 @@ export class SalesRepository implements ISalesRepository {
        ORDER BY r.created_at DESC`,
       [saleId]
     );
-    return res.rows;
+    return res.rows.map((row: Record<string, unknown>) => ({
+      ...row,
+      items: typeof row.items === 'string' ? JSON.parse(row.items) : (row.items ?? []),
+    }));
   }
 
   async listSales(

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -84,6 +84,11 @@ export interface ISalesRepository {
     quantity: number,
     queryable: Queryable
   ): Promise<number | null>;
+  incrementVariantStock(
+    variantId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
   getProductStock(productId: number, queryable: Queryable): Promise<number | null>;
   getVariantStock(variantId: number, queryable: Queryable): Promise<number | null>;
   createStockAdjustment(data: Record<string, any>, queryable: Queryable): Promise<void>;
@@ -557,6 +562,21 @@ export class SalesRepository implements ISalesRepository {
     const res = await queryable.query<{ stock: number }>(
       `UPDATE product_variants SET stock = stock - $1::int, updated_at = NOW()
         WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
+      [quantity, variantId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /** Variant counterpart of {@link incrementProductStock}. No guard, for the same reason. */
+  async incrementVariantStock(
+    variantId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null> {
+    const res = await queryable.query<{ stock: number }>(
+      `UPDATE product_variants SET stock = stock + $1::int, updated_at = NOW()
+        WHERE id = $2
         RETURNING stock`,
       [quantity, variantId]
     );

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -14,6 +14,10 @@ export interface ISalesRepository {
     saleId: number | string,
     queryable?: Queryable
   ): Promise<Record<string, any>[]>;
+  findExchangedQuantitiesBySaleId(
+    saleId: number | string,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>>;
   listSales(
     filters: SaleFilters,
     queryable?: Queryable
@@ -198,6 +202,37 @@ export class SalesRepository implements ISalesRepository {
     return res.rows.map((row: Record<string, unknown>) => ({
       ...row,
       items: typeof row.items === 'string' ? JSON.parse(row.items) : (row.items ?? []),
+    }));
+  }
+
+  /**
+   * How much of each line an exchange against this sale already took back.
+   *
+   * A refund and an exchange are two routes to the same recovery, and both draw on the
+   * quantity the sale sold. Counting only refunds would leave one direction open: return
+   * a line on an exchange for credit, then refund the same line for cash, and the goods
+   * come back twice. The exchange path caps itself against refunds for the same reason.
+   */
+  async findExchangedQuantitiesBySaleId(
+    saleId: number | string,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>> {
+    const res = await this.q(queryable).query<{
+      product_id: number;
+      variant_id: number | null;
+      quantity: string;
+    }>(
+      `SELECT eri.product_id, eri.variant_id, SUM(eri.quantity)::int AS quantity
+         FROM exchange_returned_items eri
+         JOIN exchanges e ON eri.exchange_id = e.id
+        WHERE e.original_sale_id = $1
+        GROUP BY eri.product_id, eri.variant_id`,
+      [saleId]
+    );
+    return res.rows.map((row) => ({
+      product_id: row.product_id,
+      variant_id: row.variant_id,
+      quantity: Number(row.quantity),
     }));
   }
 

--- a/server/src/modules/pos/sales/schemas.ts
+++ b/server/src/modules/pos/sales/schemas.ts
@@ -54,6 +54,9 @@ export const salesRequestContracts = {
       'Refunded stock is returned to inventory in the same transaction.',
       "A line's unit_price is accepted for backward compatibility but ignored: the " +
         'payout is always the price the line actually sold for, read from the sale.',
+      'A line is matched on (product_id, variant_id): two variants of the same product ' +
+        'are distinct lines, each with its own remaining-quantity cap. Omitting ' +
+        'variant_id matches the plain (non-variant) line for that product.',
     ],
   }),
 } as const;

--- a/server/src/modules/pos/sales/schemas.ts
+++ b/server/src/modules/pos/sales/schemas.ts
@@ -52,6 +52,8 @@ export const salesRequestContracts = {
       'Partial refunds are allowed, but the cumulative quantity refunded per line can ' +
         'never exceed what was sold — the check is against prior refunds, not this one.',
       'Refunded stock is returned to inventory in the same transaction.',
+      "A line's unit_price is accepted for backward compatibility but ignored: the " +
+        'payout is always the price the line actually sold for, read from the sale.',
     ],
   }),
 } as const;

--- a/server/src/modules/pos/sales/schemas.ts
+++ b/server/src/modules/pos/sales/schemas.ts
@@ -50,7 +50,9 @@ export const salesRequestContracts = {
     params: pathIdParams(),
     beyondSchema: [
       'Partial refunds are allowed, but the cumulative quantity refunded per line can ' +
-        'never exceed what was sold — the check is against prior refunds, not this one.',
+        'never exceed what was sold — the check is against prior refunds AND prior ' +
+        'exchanges of the same sale, not against this request alone. A refund and an ' +
+        'exchange are two routes to the same recovery and draw on one quantity.',
       'Refunded stock is returned to inventory in the same transaction.',
       "A line's unit_price is accepted for backward compatibility but ignored: the " +
         'payout is always the price the line actually sold for, read from the sale.',

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -178,6 +178,17 @@ export function calculateSaleBreakdown(input: SaleCalculationInput): SaleCalcula
   };
 }
 
+/**
+ * The composite key a refund line is matched and aggregated on: two variants of the same
+ * product are distinct lines, and a plain (non-variant) line is keyed on `product_id`
+ * alone with `variant_id` normalized to `null` (both `undefined` and `null` collapse to
+ * the same key, since the wire, the DB row and historical `refunds.items` JSON can each
+ * spell "no variant" differently).
+ */
+function lineKey(productId: number, variantId?: number | null): string {
+  return `${productId}:${variantId ?? ''}`;
+}
+
 export class SalesService {
   constructor(
     private repo: ISalesRepository = defaultRepo,
@@ -924,28 +935,34 @@ export class SalesService {
       // are aggregated here, inside the same `FOR UPDATE` lock on `sale` that makes the
       // read-then-write safe against a sibling refund committing concurrently.
       const priorRefunds = await this.repo.findRefundsBySaleId(saleId, client);
-      const previouslyRefundedByProduct = new Map<number, number>();
+      const previouslyRefundedByLine = new Map<string, number>();
       for (const priorRefund of priorRefunds) {
-        const items: Array<{ product_id: number; quantity: number }> =
+        const items: Array<{ product_id: number; variant_id?: number | null; quantity: number }> =
           typeof priorRefund.items === 'string' ? JSON.parse(priorRefund.items) : priorRefund.items;
         for (const item of items) {
-          previouslyRefundedByProduct.set(
-            item.product_id,
-            (previouslyRefundedByProduct.get(item.product_id) || 0) + Number(item.quantity)
+          const key = lineKey(item.product_id, item.variant_id);
+          previouslyRefundedByLine.set(
+            key,
+            (previouslyRefundedByLine.get(key) || 0) + Number(item.quantity)
           );
         }
       }
 
       let refundAmount = 0;
       for (const refundItem of input.items) {
-        const saleItem = saleItems.find((si) => si.product_id === refundItem.product_id);
+        const saleItem = saleItems.find(
+          (si) =>
+            si.product_id === refundItem.product_id &&
+            (si.variant_id ?? null) === (refundItem.variant_id ?? null)
+        );
         if (!saleItem)
           throw new PublicError(
             'VALIDATION_ERROR',
             `Product ${refundItem.product_id} not in this sale`
           );
 
-        const alreadyRefunded = previouslyRefundedByProduct.get(refundItem.product_id) || 0;
+        const key = lineKey(refundItem.product_id, refundItem.variant_id);
+        const alreadyRefunded = previouslyRefundedByLine.get(key) || 0;
         const remaining = Number(saleItem.quantity) - alreadyRefunded;
         if (refundItem.quantity > remaining) {
           throw new PublicError(
@@ -986,12 +1003,15 @@ export class SalesService {
       await this.repo.updateSaleRefundStatus(saleId, refundStatus, newRefundedTotal, client);
 
       if (input.restock) {
-        // Ascending by product id, the same canonical order the checkout write phase
-        // uses, so a refund and a checkout touching the same two products cannot lock
-        // them in opposite order and deadlock.
-        const restockOrder = [...input.items].sort((a, b) => a.product_id - b.product_id);
-        for (const item of restockOrder) {
-          await this.repo.incrementProductStock(item.product_id, item.quantity, client);
+        // The same canonical order the checkout write phase uses (products before
+        // variants, then ascending by id), so a refund and a checkout touching the same
+        // rows cannot lock them in opposite order and deadlock.
+        for (const item of sortForStockWrites(input.items)) {
+          if (item.variant_id) {
+            await this.repo.incrementVariantStock(item.variant_id, item.quantity, client);
+          } else {
+            await this.repo.incrementProductStock(item.product_id, item.quantity, client);
+          }
         }
       }
 

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -936,16 +936,41 @@ export class SalesService {
       // read-then-write safe against a sibling refund committing concurrently.
       const priorRefunds = await this.repo.findRefundsBySaleId(saleId, client);
       const previouslyRefundedByLine = new Map<string, number>();
+      const previouslyRefundedByProduct = new Map<number, number>();
       for (const priorRefund of priorRefunds) {
         const items: Array<{ product_id: number; variant_id?: number | null; quantity: number }> =
           typeof priorRefund.items === 'string' ? JSON.parse(priorRefund.items) : priorRefund.items;
         for (const item of items) {
           const key = lineKey(item.product_id, item.variant_id);
-          previouslyRefundedByLine.set(
-            key,
-            (previouslyRefundedByLine.get(key) || 0) + Number(item.quantity)
+          const quantity = Number(item.quantity);
+          previouslyRefundedByLine.set(key, (previouslyRefundedByLine.get(key) || 0) + quantity);
+          previouslyRefundedByProduct.set(
+            item.product_id,
+            (previouslyRefundedByProduct.get(item.product_id) || 0) + quantity
           );
         }
+      }
+
+      // What this request itself asks for, per line and per product. Aggregated before
+      // the caps are checked: three entries for the same line each pass a per-entry
+      // check on their own, and together refund three times what was sold.
+      const requestedByLine = new Map<string, number>();
+      const requestedByProduct = new Map<number, number>();
+      for (const refundItem of input.items) {
+        const key = lineKey(refundItem.product_id, refundItem.variant_id);
+        requestedByLine.set(key, (requestedByLine.get(key) || 0) + refundItem.quantity);
+        requestedByProduct.set(
+          refundItem.product_id,
+          (requestedByProduct.get(refundItem.product_id) || 0) + refundItem.quantity
+        );
+      }
+
+      const soldByProduct = new Map<number, number>();
+      for (const saleItem of saleItems) {
+        soldByProduct.set(
+          saleItem.product_id,
+          (soldByProduct.get(saleItem.product_id) || 0) + Number(saleItem.quantity)
+        );
       }
 
       let refundAmount = 0;
@@ -964,11 +989,27 @@ export class SalesService {
         const key = lineKey(refundItem.product_id, refundItem.variant_id);
         const alreadyRefunded = previouslyRefundedByLine.get(key) || 0;
         const remaining = Number(saleItem.quantity) - alreadyRefunded;
-        if (refundItem.quantity > remaining) {
+        if ((requestedByLine.get(key) || 0) > remaining) {
           throw new PublicError(
             'VALIDATION_ERROR',
             `Refund quantity exceeds sold quantity for product ${refundItem.product_id} ` +
               `(${remaining} remaining)`
+          );
+        }
+
+        // A second cap, on the product rather than the line. `variant_id` only started
+        // being recorded in `refunds.items` with #121, so a variant line refunded before
+        // that is stored under the product-only key and its per-line cap above reads
+        // zero. Summing every prior for the product, whichever way it was keyed, keeps
+        // those historical rows counting against what the sale actually sold.
+        const productRemaining =
+          (soldByProduct.get(refundItem.product_id) || 0) -
+          (previouslyRefundedByProduct.get(refundItem.product_id) || 0);
+        if ((requestedByProduct.get(refundItem.product_id) || 0) > productRemaining) {
+          throw new PublicError(
+            'VALIDATION_ERROR',
+            `Refund quantity exceeds sold quantity for product ${refundItem.product_id} ` +
+              `(${Math.max(0, productRemaining)} remaining)`
           );
         }
 

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -919,6 +919,24 @@ export class SalesService {
 
       const saleItems = await this.repo.findItemsBySaleId(saleId, client);
 
+      // Prior refunds are the only record of how much of each line has already gone
+      // back -- `refunds.items` is a JSON blob, not a normalized table (#120) -- so they
+      // are aggregated here, inside the same `FOR UPDATE` lock on `sale` that makes the
+      // read-then-write safe against a sibling refund committing concurrently.
+      const priorRefunds = await this.repo.findRefundsBySaleId(saleId, client);
+      const previouslyRefundedByProduct = new Map<number, number>();
+      for (const priorRefund of priorRefunds) {
+        const items: Array<{ product_id: number; quantity: number }> =
+          typeof priorRefund.items === 'string' ? JSON.parse(priorRefund.items) : priorRefund.items;
+        for (const item of items) {
+          previouslyRefundedByProduct.set(
+            item.product_id,
+            (previouslyRefundedByProduct.get(item.product_id) || 0) + Number(item.quantity)
+          );
+        }
+      }
+
+      let refundAmount = 0;
       for (const refundItem of input.items) {
         const saleItem = saleItems.find((si) => si.product_id === refundItem.product_id);
         if (!saleItem)
@@ -926,20 +944,26 @@ export class SalesService {
             'VALIDATION_ERROR',
             `Product ${refundItem.product_id} not in this sale`
           );
-        if (refundItem.quantity > saleItem.quantity) {
+
+        const alreadyRefunded = previouslyRefundedByProduct.get(refundItem.product_id) || 0;
+        const remaining = Number(saleItem.quantity) - alreadyRefunded;
+        if (refundItem.quantity > remaining) {
           throw new PublicError(
             'VALIDATION_ERROR',
-            `Refund quantity exceeds sold quantity for product ${refundItem.product_id}`
+            `Refund quantity exceeds sold quantity for product ${refundItem.product_id} ` +
+              `(${remaining} remaining)`
           );
         }
-      }
 
-      let refundAmount = 0;
-      for (const item of input.items) {
-        refundAmount += item.unit_price * item.quantity;
+        // The payout is what the sale line actually sold for, never the client's
+        // `unit_price` -- accepted on the wire for compatibility (see schemas.ts) and
+        // ignored, exactly as checkout re-prices every line rather than trusting it.
+        refundAmount += Number(saleItem.unit_price) * refundItem.quantity;
       }
 
       const previouslyRefunded = Number(sale.refunded_amount) || 0;
+      // Redundant with the per-line cap above once every line is accounted for, but kept
+      // as a second, cheap belt against a rounding or bookkeeping mismatch.
       if (previouslyRefunded + refundAmount > Number(sale.total)) {
         throw new PublicError('VALIDATION_ERROR', 'Refund amount exceeds sale total');
       }

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -1015,10 +1015,47 @@ export class SalesService {
         }
       }
 
+      // Only cash that actually came in can go back out of the drawer (#126). The
+      // refund used to debit `expected_cash` by its whole amount, so a card sale
+      // refunded in full left the till short by the refund on close-out.
+      //
+      // The cash taken is derived from the confirmed tender split the same way
+      // `executeSale` derives what it put in (see the cashComponentMinor block above):
+      // sum the split's Cash entries, or -- in non-split compatibility mode, where there
+      // are no `sale_payments` rows -- the whole total when the one declared method was
+      // Cash.
+      const payments = await this.repo.findPaymentsBySaleId(saleId, client);
+      const cashTakenMinor =
+        payments.length > 0
+          ? payments
+              .filter((p) => p.method === 'Cash')
+              .reduce((sum, p) => sum + toMinorUnits(Number(p.amount)), 0)
+          : sale.payment_method === 'Cash'
+            ? toMinorUnits(Number(sale.total))
+            : 0;
+
+      // Refunds draw the cash component down first, so what remains refundable in cash
+      // is the cash taken minus whatever earlier refunds against this sale already took
+      // out of the drawer. Both are capped at the cash taken, which is what makes the
+      // "two halves of a split" case stop at the split's Cash entry rather than paying
+      // out card money in cash.
+      const cashAlreadyRefundedMinor = Math.min(toMinorUnits(previouslyRefunded), cashTakenMinor);
+      const refundCashMinor = Math.min(
+        toMinorUnits(refundAmount),
+        cashTakenMinor - cashAlreadyRefundedMinor
+      );
+
       // Inside the transaction (R4): the previous after-the-fact, error-swallowing call
       // from the controller could leave a drawer movement behind for a refund that
-      // rolled back. Mirrors `executeSale`'s in-transaction sale movement.
-      await this.register.recordRefundMovement(cashierId, refundAmount, client);
+      // rolled back. Mirrors `executeSale`'s in-transaction sale movement, including its
+      // "only when it is positive" guard.
+      if (refundCashMinor > 0) {
+        await this.register.recordRefundMovement(
+          cashierId,
+          fromMinorUnits(refundCashMinor),
+          client
+        );
+      }
 
       return { refund, refundStatus, newRefundedTotal };
     }, clientOrPool);

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -937,18 +937,35 @@ export class SalesService {
       const priorRefunds = await this.repo.findRefundsBySaleId(saleId, client);
       const previouslyRefundedByLine = new Map<string, number>();
       const previouslyRefundedByProduct = new Map<number, number>();
+
+      const countAsTaken = (
+        productId: number,
+        variantId: number | null | undefined,
+        quantity: number
+      ): void => {
+        const key = lineKey(productId, variantId);
+        previouslyRefundedByLine.set(key, (previouslyRefundedByLine.get(key) || 0) + quantity);
+        previouslyRefundedByProduct.set(
+          productId,
+          (previouslyRefundedByProduct.get(productId) || 0) + quantity
+        );
+      };
+
       for (const priorRefund of priorRefunds) {
         const items: Array<{ product_id: number; variant_id?: number | null; quantity: number }> =
           typeof priorRefund.items === 'string' ? JSON.parse(priorRefund.items) : priorRefund.items;
         for (const item of items) {
-          const key = lineKey(item.product_id, item.variant_id);
-          const quantity = Number(item.quantity);
-          previouslyRefundedByLine.set(key, (previouslyRefundedByLine.get(key) || 0) + quantity);
-          previouslyRefundedByProduct.set(
-            item.product_id,
-            (previouslyRefundedByProduct.get(item.product_id) || 0) + quantity
-          );
+          countAsTaken(item.product_id, item.variant_id, Number(item.quantity));
         }
+      }
+
+      // Exchanges draw on the same sold quantity. A refund and an exchange are two
+      // routes to the same recovery, so counting only refunds leaves one direction
+      // open: return a line on an exchange for credit, then refund it for cash, and the
+      // goods come back twice. The exchange path caps itself against refunds for the
+      // same reason, which is what makes the pair symmetrical.
+      for (const exchanged of await this.repo.findExchangedQuantitiesBySaleId(saleId, client)) {
+        countAsTaken(exchanged.product_id, exchanged.variant_id, exchanged.quantity);
       }
 
       // What this request itself asks for, per line and per product. Aggregated before

--- a/server/src/modules/pos/sales/types.ts
+++ b/server/src/modules/pos/sales/types.ts
@@ -342,6 +342,7 @@ export interface ConfirmedPayment {
 
 export interface RefundItemInput {
   product_id: number;
+  variant_id?: number | null;
   quantity: number;
   unit_price: number;
 }

--- a/server/tests/concurrency/refunds.concurrency.test.ts
+++ b/server/tests/concurrency/refunds.concurrency.test.ts
@@ -79,6 +79,31 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
     return saleId;
   }
 
+  /**
+   * A two-line, 700-total sale: one Silk Dress (1 unit, 500) and one second product
+   * (1 unit, 200). Enough headroom on the sale total that a per-line-only bug would let
+   * a second refund of the fully-refunded dress line through (#120).
+   */
+  async function makeTwoLineSale(): Promise<{ saleId: number; secondProductId: number }> {
+    const secondProduct = await harness.pool.query<{ id: number }>(
+      "INSERT INTO products (name, sku, price, stock) VALUES ('Cotton Shirt', 'SKU-R2', 200, 5) RETURNING id"
+    );
+    const secondProductId = secondProduct.rows[0].id;
+
+    const sale = await harness.pool.query<{ id: number }>(
+      `INSERT INTO sales (subtotal, total, payment_method, cashier_id)
+       VALUES (700, 700, 'Cash', $1) RETURNING id`,
+      [cashierId]
+    );
+    const saleId = sale.rows[0].id;
+    await harness.pool.query(
+      `INSERT INTO sale_items (sale_id, product_id, quantity, unit_price)
+       VALUES ($1, $2, 1, 500), ($1, $3, 1, 200)`,
+      [saleId, productId, secondProductId]
+    );
+    return { saleId, secondProductId };
+  }
+
   async function openRegisterSession(): Promise<number> {
     const { rows } = await harness.pool.query<{ id: number }>(
       `INSERT INTO register_sessions (cashier_id, opening_float, expected_cash)
@@ -152,15 +177,16 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
     };
   }
 
-  it('never lets concurrent partial refunds exceed the sale total (R1)', async () => {
+  it('never lets concurrent refunds exceed what the line actually sold (R1)', async () => {
     const saleId = await makeSale();
 
-    // Three simultaneous 400 refunds against a 1000 sale: two fit, the third must not.
-    // Without the FOR UPDATE lock all three read refunded_amount = 0 and all three commit.
+    // Three simultaneous 1-unit refunds against a 2-unit line: two fit, the third must
+    // not -- caught by the per-line remaining-quantity check once the line is exhausted.
+    // Without the FOR UPDATE lock all three read the line as unrefunded and all commit.
     const outcomes = await Promise.all([
-      postRefund(saleId, refundBody(1, 400)),
-      postRefund(saleId, refundBody(1, 400)),
-      postRefund(saleId, refundBody(1, 400)),
+      postRefund(saleId, refundBody(1, 500)),
+      postRefund(saleId, refundBody(1, 500)),
+      postRefund(saleId, refundBody(1, 500)),
     ]);
 
     const accepted = outcomes.filter((o) => o.error === null);
@@ -168,15 +194,18 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
 
     expect(accepted).toHaveLength(2);
     expect(rejected).toHaveLength(1);
-    expect(rejected[0].error).toMatchObject({
-      code: 'VALIDATION_ERROR',
-      message: 'Refund amount exceeds sale total',
-    });
+    // Either message is a correct rejection for this race: the loser sees either the
+    // line already exhausted or (if it read after both winners committed) the sale
+    // already fully refunded -- which one depends on commit order, not on correctness.
+    expect(rejected[0].error).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect((rejected[0].error as Error).message).toMatch(
+      /Refund quantity exceeds sold quantity|Sale already fully refunded/
+    );
 
     const sale = await readSale(saleId);
-    expect(sale.refunded).toBe(800);
+    expect(sale.refunded).toBe(1000);
     expect(sale.refunded).toBeLessThanOrEqual(1000);
-    expect(sale.status).toBe('partial');
+    expect(sale.status).toBe('full');
     expect(await countRows('refunds')).toBe(2);
   });
 
@@ -184,8 +213,8 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
     const saleId = await makeSale();
 
     await Promise.all([
-      postRefund(saleId, refundBody(1, 400, true)),
-      postRefund(saleId, refundBody(1, 400, true)),
+      postRefund(saleId, refundBody(1, 500, true)),
+      postRefund(saleId, refundBody(1, 500, true)),
     ]);
 
     // 8 + 1 + 1. A read-then-write of an absolute value loses one of the two.
@@ -196,12 +225,39 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
     expect(Number(rows[0].stock)).toBe(10);
   });
 
+  it('lets only one of two concurrent refunds of an already-otherwise-refundable line through (#120)', async () => {
+    // The sale total (700) has plenty of headroom left after the dress line (500) is
+    // refunded once -- the unrefunded shirt line (200) leaves room a sale-total-only
+    // check would happily admit. Only the per-line remaining-quantity check, made safe
+    // by the same sale-row lock, can catch a second concurrent attempt on the same line.
+    const { saleId } = await makeTwoLineSale();
+
+    const outcomes = await Promise.all([
+      postRefund(saleId, refundBody(1, 500, true)),
+      postRefund(saleId, refundBody(1, 500, true)),
+    ]);
+
+    const accepted = outcomes.filter((o) => o.error === null);
+    const rejected = outcomes.filter((o) => o.error !== null);
+
+    expect(accepted).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].error).toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    expect(Number(rows[0].stock)).toBe(9); // restocked exactly once, not twice
+    expect(await countRows('refunds')).toBe(1);
+  });
+
   it('replays a retried refund without refunding, restocking, or paying out twice (R2)', async () => {
     const saleId = await makeSale();
     await openRegisterSession();
 
-    const first = await postRefund(saleId, refundBody(1, 400, true), 'refund-key');
-    const second = await postRefund(saleId, refundBody(1, 400, true), 'refund-key');
+    const first = await postRefund(saleId, refundBody(1, 500, true), 'refund-key');
+    const second = await postRefund(saleId, refundBody(1, 500, true), 'refund-key');
 
     expect(first.error).toBeNull();
     expect(second.error).toBeNull();
@@ -211,7 +267,7 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
 
     expect(await countRows('refunds')).toBe(1);
     expect(await countRows('register_movements')).toBe(1);
-    expect((await readSale(saleId)).refunded).toBe(400);
+    expect((await readSale(saleId)).refunded).toBe(500);
 
     const { rows } = await harness.pool.query<{ stock: number }>(
       'SELECT stock FROM products WHERE id = $1',
@@ -224,8 +280,8 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
     const saleA = await makeSale();
     const saleB = await makeSale();
 
-    await postRefund(saleA, refundBody(1, 400), 'shared-key');
-    const { error } = await postRefund(saleB, refundBody(1, 400), 'shared-key');
+    await postRefund(saleA, refundBody(1, 500), 'shared-key');
+    const { error } = await postRefund(saleB, refundBody(1, 500), 'shared-key');
 
     // The sale id lives in the fingerprinted payload, not the endpoint label, so the
     // second refund conflicts rather than replaying saleA's response.
@@ -246,7 +302,7 @@ describeWithPostgres('POST /api/v1/sales/:id/refund concurrency and idempotency'
       new Error('register write failed')
     );
 
-    const { error } = await postRefund(saleId, refundBody(1, 400, true), 'doomed-key');
+    const { error } = await postRefund(saleId, refundBody(1, 500, true), 'doomed-key');
 
     expect(error).toMatchObject({ message: 'register write failed' });
     expect(await countRows('refunds')).toBe(0);

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -607,6 +607,34 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
       expect(await readSale(sale.id)).toMatchObject({ refund_status: 'full' });
     });
 
+    it('aggregates duplicate lines within one request instead of checking each in isolation', async () => {
+      // A two-line sale with room under the total: dress 1 @ 500, shirt 1 @ 200.
+      // Three separate entries for the dress each pass a per-entry check (1 <= 1) and
+      // together refund 1500 for a line that sold 500, restocking 3 of 1 sold.
+      const sale = await sellDressAndShirt();
+
+      await expect(
+        executeRefundTransaction(
+          sale.id,
+          {
+            items: [
+              { product_id: 1, quantity: 1, unit_price: 500 },
+              { product_id: 1, quantity: 1, unit_price: 500 },
+              { product_id: 1, quantity: 1, unit_price: 500 },
+            ],
+            reason: 'Three times over',
+            restock: true,
+          },
+          1,
+          testPool
+        )
+      ).rejects.toThrow(/Refund quantity exceeds sold quantity/);
+
+      expect(await readStock(1)).toBe(9); // untouched by the rejected refund
+      const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
+      expect(refunds.rows).toHaveLength(0);
+    });
+
     it('rejects a refund naming a product that was never sold on this sale', async () => {
       const sale = await sellOneDress();
 
@@ -621,6 +649,24 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
 
       const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
       expect(refunds.rows).toHaveLength(0);
+    });
+
+    it("returns each refund's items already parsed, not as the JSON string the column holds", async () => {
+      // `refunds.items` is a TEXT column. Handed to a consumer as a string it is still
+      // iterable -- character by character -- so the refund dialog read every line as
+      // "nothing refunded yet" and silently offered the full quantity again (#120).
+      const sale = await sellOneDress();
+      await executeRefundTransaction(
+        sale.id,
+        { items: [{ product_id: 1, quantity: 1, unit_price: 500 }], reason: 'Wrong size' },
+        1,
+        testPool
+      );
+
+      const refunds = await new SalesRepository().findRefundsBySaleId(sale.id, testPool);
+      expect(refunds).toHaveLength(1);
+      expect(Array.isArray(refunds[0].items)).toBe(true);
+      expect(refunds[0].items).toEqual([{ product_id: 1, quantity: 1, unit_price: 500 }]);
     });
 
     it('refuses a further refund once the sale is fully refunded', async () => {
@@ -778,6 +824,74 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
 
         expect(await readVariantStock(variantId)).toBe(3);
         expect(await readStock(1)).toBe(10);
+      });
+
+      it('aggregates duplicate entries per line, not merely per product', async () => {
+        // A plain line and a variant line of the same product: 2 sold of product 1 in
+        // total, 1 on each line. Two entries for the plain line pass a per-entry check
+        // (1 <= 1 each) and also pass a product-level cap (2 requested <= 2 sold) --
+        // only aggregating per line catches that the plain line is refunded twice.
+        const variantId = await createVariant(4);
+        const input = {
+          items: [
+            { product_id: 1, quantity: 1, unit_price: 500 },
+            { product_id: 1, variant_id: variantId, quantity: 1, unit_price: 500 },
+          ],
+          discount: 0,
+          discount_type: 'fixed',
+          payment_method: 'Cash',
+        };
+        const totals = await calculateSaleTotals(input, testPool);
+        const sale = await executeSaleTransaction(input, totals, 1, testPool);
+
+        await expect(
+          executeRefundTransaction(
+            sale.id,
+            {
+              items: [
+                { product_id: 1, quantity: 1, unit_price: 500 },
+                { product_id: 1, quantity: 1, unit_price: 500 },
+              ],
+              reason: 'Plain line twice',
+              restock: true,
+            },
+            1,
+            testPool
+          )
+        ).rejects.toThrow(/Refund quantity exceeds sold quantity/);
+
+        const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
+        expect(refunds.rows).toHaveLength(0);
+      });
+
+      it('counts a historical refund stored without variant_id against the variant line it came from', async () => {
+        // Refunds written before #121 recorded no variant_id at all, so a variant line
+        // refunded back then sits under the product-only key. Keyed strictly per line,
+        // that prior reads as zero and the same goods are refundable a second time.
+        const variantId = await createVariant(4);
+        const sale = await sellVariant(variantId, 1);
+        expect(await readVariantStock(variantId)).toBe(3);
+
+        await testPool.query(
+          `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
+           VALUES ($1, 500, 'Legacy refund', $2, 1, 1)`,
+          [sale.id, JSON.stringify([{ product_id: 1, quantity: 1, unit_price: 500 }])]
+        );
+
+        await expect(
+          executeRefundTransaction(
+            sale.id,
+            {
+              items: [{ product_id: 1, variant_id: variantId, quantity: 1, unit_price: 500 }],
+              reason: 'Second bite',
+              restock: true,
+            },
+            1,
+            testPool
+          )
+        ).rejects.toThrow(/Refund quantity exceeds sold quantity/);
+
+        expect(await readVariantStock(variantId)).toBe(3); // no phantom restock
       });
 
       it('rejects a variant_id that does not belong to any line of this sale', async () => {

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -642,6 +642,161 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
         )
       ).rejects.toThrow('Sale already fully refunded');
     });
+
+    describe('variant lines (#121)', () => {
+      async function createVariant(stock: number, price = 500): Promise<number> {
+        const { rows } = await testPool.query<{ id: number }>(
+          `INSERT INTO product_variants (product_id, sku, price, stock, attributes)
+           VALUES (1, $1, $2, $3, '{"color":"Red"}') RETURNING id`,
+          [`SKU-VAR-${Date.now()}-${Math.floor(Math.random() * 1e6)}`, price, stock]
+        );
+        return rows[0].id;
+      }
+
+      async function readVariantStock(variantId: number): Promise<number> {
+        const { rows } = await testPool.query<{ stock: number }>(
+          'SELECT stock FROM product_variants WHERE id = $1',
+          [variantId]
+        );
+        return Number(rows[0].stock);
+      }
+
+      async function sellVariant(
+        variantId: number,
+        quantity: number,
+        unitPrice = 500
+      ): Promise<{ id: number }> {
+        const input = {
+          items: [{ product_id: 1, variant_id: variantId, quantity, unit_price: unitPrice }],
+          discount: 0,
+          discount_type: 'fixed',
+          payment_method: 'Cash',
+        };
+        const totals = await calculateSaleTotals(input, testPool);
+        return executeSaleTransaction(input, totals, 1, testPool);
+      }
+
+      it('restocks a refunded variant line to product_variants, not products (#121 repro)', async () => {
+        const variantId = await createVariant(4);
+        const sale = await sellVariant(variantId, 2);
+        expect(await readVariantStock(variantId)).toBe(2);
+        expect(await readStock(1)).toBe(10); // the plain product row is untouched
+
+        await executeRefundTransaction(
+          sale.id,
+          {
+            items: [{ product_id: 1, variant_id: variantId, quantity: 2, unit_price: 500 }],
+            reason: 'Wrong color',
+            restock: true,
+          },
+          1,
+          testPool
+        );
+
+        expect(await readVariantStock(variantId)).toBe(4);
+        expect(await readStock(1)).toBe(10);
+      });
+
+      it('still restocks a plain (non-variant) line to products', async () => {
+        const sale = await sellOneDress();
+
+        await executeRefundTransaction(
+          sale.id,
+          {
+            items: [{ product_id: 1, quantity: 1, unit_price: 500 }],
+            reason: 'Returned',
+            restock: true,
+          },
+          1,
+          testPool
+        );
+
+        expect(await readStock(1)).toBe(10);
+      });
+
+      it('caps each variant of the same product independently, not pooled by product_id', async () => {
+        const variantA = await createVariant(4);
+        const variantB = await createVariant(4);
+        const input = {
+          items: [
+            { product_id: 1, variant_id: variantA, quantity: 1, unit_price: 500 },
+            { product_id: 1, variant_id: variantB, quantity: 1, unit_price: 500 },
+          ],
+          discount: 0,
+          discount_type: 'fixed',
+          payment_method: 'Cash',
+        };
+        const totals = await calculateSaleTotals(input, testPool);
+        const sale = await executeSaleTransaction(input, totals, 1, testPool);
+
+        // Fully refund variant A only.
+        await executeRefundTransaction(
+          sale.id,
+          {
+            items: [{ product_id: 1, variant_id: variantA, quantity: 1, unit_price: 500 }],
+            reason: 'Wrong color',
+            restock: true,
+          },
+          1,
+          testPool
+        );
+
+        // Variant B still has its own unit left to refund -- a product-id-only cap would
+        // have treated A's refund as if it applied to B too and rejected this.
+        await expect(
+          executeRefundTransaction(
+            sale.id,
+            {
+              items: [{ product_id: 1, variant_id: variantB, quantity: 1, unit_price: 500 }],
+              reason: 'Wrong color too',
+              restock: true,
+            },
+            1,
+            testPool
+          )
+        ).resolves.toMatchObject({ refundStatus: 'full' });
+
+        expect(await readVariantStock(variantA)).toBe(4);
+        expect(await readVariantStock(variantB)).toBe(4);
+      });
+
+      it('does not write stock to either table when restock is false', async () => {
+        const variantId = await createVariant(4);
+        const sale = await sellVariant(variantId, 1);
+        expect(await readVariantStock(variantId)).toBe(3);
+
+        await executeRefundTransaction(
+          sale.id,
+          {
+            items: [{ product_id: 1, variant_id: variantId, quantity: 1, unit_price: 500 }],
+            reason: 'No restock',
+            restock: false,
+          },
+          1,
+          testPool
+        );
+
+        expect(await readVariantStock(variantId)).toBe(3);
+        expect(await readStock(1)).toBe(10);
+      });
+
+      it('rejects a variant_id that does not belong to any line of this sale', async () => {
+        const otherVariant = await createVariant(4);
+        const sale = await sellOneDress();
+
+        await expect(
+          executeRefundTransaction(
+            sale.id,
+            {
+              items: [{ product_id: 1, variant_id: otherVariant, quantity: 1, unit_price: 500 }],
+              reason: 'Wrong line',
+            },
+            1,
+            testPool
+          )
+        ).rejects.toThrow('Product 1 not in this sale');
+      });
+    });
   });
 
   it('should auto-fetch catalog price if unit_price is not provided', async () => {

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -317,9 +317,15 @@ describe('Sales - Schema Validation', () => {
 
 describe('Sales - PostgreSQL Service & Transaction', () => {
   beforeEach(async () => {
-    // Clear and seed test items
+    // Clear and seed test items. Refunds and exchanges reference `sales`, so they go
+    // first -- a failed DELETE here breaks every case after it, not just its own.
+    await testPool.query('DELETE FROM exchange_returned_items');
+    await testPool.query('DELETE FROM exchange_new_items');
+    await testPool.query('DELETE FROM exchanges');
+    await testPool.query('DELETE FROM refunds');
     await testPool.query('DELETE FROM sale_items');
     await testPool.query('DELETE FROM sales');
+    await testPool.query('DELETE FROM product_variants');
     await testPool.query('DELETE FROM products');
     await testPool.query('DELETE FROM users');
 
@@ -631,6 +637,36 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
       ).rejects.toThrow(/Refund quantity exceeds sold quantity/);
 
       expect(await readStock(1)).toBe(9); // untouched by the rejected refund
+      const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
+      expect(refunds.rows).toHaveLength(0);
+    });
+
+    it('counts an earlier EXCHANGE of the same line against what is left to refund', async () => {
+      // The mirror image of the exchange path's own cap. Two routes recover the same
+      // goods, so capping only one leaves the other open: return the line on an
+      // exchange for credit, then refund it for cash, and it comes back twice.
+      const sale = await sellOneDress();
+
+      const exchange = await testPool.query<{ id: number }>(
+        `INSERT INTO exchanges (exchange_number, original_sale_id, cashier_id, return_total, new_total, difference, payment_method)
+         VALUES ($1, $2, 1, 500, 0, -500, 'store_credit') RETURNING id`,
+        [`EXC-${Date.now()}`, sale.id]
+      );
+      await testPool.query(
+        `INSERT INTO exchange_returned_items (exchange_id, product_id, quantity, price, condition)
+         VALUES ($1, 1, 1, 500, 'good')`,
+        [exchange.rows[0].id]
+      );
+
+      await expect(
+        executeRefundTransaction(
+          sale.id,
+          { items: [{ product_id: 1, quantity: 1, unit_price: 500 }], reason: 'Again' },
+          1,
+          testPool
+        )
+      ).rejects.toThrow(/Refund quantity exceeds sold quantity/);
+
       const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
       expect(refunds.rows).toHaveLength(0);
     });

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -499,7 +499,7 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
       expect(await readSale(sale.id)).toMatchObject({ refund_status: 'full' });
     });
 
-    it('rejects a refund exceeding what is left to refund, and writes nothing', async () => {
+    it('rejects a refund exceeding what is left to refund on the line, and writes nothing', async () => {
       const sale = await sellTwoDresses();
 
       await executeRefundTransaction(
@@ -509,7 +509,8 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
         testPool
       );
 
-      // 500 already refunded, so a second 1000 would take the cumulative past the total.
+      // 1 of 2 already refunded, so a second request for 2 more exceeds what remains on
+      // this line -- caught before the sale-total check even runs.
       await expect(
         executeRefundTransaction(
           sale.id,
@@ -517,11 +518,109 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
           1,
           testPool
         )
-      ).rejects.toThrow('Refund amount exceeds sale total');
+      ).rejects.toThrow('Refund quantity exceeds sold quantity for product 1 (1 remaining)');
 
       expect(Number((await readSale(sale.id)).refunded_amount)).toBe(500);
       const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
       expect(refunds.rows).toHaveLength(1);
+    });
+
+    /** A one-unit cash sale of Silk Dress: total 500, stock 10 -> 9. */
+    async function sellOneDress(): Promise<{ id: number }> {
+      const input = {
+        items: [{ product_id: 1, quantity: 1, unit_price: 500 }],
+        discount: 0,
+        discount_type: 'fixed',
+        payment_method: 'Cash',
+      };
+      const totals = await calculateSaleTotals(input, testPool);
+      return executeSaleTransaction(input, totals, 1, testPool);
+    }
+
+    /** A two-line cash sale: one Silk Dress (500) and one Cotton Shirt (200). Total 700. */
+    async function sellDressAndShirt(): Promise<{ id: number }> {
+      const input = {
+        items: [
+          { product_id: 1, quantity: 1, unit_price: 500 },
+          { product_id: 2, quantity: 1, unit_price: 200 },
+        ],
+        discount: 0,
+        discount_type: 'fixed',
+        payment_method: 'Cash',
+      };
+      const totals = await calculateSaleTotals(input, testPool);
+      return executeSaleTransaction(input, totals, 1, testPool);
+    }
+
+    it('rejects a repeat refund of an already-fully-refunded line even at a lower client-chosen price (#120 repro)', async () => {
+      const sale = await sellDressAndShirt();
+
+      // Fully refund the dress line (1 of 1 sold). The sale stays 'partial' -- the
+      // shirt line is still unrefunded -- so the sale-level "already fully refunded"
+      // guard cannot be what blocks a second attempt on the dress line.
+      await executeRefundTransaction(
+        sale.id,
+        {
+          items: [{ product_id: 1, quantity: 1, unit_price: 500 }],
+          reason: 'Wrong size',
+          restock: true,
+        },
+        1,
+        testPool
+      );
+      expect(await readSale(sale.id)).toMatchObject({ refund_status: 'partial' });
+      expect(await readStock(1)).toBe(10);
+
+      // The dress line has nothing left to refund. A sale-total check alone would admit
+      // this: 14 fits easily under the 200 of headroom the unrefunded shirt line leaves.
+      // The defect is that nothing checks the *line's own* remaining quantity.
+      await expect(
+        executeRefundTransaction(
+          sale.id,
+          {
+            items: [{ product_id: 1, quantity: 1, unit_price: 14 }],
+            reason: 'Again',
+            restock: true,
+          },
+          1,
+          testPool
+        )
+      ).rejects.toThrow(/exceeds (the )?remaining|Refund quantity exceeds sold quantity/i);
+
+      expect(await readStock(1)).toBe(10); // restocked exactly once, not twice
+      const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
+      expect(refunds.rows).toHaveLength(1);
+    });
+
+    it('derives the refund amount from the persisted sale line, never from the client-supplied unit_price', async () => {
+      const sale = await sellOneDress();
+
+      const refund = await executeRefundTransaction(
+        sale.id,
+        // Sold at 500; the client asks for 9999. The payout must still be 500.
+        { items: [{ product_id: 1, quantity: 1, unit_price: 9999 }], reason: 'Overcharge claim' },
+        1,
+        testPool
+      );
+
+      expect(refund.newRefundedTotal).toBe(500);
+      expect(await readSale(sale.id)).toMatchObject({ refund_status: 'full' });
+    });
+
+    it('rejects a refund naming a product that was never sold on this sale', async () => {
+      const sale = await sellOneDress();
+
+      await expect(
+        executeRefundTransaction(
+          sale.id,
+          { items: [{ product_id: 2, quantity: 1, unit_price: 200 }], reason: 'Not sold here' },
+          1,
+          testPool
+        )
+      ).rejects.toThrow('Product 2 not in this sale');
+
+      const refunds = await testPool.query('SELECT * FROM refunds WHERE sale_id = $1', [sale.id]);
+      expect(refunds.rows).toHaveLength(0);
     });
 
     it('refuses a further refund once the sale is fully refunded', async () => {

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -1875,6 +1875,165 @@ describe('Unit 4 - SalesService split-payment integrity and confirmed response',
   });
 });
 
+describe('Refunds debit the drawer only for the cash actually taken (#126)', () => {
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM register_movements');
+    await testPool.query('DELETE FROM register_sessions');
+    await testPool.query('DELETE FROM refunds');
+    await testPool.query('DELETE FROM sale_payments');
+    await testPool.query('DELETE FROM sale_calculations');
+    await testPool.query('DELETE FROM sale_items');
+    await testPool.query('DELETE FROM sales');
+    await testPool.query('DELETE FROM products');
+    await testPool.query('DELETE FROM users');
+
+    await testPool.query(
+      'INSERT INTO users (id, name, email, password_hash, role) VALUES ($1, $2, $3, $4, $5)',
+      [1, 'Admin', 'admin@moon.com', 'hash', 'Admin']
+    );
+    await testPool.query(
+      'INSERT INTO products (id, name, sku, price, cost_price, stock) VALUES ($1, $2, $3, $4, $5, $6)',
+      [1, 'Silk Dress', 'SKU-001', 300, 50, 10]
+    );
+    await testPool.query(
+      'INSERT INTO register_sessions (cashier_id, opening_float, expected_cash) VALUES ($1, $2, $2)',
+      [1, 500]
+    );
+  });
+
+  async function expectedCash(): Promise<number> {
+    const { rows } = await testPool.query<{ expected_cash: string }>(
+      'SELECT expected_cash FROM register_sessions'
+    );
+    return Number(rows[0].expected_cash);
+  }
+
+  async function refundMovements(): Promise<number[]> {
+    const { rows } = await testPool.query<{ amount: string }>(
+      "SELECT amount FROM register_movements WHERE type = 'refund' ORDER BY id ASC"
+    );
+    return rows.map((r) => Number(r.amount));
+  }
+
+  it('writes no drawer movement for a card sale refunded in full (#126 repro)', async () => {
+    const sale = await salesService.executeSale(
+      { items: [{ product_id: 1, quantity: 1 }], payment_method: 'Card' },
+      1
+    );
+    expect(await expectedCash()).toBe(500); // a card sale put nothing in the drawer
+
+    await executeRefundTransaction(
+      sale.id,
+      { items: [{ product_id: 1, quantity: 1, unit_price: 300 }], reason: 'Returned' },
+      1,
+      testPool
+    );
+
+    expect(await refundMovements()).toEqual([]);
+    expect(await expectedCash()).toBe(500);
+  });
+
+  it('debits the full amount for a cash sale refunded in full', async () => {
+    const sale = await salesService.executeSale(
+      { items: [{ product_id: 1, quantity: 1 }], payment_method: 'Cash' },
+      1
+    );
+    expect(await expectedCash()).toBe(800); // 500 float + 300 taken
+
+    await executeRefundTransaction(
+      sale.id,
+      { items: [{ product_id: 1, quantity: 1, unit_price: 300 }], reason: 'Returned' },
+      1,
+      testPool
+    );
+
+    expect(await refundMovements()).toEqual([300]);
+    expect(await expectedCash()).toBe(500);
+  });
+
+  it('debits only the Cash entry of a split tender refunded in full', async () => {
+    const sale = await salesService.executeSale(
+      {
+        items: [{ product_id: 1, quantity: 1 }],
+        payment_method: 'Card',
+        payments: [
+          { method: 'Cash', amount: 100 },
+          { method: 'Card', amount: 200 },
+        ],
+      },
+      1
+    );
+    expect(await expectedCash()).toBe(600); // 500 float + 100 cash
+
+    await executeRefundTransaction(
+      sale.id,
+      { items: [{ product_id: 1, quantity: 1, unit_price: 300 }], reason: 'Returned' },
+      1,
+      testPool
+    );
+
+    expect(await refundMovements()).toEqual([100]);
+    expect(await expectedCash()).toBe(500);
+  });
+
+  it('never pays out more cash than the split brought in, across successive partial refunds', async () => {
+    // 100 Cash + 200 Card, refunded as two halves of 150. The first refund can only
+    // draw the 100 that was actually taken; the second must write no movement at all.
+    const sale = await salesService.executeSale(
+      {
+        items: [{ product_id: 1, quantity: 2 }], // 600
+        payment_method: 'Card',
+        payments: [
+          { method: 'Cash', amount: 100 },
+          { method: 'Card', amount: 500 },
+        ],
+      },
+      1
+    );
+    expect(await expectedCash()).toBe(600);
+
+    await executeRefundTransaction(
+      sale.id,
+      { items: [{ product_id: 1, quantity: 1, unit_price: 300 }], reason: 'First half' },
+      1,
+      testPool
+    );
+    expect(await refundMovements()).toEqual([100]);
+
+    await executeRefundTransaction(
+      sale.id,
+      { items: [{ product_id: 1, quantity: 1, unit_price: 300 }], reason: 'Second half' },
+      1,
+      testPool
+    );
+
+    expect(await refundMovements()).toEqual([100]);
+    expect(await expectedCash()).toBe(500); // back to the opening float, never below
+  });
+
+  it('writes no drawer movement for a sale paid entirely by gift card', async () => {
+    const sale = await salesService.executeSale(
+      {
+        items: [{ product_id: 1, quantity: 1 }],
+        payment_method: 'Card',
+        payments: [{ method: 'Gift Card', amount: 300 }],
+      },
+      1
+    );
+    expect(await expectedCash()).toBe(500);
+
+    await executeRefundTransaction(
+      sale.id,
+      { items: [{ product_id: 1, quantity: 1, unit_price: 300 }], reason: 'Returned' },
+      1,
+      testPool
+    );
+
+    expect(await refundMovements()).toEqual([]);
+    expect(await expectedCash()).toBe(500);
+  });
+});
+
 describe('Unit 4 - Controller: stable validation error mapping', () => {
   it('maps a SalesValidationError to a 400 VALIDATION_ERROR with the stable SPLIT_PAYMENT_MISMATCH detail code', async () => {
     vi.spyOn(salesService, 'executeSale').mockRejectedValueOnce(

--- a/server/validators/saleSchema.ts
+++ b/server/validators/saleSchema.ts
@@ -64,6 +64,7 @@ export const saleSchema = z.object({
 
 export const refundItemSchema = z.object({
   product_id: z.number().int().positive(),
+  variant_id: z.number().int().positive().optional().nullable(),
   quantity: z.number().int().positive('Quantity must be at least 1'),
   unit_price: z.number().positive(),
 });


### PR DESCRIPTION
## Summary

Three defects in `SalesService.executeRefund`, which all rewrite the same block and so ship together (plan: `docs/plans/2026-09-09-001-fix-open-bug-backlog-plan.md`, PR 2). Commits are ordered #120 → #121 → #126 → client, with the refund suite green at each.

**#120 — a line could be refunded repeatedly at a client-chosen price.** Nothing aggregated prior refunds per line: the only guards were "this one request's quantity vs. what was sold" and "cumulative amount vs. the sale total". On a multi-line sale, a line already fully refunded could be refunded again at any price the client sent, as long as an unrelated unrefunded line left headroom under the total — fabricating both a cash payout and a restock. Prior refunds are now aggregated per line from `refunds.items` (there is no `refund_items` table) under the `FOR UPDATE` lock that already serializes the cumulative check, and the payout is always `sale_items.unit_price`. The client's `unit_price` stays accepted for compatibility and is documented as ignored, matching what checkout already does.

**#121 — a refunded variant line credited the wrong stock row.** The restock always hit `products.stock`, never the `product_variants` row checkout had deducted, so a sell/refund round trip silently moved stock between them. Refund lines were also matched on `product_id` alone, collapsing two variants of one product onto whichever line was found first. Matching and capping now use the composite `(product_id, variant_id)`, and the restock branches the way the deduction already does. The restock loop moves onto the shared `sortForStockWrites` ordering — that is what keeps a refund and a checkout from deadlocking now that variant rows are in the set.

**#126 — refunds debited cash the drawer never took.** The whole refund amount went to `recordRefundMovement`, so a card, gift-card or split-tender sale refunded in full left the session short by exactly the refund at close-out. The cash taken is now derived from the confirmed tender split the same way `executeSale` derives what it put in; prior refunds draw that component down first; the movement is written only when the remainder is positive.

**Client half.** The refund dialog keyed its selection map on `product_id`, so two variants of one product were one unreachable row, and every line offered its full sold quantity regardless of prior refunds — the cashier could compose a request the server now rejects. Rows are keyed the way the server matches lines, prior refunds are fetched alongside the sale detail, and each line is capped at sold minus already refunded. A spent line stays visible but disabled and says "Fully refunded" rather than only dimming; a partially refunded one shows what is left.

### Request contract

`refundItemSchema` gains an optional nullable `variant_id`. Additive, so a refund queued offline before this change still replays. Both ratchets unchanged.

## Testing

- **Server:** 742 tests / 60 files pass, including every real-PostgreSQL suite (run against a local PostgreSQL 18 with `TEST_DATABASE_URL` set; none skipped).
- **Client:** 600 tests / 66 files pass.
- **Written test-first, and confirmed to fail against the old code before the fix:**
  - #120's repro (refund a spent line again at `unit_price: 14`) — failed with the old code by *succeeding*: it wrote a second refund row, a 14 payout and a duplicate restock.
  - #126 — 4 of its 5 new cases failed with the old code, each writing a 300 drawer movement where 0 or 100 was correct.
- **New coverage:** per-line cumulative cap incl. the two-line repro; refund priced from the sale, not the request; product not in the sale; variant restock repro (product stock untouched, variant stock restored); per-variant independent caps; `restock: false`; a variant not on the sale; the five #126 tender cases (card / cash / split / split refunded in halves / gift card); a new real-PostgreSQL concurrency case proving the per-line cap holds under the sale-row lock when the sale total still has headroom.
- **Updated existing tests** whose expectations encoded the old behaviour: the concurrency suite's refund amounts (the client's price is no longer what is paid out) and two error-message assertions now superseded by the more precise per-line message.
- `npx tsc --noEmit` clean on both halves; `eslint --max-warnings 385` holds at exactly 385 (0 errors); `check:api-docs` unchanged at 204 routes / 201 derived / 3 excused / 0 unclassified.

**Not verified in a browser.** The dialog's disabled-row and remaining-quantity states are covered by `RefundDialog.test.tsx` but I have not seen them rendered — worth a look before merge.

## Post-Deploy Monitoring & Validation

- **Log queries:** watch `POST /api/v1/sales/:id/refund` for a rise in 400 `VALIDATION_ERROR` carrying `Refund quantity exceeds sold quantity` — a small number is the fix working (requests that used to succeed wrongly), a flood would mean the prior-refund aggregation is misreading historical `refunds.items` rows.
- **Data check, first day:** `SELECT id, items FROM refunds ORDER BY id DESC LIMIT 50;` — confirm the JSON shape parses as expected on real historical rows. The parser treats a missing `variant_id` as the plain line; a genuinely unexpected shape throws rather than counting as zero refunded, which is deliberate (a silent zero would reopen #120).
- **Healthy signals:** register sessions reconcile to zero variance after a card refund; `register_movements` gains no `refund` row for a card-only sale; variant stock is conserved across a sell/refund round trip.
- **Failure signals / rollback trigger:** any refund failing that should succeed (a first-time refund of an untouched line), or `expected_cash` moving on a card refund. Rollback is a straight revert — no migration, no schema change.
- **Window/owner:** first 24h of live refunds; whoever deploys owns the initial check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN