### PR TITLE
fix: commerce and fulfillment hardening (#122, #125, #127, #128)

### DIFF
--- a/server/src/database/documentNumber.ts
+++ b/server/src/database/documentNumber.ts
@@ -1,0 +1,86 @@
+/**
+ * Allocating a human-facing document number that a UNIQUE index will accept.
+ *
+ * Delivery orders, purchase orders, layaway plans and online orders all name themselves
+ * `PREFIX-YYYYMMDD-NNNN` with a random suffix, and every one of those columns carries a
+ * UNIQUE index. Nothing checked whether the number was free, so a same-day collision
+ * surfaced as an unmapped SQLSTATE 23505 and the caller got a 500 for a create that was
+ * perfectly valid (#128). Delivery was an order of magnitude worse than the rest: a
+ * 3-digit suffix collides on the ~30th delivery of a day with probability around 35%.
+ *
+ * The fix is to insert and let the database referee, rather than to look before leaping:
+ * a check-then-insert loop (what `GiftCardsService.create` does) is TOCTOU-racy, because
+ * two callers can both find a number free and then both insert it. Here the unique index
+ * is the only authority, a violation on *that* index means "taken", and the work is
+ * retried with a fresh number.
+ *
+ * **Each attempt must be its own transaction.** In PostgreSQL a failed statement aborts
+ * the surrounding transaction, so retrying inside one would run every later statement
+ * against a dead transaction. `run` is therefore expected to open its own transaction
+ * (or be a single statement), and is called again from the top on each attempt.
+ */
+import { PublicError } from '../http/errors';
+import { constraintName, isUniqueViolation } from './constraintErrors';
+import logger from '../../lib/logger';
+
+export interface DocumentNumberOptions {
+  /** Mints a candidate. Called once per attempt, so each retry gets a fresh number. */
+  generate: () => string;
+  /**
+   * The UNIQUE constraint that means "this number is taken".
+   *
+   * Load-bearing, not decoration: an insert can violate more than one unique index, and
+   * a retry loop that re-rolled the number on *any* 23505 would spin uselessly against,
+   * say, a duplicate email before failing with a message about document numbers.
+   */
+  constraint: string;
+  /** What is being numbered, for the error a caller sees. */
+  label: string;
+  /** Attempts in total, including the first. */
+  maxAttempts?: number;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+
+/**
+ * Runs `run` with a freshly generated document number, retrying with a new one while the
+ * named unique constraint rejects it.
+ *
+ * @throws PublicError('CONFLICT') once the attempts are exhausted — a typed refusal the
+ *   caller can act on, never the 500 an unmapped 23505 produced.
+ */
+export async function withDocumentNumber<T>(
+  options: DocumentNumberOptions,
+  run: (documentNumber: string) => Promise<T>
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+
+  for (let attempt = 1; ; attempt += 1) {
+    const documentNumber = options.generate();
+
+    try {
+      return await run(documentNumber);
+    } catch (error) {
+      const collided = isUniqueViolation(error) && constraintName(error) === options.constraint;
+
+      if (!collided || attempt >= maxAttempts) {
+        if (collided) {
+          logger.warn('Exhausted document number attempts', {
+            label: options.label,
+            attempts: maxAttempts,
+          });
+          throw new PublicError(
+            'CONFLICT',
+            `Could not allocate a unique ${options.label} number; please retry`
+          );
+        }
+        throw error;
+      }
+
+      logger.warn('Document number collision, retrying with a new one', {
+        label: options.label,
+        attempt,
+      });
+    }
+  }
+}

--- a/server/src/modules/commerce/onlineOrders/repository.ts
+++ b/server/src/modules/commerce/onlineOrders/repository.ts
@@ -17,7 +17,17 @@ export interface IOnlineOrdersRepository {
     variantId: number | null | undefined,
     quantity: number,
     queryable?: Queryable
-  ): Promise<void>;
+  ): Promise<number | null>;
+  getStock(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable?: Queryable
+  ): Promise<number | null>;
+  getCatalogLine(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable?: Queryable
+  ): Promise<{ price: number; name: string } | null>;
   restoreStock(
     productId: number,
     variantId: number | null | undefined,
@@ -106,23 +116,83 @@ export class OnlineOrdersRepository implements IOnlineOrdersRepository {
     );
   }
 
+  /**
+   * Conditional relative decrement, the same shape as
+   * `SalesRepository.decrementProductStock`. This used to be an unguarded
+   * `stock = stock - $1`, so a public, unauthenticated order for more units than exist
+   * either drove stock negative or tripped migration 004's non-negative CHECK and
+   * reached the shopper as a 500 (#125). Folding the sufficiency test into the WHERE
+   * clause removes the stale-read window: under READ COMMITTED PostgreSQL re-evaluates
+   * it after a concurrent writer's row lock is released, so two orders for the last
+   * unit cannot both succeed.
+   *
+   * `$1::int` is cast explicitly because pg-mem evaluates `column - $param` with the
+   * operands inverted unless the parameter is typed.
+   *
+   * @returns the resulting stock, or null when there was not enough (or no such row).
+   */
   async deductStock(
     productId: number,
     variantId: number | null | undefined,
     quantity: number,
     queryable?: Queryable
-  ): Promise<void> {
-    if (variantId) {
-      await this.q(queryable).query(
-        'UPDATE product_variants SET stock = stock - $1 WHERE id = $2',
-        [quantity, variantId]
-      );
-    } else {
-      await this.q(queryable).query(
-        'UPDATE products SET stock = stock - $1, updated_at = NOW() WHERE id = $2',
-        [quantity, productId]
-      );
-    }
+  ): Promise<number | null> {
+    const res = variantId
+      ? await this.q(queryable).query<{ stock: number }>(
+          `UPDATE product_variants SET stock = stock - $1::int, updated_at = NOW()
+            WHERE id = $2 AND stock >= $1::int
+            RETURNING stock`,
+          [quantity, variantId]
+        )
+      : await this.q(queryable).query<{ stock: number }>(
+          `UPDATE products SET stock = stock - $1::int, updated_at = NOW()
+            WHERE id = $2 AND stock >= $1::int
+            RETURNING stock`,
+          [quantity, productId]
+        );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /**
+   * Reads stock without taking it, for the refusal path only: the guarded UPDATE above
+   * returns nothing whether the row was missing or merely short, and those are different
+   * answers to give a shopper.
+   */
+  async getStock(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable?: Queryable
+  ): Promise<number | null> {
+    const res = variantId
+      ? await this.q(queryable).query<{ stock: number }>(
+          'SELECT stock FROM product_variants WHERE id = $1',
+          [variantId]
+        )
+      : await this.q(queryable).query<{ stock: number }>(
+          'SELECT stock FROM products WHERE id = $1',
+          [productId]
+        );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /** Catalog price and name for pricing an order line server-side. */
+  async getCatalogLine(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable?: Queryable
+  ): Promise<{ price: number; name: string } | null> {
+    const res = variantId
+      ? await this.q(queryable).query<{ price: string; name: string }>(
+          `SELECT COALESCE(pv.price, p.price) AS price, p.name
+             FROM product_variants pv JOIN products p ON pv.product_id = p.id
+            WHERE pv.id = $1 AND pv.product_id = $2`,
+          [variantId, productId]
+        )
+      : await this.q(queryable).query<{ price: string; name: string }>(
+          'SELECT price, name FROM products WHERE id = $1',
+          [productId]
+        );
+    return res.rows[0] ? { price: Number(res.rows[0].price), name: res.rows[0].name } : null;
   }
 
   async restoreStock(

--- a/server/src/modules/commerce/onlineOrders/schemas.ts
+++ b/server/src/modules/commerce/onlineOrders/schemas.ts
@@ -40,8 +40,14 @@ export const onlineOrdersRequestContracts = {
     operation: 'createOnlineOrder',
     body: createOnlineOrderSchema,
     beyondSchema: [
-      'Public: a shopper places this without a token, so it reserves stock rather than ' +
-        'deducting it, and the sale is only written when the order is confirmed.',
+      'Public: a shopper places this without a token. Stock is DEDUCTED when the order ' +
+        'is placed, not reserved — cancelling a pending, processing or shipped order ' +
+        'restores it; a delivered one cannot be cancelled. (Reservation is not ' +
+        'implemented; this text used to describe it, and did not match the code.)',
+      "Each line's `price` is accepted and ignored: the order is priced from the " +
+        'catalog, since a public endpoint cannot let a caller name its own price.',
+      'An order for more units than are in stock is refused with a 409, naming how ' +
+        'many remain.',
     ],
   }),
 

--- a/server/src/modules/commerce/onlineOrders/service.ts
+++ b/server/src/modules/commerce/onlineOrders/service.ts
@@ -1,6 +1,7 @@
 import { withTransaction } from '../../../database/transaction';
 import { withDocumentNumber } from '../../../database/documentNumber';
 import { PublicError } from '../../../http/errors';
+import { sortForStockWrites } from '../../pos/stockWriteOrder';
 import { IOnlineOrdersRepository, onlineOrdersRepository as defaultRepo } from './repository';
 import { CreateOnlineOrderDTO, OnlineOrderFilters, OnlineOrderRecord } from './types';
 
@@ -115,7 +116,14 @@ export class OnlineOrdersService {
               },
               client
             );
+          }
 
+          // Stock writes in the one canonical order every path in this repo uses, and
+          // in their own pass. Deducting in request order lets two shoppers who name the
+          // same products in opposite order take their row locks in opposite order and
+          // deadlock -- SQLSTATE 40P01, which reaches the shopper as exactly the 500
+          // this issue set out to remove.
+          for (const item of sortForStockWrites(priced)) {
             const remaining = await this.repo.deductStock(
               item.product_id,
               item.variant_id,

--- a/server/src/modules/commerce/onlineOrders/service.ts
+++ b/server/src/modules/commerce/onlineOrders/service.ts
@@ -1,6 +1,15 @@
 import { withTransaction } from '../../../database/transaction';
+import { withDocumentNumber } from '../../../database/documentNumber';
+import { PublicError } from '../../../http/errors';
 import { IOnlineOrdersRepository, onlineOrdersRepository as defaultRepo } from './repository';
 import { CreateOnlineOrderDTO, OnlineOrderFilters, OnlineOrderRecord } from './types';
+
+/**
+ * Statuses a cancellation may still restore stock from. Once an order is `delivered` the
+ * goods are with the customer, so cancelling it must not put them back on the shelf --
+ * doing so invented inventory out of a data-entry correction (#125).
+ */
+const CANCELLABLE_STATUSES = new Set(['pending', 'processing', 'shipped']);
 
 export function generateOnlineOrderNumber(): string {
   const now = new Date();
@@ -12,70 +21,123 @@ export function generateOnlineOrderNumber(): string {
 }
 
 export class OnlineOrdersService {
-  constructor(private repo: IOnlineOrdersRepository = defaultRepo) {}
+  constructor(
+    private repo: IOnlineOrdersRepository = defaultRepo,
+    /**
+     * Injected rather than called directly so a test can hand it a number it knows is
+     * taken. Spying on the module export cannot work: the call site closes over the
+     * local binding, not the exported property.
+     */
+    private generateNumber: () => string = generateOnlineOrderNumber
+  ) {}
 
   getRepository(): IOnlineOrdersRepository {
     return this.repo;
   }
 
   async createOrder(data: CreateOnlineOrderDTO): Promise<OnlineOrderRecord> {
-    const subtotal = data.items.reduce((s, i) => s + i.price * i.quantity, 0);
     const shippingFee = data.shipping_fee || 0;
-    const total = subtotal + shippingFee;
-    const orderNumber = generateOnlineOrderNumber();
 
-    return withTransaction(async (client) => {
-      // Find or create customer
-      let customerId: number | null = null;
-      const custRes = await this.repo.findCustomerByPhone(data.customer_phone, client);
-      if (custRes) {
-        customerId = custRes.id;
-      } else {
-        const newCust = await this.repo.createCustomer(
-          data.customer_name,
-          data.customer_phone,
-          `${data.shipping_address}, ${data.city}`,
-          client
-        );
-        customerId = newCust.id;
-      }
+    // Retried as a whole transaction, because a failed statement aborts the one it is
+    // in; see `withDocumentNumber`.
+    return withDocumentNumber(
+      {
+        generate: this.generateNumber,
+        constraint: 'online_orders_order_number_key',
+        label: 'online order',
+      },
+      (orderNumber) =>
+        withTransaction(async (client) => {
+          // Price every line from the catalog, inside the transaction. This endpoint is
+          // public and unauthenticated, and it used to bill `data.items[].price` -- the
+          // shopper's own number -- so anyone could order at a price they chose (#125).
+          // The request's `price` is still accepted for compatibility and ignored, the
+          // same posture as checkout and refunds.
+          const priced = [];
+          for (const item of data.items) {
+            const catalog = await this.repo.getCatalogLine(
+              item.product_id,
+              item.variant_id,
+              client
+            );
+            if (!catalog) {
+              throw new PublicError(
+                'VALIDATION_ERROR',
+                `Product not available: ID ${item.product_id}`
+              );
+            }
+            priced.push({ ...item, price: catalog.price, name: catalog.name });
+          }
 
-      // Create online order
-      const order = await this.repo.createOrder(
-        {
-          order_number: orderNumber,
-          customer_id: customerId,
-          customer_name: data.customer_name,
-          customer_phone: data.customer_phone,
-          customer_email: data.customer_email || null,
-          shipping_address: data.shipping_address,
-          city: data.city,
-          subtotal,
-          shipping_fee: shippingFee,
-          total,
-          notes: data.notes || null,
-        },
-        client
-      );
+          const subtotal = priced.reduce((sum, item) => sum + item.price * item.quantity, 0);
+          const total = subtotal + shippingFee;
 
-      // Insert items & reserve stock
-      for (const item of data.items) {
-        await this.repo.createOrderItem(
-          {
-            order_id: order.id,
-            product_id: item.product_id,
-            variant_id: item.variant_id || null,
-            quantity: item.quantity,
-            price: item.price,
-          },
-          client
-        );
+          // Find or create customer
+          let customerId: number | null = null;
+          const custRes = await this.repo.findCustomerByPhone(data.customer_phone, client);
+          if (custRes) {
+            customerId = custRes.id;
+          } else {
+            const newCust = await this.repo.createCustomer(
+              data.customer_name,
+              data.customer_phone,
+              `${data.shipping_address}, ${data.city}`,
+              client
+            );
+            customerId = newCust.id;
+          }
 
-        await this.repo.deductStock(item.product_id, item.variant_id, item.quantity, client);
-      }
+          const order = await this.repo.createOrder(
+            {
+              order_number: orderNumber,
+              customer_id: customerId,
+              customer_name: data.customer_name,
+              customer_phone: data.customer_phone,
+              customer_email: data.customer_email || null,
+              shipping_address: data.shipping_address,
+              city: data.city,
+              subtotal,
+              shipping_fee: shippingFee,
+              total,
+              notes: data.notes || null,
+            },
+            client
+          );
 
-      return order;
-    });
+          for (const item of priced) {
+            await this.repo.createOrderItem(
+              {
+                order_id: order.id,
+                product_id: item.product_id,
+                variant_id: item.variant_id || null,
+                quantity: item.quantity,
+                price: item.price,
+              },
+              client
+            );
+
+            const remaining = await this.repo.deductStock(
+              item.product_id,
+              item.variant_id,
+              item.quantity,
+              client
+            );
+            if (remaining === null) {
+              // The guarded write refuses on both "no such row" and "not enough"; a
+              // re-read is the only way to tell a shopper which.
+              const available = await this.repo.getStock(item.product_id, item.variant_id, client);
+              throw new PublicError(
+                'CONFLICT',
+                available === null
+                  ? `Product not available: ID ${item.product_id}`
+                  : `Only ${available} left of ${item.name}`
+              );
+            }
+          }
+
+          return order;
+        })
+    );
   }
 
   async list(
@@ -122,8 +184,18 @@ export class OnlineOrdersService {
       return null;
     }
 
-    // If cancelling, restore inventory
+    // If cancelling, restore inventory -- but only from a status the goods could still
+    // be recovered from. Cancelling a `delivered` order used to put its units back on
+    // the shelf, creating stock that had already left the shop (#125). Cancelling an
+    // already-cancelled order is a no-op rather than a second restore.
     if (status === 'cancelled' && currentOrder.status !== 'cancelled') {
+      if (!CANCELLABLE_STATUSES.has(currentOrder.status)) {
+        throw new PublicError(
+          'CONFLICT',
+          `Cannot cancel an order that is already ${currentOrder.status}`
+        );
+      }
+
       return withTransaction(async (client) => {
         const items = await this.repo.getOrderItems(id, client);
         for (const item of items) {

--- a/server/src/modules/fulfillment/delivery/service.ts
+++ b/server/src/modules/fulfillment/delivery/service.ts
@@ -9,13 +9,16 @@ import {
   PerformanceResult,
 } from './types';
 import { PublicError } from '../../../http/errors';
+import { withDocumentNumber } from '../../../database/documentNumber';
 
 export function generateDeliveryOrderNumber(): string {
   const now = new Date();
   const y = now.getFullYear();
   const m = String(now.getMonth() + 1).padStart(2, '0');
   const d = String(now.getDate()).padStart(2, '0');
-  const rand = String(Math.floor(Math.random() * 999) + 1).padStart(3, '0');
+  // 4 digits like every other document number. The retry above is what actually makes a
+  // collision harmless; widening the suffix only makes one rarer (#128).
+  const rand = String(Math.floor(Math.random() * 9000) + 1000);
   return `DEL-${y}${m}${d}-${rand}`;
 }
 
@@ -27,7 +30,11 @@ export function resolveEstimatedDelivery(estimated_delivery?: string | null): st
 }
 
 export class DeliveryService {
-  constructor(private repo: IDeliveryRepository = defaultRepo) {}
+  constructor(
+    private repo: IDeliveryRepository = defaultRepo,
+    /** Injected so a test can hand it a number it knows is taken. */
+    private generateNumber: () => string = generateDeliveryOrderNumber
+  ) {}
 
   getRepository(): IDeliveryRepository {
     return this.repo;
@@ -70,32 +77,42 @@ export class DeliveryService {
   }
 
   async createDeliveryOrder(data: DeliveryOrderInput): Promise<Record<string, any>> {
-    const order_number = generateDeliveryOrderNumber();
     const resolvedEstimatedDelivery = resolveEstimatedDelivery(data.estimated_delivery);
 
-    return withTransaction(async (client) => {
-      const resolvedCustomerId = await this.resolveCustomer(
-        client,
-        data.customer_id,
-        data.customer_name,
-        data.phone,
-        data.address
-      );
+    // Retried as a whole transaction on a number collision; see `withDocumentNumber`.
+    // Delivery was the worst of the four for this: a 3-digit suffix collides on the
+    // ~30th delivery of a day with probability around a third (#128).
+    return withDocumentNumber(
+      {
+        generate: this.generateNumber,
+        constraint: 'delivery_orders_order_number_key',
+        label: 'delivery order',
+      },
+      (order_number) =>
+        withTransaction(async (client) => {
+          const resolvedCustomerId = await this.resolveCustomer(
+            client,
+            data.customer_id,
+            data.customer_name,
+            data.phone,
+            data.address
+          );
 
-      const order = await this.repo.createOrder(
-        order_number,
-        resolvedCustomerId,
-        resolvedEstimatedDelivery,
-        data,
-        client
-      );
+          const order = await this.repo.createOrder(
+            order_number,
+            resolvedCustomerId,
+            resolvedEstimatedDelivery,
+            data,
+            client
+          );
 
-      if (data.items && data.items.length > 0) {
-        await this.repo.createOrderItems(order.id, data.items, client);
-      }
+          if (data.items && data.items.length > 0) {
+            await this.repo.createOrderItems(order.id, data.items, client);
+          }
 
-      return order;
-    });
+          return order;
+        })
+    );
   }
 
   async updateDeliveryOrder(

--- a/server/src/modules/fulfillment/purchaseOrders/service.ts
+++ b/server/src/modules/fulfillment/purchaseOrders/service.ts
@@ -7,6 +7,7 @@ import {
   PurchaseOrderListResult,
 } from './types';
 import { PublicError } from '../../../http/errors';
+import { withDocumentNumber } from '../../../database/documentNumber';
 
 export function generatePONumber(): string {
   const now = new Date();
@@ -18,7 +19,11 @@ export function generatePONumber(): string {
 }
 
 export class PurchaseOrdersService {
-  constructor(private repo: IPurchaseOrdersRepository = defaultRepo) {}
+  constructor(
+    private repo: IPurchaseOrdersRepository = defaultRepo,
+    /** Injected so a test can hand it a number it knows is taken. */
+    private generateNumber: () => string = generatePONumber
+  ) {}
 
   getRepository(): IPurchaseOrdersRepository {
     return this.repo;
@@ -51,34 +56,43 @@ export class PurchaseOrdersService {
     data: CreatePurchaseOrderDTO,
     userId: number
   ): Promise<{ id: number; po_number: string }> {
-    const poNumber = generatePONumber();
     const total = data.items.reduce((sum, item) => sum + item.cost_price * item.quantity, 0);
 
-    const poId = await withTransaction(async (client) => {
-      const newPoId = await this.repo.create(
-        poNumber,
-        data.distributor_id,
-        data.notes || null,
-        total,
-        userId,
-        client
-      );
+    // Retried as a whole transaction on a number collision; see `withDocumentNumber`.
+    return withDocumentNumber(
+      {
+        generate: this.generateNumber,
+        constraint: 'purchase_orders_po_number_key',
+        label: 'purchase order',
+      },
+      async (poNumber) => {
+        const poId = await withTransaction(async (client) => {
+          const newPoId = await this.repo.create(
+            poNumber,
+            data.distributor_id,
+            data.notes || null,
+            total,
+            userId,
+            client
+          );
 
-      for (const item of data.items) {
-        await this.repo.createItem(
-          newPoId,
-          item.product_id,
-          item.variant_id || null,
-          item.quantity,
-          item.cost_price,
-          client
-        );
+          for (const item of data.items) {
+            await this.repo.createItem(
+              newPoId,
+              item.product_id,
+              item.variant_id || null,
+              item.quantity,
+              item.cost_price,
+              client
+            );
+          }
+
+          return newPoId;
+        });
+
+        return { id: poId, po_number: poNumber };
       }
-
-      return newPoId;
-    });
-
-    return { id: poId, po_number: poNumber };
+    );
   }
 
   async updateStatus(

--- a/server/src/modules/pos/exchanges/repository.ts
+++ b/server/src/modules/pos/exchanges/repository.ts
@@ -21,6 +21,11 @@ export interface IExchangesRepository {
   findSaleById(saleId: number, queryable?: Queryable): Promise<Record<string, any> | null>;
   findSaleByIdForUpdate(saleId: number, queryable: Queryable): Promise<SaleRow | null>;
   findSaleItems(saleId: number, queryable?: Queryable): Promise<SaleItemRow[]>;
+  getCatalogPrice(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable?: Queryable
+  ): Promise<number | null>;
   findReturnedQuantitiesBySaleId(
     saleId: number,
     queryable?: Queryable
@@ -112,6 +117,29 @@ export class ExchangesRepository implements IExchangesRepository {
       [saleId]
     );
     return res.rows;
+  }
+
+  /**
+   * The catalog price of a line going out on an exchange. Read server-side for the same
+   * reason checkout re-prices every line: `price` in the request is the caller's number.
+   */
+  async getCatalogPrice(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable?: Queryable
+  ): Promise<number | null> {
+    const res = variantId
+      ? await this.q(queryable).query<{ price: string }>(
+          `SELECT COALESCE(pv.price, p.price) AS price
+             FROM product_variants pv JOIN products p ON pv.product_id = p.id
+            WHERE pv.id = $1 AND pv.product_id = $2`,
+          [variantId, productId]
+        )
+      : await this.q(queryable).query<{ price: string }>(
+          'SELECT price FROM products WHERE id = $1',
+          [productId]
+        );
+    return res.rows[0] ? Number(res.rows[0].price) : null;
   }
 
   /** How much of each line earlier exchanges against this sale already took back. */

--- a/server/src/modules/pos/exchanges/repository.ts
+++ b/server/src/modules/pos/exchanges/repository.ts
@@ -2,8 +2,33 @@ import { Queryable } from '../../../database/transaction';
 import pool from '../../../database/pool';
 import { ExchangeRow, ReturnedItemRow, NewItemRow, ReturnedItemInput, NewItemInput } from './types';
 
+/** Just the sale columns an exchange needs; the row carries more. */
+export interface SaleRow {
+  id: number;
+  customer_id: number | null;
+}
+
+/** A line of the original sale: what may come back, and what it is worth. */
+export interface SaleItemRow {
+  product_id: number;
+  variant_id: number | null;
+  quantity: number;
+  unit_price: string | number;
+  product_name: string;
+}
+
 export interface IExchangesRepository {
   findSaleById(saleId: number, queryable?: Queryable): Promise<Record<string, any> | null>;
+  findSaleByIdForUpdate(saleId: number, queryable: Queryable): Promise<SaleRow | null>;
+  findSaleItems(saleId: number, queryable?: Queryable): Promise<SaleItemRow[]>;
+  findReturnedQuantitiesBySaleId(
+    saleId: number,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>>;
+  findRefundedQuantitiesBySaleId(
+    saleId: number,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>>;
   createExchange(
     data: {
       exchange_number: string;
@@ -63,6 +88,84 @@ export class ExchangesRepository implements IExchangesRepository {
   async findSaleById(saleId: number, queryable?: Queryable): Promise<Record<string, any> | null> {
     const res = await this.q(queryable).query('SELECT * FROM sales WHERE id = $1', [saleId]);
     return res.rows[0] || null;
+  }
+
+  /**
+   * Locks the sale for the rest of the transaction, so the cumulative check below spans
+   * sibling exchanges AND concurrent refunds of the same lines rather than racing them.
+   * Mirrors `SalesRepository.findByIdForUpdate`, which the refund path already uses.
+   */
+  async findSaleByIdForUpdate(saleId: number, queryable: Queryable): Promise<SaleRow | null> {
+    const res = await this.q(queryable).query<SaleRow>(
+      'SELECT * FROM sales WHERE id = $1 FOR UPDATE',
+      [saleId]
+    );
+    return res.rows[0] || null;
+  }
+
+  /** The lines the sale actually sold: what may be returned, and what it is worth. */
+  async findSaleItems(saleId: number, queryable?: Queryable): Promise<SaleItemRow[]> {
+    const res = await this.q(queryable).query<SaleItemRow>(
+      `SELECT si.product_id, si.variant_id, si.quantity, si.unit_price, p.name AS product_name
+         FROM sale_items si JOIN products p ON si.product_id = p.id
+        WHERE si.sale_id = $1`,
+      [saleId]
+    );
+    return res.rows;
+  }
+
+  /** How much of each line earlier exchanges against this sale already took back. */
+  async findReturnedQuantitiesBySaleId(
+    saleId: number,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>> {
+    const res = await this.q(queryable).query<{
+      product_id: number;
+      variant_id: number | null;
+      quantity: string;
+    }>(
+      `SELECT eri.product_id, eri.variant_id, SUM(eri.quantity)::int AS quantity
+         FROM exchange_returned_items eri
+         JOIN exchanges e ON eri.exchange_id = e.id
+        WHERE e.original_sale_id = $1
+        GROUP BY eri.product_id, eri.variant_id`,
+      [saleId]
+    );
+    return res.rows.map((row) => ({
+      product_id: row.product_id,
+      variant_id: row.variant_id,
+      quantity: Number(row.quantity),
+    }));
+  }
+
+  /**
+   * Prior refunds of the same sale. #122 notes the double-recovery path between the two
+   * routes: capping only exchanges would still let a line be refunded and then exchanged.
+   * `refunds.items` is a TEXT column holding JSON, so it is parsed here at the boundary.
+   */
+  async findRefundedQuantitiesBySaleId(
+    saleId: number,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>> {
+    const res = await this.q(queryable).query<{ items: string | unknown }>(
+      'SELECT items FROM refunds WHERE sale_id = $1',
+      [saleId]
+    );
+
+    const totals: Array<{ product_id: number; variant_id: number | null; quantity: number }> = [];
+    for (const row of res.rows) {
+      const items = (
+        typeof row.items === 'string' ? JSON.parse(row.items) : (row.items ?? [])
+      ) as Array<{ product_id: number; variant_id?: number | null; quantity: number }>;
+      for (const item of items) {
+        totals.push({
+          product_id: item.product_id,
+          variant_id: item.variant_id ?? null,
+          quantity: Number(item.quantity),
+        });
+      }
+    }
+    return totals;
   }
 
   async createExchange(

--- a/server/src/modules/pos/exchanges/schemas.ts
+++ b/server/src/modules/pos/exchanges/schemas.ts
@@ -48,6 +48,11 @@ export const exchangesRequestContracts = {
         '`good` does; `damaged` and `defective` are recorded and written off.',
       'The price difference either way is settled by `payment_method`; `store_credit` ' +
         'issues or consumes credit rather than moving cash.',
+      'A returned line must be a line of the named sale, matched on ' +
+        '(product_id, variant_id). Its `price` is accepted for backward compatibility ' +
+        'and ignored: the credit is what the line actually sold for.',
+      'The cumulative quantity returned per line — counting BOTH earlier exchanges and ' +
+        'earlier refunds of that sale — can never exceed what was sold.',
     ],
   }),
 

--- a/server/src/modules/pos/exchanges/service.ts
+++ b/server/src/modules/pos/exchanges/service.ts
@@ -41,6 +41,14 @@ export interface IExchangesService {
   getExchangeById(id: number | string): Promise<ExchangeDetail | null>;
 }
 
+/**
+ * The composite key a returned line is matched and capped on: two variants of one
+ * product are distinct lines, and a plain line normalizes to the empty variant.
+ */
+function lineKey(productId: number, variantId?: number | null): string {
+  return `${productId}:${variantId ?? ''}`;
+}
+
 export class ExchangesService implements IExchangesService {
   constructor(private repo: IExchangesRepository = defaultRepo) {}
 
@@ -60,7 +68,9 @@ export class ExchangesService implements IExchangesService {
     if (client) {
       // Read on the caller's connection, not a second one from the pool: holding two
       // connections per request halves the pool's effective capacity under load.
-      const originalSale = await this.repo.findSaleById(data.original_sale_id, client);
+      // Locked, so the cumulative check below cannot race a sibling exchange or a
+      // concurrent refund of the same lines (#122).
+      const originalSale = await this.repo.findSaleByIdForUpdate(data.original_sale_id, client);
       if (!originalSale) {
         throw new PublicError('NOT_FOUND', 'Original sale not found');
       }
@@ -68,7 +78,7 @@ export class ExchangesService implements IExchangesService {
     }
 
     return withTransaction(async (tx) => {
-      const originalSale = await this.repo.findSaleById(data.original_sale_id, tx);
+      const originalSale = await this.repo.findSaleByIdForUpdate(data.original_sale_id, tx);
       if (!originalSale) {
         throw new PublicError('NOT_FOUND', 'Original sale not found');
       }
@@ -82,7 +92,60 @@ export class ExchangesService implements IExchangesService {
     originalSale: Record<string, any>,
     client: Queryable
   ): Promise<ExchangeRow> {
-    const returnTotal = data.returned_items.reduce((s, i) => s + i.price * i.quantity, 0);
+    // Nothing used to check that a returned line was ever on this sale, and the credit
+    // came from `price` in the request. A cashier could hand back goods the shop never
+    // sold, at a figure they chose, and the exchange both paid for them and restocked
+    // them (#122). Every returned line is now resolved against the sale's own lines and
+    // valued from `sale_items.unit_price`.
+    const saleItems = await this.repo.findSaleItems(data.original_sale_id, client);
+
+    // Both recovery routes count against the same sold quantity. Capping exchanges alone
+    // would leave the door open: refund a line, then exchange it, and it comes back twice.
+    const alreadyTaken = new Map<string, number>();
+    for (const prior of [
+      ...(await this.repo.findReturnedQuantitiesBySaleId(data.original_sale_id, client)),
+      ...(await this.repo.findRefundedQuantitiesBySaleId(data.original_sale_id, client)),
+    ]) {
+      const key = lineKey(prior.product_id, prior.variant_id);
+      alreadyTaken.set(key, (alreadyTaken.get(key) ?? 0) + prior.quantity);
+    }
+
+    // This request's own lines, aggregated first: several entries for one line each pass
+    // an individual check and together exceed what was sold.
+    const requestedByLine = new Map<string, number>();
+    for (const item of data.returned_items) {
+      const key = lineKey(item.product_id, item.variant_id);
+      requestedByLine.set(key, (requestedByLine.get(key) ?? 0) + item.quantity);
+    }
+
+    let returnTotal = 0;
+    for (const item of data.returned_items) {
+      const saleItem = saleItems.find(
+        (si) =>
+          si.product_id === item.product_id && (si.variant_id ?? null) === (item.variant_id ?? null)
+      );
+      if (!saleItem) {
+        throw new PublicError(
+          'VALIDATION_ERROR',
+          `Product ${item.product_id} was not sold on sale ${data.original_sale_id}`
+        );
+      }
+
+      const key = lineKey(item.product_id, item.variant_id);
+      const remaining = Number(saleItem.quantity) - (alreadyTaken.get(key) ?? 0);
+      if ((requestedByLine.get(key) ?? 0) > remaining) {
+        throw new PublicError(
+          'VALIDATION_ERROR',
+          `Return quantity exceeds what remains of product ${item.product_id} ` +
+            `(${Math.max(0, remaining)} remaining)`
+        );
+      }
+
+      // Valued from the sale, never from the request -- the same rule refunds and
+      // checkout follow.
+      returnTotal += Number(saleItem.unit_price) * item.quantity;
+    }
+
     const newTotal = data.new_items.reduce((s, i) => s + i.price * i.quantity, 0);
     const difference = newTotal - returnTotal;
 

--- a/server/src/modules/pos/exchanges/service.ts
+++ b/server/src/modules/pos/exchanges/service.ts
@@ -1,6 +1,13 @@
 import { Queryable, withTransaction } from '../../../database/transaction';
 import { IExchangesRepository, exchangesRepository as defaultRepo } from './repository';
-import { CreateExchangeDTO, ExchangeFilters, ExchangeRow, ExchangeDetail } from './types';
+import {
+  CreateExchangeDTO,
+  ExchangeFilters,
+  ExchangeRow,
+  ExchangeDetail,
+  ReturnedItemInput,
+  NewItemInput,
+} from './types';
 import { sortForStockWrites } from '../stockWriteOrder';
 import { INSUFFICIENT_STOCK_CODE, type StockConflict } from '../sales/types';
 import { PublicError } from '../../../http/errors';
@@ -99,40 +106,69 @@ export class ExchangesService implements IExchangesService {
     // valued from `sale_items.unit_price`.
     const saleItems = await this.repo.findSaleItems(data.original_sale_id, client);
 
+    // A sale can hold more than one row for the same line -- checkout writes one row per
+    // request line without aggregating -- so what was sold is their sum, not the first
+    // row's quantity. Reading one row would refuse a legitimate return of the rest.
+    const soldByLine = new Map<string, { quantity: number; unitPrice: number }>();
+    const soldByProduct = new Map<number, number>();
+    for (const saleItem of saleItems) {
+      const key = lineKey(saleItem.product_id, saleItem.variant_id);
+      const sold = soldByLine.get(key);
+      const quantity = Number(saleItem.quantity);
+      soldByLine.set(key, {
+        quantity: (sold?.quantity ?? 0) + quantity,
+        unitPrice: Number(saleItem.unit_price),
+      });
+      soldByProduct.set(
+        saleItem.product_id,
+        (soldByProduct.get(saleItem.product_id) ?? 0) + quantity
+      );
+    }
+
     // Both recovery routes count against the same sold quantity. Capping exchanges alone
     // would leave the door open: refund a line, then exchange it, and it comes back twice.
-    const alreadyTaken = new Map<string, number>();
+    const alreadyTakenByLine = new Map<string, number>();
+    const alreadyTakenByProduct = new Map<number, number>();
     for (const prior of [
       ...(await this.repo.findReturnedQuantitiesBySaleId(data.original_sale_id, client)),
       ...(await this.repo.findRefundedQuantitiesBySaleId(data.original_sale_id, client)),
     ]) {
       const key = lineKey(prior.product_id, prior.variant_id);
-      alreadyTaken.set(key, (alreadyTaken.get(key) ?? 0) + prior.quantity);
+      alreadyTakenByLine.set(key, (alreadyTakenByLine.get(key) ?? 0) + prior.quantity);
+      alreadyTakenByProduct.set(
+        prior.product_id,
+        (alreadyTakenByProduct.get(prior.product_id) ?? 0) + prior.quantity
+      );
     }
 
     // This request's own lines, aggregated first: several entries for one line each pass
     // an individual check and together exceed what was sold.
     const requestedByLine = new Map<string, number>();
+    const requestedByProduct = new Map<number, number>();
     for (const item of data.returned_items) {
       const key = lineKey(item.product_id, item.variant_id);
       requestedByLine.set(key, (requestedByLine.get(key) ?? 0) + item.quantity);
+      requestedByProduct.set(
+        item.product_id,
+        (requestedByProduct.get(item.product_id) ?? 0) + item.quantity
+      );
     }
 
     let returnTotal = 0;
+    /** The sold price of each returned line, so the persisted rows agree with the header. */
+    const pricedReturns: Array<ReturnedItemInput & { price: number }> = [];
+
     for (const item of data.returned_items) {
-      const saleItem = saleItems.find(
-        (si) =>
-          si.product_id === item.product_id && (si.variant_id ?? null) === (item.variant_id ?? null)
-      );
-      if (!saleItem) {
+      const key = lineKey(item.product_id, item.variant_id);
+      const sold = soldByLine.get(key);
+      if (!sold) {
         throw new PublicError(
           'VALIDATION_ERROR',
           `Product ${item.product_id} was not sold on sale ${data.original_sale_id}`
         );
       }
 
-      const key = lineKey(item.product_id, item.variant_id);
-      const remaining = Number(saleItem.quantity) - (alreadyTaken.get(key) ?? 0);
+      const remaining = sold.quantity - (alreadyTakenByLine.get(key) ?? 0);
       if ((requestedByLine.get(key) ?? 0) > remaining) {
         throw new PublicError(
           'VALIDATION_ERROR',
@@ -141,12 +177,42 @@ export class ExchangesService implements IExchangesService {
         );
       }
 
+      // A second cap, on the product rather than the line. A refund recorded before
+      // `variant_id` existed on a refund line is stored under the product-only key, so
+      // its per-line cap above reads zero for a variant line. Summing every prior for
+      // the product, whichever way it was keyed, keeps those rows counting.
+      const productRemaining =
+        (soldByProduct.get(item.product_id) ?? 0) -
+        (alreadyTakenByProduct.get(item.product_id) ?? 0);
+      if ((requestedByProduct.get(item.product_id) ?? 0) > productRemaining) {
+        throw new PublicError(
+          'VALIDATION_ERROR',
+          `Return quantity exceeds what remains of product ${item.product_id} ` +
+            `(${Math.max(0, productRemaining)} remaining)`
+        );
+      }
+
       // Valued from the sale, never from the request -- the same rule refunds and
       // checkout follow.
-      returnTotal += Number(saleItem.unit_price) * item.quantity;
+      returnTotal += sold.unitPrice * item.quantity;
+      pricedReturns.push({ ...item, price: sold.unitPrice });
     }
 
-    const newTotal = data.new_items.reduce((s, i) => s + i.price * i.quantity, 0);
+    // The goods going OUT are priced from the catalog, for the same reason the ones
+    // coming back are priced from the sale: `price` is the caller's number. Left
+    // trusted, an exchange could take real stock out at 0.01 a unit and pay the
+    // difference as store credit.
+    let newTotal = 0;
+    const pricedNewItems: Array<NewItemInput & { price: number }> = [];
+    for (const item of data.new_items) {
+      const catalog = await this.repo.getCatalogPrice(item.product_id, item.variant_id, client);
+      if (catalog === null) {
+        throw new PublicError('VALIDATION_ERROR', `Product not found: ID ${item.product_id}`);
+      }
+      newTotal += catalog * item.quantity;
+      pricedNewItems.push({ ...item, price: catalog });
+    }
+
     const difference = newTotal - returnTotal;
 
     const exchange = await this.repo.createExchange(
@@ -166,10 +232,14 @@ export class ExchangesService implements IExchangesService {
 
     // Line rows first. They touch the exchange's own child tables, never a product row,
     // so their order is irrelevant to locking and can stay the request's.
-    for (const item of data.returned_items) {
+    //
+    // The PRICED lines are persisted, not the request's: a row storing a price the
+    // header total does not use would contradict it, and any report summing those rows
+    // would be wrong.
+    for (const item of pricedReturns) {
       await this.repo.createReturnedItem(exchange.id, item, client);
     }
-    for (const item of data.new_items) {
+    for (const item of pricedNewItems) {
       await this.repo.createNewItem(exchange.id, item, client);
     }
 

--- a/server/src/modules/pos/layaway/controller.ts
+++ b/server/src/modules/pos/layaway/controller.ts
@@ -8,6 +8,12 @@ import { layawayService, ILayawayService } from './service';
 import { PublicError } from '../../../http/errors';
 import { paginationMeta } from '../../../http/pagination';
 import { success } from '../../../http/responses';
+import {
+  IDEMPOTENCY_REPLAY_HEADER,
+  readIdempotencyKey,
+  toIdempotencyPublicError,
+  withIdempotency,
+} from '../../../http/idempotency';
 
 /** Parsed through the contracts, so the document and the validators cannot differ (#102). */
 const contracts = layawayRequestContracts;
@@ -63,16 +69,41 @@ export class LayawayController {
       const id = Number(contracts.payInstallment.parseParams<{ id: string }>(req.params).id);
       const parsed = contracts.payInstallment.parseBody<InstallmentBody>(req.body);
 
-      const result = await this.service.recordPayment(id, parsed, authReq.user!.id);
-
-      logAuditFromReq(req, 'payment', 'layaway', id, {
-        amount: parsed.amount,
-        remaining: result.remaining_balance,
-        completed: result.status === 'completed',
+      // A retried installment must not be taken twice. The claim shares the payment's
+      // transaction, so the two commit or roll back together -- a failed payment
+      // releases its key, and a corrected retry runs normally.
+      const outcome = await withIdempotency({
+        key: readIdempotencyKey(req),
+        endpoint: 'POST /api/v1/layaway/:id/pay',
+        userId: authReq.user!.id,
+        // The validated body plus the plan, so the same key against a different plan
+        // conflicts rather than replaying this one's response.
+        payload: { planId: id, ...parsed },
+        run: async (client) => {
+          const paid = await this.service.recordPayment(id, parsed, authReq.user!.id, client);
+          return { status: 200, body: success(paid), result: paid };
+        },
       });
 
-      res.json(success(result));
+      if (outcome.replayed) {
+        // No second audit entry for a request that took no second payment.
+        res.setHeader(IDEMPOTENCY_REPLAY_HEADER, 'true');
+      } else {
+        const result = outcome.result!;
+        logAuditFromReq(req, 'payment', 'layaway', id, {
+          amount: parsed.amount,
+          remaining: result.remaining_balance,
+          completed: result.status === 'completed',
+        });
+      }
+
+      res.status(outcome.status).json(outcome.body);
     } catch (err) {
+      const conflict = toIdempotencyPublicError(err);
+      if (conflict) {
+        next(conflict);
+        return;
+      }
       next(err instanceof z.ZodError ? err : this.mapDomainError(err));
     }
   }

--- a/server/src/modules/pos/layaway/repository.ts
+++ b/server/src/modules/pos/layaway/repository.ts
@@ -24,7 +24,12 @@ export interface ILayawayRepository {
   ): Promise<LayawayPlanRow>;
   createPlanItem(planId: number, item: LayawayItemInput, queryable: Queryable): Promise<void>;
   deductVariantStock(variantId: number, quantity: number, queryable: Queryable): Promise<void>;
-  deductProductStock(productId: number, quantity: number, queryable: Queryable): Promise<void>;
+  deductProductStock(
+    productId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
+  getProductStock(productId: number, queryable: Queryable): Promise<number | null>;
   createPayment(
     data: {
       plan_id: number;
@@ -45,12 +50,12 @@ export interface ILayawayRepository {
     planId: number | string,
     queryable?: Queryable
   ): Promise<LayawayPaymentRow[]>;
-  updatePlanBalance(
+  decrementPlanBalance(
     planId: number,
-    remainingBalance: number,
-    status: string,
+    amount: number,
     queryable: Queryable
-  ): Promise<void>;
+  ): Promise<number | null>;
+  cancelActivePlan(planId: number, queryable: Queryable): Promise<boolean>;
   restockVariant(variantId: number, quantity: number, queryable: Queryable): Promise<void>;
   restockProduct(productId: number, quantity: number, queryable: Queryable): Promise<void>;
   updatePlanStatus(planId: number, status: string, queryable: Queryable): Promise<void>;
@@ -116,15 +121,34 @@ export class LayawayRepository implements ILayawayRepository {
     ]);
   }
 
+  /**
+   * Guarded relative decrement, the shape every stock write in this repo now takes.
+   * Unguarded, creating a plan for more units than exist drove stock negative or tripped
+   * migration 004's non-negative CHECK and surfaced as a 500 (#127).
+   *
+   * @returns the resulting stock, or null when there was not enough (or no such row).
+   */
   async deductProductStock(
     productId: number,
     quantity: number,
     queryable: Queryable
-  ): Promise<void> {
-    await this.q(queryable).query(
-      `UPDATE products SET stock = stock - $1, updated_at = NOW() WHERE id = $2`,
+  ): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      `UPDATE products SET stock = stock - $1::int, updated_at = NOW()
+        WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
       [quantity, productId]
     );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /** Reads stock without taking it, to tell "no such product" from "not enough". */
+  async getProductStock(productId: number, queryable: Queryable): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
   }
 
   async createPayment(
@@ -242,20 +266,53 @@ export class LayawayRepository implements ILayawayRepository {
     return res.rows as unknown as LayawayPaymentRow[];
   }
 
-  async updatePlanBalance(
+  /**
+   * Takes `amount` off the balance of an ACTIVE plan that still owes at least that much,
+   * in one statement (#127).
+   *
+   * The balance used to be read outside the transaction, reduced in JavaScript and
+   * written back as an absolute value, which loses an update: two installments both read
+   * 800, both wrote 400, and one customer's payment stopped existing on the plan while
+   * its payment row stayed on the books. Folding both the status and the sufficiency test
+   * into the WHERE clause removes the stale-read window -- under READ COMMITTED
+   * PostgreSQL re-evaluates them after the other writer's row lock is released -- and
+   * makes a payment racing a cancellation refuse instead of applying to a dead plan.
+   *
+   * `$1::numeric` is cast explicitly: pg-mem evaluates `column - $param` with the operands
+   * inverted unless the parameter is typed, which would turn the decrement into a negation.
+   *
+   * @returns the resulting balance, or null when the plan is not active or owes less.
+   */
+  async decrementPlanBalance(
     planId: number,
-    remainingBalance: number,
-    status: string,
+    amount: number,
     queryable: Queryable
-  ): Promise<void> {
-    await this.q(queryable).query(
-      `UPDATE layaway_plans SET
-         remaining_balance = $1,
-         status = $2,
-         updated_at = NOW()
-       WHERE id = $3`,
-      [remainingBalance, status, planId]
+  ): Promise<number | null> {
+    const res = await this.q(queryable).query<{ remaining_balance: string }>(
+      `UPDATE layaway_plans
+          SET remaining_balance = remaining_balance - $1::numeric,
+              updated_at = NOW()
+        WHERE id = $2 AND status = 'active' AND remaining_balance >= $1::numeric
+        RETURNING remaining_balance`,
+      [amount, planId]
     );
+    return res.rows[0] ? Number(res.rows[0].remaining_balance) : null;
+  }
+
+  /**
+   * Cancels an active plan in one statement, so a cancellation racing a payment is
+   * decided by the database rather than by which caller read the row first.
+   *
+   * @returns true when this call is the one that cancelled it.
+   */
+  async cancelActivePlan(planId: number, queryable: Queryable): Promise<boolean> {
+    const res = await this.q(queryable).query(
+      `UPDATE layaway_plans SET status = 'cancelled', updated_at = NOW()
+        WHERE id = $1 AND status = 'active'
+        RETURNING id`,
+      [planId]
+    );
+    return res.rows.length > 0;
   }
 
   async restockVariant(variantId: number, quantity: number, queryable: Queryable): Promise<void> {

--- a/server/src/modules/pos/layaway/repository.ts
+++ b/server/src/modules/pos/layaway/repository.ts
@@ -23,7 +23,12 @@ export interface ILayawayRepository {
     queryable: Queryable
   ): Promise<LayawayPlanRow>;
   createPlanItem(planId: number, item: LayawayItemInput, queryable: Queryable): Promise<void>;
-  deductVariantStock(variantId: number, quantity: number, queryable: Queryable): Promise<void>;
+  deductVariantStock(
+    variantId: number,
+    quantity: number,
+    queryable: Queryable
+  ): Promise<number | null>;
+  getVariantStock(variantId: number, queryable: Queryable): Promise<number | null>;
   deductProductStock(
     productId: number,
     quantity: number,
@@ -110,15 +115,28 @@ export class LayawayRepository implements ILayawayRepository {
     );
   }
 
+  /** Variant counterpart of {@link deductProductStock}, guarded for the same reason. */
   async deductVariantStock(
     variantId: number,
     quantity: number,
     queryable: Queryable
-  ): Promise<void> {
-    await this.q(queryable).query(`UPDATE product_variants SET stock = stock - $1 WHERE id = $2`, [
-      quantity,
-      variantId,
-    ]);
+  ): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      `UPDATE product_variants SET stock = stock - $1::int, updated_at = NOW()
+        WHERE id = $2 AND stock >= $1::int
+        RETURNING stock`,
+      [quantity, variantId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /** Reads variant stock without taking it, for the refusal path. */
+  async getVariantStock(variantId: number, queryable: Queryable): Promise<number | null> {
+    const res = await this.q(queryable).query<{ stock: number }>(
+      'SELECT stock FROM product_variants WHERE id = $1',
+      [variantId]
+    );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
   }
 
   /**

--- a/server/src/modules/pos/layaway/routes.ts
+++ b/server/src/modules/pos/layaway/routes.ts
@@ -5,37 +5,24 @@ import { layawayController } from './controller';
 const router: Router = Router();
 
 // POST /api/layaway
-router.post(
-  '/',
-  verifyToken,
-  requireRole('Admin', 'Cashier'),
-  (req, res, next) => layawayController.createPlan(req, res, next)
+router.post('/', verifyToken, requireRole('Admin', 'Cashier'), (req, res, next) =>
+  layawayController.createPlan(req, res, next)
 );
 
 // GET /api/layaway
-router.get('/', verifyToken, (req, res, next) =>
-  layawayController.getPlans(req, res, next)
-);
+router.get('/', verifyToken, (req, res, next) => layawayController.getPlans(req, res, next));
 
 // GET /api/layaway/:id
-router.get('/:id', verifyToken, (req, res, next) =>
-  layawayController.getPlanById(req, res, next)
-);
+router.get('/:id', verifyToken, (req, res, next) => layawayController.getPlanById(req, res, next));
 
 // POST /api/layaway/:id/pay
-router.post(
-  '/:id/pay',
-  verifyToken,
-  requireRole('Admin', 'Cashier'),
-  (req, res, next) => layawayController.payInstallment(req, res, next)
+router.post('/:id/pay', verifyToken, requireRole('Admin', 'Cashier'), (req, res, next) =>
+  layawayController.payInstallment(req, res, next)
 );
 
 // POST /api/layaway/:id/cancel
-router.post(
-  '/:id/cancel',
-  verifyToken,
-  requireRole('Admin'),
-  (req, res, next) => layawayController.cancelPlan(req, res, next)
+router.post('/:id/cancel', verifyToken, requireRole('Admin'), (req, res, next) =>
+  layawayController.cancelPlan(req, res, next)
 );
 
 export default router;

--- a/server/src/modules/pos/layaway/schemas.ts
+++ b/server/src/modules/pos/layaway/schemas.ts
@@ -74,6 +74,12 @@ export const layawayRequestContracts = {
     beyondSchema: [
       '`amount` is this payment, not the running total. Paying off the balance completes ' +
         'the plan and releases the goods.',
+      'Send an `Idempotency-Key` header. A repeated key returns the original outcome ' +
+        'byte-identically with `Idempotent-Replay: true`; the same key against a ' +
+        'different plan or amount is a 409 `IDEMPOTENCY_KEY_REUSED`. Generate one per ' +
+        'installment taken, not per HTTP request, so a transport retry shares it.',
+      'The balance moves by a guarded relative write, so two installments taken at once ' +
+        'both land, and one that would take the plan past zero is refused.',
     ],
   }),
 

--- a/server/src/modules/pos/layaway/service.ts
+++ b/server/src/modules/pos/layaway/service.ts
@@ -1,4 +1,5 @@
 import { withTransaction } from '../../../database/transaction';
+import { withDocumentNumber } from '../../../database/documentNumber';
 import { ILayawayRepository, layawayRepository as defaultRepo } from './repository';
 import {
   CreateLayawayDTO,
@@ -25,13 +26,18 @@ export interface ILayawayService {
   recordPayment(
     planId: number,
     data: InstallmentDTO,
-    cashierId: number
+    cashierId: number,
+    clientOrPool?: Parameters<typeof withTransaction>[1]
   ): Promise<{ remaining_balance: number; status: string }>;
   cancelPlan(planId: number): Promise<{ status: string }>;
 }
 
 export class LayawayService implements ILayawayService {
-  constructor(private repo: ILayawayRepository = defaultRepo) {}
+  constructor(
+    private repo: ILayawayRepository = defaultRepo,
+    /** Injected so a test can hand it a number it knows is taken; see OnlineOrdersService. */
+    private generateNumber: () => string = generatePlanNumber
+  ) {}
 
   getRepository(): ILayawayRepository {
     return this.repo;
@@ -42,47 +48,70 @@ export class LayawayService implements ILayawayService {
       throw new PublicError('VALIDATION_ERROR', 'Deposit cannot equal or exceed total amount');
     }
 
-    const planNumber = generatePlanNumber();
     const remainingBalance = data.total_amount - data.deposit_amount;
 
-    return withTransaction(async (client) => {
-      const plan = await this.repo.createPlan(
-        {
-          plan_number: planNumber,
-          customer_id: data.customer_id,
-          total_amount: data.total_amount,
-          deposit_amount: data.deposit_amount,
-          remaining_balance: remainingBalance,
-          due_date: data.due_date,
-          notes: data.notes || null,
-          created_by: userId,
-        },
-        client
-      );
+    // Retried as a whole transaction on a plan-number collision; see `withDocumentNumber`.
+    return withDocumentNumber(
+      {
+        generate: this.generateNumber,
+        constraint: 'layaway_plans_plan_number_key',
+        label: 'layaway plan',
+      },
+      (planNumber) =>
+        withTransaction(async (client) => {
+          const plan = await this.repo.createPlan(
+            {
+              plan_number: planNumber,
+              customer_id: data.customer_id,
+              total_amount: data.total_amount,
+              deposit_amount: data.deposit_amount,
+              remaining_balance: remainingBalance,
+              due_date: data.due_date,
+              notes: data.notes || null,
+              created_by: userId,
+            },
+            client
+          );
 
-      for (const item of data.items) {
-        await this.repo.createPlanItem(plan.id, item, client);
+          for (const item of data.items) {
+            await this.repo.createPlanItem(plan.id, item, client);
 
-        if (item.variant_id) {
-          await this.repo.deductVariantStock(item.variant_id, item.quantity, client);
-        } else {
-          await this.repo.deductProductStock(item.product_id, item.quantity, client);
-        }
-      }
+            if (item.variant_id) {
+              await this.repo.deductVariantStock(item.variant_id, item.quantity, client);
+            } else {
+              // Guarded, so a plan for more units than exist is a typed refusal rather
+              // than negative stock or an unmapped CHECK violation.
+              const remaining = await this.repo.deductProductStock(
+                item.product_id,
+                item.quantity,
+                client
+              );
+              if (remaining === null) {
+                const available = await this.repo.getProductStock(item.product_id, client);
+                throw new PublicError(
+                  'CONFLICT',
+                  available === null
+                    ? `Product not found: ID ${item.product_id}`
+                    : `Only ${available} left of product ${item.product_id}`
+                );
+              }
+            }
+          }
 
-      await this.repo.createPayment(
-        {
-          plan_id: plan.id,
-          amount: data.deposit_amount,
-          payment_method: data.payment_method || 'cash',
-          notes: 'Initial deposit',
-          cashier_id: userId,
-        },
-        client
-      );
+          await this.repo.createPayment(
+            {
+              plan_id: plan.id,
+              amount: data.deposit_amount,
+              payment_method: data.payment_method || 'cash',
+              notes: 'Initial deposit',
+              cashier_id: userId,
+            },
+            client
+          );
 
-      return plan;
-    });
+          return plan;
+        })
+    );
   }
 
   async listPlans(filters: LayawayFilters): Promise<{ rows: LayawayPlanRow[]; total: number }> {
@@ -108,7 +137,9 @@ export class LayawayService implements ILayawayService {
   async recordPayment(
     planId: number,
     data: InstallmentDTO,
-    cashierId: number
+    cashierId: number,
+    /** When the caller already owns a transaction (idempotency), run inside it. */
+    clientOrPool?: Parameters<typeof withTransaction>[1]
   ): Promise<{ remaining_balance: number; status: string }> {
     const plan = await this.repo.findById(planId);
     if (!plan) {
@@ -118,6 +149,9 @@ export class LayawayService implements ILayawayService {
       throw new PublicError('CONFLICT', 'Plan is not active');
     }
 
+    // The reads above are a courtesy that produces a better message; they are NOT what
+    // makes this safe. The balance moves by one guarded relative statement inside the
+    // transaction below, so two installments cannot both act on the same stale figure.
     const remaining = Number(plan.remaining_balance);
     if (data.amount > remaining) {
       throw new PublicError(
@@ -126,11 +160,20 @@ export class LayawayService implements ILayawayService {
       );
     }
 
-    const newRemaining = remaining - data.amount;
-    const isCompleted = newRemaining <= 0;
-    const newStatus = isCompleted ? 'completed' : 'active';
+    return withTransaction(async (client) => {
+      const newRemaining = await this.repo.decrementPlanBalance(planId, data.amount, client);
+      if (newRemaining === null) {
+        // The statement refused: the plan is no longer active, or no longer owes this
+        // much. Re-read to say which, since the UPDATE cannot tell us.
+        const current = await this.repo.findById(planId, client);
+        throw current && current.status !== 'active'
+          ? new PublicError('CONFLICT', 'Plan is not active')
+          : new PublicError(
+              'VALIDATION_ERROR',
+              `Payment amount exceeds remaining balance of ${Number(current?.remaining_balance ?? 0)}`
+            );
+      }
 
-    await withTransaction(async (client) => {
       await this.repo.createPayment(
         {
           plan_id: planId,
@@ -142,13 +185,16 @@ export class LayawayService implements ILayawayService {
         client
       );
 
-      await this.repo.updatePlanBalance(planId, newRemaining, newStatus, client);
-    });
+      // Derived from the balance the database returned, never from the pre-read: with
+      // two installments in flight, only the winner of each statement knows what the
+      // plan actually owes afterwards.
+      const newStatus = newRemaining <= 0 ? 'completed' : 'active';
+      if (newStatus !== 'active') {
+        await this.repo.updatePlanStatus(planId, newStatus, client);
+      }
 
-    return {
-      remaining_balance: newRemaining,
-      status: newStatus,
-    };
+      return { remaining_balance: newRemaining, status: newStatus };
+    }, clientOrPool);
   }
 
   async cancelPlan(planId: number): Promise<{ status: string }> {
@@ -160,7 +206,16 @@ export class LayawayService implements ILayawayService {
       throw new PublicError('CONFLICT', 'Only active plans can be cancelled');
     }
 
-    await withTransaction(async (client) => {
+    return withTransaction(async (client) => {
+      // Claim the cancellation FIRST, with the active check in the statement itself. A
+      // cancel racing an installment used to be decided by whichever read the row first,
+      // so both could proceed -- restocking goods for a plan that was being paid off, or
+      // booking a payment against a plan that had just been cancelled.
+      const cancelled = await this.repo.cancelActivePlan(planId, client);
+      if (!cancelled) {
+        throw new PublicError('CONFLICT', 'Only active plans can be cancelled');
+      }
+
       const items = await this.repo.findItemsByPlanId(planId, client);
       for (const item of items) {
         if (item.variant_id) {
@@ -170,10 +225,8 @@ export class LayawayService implements ILayawayService {
         }
       }
 
-      await this.repo.updatePlanStatus(planId, 'cancelled', client);
+      return { status: 'cancelled' };
     });
-
-    return { status: 'cancelled' };
   }
 }
 

--- a/server/src/modules/pos/layaway/service.ts
+++ b/server/src/modules/pos/layaway/service.ts
@@ -1,5 +1,6 @@
 import { withTransaction } from '../../../database/transaction';
 import { withDocumentNumber } from '../../../database/documentNumber';
+import { sortForStockWrites } from '../stockWriteOrder';
 import { ILayawayRepository, layawayRepository as defaultRepo } from './repository';
 import {
   CreateLayawayDTO,
@@ -75,26 +76,29 @@ export class LayawayService implements ILayawayService {
 
           for (const item of data.items) {
             await this.repo.createPlanItem(plan.id, item, client);
+          }
 
-            if (item.variant_id) {
-              await this.repo.deductVariantStock(item.variant_id, item.quantity, client);
-            } else {
-              // Guarded, so a plan for more units than exist is a typed refusal rather
-              // than negative stock or an unmapped CHECK violation.
-              const remaining = await this.repo.deductProductStock(
-                item.product_id,
-                item.quantity,
-                client
+          // Stock writes in the one canonical order every path in this repo uses.
+          // Request order would let two plans naming the same products in opposite
+          // order take their row locks in opposite order and deadlock -- SQLSTATE
+          // 40P01, which reaches the caller as exactly the 500 this issue is about.
+          for (const item of sortForStockWrites(data.items)) {
+            // Guarded on both sides, so a plan for more units than exist is a typed
+            // refusal rather than negative stock or an unmapped CHECK violation.
+            const remaining = item.variant_id
+              ? await this.repo.deductVariantStock(item.variant_id, item.quantity, client)
+              : await this.repo.deductProductStock(item.product_id, item.quantity, client);
+
+            if (remaining === null) {
+              const available = item.variant_id
+                ? await this.repo.getVariantStock(item.variant_id, client)
+                : await this.repo.getProductStock(item.product_id, client);
+              throw new PublicError(
+                'CONFLICT',
+                available === null
+                  ? `Product not found: ID ${item.product_id}`
+                  : `Only ${available} left of product ${item.product_id}`
               );
-              if (remaining === null) {
-                const available = await this.repo.getProductStock(item.product_id, client);
-                throw new PublicError(
-                  'CONFLICT',
-                  available === null
-                    ? `Product not found: ID ${item.product_id}`
-                    : `Only ${available} left of product ${item.product_id}`
-                );
-              }
             }
           }
 

--- a/server/tests/concurrency/balances.concurrency.test.ts
+++ b/server/tests/concurrency/balances.concurrency.test.ts
@@ -99,12 +99,23 @@ describeWithPostgres('gift card and exchange balance invariants', () => {
     return code;
   }
 
+  /**
+   * Creates a product AND records it as sold on the shared sale. Since #122 an exchange
+   * may only take back a line the named sale actually sold, so a product that was never
+   * on it is refused before the stock behaviour under test here is reached.
+   */
   async function makeProduct(sku: string, stock: number): Promise<number> {
     const { rows } = await harness.pool.query<{ id: number }>(
       'INSERT INTO products (name, sku, price, stock) VALUES ($1, $2, 100, $3) RETURNING id',
       [`Product ${sku}`, sku, stock]
     );
-    return rows[0].id;
+    const productId = rows[0].id;
+
+    await harness.pool.query(
+      'INSERT INTO sale_items (sale_id, product_id, quantity, unit_price) VALUES ($1, $2, 100, 10)',
+      [saleId, productId]
+    );
+    return productId;
   }
 
   async function redeem(code: string, amount: number, key?: string): Promise<Outcome> {

--- a/server/tests/concurrency/exchanges.concurrency.test.ts
+++ b/server/tests/concurrency/exchanges.concurrency.test.ts
@@ -44,12 +44,27 @@ describeWithPostgres('exchange stock under concurrency', () => {
     saleId = sales.rows[0].id;
   });
 
+  /**
+   * Creates a product AND records it as sold on the original sale.
+   *
+   * Since #122 an exchange may only take back a line the named sale actually sold, so a
+   * fixture that creates a bare sale with no lines is refused before any of the stock
+   * behaviour below is reached. The sold quantity is deliberately generous: these cases
+   * are about locking and rollback, not about the cumulative return cap, which
+   * `exchanges.validation.test.ts` owns.
+   */
   async function makeProduct(sku: string, stock: number): Promise<number> {
     const { rows } = await harness.pool.query<{ id: number }>(
       'INSERT INTO products (name, sku, price, stock) VALUES ($1, $2, 100, $3) RETURNING id',
       [`Product ${sku}`, sku, stock]
     );
-    return rows[0].id;
+    const productId = rows[0].id;
+
+    await harness.pool.query(
+      'INSERT INTO sale_items (sale_id, product_id, quantity, unit_price) VALUES ($1, $2, 100, 100)',
+      [saleId, productId]
+    );
+    return productId;
   }
 
   async function stockOf(productId: number): Promise<number> {

--- a/server/tests/concurrency/layaway.concurrency.test.ts
+++ b/server/tests/concurrency/layaway.concurrency.test.ts
@@ -83,6 +83,13 @@ describeWithPostgres('layaway installments under concurrency (#127)', () => {
     return { remaining: Number(rows[0].remaining_balance), status: rows[0].status };
   }
 
+  async function countRowsIn(table: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM ${table}`
+    );
+    return rows[0].n;
+  }
+
   async function countPayments(planId: number): Promise<number> {
     const { rows } = await harness.pool.query<{ n: number }>(
       'SELECT COUNT(*)::int AS n FROM layaway_payments WHERE plan_id = $1',
@@ -202,6 +209,45 @@ describeWithPostgres('layaway installments under concurrency (#127)', () => {
     expect(error).toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
     expect((await readPlan(planB)).remaining).toBe(800);
     expect(await countPayments(planB)).toBe(0);
+  });
+
+  it('refuses a plan for more units than exist, on a variant line as well as a plain one', async () => {
+    // The product path was guarded and the variant path beside it was not, so a plan
+    // for more of a variant than exists drove its stock negative or tripped migration
+    // 004's CHECK and surfaced as the 500 this issue is about.
+    const { rows: products } = await harness.pool.query<{ id: number }>(
+      "INSERT INTO products (name, sku, price, stock) VALUES ('Silk Dress', 'SKU-L1', 500, 2) RETURNING id"
+    );
+    const productId = products[0].id;
+    const { rows: variants } = await harness.pool.query<{ id: number }>(
+      `INSERT INTO product_variants (product_id, sku, price, stock, attributes)
+       VALUES ($1, 'SKU-L1-RED', 500, 2, '{"color":"Red"}') RETURNING id`,
+      [productId]
+    );
+    const variantId = variants[0].id;
+
+    const plan = (items: unknown[]) => ({
+      customer_id: customerId,
+      total_amount: 1000,
+      deposit_amount: 200,
+      due_date: new Date(Date.now() + 30 * 86400000).toISOString(),
+      items: items as never,
+    });
+
+    await expect(
+      service.createPlan(
+        plan([{ product_id: productId, variant_id: variantId, quantity: 5, price: 500 }]),
+        cashierId
+      )
+    ).rejects.toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
+
+    // Refused, not written: the variant's stock is untouched and no plan exists.
+    const { rows: after } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM product_variants WHERE id = $1',
+      [variantId]
+    );
+    expect(Number(after[0].stock)).toBe(2);
+    expect(await countRowsIn('layaway_plans')).toBe(0);
   });
 
   it('serializes a cancel against a payment: one wins, the plan stays consistent', async () => {

--- a/server/tests/concurrency/layaway.concurrency.test.ts
+++ b/server/tests/concurrency/layaway.concurrency.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Layaway installments under genuine concurrency (#127).
+ *
+ * `recordPayment` read `remaining_balance` outside its transaction, subtracted in
+ * JavaScript, and wrote the absolute result back. Two installments taken at the same
+ * till, or on two tills, both read 800, both wrote 400, and one customer's money
+ * disappeared from the plan while its payment row stayed on the books.
+ *
+ * This is invisible on pg-mem, which has no MVCC: two "concurrent" writers there are
+ * really sequential, so the lost update never happens and the suite passes against the
+ * broken code. Only a real database can show it.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { LayawayRepository } from '../../src/modules/pos/layaway/repository';
+import { LayawayService } from '../../src/modules/pos/layaway/service';
+import { LayawayController } from '../../src/modules/pos/layaway/controller';
+import * as auditLogger from '../../../server/middleware/auditLogger';
+
+interface CapturedResponse {
+  status: number | null;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+describeWithPostgres('layaway installments under concurrency (#127)', () => {
+  let harness: RealPostgresHarness;
+  const repo = new LayawayRepository();
+  const service = new LayawayService(repo);
+  let customerId: number;
+  let cashierId: number;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('layaway-concurrency', { maxConnections: 6 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+
+    const users = await harness.pool.query<{ id: number }>(
+      "INSERT INTO users (name, email, password_hash, role) VALUES ('Cashier', 'c@moon.com', 'x', 'Cashier') RETURNING id"
+    );
+    cashierId = users.rows[0].id;
+
+    const customers = await harness.pool.query<{ id: number }>(
+      "INSERT INTO customers (name, phone) VALUES ('Nadia', '0100') RETURNING id"
+    );
+    customerId = customers.rows[0].id;
+
+    // The audit logger reads req.socket.remoteAddress, which a hand-built request has
+    // no reason to carry; what it writes is not what these cases are about.
+    vi.spyOn(auditLogger, 'logAuditFromReq').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** An active plan of 1000 with a 200 deposit: 800 left to pay. */
+  async function makePlan(remaining = 800): Promise<number> {
+    const { rows } = await harness.pool.query<{ id: number }>(
+      `INSERT INTO layaway_plans (plan_number, customer_id, total_amount, deposit_amount, remaining_balance, due_date, status, created_by)
+       VALUES ($1, $2, 1000, 200, $3, NOW() + INTERVAL '30 days', 'active', $4) RETURNING id`,
+      [`LAY-${Date.now()}-${Math.floor(Math.random() * 1e6)}`, customerId, remaining, cashierId]
+    );
+    return rows[0].id;
+  }
+
+  async function readPlan(planId: number) {
+    const { rows } = await harness.pool.query<{ remaining_balance: string; status: string }>(
+      'SELECT remaining_balance, status FROM layaway_plans WHERE id = $1',
+      [planId]
+    );
+    return { remaining: Number(rows[0].remaining_balance), status: rows[0].status };
+  }
+
+  async function countPayments(planId: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      'SELECT COUNT(*)::int AS n FROM layaway_payments WHERE plan_id = $1',
+      [planId]
+    );
+    return rows[0].n;
+  }
+
+  /** Drives the real controller, which is where the idempotency wrapper lives. */
+  async function payViaController(
+    planId: number,
+    amount: number,
+    key?: string
+  ): Promise<{ response: CapturedResponse; error: unknown }> {
+    const captured: CapturedResponse = { status: null, body: undefined, headers: {} };
+    let error: unknown = null;
+
+    const res = {
+      status(code: number) {
+        captured.status = code;
+        return this;
+      },
+      json(payload: unknown) {
+        captured.body = payload;
+        return this;
+      },
+      setHeader(name: string, value: string) {
+        captured.headers[name] = value;
+      },
+    } as unknown as Response;
+
+    await new LayawayController(service).payInstallment(
+      {
+        params: { id: String(planId) },
+        body: { amount },
+        user: { id: cashierId, name: 'Cashier' },
+        headers: key ? { 'idempotency-key': key } : {},
+      } as unknown as Request,
+      res,
+      ((err: unknown) => {
+        error = err;
+      }) as NextFunction
+    );
+
+    return { response: captured, error };
+  }
+
+  it('lands both of two concurrent installments (#127 repro)', async () => {
+    const planId = await makePlan(800);
+
+    // Both read 800 under the old code, both wrote 400, and 400 of a customer's money
+    // stopped existing on the plan while both payment rows remained.
+    const outcomes = await Promise.allSettled([
+      service.recordPayment(planId, { amount: 400 }, cashierId),
+      service.recordPayment(planId, { amount: 400 }, cashierId),
+    ]);
+
+    expect(outcomes.filter((o) => o.status === 'fulfilled')).toHaveLength(2);
+
+    const plan = await readPlan(planId);
+    expect(plan.remaining).toBe(0);
+    expect(plan.status).toBe('completed');
+    expect(await countPayments(planId)).toBe(2);
+  });
+
+  it('never takes a plan below zero, however many installments race', async () => {
+    const planId = await makePlan(500);
+
+    const outcomes = await Promise.allSettled(
+      Array.from({ length: 5 }, () => service.recordPayment(planId, { amount: 200 }, cashierId))
+    );
+
+    const fulfilled = outcomes.filter((o) => o.status === 'fulfilled');
+    // 500 pays for two 200s; the third would overshoot and must be refused.
+    expect(fulfilled).toHaveLength(2);
+
+    const plan = await readPlan(planId);
+    expect(plan.remaining).toBe(100);
+    expect(plan.remaining).toBeGreaterThanOrEqual(0);
+    expect(await countPayments(planId)).toBe(2);
+  });
+
+  it('refuses an installment that would overshoot, and writes no payment row', async () => {
+    const planId = await makePlan(300);
+
+    await expect(service.recordPayment(planId, { amount: 400 }, cashierId)).rejects.toMatchObject({
+      name: 'PublicError',
+    });
+
+    expect((await readPlan(planId)).remaining).toBe(300);
+    expect(await countPayments(planId)).toBe(0);
+  });
+
+  it('takes a retried installment once, and says it replayed', async () => {
+    const planId = await makePlan(800);
+
+    const first = await payViaController(planId, 400, 'installment-key');
+    const second = await payViaController(planId, 400, 'installment-key');
+
+    expect(first.error).toBeNull();
+    expect(second.error).toBeNull();
+    expect(second.response.headers['Idempotent-Replay']).toBe('true');
+    expect(JSON.stringify(second.response.body)).toBe(JSON.stringify(first.response.body));
+
+    // One payment, one deduction: the retry took nothing further from the customer.
+    expect((await readPlan(planId)).remaining).toBe(400);
+    expect(await countPayments(planId)).toBe(1);
+  });
+
+  it('refuses one key reused against a different plan instead of replaying it', async () => {
+    const planA = await makePlan(800);
+    const planB = await makePlan(800);
+
+    await payViaController(planA, 400, 'shared-key');
+    const { error } = await payViaController(planB, 400, 'shared-key');
+
+    expect(error).toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
+    expect((await readPlan(planB)).remaining).toBe(800);
+    expect(await countPayments(planB)).toBe(0);
+  });
+
+  it('serializes a cancel against a payment: one wins, the plan stays consistent', async () => {
+    const planId = await makePlan(800);
+
+    const outcomes = await Promise.allSettled([
+      service.recordPayment(planId, { amount: 800 }, cashierId),
+      service.cancelPlan(planId),
+    ]);
+
+    const plan = await readPlan(planId);
+
+    // Whichever ran first, the plan cannot end up both paid off and cancelled, and a
+    // payment cannot be booked against a cancelled plan.
+    if (plan.status === 'completed') {
+      expect(plan.remaining).toBe(0);
+      expect(await countPayments(planId)).toBe(1);
+    } else {
+      expect(plan.status).toBe('cancelled');
+      expect(await countPayments(planId)).toBe(0);
+    }
+
+    expect(outcomes.filter((o) => o.status === 'fulfilled').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/tests/concurrency/onlineOrders.concurrency.test.ts
+++ b/server/tests/concurrency/onlineOrders.concurrency.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Online orders against real PostgreSQL: the guarded stock write, transaction
+ * atomicity, and the document-number retry (#125, #128).
+ *
+ * None of these can be shown on pg-mem. The oversell race needs two genuinely concurrent
+ * connections and real MVCC; the rollback assertions need a ROLLBACK that actually undoes
+ * writes (pg-mem accepts the statement and keeps the rows); and the number retry keys on
+ * `err.constraint`, which pg-mem does not populate.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import { OnlineOrdersRepository } from '../../src/modules/commerce/onlineOrders/repository';
+import { OnlineOrdersService } from '../../src/modules/commerce/onlineOrders/service';
+
+const order = (overrides: Record<string, unknown> = {}) => ({
+  customer_name: 'Nadia',
+  customer_phone: '01000000000',
+  shipping_address: '12 Nile St',
+  city: 'Cairo',
+  items: [{ product_id: 1, quantity: 1, price: 500 }],
+  shipping_fee: 0,
+  ...overrides,
+});
+
+describeWithPostgres('online orders under concurrency (#125, #128)', () => {
+  let harness: RealPostgresHarness;
+  const repo = new OnlineOrdersRepository();
+  const service = new OnlineOrdersService(repo);
+
+  beforeAll(async () => {
+    // Four connections: the oversell race runs three orders at once, each holding one.
+    harness = await setupRealPostgres('online-orders-concurrency', { maxConnections: 6 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    await harness.pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 1)`
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function stockOf(productId: number): Promise<number> {
+    const { rows } = await harness.pool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  async function countRows(table: string): Promise<number> {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM ${table}`
+    );
+    return rows[0].n;
+  }
+
+  it('lets exactly one of three concurrent orders take the last unit', async () => {
+    const outcomes = await Promise.allSettled([
+      service.createOrder(order()),
+      service.createOrder(order()),
+      service.createOrder(order()),
+    ]);
+
+    const fulfilled = outcomes.filter((o) => o.status === 'fulfilled');
+    const rejected = outcomes.filter((o) => o.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(2);
+    for (const outcome of rejected) {
+      expect((outcome as PromiseRejectedResult).reason).toMatchObject({ code: 'CONFLICT' });
+    }
+
+    // Never negative, and never oversold: the guard is in the WHERE clause, so the two
+    // losers' updates matched no row rather than reading a stale count.
+    expect(await stockOf(1)).toBe(0);
+    expect(await countRows('online_orders')).toBe(1);
+  });
+
+  it('rolls the order and its items back when a later line is out of stock', async () => {
+    await harness.pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (2, 'Cotton Shirt', 'SKU-002', 200, 100, 0)`
+    );
+
+    await expect(
+      service.createOrder(
+        order({
+          items: [
+            { product_id: 1, quantity: 1, price: 500 },
+            { product_id: 2, quantity: 1, price: 200 },
+          ],
+        })
+      )
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    // The first line's deduction happened before the second line refused; only a real
+    // rollback puts it back.
+    expect(await stockOf(1)).toBe(1);
+    expect(await countRows('online_orders')).toBe(0);
+    expect(await countRows('online_order_items')).toBe(0);
+  });
+
+  /** Seeds an order that already owns `number`, so the next attempt at it collides. */
+  async function occupyOrderNumber(number: string): Promise<void> {
+    await harness.pool.query(
+      `INSERT INTO online_orders (order_number, customer_name, customer_phone, shipping_address, city, subtotal, total)
+       VALUES ($1, 'Someone', '0100', 'x', 'Cairo', 0, 0)`,
+      [number]
+    );
+  }
+
+  it('re-rolls a colliding order number instead of surfacing a 500 (#128)', async () => {
+    await harness.pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (3, 'Wool Coat', 'SKU-003', 900, 400, 10)`
+    );
+
+    // The first number is already taken. A generator that cannot see that -- which is
+    // every random one -- must be allowed to try again.
+    const taken = 'WEB-20260909-0001';
+    await occupyOrderNumber(taken);
+
+    const numbers = [taken, 'WEB-20260909-0002'];
+    let calls = 0;
+    const colliding = new OnlineOrdersService(repo, () => numbers[calls++] ?? 'WEB-FALLBACK');
+
+    const created = await colliding.createOrder(
+      order({ items: [{ product_id: 3, quantity: 1, price: 900 }] })
+    );
+
+    expect(created.order_number).toBe('WEB-20260909-0002');
+    expect(calls).toBe(2);
+    expect(await countRows('online_orders')).toBe(2);
+  });
+
+  it('gives up with a typed conflict, never a 500, when every number collides', async () => {
+    await harness.pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (4, 'Linen Shirt', 'SKU-004', 300, 100, 10)`
+    );
+
+    const taken = 'WEB-20260909-9999';
+    await occupyOrderNumber(taken);
+
+    const alwaysColliding = new OnlineOrdersService(repo, () => taken);
+
+    await expect(
+      alwaysColliding.createOrder(order({ items: [{ product_id: 4, quantity: 1, price: 300 }] }))
+    ).rejects.toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
+
+    // The bounded retry gave up rather than spinning, and wrote nothing.
+    expect(await countRows('online_orders')).toBe(1);
+  });
+
+  it('does not retry a unique violation on a different column of the same insert', async () => {
+    // A retry loop that re-rolled on any 23505 would spin against, say, a duplicate
+    // customer phone and then blame the order number for it.
+    await harness.pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (5, 'Silk Scarf', 'SKU-005', 150, 60, 10)`
+    );
+    await harness.pool.query(
+      `CREATE UNIQUE INDEX online_orders_city_unique ON online_orders (city)`
+    );
+    await occupyOrderNumber('WEB-20260909-7777');
+
+    let calls = 0;
+    const service2 = new OnlineOrdersService(repo, () => {
+      calls += 1;
+      return `WEB-20260909-${8000 + calls}`;
+    });
+
+    // 'Cairo' is already taken by the seeded row, so this fails on the OTHER index.
+    await expect(
+      service2.createOrder(order({ items: [{ product_id: 5, quantity: 1, price: 150 }] }))
+    ).rejects.toMatchObject({ code: '23505' });
+
+    // Surfaced on the first attempt rather than re-rolled four more times.
+    expect(calls).toBe(1);
+
+    await harness.pool.query('DROP INDEX online_orders_city_unique');
+  });
+});

--- a/server/tests/documentNumber.test.ts
+++ b/server/tests/documentNumber.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The document-number allocator (#128), on its own.
+ *
+ * The four modules that use it are covered against a real database, where the retry keys
+ * on `err.constraint`. These cases are about the helper's own decisions -- when it
+ * retries, when it refuses to, and what it throws once it gives up -- which are pure
+ * control flow and need no database at all.
+ */
+import { describe, expect, it } from 'vitest';
+import { withDocumentNumber } from '../src/database/documentNumber';
+import { PublicError } from '../src/http/errors';
+
+/** A rejection shaped like the one node-postgres raises for a unique violation. */
+function uniqueViolation(constraint?: string): Error {
+  return Object.assign(new Error('duplicate key value violates unique constraint'), {
+    code: '23505',
+    constraint,
+  });
+}
+
+const options = (overrides: Partial<Parameters<typeof withDocumentNumber>[0]> = {}) => ({
+  generate: () => 'DOC-1',
+  constraint: 'widgets_number_key',
+  label: 'widget',
+  ...overrides,
+});
+
+describe('withDocumentNumber (#128)', () => {
+  it('passes the generated number through and returns what the work returned', async () => {
+    const result = await withDocumentNumber(options(), async (number) => `used ${number}`);
+    expect(result).toBe('used DOC-1');
+  });
+
+  it('generates a fresh number for each attempt, not one reused across them', async () => {
+    const issued: string[] = [];
+    let attempts = 0;
+
+    const result = await withDocumentNumber(
+      options({ generate: () => `DOC-${issued.length + 1}` }),
+      async (number) => {
+        issued.push(number);
+        attempts += 1;
+        if (attempts < 3) throw uniqueViolation('widgets_number_key');
+        return number;
+      }
+    );
+
+    expect(issued).toEqual(['DOC-1', 'DOC-2', 'DOC-3']);
+    expect(result).toBe('DOC-3');
+  });
+
+  it('gives up with a typed CONFLICT once the attempts are spent, never a raw 23505', async () => {
+    let attempts = 0;
+
+    const failing = withDocumentNumber(options({ maxAttempts: 3 }), async () => {
+      attempts += 1;
+      throw uniqueViolation('widgets_number_key');
+    });
+
+    await expect(failing).rejects.toBeInstanceOf(PublicError);
+    await expect(failing).rejects.toMatchObject({ code: 'CONFLICT' });
+    await expect(failing).rejects.toThrow(/widget number/);
+    expect(attempts).toBe(3);
+  });
+
+  it('does not retry a unique violation on a different constraint', async () => {
+    // The load-bearing narrowing: an insert can break more than one unique index, and
+    // re-rolling the document number cannot fix a duplicate email.
+    let attempts = 0;
+
+    const failing = withDocumentNumber(options(), async () => {
+      attempts += 1;
+      throw uniqueViolation('widgets_email_key');
+    });
+
+    await expect(failing).rejects.toMatchObject({ code: '23505' });
+    expect(attempts).toBe(1);
+  });
+
+  it('does not retry a unique violation that names no constraint', async () => {
+    // Without a name there is nothing to say the document number is what collided, so
+    // the error is surfaced rather than guessed at.
+    let attempts = 0;
+
+    const failing = withDocumentNumber(options(), async () => {
+      attempts += 1;
+      throw uniqueViolation(undefined);
+    });
+
+    await expect(failing).rejects.toMatchObject({ code: '23505' });
+    expect(attempts).toBe(1);
+  });
+
+  it('does not retry an error that is not a unique violation at all', async () => {
+    let attempts = 0;
+
+    const failing = withDocumentNumber(options(), async () => {
+      attempts += 1;
+      throw new Error('connection terminated');
+    });
+
+    await expect(failing).rejects.toThrow('connection terminated');
+    expect(attempts).toBe(1);
+  });
+
+  it('succeeds on the last permitted attempt rather than one short of it', async () => {
+    let attempts = 0;
+
+    const result = await withDocumentNumber(options({ maxAttempts: 3 }), async (number) => {
+      attempts += 1;
+      if (attempts < 3) throw uniqueViolation('widgets_number_key');
+      return number;
+    });
+
+    expect(result).toBe('DOC-1');
+    expect(attempts).toBe(3);
+  });
+});

--- a/server/tests/exchanges.test.ts
+++ b/server/tests/exchanges.test.ts
@@ -92,6 +92,20 @@ describe('Exchange stock invariants', () => {
 
     const repo = {
       findSaleById: vi.fn().mockResolvedValue({ id: 1, customer_id: null }),
+      findSaleByIdForUpdate: vi.fn().mockResolvedValue({ id: 1, customer_id: null }),
+      // Every returned line these cases use must be a line of the sale, since #122; the
+      // quantities are generous so the cumulative cap is not what is under test here.
+      findSaleItems: vi.fn().mockResolvedValue([
+        { product_id: 1, variant_id: null, quantity: 99, unit_price: 100 },
+        { product_id: 2, variant_id: null, quantity: 99, unit_price: 100 },
+        { product_id: 4, variant_id: null, quantity: 99, unit_price: 100 },
+        { product_id: 5, variant_id: null, quantity: 99, unit_price: 100 },
+        { product_id: 7, variant_id: null, quantity: 99, unit_price: 100 },
+        { product_id: 1, variant_id: 3, quantity: 99, unit_price: 100 },
+        { product_id: 2, variant_id: 4, quantity: 99, unit_price: 100 },
+      ]),
+      findReturnedQuantitiesBySaleId: vi.fn().mockResolvedValue([]),
+      findRefundedQuantitiesBySaleId: vi.fn().mockResolvedValue([]),
       createExchange: vi.fn().mockResolvedValue({ id: 10, exchange_number: 'EXC-1' }),
       createReturnedItem: vi.fn().mockResolvedValue(undefined),
       createNewItem: vi.fn().mockResolvedValue(undefined),

--- a/server/tests/exchanges.test.ts
+++ b/server/tests/exchanges.test.ts
@@ -104,6 +104,7 @@ describe('Exchange stock invariants', () => {
         { product_id: 1, variant_id: 3, quantity: 99, unit_price: 100 },
         { product_id: 2, variant_id: 4, quantity: 99, unit_price: 100 },
       ]),
+      getCatalogPrice: vi.fn().mockResolvedValue(10),
       findReturnedQuantitiesBySaleId: vi.fn().mockResolvedValue([]),
       findRefundedQuantitiesBySaleId: vi.fn().mockResolvedValue([]),
       createExchange: vi.fn().mockResolvedValue({ id: 10, exchange_number: 'EXC-1' }),

--- a/server/tests/exchanges.validation.test.ts
+++ b/server/tests/exchanges.validation.test.ts
@@ -156,6 +156,97 @@ describe('exchange returned-item validation (#122)', () => {
     expect(Number(created.return_total)).toBe(500);
   });
 
+  it('prices the goods going OUT from the catalog, not from the request', async () => {
+    // The returned side was the reported defect, but `new_items` carried the caller's
+    // price too: an exchange could take real stock out at 0.01 a unit and pay the
+    // difference out as store credit.
+    const created = await service.createExchange(
+      exchange([returned(1, 1)], [{ product_id: 2, quantity: 1, price: 0.01 }]),
+      1
+    );
+
+    // Cotton Shirt is 200 in the catalog.
+    expect(Number(created.new_total)).toBe(200);
+    // 200 out, 500 back: the shop owes the customer 300.
+    expect(Number(created.difference)).toBe(-300);
+  });
+
+  it('persists the sold price on the returned line, not the fabricated one', async () => {
+    const created = await service.createExchange(exchange([returned(1, 1, 99999)]), 1);
+
+    // A row storing a price the header does not use would contradict it, and any report
+    // summing these rows would be wrong.
+    const { rows } = await testPool.query<{ price: string }>(
+      'SELECT price FROM exchange_returned_items WHERE exchange_id = $1',
+      [created.id]
+    );
+    expect(Number(rows[0].price)).toBe(500);
+  });
+
+  it('counts a historical refund stored without variant_id against the variant line', async () => {
+    // Refund lines only started carrying variant_id in the refund-integrity work, so a
+    // variant line refunded before that sits under the product-only key. Keyed strictly
+    // per line, that prior reads as zero and the same unit is recoverable twice.
+    await testPool.query(
+      `INSERT INTO product_variants (id, product_id, sku, price, stock, attributes)
+       VALUES (10, 1, 'SKU-001-RED', 500, 4, '{"color":"Red"}')`
+    );
+    const sale = await testPool.query<{ id: number }>(
+      `INSERT INTO sales (subtotal, total, payment_method, cashier_id)
+       VALUES (500, 500, 'Cash', 1) RETURNING id`
+    );
+    const variantSaleId = sale.rows[0].id;
+    await testPool.query(
+      `INSERT INTO sale_items (sale_id, product_id, variant_id, quantity, unit_price)
+       VALUES ($1, 1, 10, 1, 500)`,
+      [variantSaleId]
+    );
+    await testPool.query(
+      `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
+       VALUES ($1, 500, 'Returned', $2, 1, 1)`,
+      // No variant_id, exactly as a pre-#121 refund recorded it.
+      [variantSaleId, JSON.stringify([{ product_id: 1, quantity: 1, unit_price: 500 }])]
+    );
+
+    await expect(
+      service.createExchange(
+        {
+          original_sale_id: variantSaleId,
+          returned_items: [{ ...returned(1, 1), variant_id: 10 }] as never,
+          new_items: [] as never,
+        },
+        1
+      )
+    ).rejects.toThrow(/exceeds what remains of product 1/);
+  });
+
+  it('sums duplicate rows for one line rather than reading only the first', async () => {
+    // Checkout writes one sale_items row per request line without aggregating, so a
+    // sale can list the same product twice. Reading one row would refuse a legitimate
+    // return of the rest.
+    const sale = await testPool.query<{ id: number }>(
+      `INSERT INTO sales (subtotal, total, payment_method, cashier_id)
+       VALUES (1000, 1000, 'Cash', 1) RETURNING id`
+    );
+    const splitSaleId = sale.rows[0].id;
+    await testPool.query(
+      `INSERT INTO sale_items (sale_id, product_id, quantity, unit_price)
+       VALUES ($1, 1, 1, 500), ($1, 1, 1, 500)`,
+      [splitSaleId]
+    );
+
+    // Two units were sold across two rows; both may come back.
+    const created = await service.createExchange(
+      {
+        original_sale_id: splitSaleId,
+        returned_items: [returned(1, 2)] as never,
+        new_items: [] as never,
+      },
+      1
+    );
+    expect(Number(created.return_total)).toBe(1000);
+  });
+
   it('restocks a good return and leaves a damaged one off the shelf', async () => {
     const before = await stockOf(1);
 

--- a/server/tests/exchanges.validation.test.ts
+++ b/server/tests/exchanges.validation.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Exchanges may only take back what the named sale actually sold (#122).
+ *
+ * `writeExchange` credited `price` from the request and never checked that a returned
+ * line was ever on the sale. A cashier could hand back goods the shop had not sold, at a
+ * figure they chose: the exchange paid for them AND restocked them, so both money and
+ * inventory appeared out of nothing. Capping only exchanges would still leave the
+ * double-recovery path the issue notes -- refund a line, then exchange the same line --
+ * so prior refunds count against the same sold quantity.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { ExchangesRepository } from '../src/modules/pos/exchanges/repository';
+import { ExchangesService } from '../src/modules/pos/exchanges/service';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+
+describe('exchange returned-item validation (#122)', () => {
+  let testPool: PgPool;
+  const repo = new ExchangesRepository();
+  const service = new ExchangesService(repo);
+  let saleId: number;
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM exchange_returned_items');
+    await testPool.query('DELETE FROM exchange_new_items');
+    await testPool.query('DELETE FROM exchanges');
+    await testPool.query('DELETE FROM refunds');
+    await testPool.query('DELETE FROM sale_items');
+    await testPool.query('DELETE FROM sales');
+    await testPool.query('DELETE FROM products');
+    await testPool.query('DELETE FROM users');
+
+    await testPool.query(
+      "INSERT INTO users (id, name, email, password_hash, role) VALUES (1, 'Cashier', 'c@moon.com', 'x', 'Cashier')"
+    );
+    await testPool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 10),
+              (2, 'Cotton Shirt', 'SKU-002', 200, 100, 10),
+              (3, 'Never Sold', 'SKU-003', 900, 400, 10)`
+    );
+
+    // A sale of 2 dresses at 500 and 1 shirt at 200.
+    const sale = await testPool.query<{ id: number }>(
+      `INSERT INTO sales (subtotal, total, payment_method, cashier_id)
+       VALUES (1200, 1200, 'Cash', 1) RETURNING id`
+    );
+    saleId = sale.rows[0].id;
+    await testPool.query(
+      `INSERT INTO sale_items (sale_id, product_id, quantity, unit_price)
+       VALUES ($1, 1, 2, 500), ($1, 2, 1, 200)`,
+      [saleId]
+    );
+  });
+
+  const exchange = (returned: unknown[], newItems: unknown[] = []) => ({
+    original_sale_id: saleId,
+    returned_items: returned as never,
+    new_items: newItems as never,
+  });
+
+  const returned = (productId: number, quantity = 1, price = 10) => ({
+    product_id: productId,
+    quantity,
+    price,
+    reason: 'size',
+    condition: 'good' as const,
+  });
+
+  async function stockOf(productId: number): Promise<number> {
+    const { rows } = await testPool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  it('refuses a return of goods that were never on the sale (#122 repro)', async () => {
+    await expect(service.createExchange(exchange([returned(3)]), 1)).rejects.toMatchObject({
+      name: 'PublicError',
+      code: 'VALIDATION_ERROR',
+    });
+
+    // Neither the ledger nor the shelf gained anything from the attempt.
+    expect((await testPool.query('SELECT * FROM exchanges')).rows).toHaveLength(0);
+    expect(await stockOf(3)).toBe(10);
+  });
+
+  it('refuses more units than the sale sold of that line', async () => {
+    await expect(
+      service.createExchange(exchange([returned(1, 3)])) // 2 were sold
+    ).rejects.toThrow(/exceeds what remains of product 1/);
+  });
+
+  it('aggregates duplicate entries for one line before capping', async () => {
+    // Two entries of 2 each pass an individual check against the 2 sold and together
+    // take back twice what was bought.
+    await expect(
+      service.createExchange(exchange([returned(1, 2), returned(1, 2)]), 1)
+    ).rejects.toThrow(/exceeds what remains of product 1/);
+  });
+
+  it('credits the price the line actually sold for, not the one in the request', async () => {
+    const created = await service.createExchange(exchange([returned(1, 1, 99999)]), 1);
+
+    // Sold at 500; the request said 99999.
+    expect(Number(created.return_total)).toBe(500);
+  });
+
+  it('counts an earlier exchange of the same line against what is left', async () => {
+    await service.createExchange(exchange([returned(1, 2)]), 1); // takes both dresses
+
+    await expect(service.createExchange(exchange([returned(1, 1)]), 1)).rejects.toThrow(
+      /exceeds what remains of product 1 \(0 remaining\)/
+    );
+  });
+
+  it('counts an earlier REFUND of the same line against what is left (#122 double recovery)', async () => {
+    // The goods came back through the refund endpoint. Exchanging them again would
+    // recover the same units twice -- once as cash, once as credit plus stock.
+    await testPool.query(
+      `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
+       VALUES ($1, 1000, 'Returned', $2, 1, 1)`,
+      [saleId, JSON.stringify([{ product_id: 1, quantity: 2, unit_price: 500 }])]
+    );
+
+    await expect(service.createExchange(exchange([returned(1, 1)]), 1)).rejects.toThrow(
+      /exceeds what remains of product 1 \(0 remaining\)/
+    );
+  });
+
+  it('allows what genuinely remains after a partial refund', async () => {
+    await testPool.query(
+      `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
+       VALUES ($1, 500, 'Returned', $2, 1, 1)`,
+      [saleId, JSON.stringify([{ product_id: 1, quantity: 1, unit_price: 500 }])]
+    );
+
+    // One dress of the two is still the customer's to bring back.
+    const created = await service.createExchange(exchange([returned(1, 1)]), 1);
+    expect(Number(created.return_total)).toBe(500);
+  });
+
+  it('restocks a good return and leaves a damaged one off the shelf', async () => {
+    const before = await stockOf(1);
+
+    await service.createExchange(exchange([returned(1, 1)]), 1);
+    expect(await stockOf(1)).toBe(before + 1);
+
+    await service.createExchange(
+      exchange([{ ...returned(1, 1), condition: 'damaged' as const }]),
+      1
+    );
+    expect(await stockOf(1)).toBe(before + 1);
+  });
+});

--- a/server/tests/onlineOrders.test.ts
+++ b/server/tests/onlineOrders.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Online orders: a public endpoint that priced itself, and an unguarded stock write
+ * (#125).
+ *
+ * `POST /api/v1/online-orders` takes no token -- a shopper places it -- and it used to
+ * bill `items[].price` straight from the request body, so anyone could order at a price
+ * they chose. The stock write was an unguarded `stock = stock - $1`, so an over-order
+ * either drove stock negative or tripped migration 004's non-negative CHECK and reached
+ * the shopper as a 500. Cancelling a delivered order put its units back on the shelf.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { OnlineOrdersRepository } from '../src/modules/commerce/onlineOrders/repository';
+import { OnlineOrdersService } from '../src/modules/commerce/onlineOrders/service';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+
+const order = (overrides: Record<string, unknown> = {}) => ({
+  customer_name: 'Nadia',
+  customer_phone: '01000000000',
+  shipping_address: '12 Nile St',
+  city: 'Cairo',
+  items: [{ product_id: 1, quantity: 1, price: 500 }],
+  shipping_fee: 0,
+  ...overrides,
+});
+
+describe('online orders (#125)', () => {
+  let testPool: PgPool;
+  const repo = new OnlineOrdersRepository();
+  const service = new OnlineOrdersService(repo);
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM online_order_items');
+    await testPool.query('DELETE FROM online_orders');
+    await testPool.query('DELETE FROM product_variants');
+    await testPool.query('DELETE FROM products');
+    await testPool.query('DELETE FROM customers');
+
+    await testPool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 5)`
+    );
+  });
+
+  async function stockOf(productId: number): Promise<number> {
+    const { rows } = await testPool.query<{ stock: number }>(
+      'SELECT stock FROM products WHERE id = $1',
+      [productId]
+    );
+    return Number(rows[0].stock);
+  }
+
+  it('prices from the catalog, not from the price the shopper sent (#125 repro)', async () => {
+    const created = await service.createOrder(
+      order({ items: [{ product_id: 1, quantity: 1, price: 0.01 }] })
+    );
+
+    expect(Number(created.subtotal)).toBe(500);
+    expect(Number(created.total)).toBe(500);
+
+    const { rows } = await testPool.query<{ price: string }>(
+      'SELECT price FROM online_order_items WHERE order_id = $1',
+      [created.id]
+    );
+    expect(Number(rows[0].price)).toBe(500);
+  });
+
+  it('adds the shipping fee to the catalog-priced subtotal', async () => {
+    const created = await service.createOrder(
+      order({ items: [{ product_id: 1, quantity: 2, price: 1 }], shipping_fee: 50 })
+    );
+
+    expect(Number(created.subtotal)).toBe(1000);
+    expect(Number(created.total)).toBe(1050);
+  });
+
+  it('refuses an over-order with a typed conflict and writes no stock', async () => {
+    await expect(
+      service.createOrder(order({ items: [{ product_id: 1, quantity: 6, price: 500 }] }))
+    ).rejects.toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
+
+    expect(await stockOf(1)).toBe(5);
+    // That the order row is rolled back too is asserted in the real-PostgreSQL suite:
+    // pg-mem accepts ROLLBACK and keeps the rows anyway, so a claim about atomicity
+    // made here would pass without proving anything.
+  });
+
+  it('names how many are left when it refuses', async () => {
+    await expect(
+      service.createOrder(order({ items: [{ product_id: 1, quantity: 6, price: 500 }] }))
+    ).rejects.toThrow(/Only 5 left of Silk Dress/);
+  });
+
+  it('deducts exactly the ordered quantity when it fits', async () => {
+    await service.createOrder(order({ items: [{ product_id: 1, quantity: 2, price: 500 }] }));
+    expect(await stockOf(1)).toBe(3);
+  });
+
+  it('refuses a product that does not exist rather than pricing it at nothing', async () => {
+    await expect(
+      service.createOrder(order({ items: [{ product_id: 999, quantity: 1, price: 500 }] }))
+    ).rejects.toMatchObject({ name: 'PublicError', code: 'VALIDATION_ERROR' });
+  });
+
+  describe('variant lines', () => {
+    beforeEach(async () => {
+      await testPool.query(
+        `INSERT INTO product_variants (id, product_id, sku, price, stock, attributes)
+         VALUES (10, 1, 'SKU-001-RED', 550, 2, '{"color":"Red"}')`
+      );
+    });
+
+    it('prices and deducts from the variant, not its parent product', async () => {
+      const created = await service.createOrder(
+        order({ items: [{ product_id: 1, variant_id: 10, quantity: 1, price: 1 }] })
+      );
+
+      expect(Number(created.subtotal)).toBe(550);
+
+      const { rows } = await testPool.query<{ stock: number }>(
+        'SELECT stock FROM product_variants WHERE id = 10'
+      );
+      expect(Number(rows[0].stock)).toBe(1);
+      expect(await stockOf(1)).toBe(5); // the parent product is untouched
+    });
+
+    it("refuses an over-order of a variant on the variant's own stock", async () => {
+      await expect(
+        service.createOrder(
+          order({ items: [{ product_id: 1, variant_id: 10, quantity: 3, price: 1 }] })
+        )
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+    });
+  });
+
+  describe('cancellation', () => {
+    async function place(): Promise<number> {
+      const created = await service.createOrder(
+        order({ items: [{ product_id: 1, quantity: 2, price: 500 }] })
+      );
+      return created.id;
+    }
+
+    it('restores stock once when a pending order is cancelled', async () => {
+      const id = await place();
+      expect(await stockOf(1)).toBe(3);
+
+      await service.updateStatus(id, 'cancelled');
+      expect(await stockOf(1)).toBe(5);
+    });
+
+    it('does not restore twice when an already-cancelled order is cancelled again', async () => {
+      const id = await place();
+      await service.updateStatus(id, 'cancelled');
+      await service.updateStatus(id, 'cancelled');
+
+      expect(await stockOf(1)).toBe(5);
+    });
+
+    it('refuses to cancel a delivered order, and restores nothing (#125)', async () => {
+      const id = await place();
+      await service.updateStatus(id, 'delivered');
+      expect(await stockOf(1)).toBe(3);
+
+      await expect(service.updateStatus(id, 'cancelled')).rejects.toMatchObject({
+        name: 'PublicError',
+        code: 'CONFLICT',
+      });
+
+      // The goods are with the customer; cancelling must not put them back on the shelf.
+      expect(await stockOf(1)).toBe(3);
+    });
+
+    it('still cancels a shipped order, which can be recovered', async () => {
+      const id = await place();
+      await service.updateStatus(id, 'shipped');
+
+      await service.updateStatus(id, 'cancelled');
+      expect(await stockOf(1)).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Four independent integrity defects, grouped because none of them shares a module with the others (plan: `docs/plans/2026-09-09-001-fix-open-bug-backlog-plan.md`, PR 4). Commits are one per issue.

**#122 — an exchange could take back goods the shop never sold.** `writeExchange` credited `price` straight from the request and never checked that a returned line had been on the named sale. The exchange both paid for the goods and restocked them, so money and inventory appeared out of nothing. Lines now resolve against the sale's own lines on `(product_id, variant_id)` and are valued from `sale_items.unit_price`. The cumulative quantity per line is capped by what was sold, counting **both** earlier exchanges and earlier refunds — capping exchanges alone leaves the double-recovery path the issue notes, where a line is refunded for cash and then exchanged for credit. The sale row is locked `FOR UPDATE`, as the refund path does, so the check cannot race a concurrent refund.

**#125 — a public endpoint priced its own orders.** `POST /api/v1/online-orders` takes no token and billed `items[].price` from the request body. Lines are priced from the catalog inside the transaction; the request's `price` is accepted for compatibility and ignored. The stock write was an unguarded `stock = stock - $1`, so an over-order either drove stock negative or tripped migration 004's non-negative CHECK and reached the shopper as a 500 — it now takes the guarded relative shape, and a refusal is re-read to tell "no such product" from "only N left". Cancelling a **delivered** order used to restore its units to the shelf; only pending/processing/shipped can be cancelled with a restore now. The published contract described stock reservation this endpoint has never implemented, and now describes what the code does.

**#127 — concurrent layaway installments lost one another.** The balance was read outside the transaction, reduced in JavaScript, and written back absolute. Writing the failing real-PostgreSQL test first turned up two more of the same shape the issue did not mention: **five concurrent 200s against a 500 balance took four of them** (800 accepted for 500 owed), and **a payment could be booked against a plan that had just been cancelled**. The balance now moves in one statement carrying both the active check and the sufficiency check; status is derived from what the database returned; `cancelPlan` claims its transition the same way. `createPlan`'s stock deduction is guarded, and `POST /layaway/:id/pay` is wrapped in `withIdempotency` sharing the payment's transaction.

**#128 — a colliding document number surfaced as a 500.** Delivery orders, purchase orders, layaway plans and online orders all mint `PREFIX-YYYYMMDD-NNNN` against a UNIQUE index without checking. All four now allocate through a shared helper: insert, and if *that* index rejects it, re-roll and retry the whole transaction — each attempt its own, since a failed statement aborts the one it is in. Delivery's 3-digit suffix (which collides on the ~30th delivery of a day with probability around a third) widens to 4, but the retry is the fix; a birthday problem has no safe constant.

> **Note on the plan's `GiftCardsService.create` premise.** The plan records that it does *not* re-roll on collision — it runs a check-then-insert loop, which is itself TOCTOU-racy. This PR adopts the stronger catch-and-retry pattern and does not touch gift cards; a follow-up carries that loop.

## Testing

- **766 tests / 65 files pass**, including every real-PostgreSQL suite (local PostgreSQL 18, none skipped).
- **Verified against the old code**, by disabling each guard and confirming a distinct test fails:
  - #122: **7 of 8** new cases fail.
  - #127: the 5-way race and the cancel-vs-payment case fail (the 2-installment repro is timing-dependent and passed by luck, which is why the wider race is the one that pins it).
  - #128: the helper's 7 cases, including the two *negative* ones — a unique violation on a different constraint, and one naming no constraint, are both surfaced rather than retried.
- **New suites**: `exchanges.validation.test.ts` (8), `onlineOrders.test.ts` (12), `documentNumber.test.ts` (7), `concurrency/layaway.concurrency.test.ts` (6), `concurrency/onlineOrders.concurrency.test.ts` (5).
- **Two existing real-PG fixtures were corrected, not weakened**: `exchanges.concurrency.test.ts` and `balances.concurrency.test.ts` created a bare sale with no `sale_items`. Under #122 that is a sale nothing can be returned against — correctly — so they now record the products they exchange as lines of it.
- `tsc --noEmit` clean; `eslint --max-warnings 385` at exactly 385, 0 errors (four `Record<string, any>` returns were given precise types rather than raising the ratchet); `check:api-docs` unchanged at 204 / 201 derived / 3 excused / 0 unclassified.

**No UI in this PR** — all four are server-side, so there is nothing to view in a browser.

## Post-Deploy Monitoring & Validation

- **Log queries:**
  - `POST /api/v1/exchanges` — a rise in 400s carrying `was not sold on sale` or `exceeds what remains` is the fix working; a *flood* would mean the prior-refund aggregation is misreading historical `refunds.items`.
  - `POST /api/v1/online-orders` — 409s naming a remaining quantity replace what used to be 500s.
  - Any remaining unmapped `23505` on `delivery_orders`/`purchase_orders`/`layaway_plans`/`online_orders` number columns should now be zero; a `Could not allocate a unique ... number` CONFLICT means five attempts collided, which would indicate the generator, not the retry.
- **Data checks, first day:** `SELECT id, items FROM refunds ORDER BY id DESC LIMIT 50;` (the exchange cap parses this JSON); `SELECT id, remaining_balance, status FROM layaway_plans WHERE remaining_balance < 0;` should be empty and stay empty.
- **Healthy signals:** an exchange of a genuinely-sold line still completes and credits the sold price; two tills taking layaway installments on one plan both land; an online order deducts exactly what was ordered at catalog prices; a delivery created on a busy day gets a number without error.
- **Failure signals / rollback trigger:** a legitimate exchange refused (a first return of an untouched line), a layaway payment refused against a plan that plainly owes more, or any order priced at something other than the catalog. Rollback is a straight revert — no migration, no schema change.
- **Window/owner:** first 24h plus the first deliberate exchange and layaway installment; whoever deploys owns the initial check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN