### PR TITLE
docs: record what the bug backlog taught (#119–#130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,3 +191,22 @@ prune stale ones; anything cross-project belongs in the global instructions inst
 - Playwright's `element is not stable` on the POS grid is `useAutoAnimate` animating cards
   out, not a slow render. It reads identically to a moving element and ends in
   `element was detached from the DOM` (2026-09-07)
+- `refunds.items` is a `TEXT` column holding JSON and is the **only** record of how much
+  of each sale line has been refunded — there is no `refund_items` table. It is parsed in
+  `findRefundsBySaleId`, not by callers; handed on as a string it is still iterable, so a
+  consumer reads it character by character and silently sees no prior refunds (2026-09-09)
+- A refund and an exchange are two routes to the same recovery and draw on one sold
+  quantity, so each caps against the other's history. Capping one alone leaves the
+  opposite direction open, and it is easy to close only the direction the issue named
+  (2026-09-09)
+- Zod strips unknown keys, so a field missing from a request schema never reaches the
+  service however carefully the service handles it. `bundle_id` was absent from
+  `saleItemSchema`, so `resolveBundleGroup` had never executed — while service-level tests
+  that called past the schema passed the whole time. Test the boundary, not just the
+  service (2026-09-09)
+- pg-mem reports `err.code` for a unique violation but **not** `err.constraint`. Logic that
+  narrows by constraint name — the document-number retry — can only be proven on real
+  PostgreSQL; on pg-mem the narrowed branch simply never runs (2026-09-09)
+- The cart line's `data-testid` is built from `lineKey`, and `e2e/support/locators.ts`
+  rebuilds that same string by hand. Adding a segment to the key breaks every cart-line
+  locator with no type error — seven smoke specs — so the two move together (2026-09-09)

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -27,6 +27,19 @@ prove on rollback which row was its own — declares it with the line
 The script refuses to run against a database whose name does not look disposable, and
 works in its own `migration_verify` schema.
 
+**A migration that both moves data and narrows a CHECK must drop the constraint first.**
+`010` remaps `purchase_orders.status` into the vocabulary the application speaks, and the
+old constraint did not admit two of the values it writes — so backfilling before dropping
+made the UPDATE itself a CHECK violation. Drop, backfill, then add the narrowed
+constraint *validated*: the backfill immediately above guarantees every row conforms, so
+the `NOT VALID` that `009` needed does not apply. Its `.down.sql` does the same in
+reverse, for the same reason.
+
+Note that replaying an *older* migration's raw SQL after a newer one has narrowed the
+same object undoes the narrowing — `009` re-adds its own wider list. That is inherent to
+what "replay migration N" means, not a bug in either file, and it is why
+`migration009.test.ts` replays both in order rather than only the one it is named for.
+
 ## Rate-limit bucketing
 
 The global limiter is keyed on the **authenticated user**, not on the IP. Several tills
@@ -65,6 +78,14 @@ byte-identically with `Idempotent-Replay: true`; the same key with a different p
 endpoint, or user returns `409` with the code `IDEMPOTENCY_KEY_REUSED`. Keys live 24h and
 identify a *committed outcome* — a failed mutation releases its key, so a corrected retry
 under the same key runs normally.
+
+**`POST /api/v1/layaway/:id/pay` joined that set with #127.** An installment is money
+taken from a customer, so a retried request must not take it twice. Its claim shares the
+payment's transaction, which is what makes the pair atomic: the alternative — claiming in
+one transaction and paying in another — can leave a key recorded for a payment that
+rolled back, and the customer's retry is then answered with a replay of a payment that
+never happened. The plan id is part of the fingerprinted payload, so one key reused
+against a different plan conflicts rather than replaying this one's response.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

The documentation half of the twelve-issue backlog (plan: `docs/plans/2026-09-09-001-fix-open-bug-backlog-plan.md`, *Documentation / Operational Notes*). No code changes — this is the part that is easy to skip and expensive to have skipped.

**Five `CLAUDE.md` Learnings**, chosen because each cost real time to find and none is derivable from reading the code:

- **`refunds.items` is the only record of per-line refunded quantity** — there is no `refund_items` table — and handing it on unparsed fails *silently*: a JSON string is still iterable, so a consumer walks it character by character and concludes nothing has been refunded.
- **A refund and an exchange are two routes to one recovery** and each must cap against the other's history. It is easy to close only the direction the issue named; that is exactly what happened first time.
- **Zod strips unknown keys**, so a field missing from a request schema never reaches the service however carefully the service handles it. `bundle_id` was absent from `saleItemSchema`, so the bundle allocation had never once executed — while service-level tests that call *past* the schema passed the whole time.
- **pg-mem reports `err.code` for a unique violation but not `err.constraint`**, so constraint-narrowed logic can only be proven on real PostgreSQL; on pg-mem the narrowed branch simply never runs.
- **The cart line's `data-testid` and the E2E locator build the same string in two places**, with no type error between them. Adding a segment to the key broke seven smoke specs.

**Two `server/CLAUDE.md` notes:**

- The layaway pay endpoint's new `Idempotency-Key` support, alongside `POST /sales` — including *why* its claim shares the payment's transaction. Claiming in one transaction and paying in another can leave a key recorded for a payment that rolled back, and the customer's retry is then answered with a replay of a payment that never happened.
- Migration verification gains the ordering rule a CHECK-narrowing migration needs: **drop the constraint before the backfill**, because the old constraint does not admit the values the backfill writes — so backfilling first makes the `UPDATE` itself a violation. Plus the non-obvious corollary that replaying an *older* migration's raw SQL after a newer one narrowed the same object undoes the narrowing, which is inherent to what "replay migration N" means and is why `migration009.test.ts` replays both in order.

## Testing

Documentation only; no code paths change and no tests were added. `prettier --check` reports pre-existing formatting drift in both markdown files on `main` as well, so I have deliberately **not** reformatted them — that would bury five lines of content in a whole-file diff.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR changes only markdown read by people and agents, and ships no runtime code.

## Note on merge order

The purchase-order status-vocabulary Learning is already carried by PR #131, since it belongs with the migration that caused it. These entries append to the same list, so whichever of the two merges second may need a one-line append conflict resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN