### PR TITLE
fix(bundles): one wire name for the price, and a bundle that sells at it (#123, #124)

### DIFF
--- a/client/src/features/inventory/pages/Bundles.test.tsx
+++ b/client/src/features/inventory/pages/Bundles.test.tsx
@@ -75,6 +75,20 @@ describe('Bundles card actions', () => {
     expect(nesting).toEqual([]);
   });
 
+  /**
+   * #124: the card reads `price`, and the server's list projected a column nothing
+   * writes, so every card rendered 0.00. This pins the wire name the card depends on.
+   */
+  it('renders the bundle price the list returned, alongside the catalog total it saves against', async () => {
+    renderBundles();
+    await screen.findByText('Winter capsule');
+
+    // 200 is `price` (the bundle price) and 260 is `original_price`; a card reading the
+    // wrong field would show neither, or show the same number twice.
+    expect(screen.getAllByText(/200/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/260/).length).toBeGreaterThan(0);
+  });
+
   it('names each row action for its own bundle rather than repeating a bare verb', async () => {
     renderBundles();
     await screen.findByText('Winter capsule');

--- a/client/src/features/pos/components/CartPanel.tsx
+++ b/client/src/features/pos/components/CartPanel.tsx
@@ -232,13 +232,13 @@ export default function CartPanel({ checkoutTriggerRef }: CartPanelProps = {}): 
               isEditingMemo={editingMemo === lineKey(item)}
               onStartEditingMemo={() => setEditingMemo(lineKey(item))}
               onCommitMemo={(memo) => {
-                setItemMemo(item.product_id, memo, item.variant_id);
+                setItemMemo(item.product_id, memo, item.variant_id, item.bundle_id);
                 setEditingMemo(null);
               }}
               onQuantityChange={(quantity) =>
-                updateQuantity(item.product_id, quantity, item.variant_id)
+                updateQuantity(item.product_id, quantity, item.variant_id, item.bundle_id)
               }
-              onRemove={() => removeItem(item.product_id, item.variant_id)}
+              onRemove={() => removeItem(item.product_id, item.variant_id, item.bundle_id)}
             />
           ))
         )}

--- a/client/src/features/pos/lib/cartLines.ts
+++ b/client/src/features/pos/lib/cartLines.ts
@@ -1,10 +1,13 @@
 /**
- * How a cart line is identified in the UI: by product AND variant, since the
- * same product can appear twice under different variants. Shared by the cart
- * list, its `data-testid`, and the memo-editing state that keys off it.
+ * How a cart line is identified in the UI: by product, variant AND bundle. The same
+ * product can appear twice under different variants, and since #124 it can also appear
+ * both loose and as a member of a bundle -- those are priced differently and the server
+ * validates the bundle group against its definition, so they are two lines that must
+ * never be mistaken for each other. Shared by the cart list, its `data-testid`, and the
+ * memo-editing state that keys off it.
  */
 import type { CartItem } from '../store/cartStore';
 
-export function lineKey(item: Pick<CartItem, 'product_id' | 'variant_id'>): string {
-  return `${item.product_id}-${item.variant_id || 0}`;
+export function lineKey(item: Pick<CartItem, 'product_id' | 'variant_id' | 'bundle_id'>): string {
+  return `${item.product_id}-${item.variant_id || 0}-${item.bundle_id || 0}`;
 }

--- a/client/src/features/pos/lib/salePayload.test.ts
+++ b/client/src/features/pos/lib/salePayload.test.ts
@@ -51,6 +51,19 @@ describe('buildSalePayload', () => {
     }
     expect(payload.items[0]).not.toHaveProperty('variant_id');
     expect(payload.items[0]).not.toHaveProperty('memo');
+    expect(payload.items[0]).not.toHaveProperty('bundle_id');
+  });
+
+  /**
+   * #124: the server prices a bundle group only when its lines say which bundle they
+   * belong to. Both bodies carry it -- a bundle sale queued offline must not replay at
+   * catalog prices.
+   */
+  it('sends bundle_id on a bundle line, in both the full and the offline body', () => {
+    const bundleLine = composition({ items: [{ ...SILK_DRESS, bundle_id: 7 }] });
+
+    expect(buildSalePayload(bundleLine).items[0]).toMatchObject({ bundle_id: 7 });
+    expect(buildOfflineSalePayload(bundleLine).items[0]).toMatchObject({ bundle_id: 7 });
   });
 
   it('carries every configured extra through', () => {

--- a/client/src/features/pos/lib/salePayload.ts
+++ b/client/src/features/pos/lib/salePayload.ts
@@ -58,6 +58,9 @@ export function buildSalePayload(composition: SaleComposition): SaleData {
       quantity: i.quantity,
       unit_price: i.unit_price,
       ...(i.variant_id ? { variant_id: i.variant_id } : {}),
+      // Spread conditionally like every other optional field, so a cart with no bundle
+      // line composes byte-identically to before and its idempotency key is unchanged.
+      ...(i.bundle_id ? { bundle_id: i.bundle_id } : {}),
       ...(i.memo ? { memo: i.memo } : {}),
     })),
     discount,
@@ -88,6 +91,9 @@ export function buildOfflineSalePayload(composition: SaleComposition): SaleData 
     items: items.map((i) => ({
       product_id: i.product_id,
       ...(i.variant_id ? { variant_id: i.variant_id } : {}),
+      // Carried into the queue too: without it a bundle sale that was rung up offline
+      // replays at catalog prices, which is the defect this field exists to close.
+      ...(i.bundle_id ? { bundle_id: i.bundle_id } : {}),
       quantity: i.quantity,
       unit_price: i.unit_price,
     })),

--- a/client/src/features/pos/pages/POS.tsx
+++ b/client/src/features/pos/pages/POS.tsx
@@ -242,7 +242,7 @@ export default function POS() {
         stock: product?.stock ?? 0,
       };
     });
-    addBundle({ name: bundle.name, price: bundle.price, items: itemsWithStock });
+    addBundle({ id: bundle.id, name: bundle.name, price: bundle.price, items: itemsWithStock });
     toast.success(t('pos.productFound', { name: bundle.name }));
   };
 

--- a/client/src/features/pos/pages/POS.tsx
+++ b/client/src/features/pos/pages/POS.tsx
@@ -118,21 +118,24 @@ export default function POS() {
           toast.success(t('cart.holdSuccess'));
         }
       },
+      // Each shortcut names the last line by its whole identity. Passing the product id
+      // alone matched any line with that product and no variant -- so with a variant or
+      // bundle line last, it moved a different line than the one it meant.
       incrementLastItem: () => {
         const last = items[items.length - 1];
         if (last && last.quantity < last.stock) {
-          updateQuantity(last.product_id, last.quantity + 1);
+          updateQuantity(last.product_id, last.quantity + 1, last.variant_id, last.bundle_id);
         }
       },
       decrementLastItem: () => {
         const last = items[items.length - 1];
         if (last && last.quantity > 1) {
-          updateQuantity(last.product_id, last.quantity - 1);
+          updateQuantity(last.product_id, last.quantity - 1, last.variant_id, last.bundle_id);
         }
       },
       removeLastItem: () => {
         const last = items[items.length - 1];
-        if (last) removeItem(last.product_id);
+        if (last) removeItem(last.product_id, last.variant_id, last.bundle_id);
       },
       showHelp: () => setShowShortcuts(true),
     }),

--- a/client/src/features/pos/store/cartStore.test.ts
+++ b/client/src/features/pos/store/cartStore.test.ts
@@ -280,6 +280,65 @@ describe('Cart - restoreFromHeld', () => {
   });
 });
 
+/**
+ * #124: the server tells a bundle member from a loose line of the same product only by
+ * `bundle_id`. Without it every bundle line was priced from the catalog, so the cashier
+ * saw the bundle price and the customer paid the sum of the parts.
+ */
+describe('Cart - addBundle', () => {
+  const bundle = {
+    id: 7,
+    name: 'Outfit Bundle',
+    price: 630,
+    items: [
+      { product_id: 1, product_name: 'Silk Dress', product_price: 500, quantity: 1, stock: 10 },
+      { product_id: 2, product_name: 'Cotton Shirt', product_price: 200, quantity: 1, stock: 10 },
+    ],
+  };
+
+  beforeEach(() => {
+    useCartStore.getState().clearCart();
+  });
+
+  it('tags every line with the bundle it came from', () => {
+    useCartStore.getState().addBundle(bundle);
+
+    const { items } = useCartStore.getState();
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.bundle_id)).toEqual([7, 7]);
+  });
+
+  it('allocates the bundle price across its lines rather than charging catalog', () => {
+    useCartStore.getState().addBundle(bundle);
+
+    const total = useCartStore
+      .getState()
+      .items.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
+    expect(total).toBeCloseTo(630, 2);
+  });
+
+  it('keeps a loose line of the same product separate from the bundle line', () => {
+    // Ringing the dress up on its own, then adding a bundle that contains it, must
+    // leave two lines: the loose one at catalog, the bundle one at its allocation.
+    useCartStore.getState().addItem({ id: 1, name: 'Silk Dress', price: 500, stock: 10 });
+    useCartStore.getState().addBundle(bundle);
+
+    const dressLines = useCartStore.getState().items.filter((i) => i.product_id === 1);
+    expect(dressLines).toHaveLength(2);
+    expect(dressLines.find((i) => !i.bundle_id)?.unit_price).toBe(500);
+    expect(dressLines.find((i) => i.bundle_id === 7)?.unit_price).toBeLessThan(500);
+  });
+
+  it('merges a second copy of the same bundle into its own lines', () => {
+    useCartStore.getState().addBundle(bundle);
+    useCartStore.getState().addBundle(bundle);
+
+    const { items } = useCartStore.getState();
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.quantity)).toEqual([2, 2]);
+  });
+});
+
 describe('Cart - acknowledgeReview', () => {
   it('clears the needsReview flag', () => {
     useCartStore.setState({ needsReview: true });
@@ -329,6 +388,24 @@ describe('Cart - sanitizeCartItem', () => {
     expect(
       sanitizeCartItem({ product_id: 1, unit_price: 100, quantity: 0, stock: 5 })?.quantity
     ).toBe(1);
+  });
+
+  it('preserves bundle_id through rehydration', () => {
+    // A till that reloads mid-sale restores its cart from localStorage. Dropping the
+    // tag here would check the bundle out at catalog prices (#124).
+    const item = sanitizeCartItem({
+      product_id: 1,
+      unit_price: 450,
+      quantity: 1,
+      stock: 5,
+      bundle_id: 7,
+    });
+    expect(item?.bundle_id).toBe(7);
+  });
+
+  it('leaves bundle_id off a line that never had one', () => {
+    const item = sanitizeCartItem({ product_id: 1, unit_price: 100, quantity: 1, stock: 5 });
+    expect(item?.bundle_id).toBeUndefined();
   });
 
   it('preserves an explicit null variant_id as null, not 0 or undefined', () => {

--- a/client/src/features/pos/store/cartStore.test.ts
+++ b/client/src/features/pos/store/cartStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { calculateTotals } from '../../../shared/lib/checkout';
+import { lineKey } from '../lib/cartLines';
 import { useCartStore, sanitizeCartItem, type Product, type CartPersistedV0 } from './cartStore';
 
 /**
@@ -336,6 +337,65 @@ describe('Cart - addBundle', () => {
     const { items } = useCartStore.getState();
     expect(items).toHaveLength(2);
     expect(items.map((i) => i.quantity)).toEqual([2, 2]);
+  });
+
+  /**
+   * A bundle line and a loose line can hold the same product at different prices, so
+   * every action that names a line has to name the bundle too. Identifying a line by
+   * (product, variant) alone now matches two of them.
+   */
+  describe('once a loose line and a bundle line coexist', () => {
+    beforeEach(() => {
+      useCartStore.getState().addItem({ id: 1, name: 'Silk Dress', price: 500, stock: 10 });
+      useCartStore.getState().addBundle(bundle);
+    });
+
+    it('scanning the product again adds to the loose line, not the bundle line', () => {
+      useCartStore.getState().addItem({ id: 1, name: 'Silk Dress', price: 500, stock: 10 });
+
+      const items = useCartStore.getState().items.filter((i) => i.product_id === 1);
+      expect(items).toHaveLength(2);
+      expect(items.find((i) => !i.bundle_id)?.quantity).toBe(2);
+      // Incrementing the bundle's line would break the group against its definition.
+      expect(items.find((i) => i.bundle_id === 7)?.quantity).toBe(1);
+    });
+
+    it('removing the loose line leaves the bundle line intact', () => {
+      useCartStore.getState().removeItem(1, null, null);
+
+      const items = useCartStore.getState().items.filter((i) => i.product_id === 1);
+      expect(items).toHaveLength(1);
+      expect(items[0].bundle_id).toBe(7);
+    });
+
+    it('removing the bundle line leaves the loose line intact', () => {
+      useCartStore.getState().removeItem(1, null, 7);
+
+      const items = useCartStore.getState().items.filter((i) => i.product_id === 1);
+      expect(items).toHaveLength(1);
+      expect(items[0].bundle_id).toBeUndefined();
+    });
+
+    it('changing the quantity of one does not change the other', () => {
+      useCartStore.getState().updateQuantity(1, 5, null, null);
+
+      const items = useCartStore.getState().items.filter((i) => i.product_id === 1);
+      expect(items.find((i) => !i.bundle_id)?.quantity).toBe(5);
+      expect(items.find((i) => i.bundle_id === 7)?.quantity).toBe(1);
+    });
+
+    it('a memo written on one does not appear on the other', () => {
+      useCartStore.getState().setItemMemo(1, 'gift wrap', null, null);
+
+      const items = useCartStore.getState().items.filter((i) => i.product_id === 1);
+      expect(items.find((i) => !i.bundle_id)?.memo).toBe('gift wrap');
+      expect(items.find((i) => i.bundle_id === 7)?.memo).toBe('[Outfit Bundle]');
+    });
+
+    it('gives the two lines distinct keys, so the UI can tell them apart', () => {
+      const [a, b] = useCartStore.getState().items.filter((i) => i.product_id === 1);
+      expect(lineKey(a)).not.toBe(lineKey(b));
+    });
   });
 });
 

--- a/client/src/features/pos/store/cartStore.ts
+++ b/client/src/features/pos/store/cartStore.ts
@@ -11,6 +11,13 @@ export interface CartItem {
   quantity: number;
   stock: number;
   memo?: string;
+  /**
+   * The bundle this line came from. Sent to the server, which re-derives the
+   * allocation itself -- the prices computed here are for the cashier's screen, and the
+   * server has no other way to tell a bundle member from a loose line of the same
+   * product (#124).
+   */
+  bundle_id?: number | null;
 }
 
 /** addItem input: the product columns the cart needs, plus POS-side variant selection */
@@ -20,6 +27,7 @@ export type Product = Pick<ServerProduct, 'id' | 'name' | 'price' | 'stock'> & {
 };
 
 export interface BundleForCart {
+  id: number;
   name: string;
   price: number;
   items: {
@@ -162,6 +170,14 @@ export function sanitizeCartItem(raw: unknown): CartItem | null {
       ? null
       : sanitizeFiniteNumber(r.variant_id, 0);
 
+  // Preserved through rehydration: a cart restored from localStorage that lost its
+  // bundle tagging would check out at catalog prices, which is the whole of #124 again
+  // for exactly the carts a till reload is most likely to produce.
+  const bundleId =
+    r.bundle_id === null || r.bundle_id === undefined
+      ? null
+      : sanitizeFiniteNumber(r.bundle_id, 0) || null;
+
   return {
     product_id: productId,
     variant_id: variantId,
@@ -169,6 +185,7 @@ export function sanitizeCartItem(raw: unknown): CartItem | null {
     unit_price: unitPrice,
     quantity,
     stock: sanitizeFiniteNumber(r.stock, 0),
+    ...(bundleId ? { bundle_id: bundleId } : {}),
     ...(typeof r.memo === 'string' && r.memo ? { memo: r.memo } : {}),
   };
 }
@@ -294,8 +311,12 @@ export const useCartStore = create<CartState>()(
                 : 1 / bundle.items.length;
             const adjustedUnitPrice = (proportion * bundle.price) / item.quantity;
 
+            // Only another line of the SAME bundle merges. A loose line of the same
+            // product must stay separate: the server validates a bundle group against
+            // its definition, so folding a loose unit into it would both fail that
+            // check and price the loose unit at the bundle's discount.
             const existing = newItems.find(
-              (i) => i.product_id === item.product_id && !i.variant_id
+              (i) => i.product_id === item.product_id && !i.variant_id && i.bundle_id === bundle.id
             );
             if (existing) {
               existing.quantity += item.quantity;
@@ -307,6 +328,7 @@ export const useCartStore = create<CartState>()(
                 quantity: item.quantity,
                 stock: item.stock,
                 memo: `[${bundle.name}]`,
+                bundle_id: bundle.id,
               });
             }
           }

--- a/client/src/features/pos/store/cartStore.ts
+++ b/client/src/features/pos/store/cartStore.ts
@@ -26,6 +26,25 @@ export type Product = Pick<ServerProduct, 'id' | 'name' | 'price' | 'stock'> & {
   variant_attributes?: Record<string, string>;
 };
 
+/**
+ * Whether a cart line is the one an action names. Product and variant are not enough
+ * since #124: a product can be in the cart twice, once loose and once as a member of a
+ * bundle, at different prices. `bundleId` left undefined means the loose line, which is
+ * what every pre-bundle call site meant and still means.
+ */
+export function isSameLine(
+  line: CartItem,
+  productId: number,
+  variantId?: number | null,
+  bundleId?: number | null
+): boolean {
+  return (
+    line.product_id === productId &&
+    (line.variant_id || null) === (variantId || null) &&
+    (line.bundle_id || null) === (bundleId || null)
+  );
+}
+
 export interface BundleForCart {
   id: number;
   name: string;
@@ -86,9 +105,20 @@ interface CartState {
   setCheckoutAttempt: (attempt: { fingerprint: string; key: string } | null) => void;
   addItem: (product: Product) => void;
   addBundle: (bundle: BundleForCart) => void;
-  removeItem: (productId: number, variantId?: number | null) => void;
-  updateQuantity: (productId: number, quantity: number, variantId?: number | null) => void;
-  setItemMemo: (productId: number, memo: string, variantId?: number | null) => void;
+  // `bundleId` completes the line's identity; omitted means the loose line.
+  removeItem: (productId: number, variantId?: number | null, bundleId?: number | null) => void;
+  updateQuantity: (
+    productId: number,
+    quantity: number,
+    variantId?: number | null,
+    bundleId?: number | null
+  ) => void;
+  setItemMemo: (
+    productId: number,
+    memo: string,
+    variantId?: number | null,
+    bundleId?: number | null
+  ) => void;
   setDiscount: (discount: number) => void;
   setDiscountType: (discountType: DiscountType) => void;
   setNotes: (notes: string) => void;
@@ -263,15 +293,15 @@ export const useCartStore = create<CartState>()(
       addItem: (product) =>
         set((state) => {
           const variantId = product.variant_id || null;
-          const existing = state.items.find(
-            (i) => i.product_id === product.id && (i.variant_id || null) === variantId
-          );
+          // Scanning a product that is already in the cart as part of a bundle adds a
+          // separate loose line rather than incrementing the bundle's. Folding it in
+          // would charge the loose unit the bundle's discounted allocation, and would
+          // break the group against its definition when the server re-checks it (#124).
+          const existing = state.items.find((i) => isSameLine(i, product.id, variantId));
           if (existing) {
             return {
               items: state.items.map((i) =>
-                i.product_id === product.id && (i.variant_id || null) === variantId
-                  ? { ...i, quantity: i.quantity + 1 }
-                  : i
+                isSameLine(i, product.id, variantId) ? { ...i, quantity: i.quantity + 1 } : i
               ),
               lastUpdated: Date.now(),
             };
@@ -315,9 +345,7 @@ export const useCartStore = create<CartState>()(
             // product must stay separate: the server validates a bundle group against
             // its definition, so folding a loose unit into it would both fail that
             // check and price the loose unit at the bundle's discount.
-            const existing = newItems.find(
-              (i) => i.product_id === item.product_id && !i.variant_id && i.bundle_id === bundle.id
-            );
+            const existing = newItems.find((i) => isSameLine(i, item.product_id, null, bundle.id));
             if (existing) {
               existing.quantity += item.quantity;
             } else {
@@ -336,30 +364,26 @@ export const useCartStore = create<CartState>()(
           return { items: newItems, lastUpdated: Date.now() };
         }),
 
-      removeItem: (productId, variantId) =>
+      removeItem: (productId, variantId, bundleId) =>
         set((state) => ({
-          items: state.items.filter(
-            (i) => !(i.product_id === productId && (i.variant_id || null) === (variantId || null))
-          ),
+          items: state.items.filter((i) => !isSameLine(i, productId, variantId, bundleId)),
           lastUpdated: Date.now(),
         })),
 
-      updateQuantity: (productId, quantity, variantId) =>
+      updateQuantity: (productId, quantity, variantId, bundleId) =>
         set((state) => ({
           items: state.items.map((i) =>
-            i.product_id === productId && (i.variant_id || null) === (variantId || null)
+            isSameLine(i, productId, variantId, bundleId)
               ? { ...i, quantity: Math.max(1, quantity) }
               : i
           ),
           lastUpdated: Date.now(),
         })),
 
-      setItemMemo: (productId, memo, variantId) =>
+      setItemMemo: (productId, memo, variantId, bundleId) =>
         set((state) => ({
           items: state.items.map((i) =>
-            i.product_id === productId && (i.variant_id || null) === (variantId || null)
-              ? { ...i, memo }
-              : i
+            isSameLine(i, productId, variantId, bundleId) ? { ...i, memo } : i
           ),
         })),
 

--- a/client/src/features/pos/types.ts
+++ b/client/src/features/pos/types.ts
@@ -72,6 +72,12 @@ export interface SaleItemInput {
   quantity: number;
   unit_price: number;
   memo?: string | null;
+  /**
+   * The bundle this line belongs to, when it came from one. Declared here and not only
+   * spread into the payload: #124 was a field the server silently dropped, and a wire
+   * type that does not mention it lets the next mapper drop it again with no type error.
+   */
+  bundle_id?: number | null;
 }
 
 export interface PaymentEntry {

--- a/e2e/support/locators.ts
+++ b/e2e/support/locators.ts
@@ -55,9 +55,16 @@ export function posPage(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOpti
 }
 
 export function cartPanel(page: Page, { locale = DEFAULT_TEST_LOCALE }: LocaleOptions = {}) {
-  /** One cart line. Keyed by product and variant, matching the component's own key. */
-  const line = (productId: number, variantId = 0): Locator =>
-    page.getByTestId(`cart-line-${productId}-${variantId}`);
+  /**
+   * One cart line. Keyed by product, variant AND bundle, matching the component's own
+   * key — `cartLines.ts` builds both, and this string is coupled to it by construction.
+   *
+   * The bundle segment joined the key with #124: a product can now sit in the cart twice,
+   * once loose and once as a member of a bundle, at different prices. `0` is the loose
+   * line, which is what every caller here means.
+   */
+  const line = (productId: number, variantId = 0, bundleId = 0): Locator =>
+    page.getByTestId(`cart-line-${productId}-${variantId}-${bundleId}`);
 
   return {
     line,

--- a/server/src/modules/inventory/bundles/repository.ts
+++ b/server/src/modules/inventory/bundles/repository.ts
@@ -9,6 +9,24 @@ import {
   BundleItemDTO,
 } from './types';
 
+/**
+ * Derives the two figures the client declares non-optional from the two the database
+ * supplies. Computed here rather than in the client so the bundle's arithmetic has one
+ * authority, the same reason checkout re-prices every line server-side.
+ */
+export function withSavings(row: BundleRecord): BundleRecord {
+  const price = Number(row.price ?? 0);
+  const original = Number(row.original_price ?? 0);
+  const savings = Math.max(0, original - price);
+  return {
+    ...row,
+    price,
+    original_price: original,
+    savings,
+    savings_percent: original > 0 ? Math.round((savings / original) * 100) : 0,
+  };
+}
+
 export interface IBundlesRepository {
   list(
     filters: BundleFilters,
@@ -19,6 +37,7 @@ export interface IBundlesRepository {
     bundleId: number | string,
     queryable?: Queryable
   ): Promise<BundleItemRecord[]>;
+  findItemsByBundleIds(bundleIds: number[], queryable?: Queryable): Promise<BundleItemRecord[]>;
   create(data: CreateBundleDTO, queryable?: Queryable): Promise<BundleRecord>;
   update(
     id: number | string,
@@ -65,29 +84,50 @@ export class BundlesRepository implements IBundlesRepository {
     const limitIdx = params.length + 1;
     const offsetIdx = params.length + 2;
 
+    // `b.bundle_price AS price`, not `b.price`: the writer has always written
+    // `bundle_price` while this projection read the `price` column nothing writes, so
+    // every row came back priced at its column default of 0 (#124).
     const bundles = await this.q(queryable).query<BundleRecord>(
-      `SELECT b.id, b.name, b.description, b.price, b.discount_type, b.discount_value, b.status, b.created_at, b.updated_at,
+      `SELECT b.id, b.name, b.description, b.bundle_price AS price, b.status, b.created_at, b.updated_at,
               COUNT(bi.id)::int as item_count,
               COALESCE(SUM(p.price * bi.quantity), 0) as original_price
        FROM product_bundles b
        LEFT JOIN bundle_items bi ON bi.bundle_id = b.id
        LEFT JOIN products p ON bi.product_id = p.id
        ${where}
-       GROUP BY b.id, b.name, b.description, b.price, b.discount_type, b.discount_value, b.status, b.created_at, b.updated_at
+       GROUP BY b.id, b.name, b.description, b.bundle_price, b.status, b.created_at, b.updated_at
        ORDER BY ${sortColumn} ${direction}, b.id ${direction}
        LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
       [...params, pageSize, offset]
     );
 
+    // The items belong to the list response, not just the detail one: the POS reads
+    // this endpoint and prices a bundle tile from them, and the Bundles page counts
+    // them. One extra query for the page rather than a per-row N+1.
+    const ids = bundles.rows.map((b) => b.id);
+    const items = ids.length > 0 ? await this.findItemsByBundleIds(ids, queryable) : [];
+    const itemsByBundle = new Map<number, BundleItemRecord[]>();
+    for (const item of items) {
+      const list = itemsByBundle.get(item.bundle_id) ?? [];
+      list.push(item);
+      itemsByBundle.set(item.bundle_id, list);
+    }
+
     return {
-      rows: bundles.rows,
+      rows: bundles.rows.map((row) =>
+        withSavings({ ...row, items: itemsByBundle.get(row.id) ?? [] })
+      ),
       total: Number(countResult.rows[0]?.total || 0),
     };
   }
 
   async findById(id: number | string, queryable?: Queryable): Promise<BundleRecord | null> {
+    // Named columns rather than `SELECT *`, so the dead `price` column cannot ride along
+    // beside the aliased one and hand a consumer two answers for the same question.
     const res = await this.q(queryable).query<BundleRecord>(
-      'SELECT * FROM product_bundles WHERE id = $1',
+      `SELECT id, name, description, bundle_price AS price, status, starts_at, expires_at,
+              created_at, updated_at
+       FROM product_bundles WHERE id = $1`,
       [id]
     );
     return res.rows[0] || null;
@@ -98,7 +138,7 @@ export class BundlesRepository implements IBundlesRepository {
     queryable?: Queryable
   ): Promise<BundleItemRecord[]> {
     const res = await this.q(queryable).query<BundleItemRecord>(
-      `SELECT bi.*, p.name as product_name, p.sku, p.price as original_price, p.stock, p.image_url
+      `SELECT bi.*, p.name as product_name, p.sku, p.price as product_price, p.stock, p.image_url
        FROM bundle_items bi
        JOIN products p ON bi.product_id = p.id
        WHERE bi.bundle_id = $1`,
@@ -107,16 +147,33 @@ export class BundlesRepository implements IBundlesRepository {
     return res.rows;
   }
 
+  async findItemsByBundleIds(
+    bundleIds: number[],
+    queryable?: Queryable
+  ): Promise<BundleItemRecord[]> {
+    const res = await this.q(queryable).query<BundleItemRecord>(
+      `SELECT bi.*, p.name as product_name, p.sku, p.price as product_price, p.stock, p.image_url
+       FROM bundle_items bi
+       JOIN products p ON bi.product_id = p.id
+       WHERE bi.bundle_id = ANY($1::int[])`,
+      [bundleIds]
+    );
+    return res.rows;
+  }
+
   async create(data: CreateBundleDTO, queryable?: Queryable): Promise<BundleRecord> {
     const res = await this.q(queryable).query<BundleRecord>(
       `INSERT INTO product_bundles (name, description, bundle_price, starts_at, expires_at, status)
-       VALUES ($1, $2, $3, $4, $5, 'active') RETURNING *`,
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, name, description, bundle_price AS price, status, starts_at, expires_at,
+                 created_at, updated_at`,
       [
         data.name,
         data.description || null,
-        data.bundle_price,
+        data.price,
         data.starts_at || null,
         data.expires_at || null,
+        data.status ?? 'active',
       ]
     );
     return res.rows[0];
@@ -128,14 +185,19 @@ export class BundlesRepository implements IBundlesRepository {
     queryable?: Queryable
   ): Promise<BundleRecord | null> {
     const res = await this.q(queryable).query<BundleRecord>(
-      `UPDATE product_bundles SET name = $1, description = $2, bundle_price = $3, starts_at = $4, expires_at = $5, updated_at = NOW()
-       WHERE id = $6 RETURNING *`,
+      `UPDATE product_bundles
+          SET name = $1, description = $2, bundle_price = $3, starts_at = $4, expires_at = $5,
+              status = COALESCE($6, status), updated_at = NOW()
+        WHERE id = $7
+       RETURNING id, name, description, bundle_price AS price, status, starts_at, expires_at,
+                 created_at, updated_at`,
       [
         data.name,
         data.description || null,
-        data.bundle_price,
+        data.price,
         data.starts_at || null,
         data.expires_at || null,
+        data.status ?? null,
         id,
       ]
     );

--- a/server/src/modules/inventory/bundles/schemas.ts
+++ b/server/src/modules/inventory/bundles/schemas.ts
@@ -8,7 +8,15 @@ import { bundleListQuerySchema } from './types';
 export const bundleSchema = z.object({
   name: z.string().min(1).max(100),
   description: z.string().max(500).optional(),
-  bundle_price: z.number().positive(),
+  /**
+   * One wire name for the bundle's price (#123). The column is still `bundle_price`,
+   * and the repository maps between the two -- the client, its types and the POS cart
+   * have all said `price` since they were written, so the schema was the outlier and a
+   * create from the Bundles page failed validation on a field it never sends.
+   */
+  price: z.number().positive(),
+  /** Mirrors the column's own CHECK, so an unknown value is a 400 rather than a 23514. */
+  status: z.enum(['active', 'inactive']).optional(),
   starts_at: z.string().optional().nullable(),
   expires_at: z.string().optional().nullable(),
   items: z
@@ -49,7 +57,8 @@ export const bundlesRequestContracts = {
     body: bundleSchema,
     beyondSchema: [
       'At least two products: one product at a discount is a price change, not a bundle.',
-      '`bundle_price` is the total for the set, not a per-item price or a discount rate.',
+      '`price` is the total for the set, not a per-item price or a discount rate.',
+      '`status` defaults to `active` when omitted.',
       '`starts_at` and `expires_at` are strings and are not range-checked here.',
     ],
   }),

--- a/server/src/modules/inventory/bundles/service.ts
+++ b/server/src/modules/inventory/bundles/service.ts
@@ -1,5 +1,5 @@
 import { withTransaction } from '../../../database/transaction';
-import { IBundlesRepository, bundlesRepository as defaultRepo } from './repository';
+import { IBundlesRepository, bundlesRepository as defaultRepo, withSavings } from './repository';
 import {
   BundleFilters,
   CreateBundleDTO,
@@ -24,8 +24,16 @@ export class BundlesService {
     if (!bundle) return null;
 
     const items = await this.repo.findItemsByBundleId(id);
+    // The detail response carries the same derived figures as the list, computed from
+    // the items it has just read; the page renders original price and savings from both.
+    const originalPrice = items.reduce(
+      (sum, item) => sum + Number(item.product_price ?? 0) * Number(item.quantity ?? 0),
+      0
+    );
+
     return {
-      ...bundle,
+      ...withSavings({ ...bundle, original_price: originalPrice }),
+      item_count: items.length,
       items,
     };
   }

--- a/server/src/modules/inventory/bundles/service.ts
+++ b/server/src/modules/inventory/bundles/service.ts
@@ -39,11 +39,16 @@ export class BundlesService {
   }
 
   async create(data: CreateBundleDTO): Promise<BundleRecord> {
-    return withTransaction(async (client) => {
+    const created = await withTransaction(async (client) => {
       const bundle = await this.repo.create(data, client);
       await this.repo.createBundleItems(bundle.id, data.items, client);
       return bundle;
     });
+
+    // Re-read so the mutation response is the same shape as a read: the INSERT's
+    // RETURNING cannot supply `items` or the figures derived from them, and the client
+    // declares those non-optional.
+    return (await this.findById(created.id)) ?? created;
   }
 
   async update(
@@ -62,7 +67,8 @@ export class BundlesService {
       return b;
     });
 
-    return { success: true, data: updated! };
+    // Same shape as a read, for the same reason as `create`.
+    return { success: true, data: (await this.findById(id)) ?? updated! };
   }
 
   async delete(id: number | string): Promise<{ success: boolean; error?: string }> {

--- a/server/src/modules/inventory/bundles/types.ts
+++ b/server/src/modules/inventory/bundles/types.ts
@@ -1,16 +1,23 @@
 import { z } from 'zod';
 import { createListQuerySchema } from '../../../http/pagination';
 
+/**
+ * A bundle as it goes over the wire. `price` is the column `bundle_price`, aliased on
+ * every read path so exactly one name for the value reaches a consumer (#123, #124).
+ */
 export interface BundleRecord {
   id: number;
   name: string;
   description?: string | null;
-  bundle_price: number;
+  price: number;
   starts_at?: string | null;
   expires_at?: string | null;
   status: string;
   item_count?: number;
   original_price?: number;
+  savings?: number;
+  savings_percent?: number;
+  items?: BundleItemRecord[];
   created_at: string;
   updated_at: string;
 }
@@ -22,7 +29,8 @@ export interface BundleItemRecord {
   quantity: number;
   product_name?: string;
   sku?: string;
-  original_price?: number;
+  /** The product's own catalog price -- what the line would cost outside the bundle. */
+  product_price?: number;
   stock?: number;
   image_url?: string | null;
 }
@@ -39,7 +47,8 @@ export interface BundleItemDTO {
 export interface CreateBundleDTO {
   name: string;
   description?: string | null;
-  bundle_price: number;
+  price: number;
+  status?: 'active' | 'inactive';
   starts_at?: string | null;
   expires_at?: string | null;
   items: BundleItemDTO[];

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -402,16 +402,14 @@ export class SalesService {
       }
     }
 
-    // The bundles table has both a legacy `price` column and the `bundle_price`
-    // column that the bundles module's own create/update paths write to (see
-    // server/src/modules/inventory/bundles/repository.ts); prefer the latter.
-    const bundleRow = bundle as unknown as { bundle_price?: number; price?: number };
-    const bundlePriceMajor = Number(bundleRow.bundle_price ?? bundleRow.price ?? 0);
+    // `price` on the wire, `bundle_price` in the column: the bundles repository aliases
+    // it on every read path (#123), so there is one name to read here.
+    const bundlePriceMajor = Number(bundle.price ?? 0);
     const totalAllocatedMinor = toMinorUnits(bundlePriceMajor) * (multiplier || 1);
 
     const catalogLineMinor: number[] = bundleItems.map((bi) => {
       const requestedQty = requestedByProduct.get(bi.product_id)!;
-      return toMinorUnits(Number(bi.original_price || 0)) * requestedQty;
+      return toMinorUnits(Number(bi.product_price || 0)) * requestedQty;
     });
     const totalCatalogMinor = catalogLineMinor.reduce((s, v) => s + v, 0);
 

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -316,6 +316,42 @@ export class SalesService {
       calcLines.push(...bundleCalcLines);
     }
 
+    // A product can now legitimately appear on more than one line -- loose and inside a
+    // bundle (#124) -- and each line's own check passes while their sum does not. Without
+    // this pass the cart reaches the write phase, where the guarded decrement refuses and
+    // the cashier gets a bare conflict instead of the itemized list this pre-check exists
+    // to produce.
+    if (checkStock) {
+      const requestedByRow = new Map<string, { line: ResolvedSaleLine; requested: number }>();
+      for (const line of resolvedItems) {
+        const key = `${line.product_id}:${line.variant_id ?? ''}`;
+        const entry = requestedByRow.get(key);
+        if (entry) entry.requested += line.quantity;
+        else requestedByRow.set(key, { line, requested: line.quantity });
+      }
+
+      for (const [key, { line, requested }] of requestedByRow) {
+        // Only rows that actually span lines; a single-line row was already checked
+        // against the same number during resolution.
+        if (requested === line.quantity) continue;
+        if (stockConflicts.some((c) => `${c.productId}:${c.variantId ?? ''}` === key)) continue;
+
+        const available =
+          line.variant_id != null
+            ? await this.repo.getVariantStock(line.variant_id, queryable)
+            : await this.repo.getProductStock(line.product_id, queryable);
+
+        if (available !== null && available < requested) {
+          stockConflicts.push({
+            productId: line.product_id,
+            variantId: line.variant_id ?? null,
+            requested,
+            available: Math.max(0, available),
+          });
+        }
+      }
+    }
+
     if (stockConflicts.length > 0) {
       // The message names the first line only: it is prose for a person, and the machine
       // -readable list is what a client reads. Wording unchanged from before this was typed.
@@ -404,7 +440,15 @@ export class SalesService {
 
     // `price` on the wire, `bundle_price` in the column: the bundles repository aliases
     // it on every read path (#123), so there is one name to read here.
+    //
+    // A non-positive price is refused rather than allocated. `product_bundles.bundle_price`
+    // is `NUMERIC DEFAULT 0`, so a row that predates the create path working carries 0 --
+    // and allocating 0 across the members would ring the whole bundle up free, silently
+    // and with no error for anyone to notice.
     const bundlePriceMajor = Number(bundle.price ?? 0);
+    if (!Number.isFinite(bundlePriceMajor) || bundlePriceMajor <= 0) {
+      throw new PublicError('VALIDATION_ERROR', `Bundle has no price set: ID ${bundleId}`);
+    }
     const totalAllocatedMinor = toMinorUnits(bundlePriceMajor) * (multiplier || 1);
 
     const catalogLineMinor: number[] = bundleItems.map((bi) => {

--- a/server/tests/bundles.test.ts
+++ b/server/tests/bundles.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Bundles: one wire name for the price, and a list that returns what was written
+ * (#123, #124).
+ *
+ * The write path has always written the `bundle_price` column while the list projected
+ * the `price` column nothing writes, so every row came back at that column's default of
+ * 0. The request schema meanwhile demanded `bundle_price`, a field the Bundles page has
+ * never sent -- so creating a bundle from the UI failed validation outright, and the two
+ * halves of the defect hid each other: nothing could be created, so nothing was listed
+ * at the wrong price.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { BundlesRepository } from '../src/modules/inventory/bundles/repository';
+import { BundlesService } from '../src/modules/inventory/bundles/service';
+import { bundleSchema } from '../src/modules/inventory/bundles/schemas';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+
+/** Exactly what the Bundles page submits: `price` and `status`, never `bundle_price`. */
+const pagePayload = (overrides: Record<string, unknown> = {}) => ({
+  name: 'Winter capsule',
+  description: 'Coat and scarf',
+  price: 500,
+  status: 'active',
+  items: [
+    { product_id: 1, product_name: 'Silk Dress', product_price: 400, quantity: 1 },
+    { product_id: 2, product_name: 'Cotton Shirt', product_price: 200, quantity: 1 },
+  ],
+  ...overrides,
+});
+
+const listFilters = {
+  page: 1,
+  pageSize: 25,
+  sortBy: 'createdAt' as const,
+  sortOrder: 'desc' as const,
+};
+
+describe('bundle price contract (#123, #124)', () => {
+  let testPool: PgPool;
+  const repo = new BundlesRepository();
+  const service = new BundlesService(repo);
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM bundle_items');
+    await testPool.query('DELETE FROM product_bundles');
+    await testPool.query('DELETE FROM products');
+
+    await testPool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 400, 200, 10),
+              (2, 'Cotton Shirt', 'SKU-002', 200, 100, 10)`
+    );
+  });
+
+  describe('the request contract', () => {
+    it("accepts the Bundles page's own payload (#123 repro)", () => {
+      const parsed = bundleSchema.safeParse(pagePayload());
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.price).toBe(500);
+        expect(parsed.data.status).toBe('active');
+      }
+    });
+
+    it('rejects a status outside the column CHECK as a 400, not a database error', () => {
+      const parsed = bundleSchema.safeParse(pagePayload({ status: 'archived' }));
+      expect(parsed.success).toBe(false);
+    });
+
+    it('rejects a missing or non-positive price, naming the field', () => {
+      expect(bundleSchema.safeParse(pagePayload({ price: undefined })).success).toBe(false);
+      const zero = bundleSchema.safeParse(pagePayload({ price: 0 }));
+      expect(zero.success).toBe(false);
+      if (!zero.success) {
+        expect(zero.error.issues[0].path).toContain('price');
+      }
+    });
+
+    it('still requires at least two products', () => {
+      expect(
+        bundleSchema.safeParse(pagePayload({ items: [{ product_id: 1, quantity: 1 }] })).success
+      ).toBe(false);
+    });
+  });
+
+  describe('the round trip', () => {
+    it('persists the submitted price to bundle_price and reads it back as price (#124 repro)', async () => {
+      const parsed = bundleSchema.parse(pagePayload());
+      const created = await service.create(parsed);
+
+      expect(Number(created.price)).toBe(500);
+
+      // The column the writer actually wrote, checked directly: an alias that agreed
+      // with itself on both sides would prove nothing.
+      const stored = await testPool.query<{ bundle_price: string; status: string }>(
+        'SELECT bundle_price, status FROM product_bundles WHERE id = $1',
+        [created.id]
+      );
+      expect(Number(stored.rows[0].bundle_price)).toBe(500);
+      expect(stored.rows[0].status).toBe('active');
+
+      const { rows } = await service.list(listFilters);
+      expect(rows).toHaveLength(1);
+      expect(Number(rows[0].price)).toBe(500);
+    });
+
+    it('returns the derived figures the client declares non-optional', async () => {
+      const created = await service.create(bundleSchema.parse(pagePayload()));
+
+      const { rows } = await service.list(listFilters);
+      // 400 + 200 sold separately, 500 as a set.
+      expect(Number(rows[0].original_price)).toBe(600);
+      expect(Number(rows[0].savings)).toBe(100);
+      expect(Number(rows[0].savings_percent)).toBe(17);
+      expect(rows[0].items).toHaveLength(2);
+      expect(rows[0].items?.[0]).toMatchObject({ product_name: expect.any(String) });
+
+      const detail = await service.findById(created.id);
+      expect(Number(detail?.price)).toBe(500);
+      expect(Number(detail?.original_price)).toBe(600);
+      expect(Number(detail?.savings_percent)).toBe(17);
+    });
+
+    it("carries each line's catalog price as product_price, the name the client reads", async () => {
+      const created = await service.create(bundleSchema.parse(pagePayload()));
+
+      const detail = await service.findById(created.id);
+      const dress = detail?.items.find((item) => item.product_id === 1);
+      expect(Number(dress?.product_price)).toBe(400);
+      expect(dress?.product_name).toBe('Silk Dress');
+    });
+
+    it('edits the price and the status, and the list reflects both', async () => {
+      const created = await service.create(bundleSchema.parse(pagePayload()));
+
+      const updated = await service.update(
+        created.id,
+        bundleSchema.parse(pagePayload({ price: 450, status: 'inactive' }))
+      );
+      expect(updated.success).toBe(true);
+      expect(Number(updated.data?.price)).toBe(450);
+      expect(updated.data?.status).toBe('inactive');
+
+      const { rows } = await service.list(listFilters);
+      expect(Number(rows[0].price)).toBe(450);
+      expect(rows[0].status).toBe('inactive');
+    });
+
+    it('defaults status to active when the payload omits it', async () => {
+      const created = await service.create(bundleSchema.parse(pagePayload({ status: undefined })));
+      expect(created.status).toBe('active');
+    });
+
+    it('never returns the dead price column alongside the aliased one', async () => {
+      const created = await service.create(bundleSchema.parse(pagePayload()));
+
+      // The legacy `price` column is still there and still 0; nothing may read it, and
+      // no response may carry two answers for one question.
+      const legacy = await testPool.query<{ price: string }>(
+        'SELECT price FROM product_bundles WHERE id = $1',
+        [created.id]
+      );
+      expect(Number(legacy.rows[0].price)).toBe(0);
+
+      const detail = await service.findById(created.id);
+      expect(Number(detail?.price)).toBe(500);
+    });
+  });
+});

--- a/server/tests/concurrency/checkout.concurrency.test.ts
+++ b/server/tests/concurrency/checkout.concurrency.test.ts
@@ -127,12 +127,13 @@ describeWithPostgres('checkout stock under concurrency', () => {
       expect(await countRows('stock_adjustments')).toBe(0);
     });
 
-    it('reports available as what was really on the shelf, not the mid-transaction figure', async () => {
-      // Two lines of one product, 5 in stock. The first decrement succeeds and drives the
-      // row to 0; the second is refused. Reporting 0 would be a number that stops being
-      // true the instant this transaction rolls back -- and the cashier would be told to
-      // remove a line they can in fact still sell 5 of. Only a real database can prove
-      // this, because it needs the rollback to actually happen.
+    it('counts two lines of one product against one stock figure, and says so before writing', async () => {
+      // Two lines of one product, 5 in stock, 6 asked for. Each line passes a check
+      // against 5 on its own; only their sum does not. This used to reach the write
+      // phase, where the first decrement drove the row to 0 and the second was refused,
+      // and the cashier was told "1 requested, 5 available" -- true of neither line and
+      // impossible to act on. The pre-check now reports the cart's own arithmetic: 6
+      // wanted, 5 there.
       const productId = await makeProduct('SKU-SPLIT', 5);
 
       await expect(
@@ -148,9 +149,10 @@ describeWithPostgres('checkout stock under concurrency', () => {
         )
       ).rejects.toMatchObject({
         name: 'InsufficientStockError',
-        conflicts: [{ productId, variantId: null, requested: 1, available: 5 }],
+        conflicts: [{ productId, variantId: null, requested: 6, available: 5 }],
       });
 
+      // Refused before anything was written, so the shelf figure never moved.
       expect(await stockOf(productId)).toBe(5);
       expect(await countRows('sales')).toBe(0);
       expect(await countRows('stock_adjustments')).toBe(0);
@@ -172,7 +174,14 @@ describeWithPostgres('checkout stock under concurrency', () => {
         });
 
       try {
-        await expect(sell(productId, 1)).rejects.toBeInstanceOf(InsufficientStockError);
+        // `available` is re-read from the row rather than reported from the failed
+        // update, so it is what is really on the shelf -- here 0, because the concurrent
+        // buyer genuinely took it.
+        const rejection = expect(sell(productId, 1)).rejects;
+        await rejection.toBeInstanceOf(InsufficientStockError);
+        await rejection.toMatchObject({
+          conflicts: [{ productId, variantId: null, requested: 1, available: 0 }],
+        });
       } finally {
         vi.restoreAllMocks();
       }

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -1187,6 +1187,69 @@ describe('Unit 2 - SalesService authoritative calculation and snapshot persisten
     expect(Number(sale.total)).toBe(630);
   });
 
+  it('refuses to sell a bundle whose price was never set, rather than giving it away', async () => {
+    // `product_bundles.bundle_price` is NUMERIC DEFAULT 0, so a row that predates the
+    // create path working carries 0. Allocating 0 across the members would ring the
+    // whole bundle up free, with no error for anyone to notice.
+    await testPool.query(
+      `INSERT INTO product_bundles (id, name, bundle_price, status) VALUES ($1, $2, $3, $4)`,
+      [2, 'Unpriced Bundle', 0, 'active']
+    );
+    await testPool.query(
+      'INSERT INTO bundle_items (bundle_id, product_id, quantity) VALUES ($1, $2, $3), ($1, $4, $5)',
+      [2, 1, 1, 2, 1]
+    );
+
+    await expect(
+      salesService.executeSale(
+        {
+          items: [
+            { product_id: 1, quantity: 1, bundle_id: 2 },
+            { product_id: 2, quantity: 1, bundle_id: 2 },
+          ],
+          payment_method: 'Cash',
+        },
+        1
+      )
+    ).rejects.toThrow(/Bundle has no price set/);
+
+    expect((await testPool.query('SELECT * FROM sales')).rows).toHaveLength(0);
+  });
+
+  it('counts a product ordered both loose and inside a bundle against one stock figure', async () => {
+    // Two lines, one product. Each passes its own check against stock 1; together they
+    // ask for 2. Without an aggregate pass the cart reaches the write phase and fails
+    // there with a bare conflict instead of the itemized shortfall.
+    await testPool.query('UPDATE products SET stock = 1 WHERE id = 1');
+    await testPool.query(
+      `INSERT INTO product_bundles (id, name, bundle_price, status) VALUES ($1, $2, $3, $4)`,
+      [3, 'Outfit Bundle', 630, 'active']
+    );
+    await testPool.query(
+      'INSERT INTO bundle_items (bundle_id, product_id, quantity) VALUES ($1, $2, $3), ($1, $4, $5)',
+      [3, 1, 1, 2, 1]
+    );
+
+    await expect(
+      salesService.executeSale(
+        {
+          items: [
+            { product_id: 1, quantity: 1 },
+            { product_id: 1, quantity: 1, bundle_id: 3 },
+            { product_id: 2, quantity: 1, bundle_id: 3 },
+          ],
+          payment_method: 'Cash',
+        },
+        1
+      )
+    ).rejects.toMatchObject({
+      name: 'InsufficientStockError',
+      conflicts: expect.arrayContaining([
+        expect.objectContaining({ productId: 1, requested: 2, available: 1 }),
+      ]),
+    });
+  });
+
   it('integration: a valid bundle checkout persists the server-validated allocated bundle price, not the catalog total', async () => {
     await testPool.query(
       `INSERT INTO product_bundles (id, name, bundle_price, status) VALUES ($1, $2, $3, $4)`,

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -1133,6 +1133,60 @@ describe('Unit 2 - SalesService authoritative calculation and snapshot persisten
     expect(Number(inclusiveSale.total)).toBe(1000); // tax already included in the taxable base
   });
 
+  /**
+   * #124: every other bundle test in this file calls the service directly, so they
+   * proved `resolveBundleGroup` works while the field it keys on was being stripped one
+   * layer above them. Zod drops unknown keys, `bundle_id` was not in `saleItemSchema`,
+   * and so the allocation path had never executed against a real request: the cashier
+   * saw the bundle price and the customer was charged the catalog total.
+   */
+  it('keeps bundle_id through request validation, the layer that used to drop it (#124 repro)', () => {
+    const parsed = saleSchema.parse({
+      items: [
+        { product_id: 1, quantity: 1, unit_price: 500, bundle_id: 7 },
+        { product_id: 2, quantity: 1, unit_price: 200, bundle_id: 7 },
+      ],
+      payment_method: 'Cash',
+    });
+
+    expect(parsed.items.map((item) => item.bundle_id)).toEqual([7, 7]);
+  });
+
+  it('leaves bundle_id absent on an ordinary catalog line', () => {
+    const parsed = saleSchema.parse({
+      items: [{ product_id: 1, quantity: 1, unit_price: 500 }],
+      payment_method: 'Cash',
+    });
+
+    expect(parsed.items[0].bundle_id).toBeUndefined();
+  });
+
+  it('integration: a request validated through the schema prices the bundle at its bundle price', async () => {
+    await testPool.query(
+      `INSERT INTO product_bundles (id, name, bundle_price, status) VALUES ($1, $2, $3, $4)`,
+      [1, 'Outfit Bundle', 630, 'active']
+    );
+    await testPool.query(
+      'INSERT INTO bundle_items (bundle_id, product_id, quantity) VALUES ($1, $2, $3), ($1, $4, $5)',
+      [1, 1, 1, 2, 1]
+    );
+
+    // The whole path, not the service alone: parse the body the POS actually sends,
+    // then check out with exactly what validation produced.
+    const parsed = saleSchema.parse({
+      items: [
+        { product_id: 1, quantity: 1, unit_price: 500, bundle_id: 1 },
+        { product_id: 2, quantity: 1, unit_price: 200, bundle_id: 1 },
+      ],
+      payment_method: 'Cash',
+    });
+
+    const sale = await salesService.executeSale(parsed, 1);
+
+    // 500 + 200 as loose items; 630 as the bundle.
+    expect(Number(sale.total)).toBe(630);
+  });
+
   it('integration: a valid bundle checkout persists the server-validated allocated bundle price, not the catalog total', async () => {
     await testPool.query(
       `INSERT INTO product_bundles (id, name, bundle_price, status) VALUES ($1, $2, $3, $4)`,

--- a/server/validators/saleSchema.ts
+++ b/server/validators/saleSchema.ts
@@ -6,6 +6,14 @@ export const saleItemSchema = z.object({
   quantity: z.number().int().positive('Quantity must be at least 1'),
   unit_price: z.number().positive(),
   memo: z.string().max(200).optional().nullable(),
+  /**
+   * The bundle this line belongs to. Zod strips unknown keys, so until this field
+   * existed the client's `bundle_id` never reached the service and every bundle line
+   * was priced from the catalog -- the cashier was shown the bundle price and the
+   * customer was charged the sum of the parts (#124). The server still prices the group
+   * itself; this only identifies which group a line belongs to.
+   */
+  bundle_id: z.number().int().positive().optional().nullable(),
 });
 
 // Split-payment integrity (Unit 4 of the checkout total-parity plan, #49):


### PR DESCRIPTION
## Summary

Bundles were broken end to end, by two mismatched names and a stripped field. Plan: `docs/plans/2026-09-09-001-fix-open-bug-backlog-plan.md`, PR 3.

**#123 — a bundle could not be created at all.** The request schema demanded `bundle_price`. The Bundles page has never sent that: it sends `price` and `status`, as do `client/src/features/inventory/types.ts`, `usePosData` and the POS cart. Every create from the UI failed validation on a field the client does not have.

**#124 — and any bundle that did exist listed at 0.** `create`/`update` wrote the `bundle_price` column while the list projected `price`, a column nothing writes, so rows came back at that column's default. The two halves hid each other: nothing could be created, so nothing was observed listing at the wrong price.

The wire name is now `price` throughout; the repository maps it to the `bundle_price` column on write and aliases it back on every read, so one name for the value reaches a consumer. `findById` names its columns instead of `SELECT *`, which stops the dead `price` column riding along beside the aliased one. `status` is accepted and persisted, its enum mirroring the column's own CHECK so an unknown value is a 400 rather than an unmapped 23514.

The list also now returns what the client declares non-optional and the server never sent: `savings`, `savings_percent`, and the `items` the POS prices a bundle tile from (one extra query per page, not an N+1). Per-item catalog price is `product_price`, the name the client reads.

**#124, second half — `bundle_id` never reached the server.** `resolveBundleGroup`, the allocation that prices a bundle from its own price rather than the sum of its parts, had never executed: `saleItemSchema` had no `bundle_id`, Zod strips unknown keys, and the field the path keys on was discarded one layer above a service that handled it correctly. Every pre-existing bundle test called the service directly, so they all passed while the real request path charged catalog prices — the cashier saw the bundle price and the customer paid the sum of the parts.

Three client places had to carry the field, not one: `addBundle` tags its lines, `salePayload` spreads it into the full **and** the offline body (a bundle sale queued offline would otherwise replay at catalog prices), and `sanitizeCartItem` preserves it through rehydration (a till that reloads mid-sale restores its cart from `localStorage`). `addBundle` also stops merging a bundle line into a loose line of the same product — they are priced differently, and the server validates the group against its definition, so merging both mispriced the loose unit and broke the match.

The dead `product_bundles.price` column is left in place, now read by nothing; retiring it is a follow-up migration.

## Testing

- **Server:** 741 tests / 61 files, including every real-PostgreSQL suite (local PostgreSQL 18, none skipped). **Client:** 602 tests / 65 files.
- **New `server/tests/bundles.test.ts` (10 cases)** — the page's own payload validates; `status: 'archived'` is a 400; a missing/zero `price` names the field; the round trip persists to `bundle_price` and reads back as `price` (asserted against the column directly, so an alias agreeing with itself proves nothing); derived figures; `product_price` on each line; edit price + status; status defaults to active; the dead column stays 0 and unread.
- **Verified against the old code:** reverting the schema field name and the list projection fails **8 of those 10**.
- **New checkout-boundary cases in `sales.test.ts`** — `bundle_id` survives `saleSchema.parse`, is absent on an ordinary line, and a body parsed through the schema then checked out totals 630 rather than the 700 catalog sum. Removing the schema field fails both, which is exactly the gap the existing service-level bundle tests could not see.
- **New client cases** — `addBundle` tags lines, allocates to the bundle price, keeps a loose line separate, merges a second copy of the same bundle; `sanitizeCartItem` preserves `bundle_id`; both payload builders send it. Reverting the client plumbing fails 5 of them.
- `tsc --noEmit` clean both halves; `eslint --max-warnings 385` at exactly 385 (0 errors); client lint unchanged at 17 warnings; `check:api-docs` unchanged at 204 / 201 derived / 3 excused / 0 unclassified.

One pre-existing flake was observed in `Layaway.test.tsx` ("debounces product search") on a first full-suite run; it passes in isolation and on re-run, and is unrelated to these files.

**Not verified in a browser.** The Bundles create/edit form and the POS bundle tile are covered by tests but I have not seen them rendered — worth a look before merge, since #123 means nobody has successfully created a bundle through the UI.

## Post-Deploy Monitoring & Validation

- **Data check before/after:** `SELECT id, name, price, bundle_price, status FROM product_bundles;` — pre-existing rows will show `price` as 0 and the real value in `bundle_price`. After deploy the API reports `bundle_price`; nothing backfills or rewrites the dead column, and nothing reads it.
- **Log queries:** watch `POST /api/v1/bundles` and `PUT /api/v1/bundles/:id` for 400s mentioning `price` or `status` (a client still sending `bundle_price` would surface here — there is none in this repo, and `product_bundles` is empty in practice precisely because the create path has never worked), and `POST /api/v1/sales` for `Bundle allocation does not match its definition` / `Bundle not found or inactive`, which is `resolveBundleGroup` running for the first time.
- **Healthy signals:** a bundle can be created and edited from the Bundles page; its card shows the price entered, not 0.00; a POS bundle tile adds lines that total the bundle price; the persisted `sale_items` for a bundle sale sum to that same price.
- **Failure signals / rollback trigger:** any bundle checkout rejected with a `Bundle allocation` error for a cart the cashier composed normally — that would mean the client's group and the server's definition disagree — or a bundle sale whose persisted total is the catalog sum. Rollback is a straight revert; no migration, no schema change, and the column mapping is read-path only.
- **Window/owner:** first 24h, plus the first deliberate bundle sale; whoever deploys owns the initial check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN