### PR TITLE
fix: the PO list total, and a register report any cashier could read (#129, #130)

### DIFF
--- a/client/src/features/purchasing/pages/PurchaseOrders.test.tsx
+++ b/client/src/features/purchasing/pages/PurchaseOrders.test.tsx
@@ -64,6 +64,21 @@ describe('PurchaseOrders', () => {
     );
   });
 
+  /**
+   * #129: the Total column reads `total`, and the server's list projected a column
+   * nothing writes — so the field was simply absent and every row rendered `NaN EG`.
+   * This pins the wire name the column depends on.
+   */
+  it('renders each order’s value, never NaN', async () => {
+    const transport = createMemoryTransport({ 'purchase-orders': [DRAFT_ORDER] });
+
+    render(<PurchaseOrders />, { wrapper: wrapperFor(transport) });
+
+    await screen.findByText('PO-0003');
+    expect(screen.getAllByText(/1,800/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+
   it('marks a draft order sent through the status sub-action', async () => {
     const transport = createMemoryTransport({ 'purchase-orders': [DRAFT_ORDER] });
 

--- a/server/src/modules/fulfillment/purchaseOrders/repository.ts
+++ b/server/src/modules/fulfillment/purchaseOrders/repository.ts
@@ -96,7 +96,11 @@ export class PurchaseOrdersRepository implements IPurchaseOrdersRepository {
     const offsetIdx = paramIdx++;
 
     const orders = await this.q(queryable).query(
-      `SELECT po.id, po.po_number, po.distributor_id, po.total_amount, po.status,
+      // `po.total`, not `po.total_amount`: `create` writes `total`, and the table carries
+      // both columns from migration 009. The projection read the one nothing writes, so
+      // every row came back at its default and the client's `accessorKey: 'total'` found
+      // no field at all -- the Total column rendered `NaN EG` (#129).
+      `SELECT po.id, po.po_number, po.distributor_id, po.total, po.status,
               po.expected_delivery, po.notes, po.created_by, po.created_at, po.updated_at,
               d.name as distributor_name, u.name as created_by_name,
               COUNT(poi.id)::int as item_count
@@ -105,7 +109,7 @@ export class PurchaseOrdersRepository implements IPurchaseOrdersRepository {
        LEFT JOIN users u ON po.created_by = u.id
        LEFT JOIN purchase_order_items poi ON poi.po_id = po.id
        ${whereClause}
-       GROUP BY po.id, po.po_number, po.distributor_id, po.total_amount, po.status,
+       GROUP BY po.id, po.po_number, po.distributor_id, po.total, po.status,
                 po.expected_delivery, po.notes, po.created_by, po.created_at, po.updated_at,
                 d.name, u.name
        ORDER BY po.created_at ${direction}, po.id ${direction}

--- a/server/src/modules/pos/register/controller.ts
+++ b/server/src/modules/pos/register/controller.ts
@@ -99,10 +99,24 @@ export class RegisterController {
 
   async getSessionReport(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const authReq = req as AuthRequest;
       const { id } = contracts.getSessionReport.parseParams<{ id: string }>(req.params);
       const result = await this.service.getSessionReport(id);
       if (result.error) {
         throw new PublicError('NOT_FOUND', result.error);
+      }
+
+      // Every sibling handler in this controller resolves its session from the token;
+      // this one took an id from the URL and answered for it, so any Cashier could read
+      // any other cashier's X/Z report — takings, movements and float — by walking a
+      // sequential id (#130). An Admin still reads any session, which is what the
+      // end-of-day review needs.
+      const user = authReq.user!;
+      const session = result.report!.session;
+      if (user.role !== 'Admin' && Number(session.cashier_id) !== user.id) {
+        // FORBIDDEN rather than NOT_FOUND: the id space is sequential and already
+        // enumerable, so a 404 would conceal nothing and a 403 is the honest answer.
+        throw new PublicError('FORBIDDEN', 'This register session belongs to another cashier');
       }
 
       res.json(success(result.report));

--- a/server/src/modules/pos/register/schemas.ts
+++ b/server/src/modules/pos/register/schemas.ts
@@ -84,6 +84,10 @@ export const registerRequestContracts = {
     path: '/api/v1/register/{id}/report',
     operation: 'getSessionReport',
     params: pathIdParams(),
+    beyondSchema: [
+      'A Cashier may read only their own sessions; another cashier’s is a 403. An Admin ' +
+        'may read any, which is what an end-of-day review needs.',
+    ],
   }),
 
   forceCloseSession: defineRequestContract({

--- a/server/tests/purchaseOrders.list.test.ts
+++ b/server/tests/purchaseOrders.list.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The purchase-orders list projects the column the writer wrote (#129).
+ *
+ * `purchase_orders` carries both `total` and `total_amount` since migration 009. `create`
+ * writes `total`; the list projected `total_amount`, which nothing writes. Every row came
+ * back at that column's default, and the client's `accessorKey: 'total'` found no field
+ * of that name at all -- so the Total column rendered `NaN EG` for every order.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import type { Pool as PgPool } from 'pg';
+import { createPgMemPool } from './support/pgMem';
+import { setPool, closePool } from '../src/database/pool';
+import { runMigrationsUp } from '../src/database/migrate';
+import { PurchaseOrdersRepository } from '../src/modules/fulfillment/purchaseOrders/repository';
+import { PurchaseOrdersService } from '../src/modules/fulfillment/purchaseOrders/service';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/database/migrations');
+
+const listFilters = {
+  page: 1,
+  pageSize: 25,
+  sortBy: 'createdAt' as const,
+  sortOrder: 'desc' as const,
+};
+
+describe('purchase orders list total (#129)', () => {
+  let testPool: PgPool;
+  const repo = new PurchaseOrdersRepository();
+  const service = new PurchaseOrdersService(repo);
+
+  beforeAll(async () => {
+    testPool = createPgMemPool();
+    setPool(testPool);
+    await runMigrationsUp(testPool, MIGRATIONS_DIR);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  beforeEach(async () => {
+    await testPool.query('DELETE FROM purchase_order_items');
+    await testPool.query('DELETE FROM purchase_orders');
+    await testPool.query('DELETE FROM products');
+    await testPool.query('DELETE FROM distributors');
+    await testPool.query('DELETE FROM users');
+
+    await testPool.query(
+      "INSERT INTO users (id, name, email, password_hash, role) VALUES (1, 'Admin', 'a@moon.com', 'x', 'Admin')"
+    );
+    await testPool.query("INSERT INTO distributors (id, name) VALUES (1, 'Acme Textiles')");
+    await testPool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 10),
+              (2, 'Cotton Shirt', 'SKU-002', 200, 100, 10)`
+    );
+  });
+
+  it('returns the value the order was created with (#129 repro)', async () => {
+    // 2 x 200 + 1 x 100 = 500.
+    await service.create(
+      {
+        distributor_id: 1,
+        items: [
+          { product_id: 1, quantity: 2, cost_price: 200 },
+          { product_id: 2, quantity: 1, cost_price: 100 },
+        ],
+      },
+      1
+    );
+
+    const { rows } = await service.list(listFilters);
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].total)).toBe(500);
+
+    // Not the column nothing writes: it is still there, still at its default, and no
+    // longer read by anything.
+    const stored = await testPool.query<{ total: string; total_amount: string }>(
+      'SELECT total, total_amount FROM purchase_orders'
+    );
+    expect(Number(stored.rows[0].total)).toBe(500);
+    expect(Number(stored.rows[0].total_amount)).toBe(0);
+  });
+
+  it('renders a real number for an order with no items rather than nothing at all', async () => {
+    await testPool.query(
+      `INSERT INTO purchase_orders (po_number, distributor_id, total, created_by)
+       VALUES ('PO-EMPTY', 1, 0, 1)`
+    );
+
+    const { rows } = await service.list(listFilters);
+    expect(rows[0].total).toBeDefined();
+    expect(Number(rows[0].total)).toBe(0);
+    expect(Number.isNaN(Number(rows[0].total))).toBe(false);
+  });
+
+  it('agrees with the detail view for the same order', async () => {
+    const created = await service.create(
+      { distributor_id: 1, items: [{ product_id: 1, quantity: 3, cost_price: 150 }] },
+      1
+    );
+
+    const { rows } = await service.list(listFilters);
+    const detail = await service.findById(created.id);
+
+    expect(Number(rows[0].total)).toBe(450);
+    expect(Number(detail?.total)).toBe(450);
+  });
+});

--- a/server/tests/register.test.ts
+++ b/server/tests/register.test.ts
@@ -156,3 +156,80 @@ describe('RegisterService.recordSaleMovement - transaction threading', () => {
     await expect(service.recordSaleMovement(1, 999999, 100, testPool)).rejects.toBeTruthy();
   });
 });
+
+/**
+ * #130: `GET /api/v1/register/:id/report` took an id from the URL and answered for it.
+ * Every sibling handler in the same controller resolves its session from the token, so
+ * this one was the outlier -- and register session ids are sequential, so any Cashier
+ * could read any other cashier's takings, movements and float by walking them.
+ */
+describe('Register session report authorization', () => {
+  const session = (cashierId: number) => ({
+    report: {
+      session: { id: 7, cashier_id: cashierId, opening_float: 500, expected_cash: 800 },
+      movements: [],
+      summary: { total_sales: 0, total_refunds: 0, total_cash_in: 0, total_cash_out: 0 },
+    },
+  });
+
+  function callReport(reportOwnerId: number, caller: { id: number; role: string }) {
+    const service = {
+      getSessionReport: vi.fn().mockResolvedValue(session(reportOwnerId)),
+    } as unknown as IRegisterService;
+    const json = vi.fn();
+    const next = vi.fn();
+
+    return new RegisterController(service)
+      .getSessionReport(
+        { params: { id: '7' }, user: { ...caller, name: 'X', email: 'x@moon.com' } } as never,
+        { json } as unknown as Response,
+        next
+      )
+      .then(() => ({ json, next }));
+  }
+
+  it('lets a cashier read their own session report', async () => {
+    const { json, next } = await callReport(4, { id: 4, role: 'Cashier' });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ movements: [] }) })
+    );
+  });
+
+  it("refuses another cashier's session, and answers with no session data (#130 repro)", async () => {
+    const { json, next } = await callReport(4, { id: 9, role: 'Cashier' });
+
+    expect(json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'PublicError', code: 'FORBIDDEN' })
+    );
+  });
+
+  it('lets an Admin read any cashier’s session report', async () => {
+    const { json, next } = await callReport(4, { id: 1, role: 'Admin' });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalled();
+  });
+
+  it('still answers 404 for a session that does not exist', async () => {
+    const service = {
+      getSessionReport: vi.fn().mockResolvedValue({ error: 'Session not found' }),
+    } as unknown as IRegisterService;
+    const next = vi.fn();
+
+    await new RegisterController(service).getSessionReport(
+      {
+        params: { id: '999' },
+        user: { id: 4, role: 'Cashier', name: 'X', email: 'x@moon.com' },
+      } as never,
+      { json: vi.fn() } as unknown as Response,
+      next
+    );
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'PublicError', code: 'NOT_FOUND' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The last two of the backlog (plan: `docs/plans/2026-09-09-001-fix-open-bug-backlog-plan.md`, PR 5). Both are small; one is a privilege escalation.

**#129 — every purchase order showed `NaN EG`.** `purchase_orders` carries both `total` and `total_amount` since migration 009. `create` writes `total`; the list projected `total_amount`, which nothing writes. So the row came back at that column's default *and* under a name the client does not read — its `accessorKey: 'total'` found no field at all, which is what turns into `NaN` after `formatCurrency`. The projection and its `GROUP BY` now name the column the writer wrote. `total_amount` stays in the table, read by nothing; retiring it is a follow-up migration.

**#130 — any Cashier could read any other cashier's X/Z report.** `GET /api/v1/register/:id/report` took an id from the URL and answered for it. Every sibling handler in the same controller resolves its session from `authReq.user!.id`; this one was the outlier, and register session ids are sequential — so a cashier could walk them and read a colleague's takings, movements and opening float. The handler now compares the report's own session against the caller, with an Admin bypass (the end-of-day review needs it).

`FORBIDDEN` rather than `NOT_FOUND` deliberately: the id space is already enumerable, so a 404 would conceal nothing that isn't already discoverable, and a 403 is the honest answer. The check reads the session off the report the service already returned, so it costs no extra query.

## Testing

- **735 tests / 61 files pass** (server, including every real-PostgreSQL suite; none skipped). Client suite green, lint unchanged at 17 warnings.
- **Verified against the old code:** reverting the projection fails all 3 new `purchaseOrders.list.test.ts` cases; reverting the ownership check fails the #130 repro.
- **New/updated coverage:** the list returns the created value; an order with no items renders a real `0` rather than nothing; the list and the detail dialog agree. For #130: a cashier reads their own report, is refused another's *with no session data in the response*, an Admin reads any, and a missing session is still a 404 for both roles. The client's `PurchaseOrders.test.tsx` now asserts the row renders its value and no `NaN` — pinning the wire name the column depends on.
- `tsc --noEmit` clean both halves; `eslint --max-warnings 385` at exactly 385, 0 errors; `check:api-docs` unchanged at 204 / 201 derived / 3 excused / 0 unclassified.

**Not verified in a browser.** The Purchase Orders list change is one column's value and is covered by a client test, but I have not seen it rendered.

## Post-Deploy Monitoring & Validation

- **#130 is the one to watch.** After deploy, `GET /api/v1/register/:id/report` will start returning 403 where it used to return 200. That is the fix, but it is also the only behaviour change a user can feel: a Cashier who had bookmarked or been linked to a colleague's report now gets refused. Watch for 403s on that path in the first day — a handful is expected; a steady stream would mean a legitimate workflow was relying on cross-cashier reads, which would be worth a conversation rather than a revert.
- **Log query:** `GET /api/v1/register/*/report` grouped by status. Also confirm Admin reads still return 200.
- **#129 healthy signal:** no row in the Purchase Orders list renders `NaN EG`; the list value and the detail dialog agree for the same order.
- **Data check:** `SELECT id, total, total_amount FROM purchase_orders LIMIT 20;` — existing rows will show the real value in `total` and `0` in `total_amount`. Nothing backfills or rewrites the dead column, and nothing reads it.
- **Failure signals / rollback trigger:** an Admin refused a report, or a cashier refused their *own* session (would mean `cashier_id` is not what the token carries). Rollback is a straight revert; no migration, no schema change.
- **Window/owner:** first 24h, plus the first end-of-day close; whoever deploys owns the initial check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN