### PR TITLE
fix(online-orders): claim the customer row by upsert, not check-then-insert

### DIFF
--- a/server/src/modules/commerce/onlineOrders/repository.ts
+++ b/server/src/modules/commerce/onlineOrders/repository.ts
@@ -65,6 +65,18 @@ export class OnlineOrdersRepository implements IOnlineOrdersRepository {
     return res.rows[0] || null;
   }
 
+  /**
+   * Claims the customer row for a phone number, whoever gets there first.
+   *
+   * `customers.phone` is UNIQUE and the caller reaches this through a
+   * find-then-create pair, so two simultaneous first orders from one phone both
+   * saw no customer and both inserted -- the loser's 23505 escaped the
+   * document-number retry (which narrows on the order-number constraint) and
+   * reached the shopper as a 500. The upsert makes the insert the only authority:
+   * a concurrent winner's row is returned instead of colliding with it. The
+   * conflicting update deliberately touches nothing but `updated_at`, because an
+   * existing customer's name and address are theirs, not the new order's.
+   */
   async createCustomer(
     name: string,
     phone: string,
@@ -72,7 +84,9 @@ export class OnlineOrdersRepository implements IOnlineOrdersRepository {
     queryable?: Queryable
   ): Promise<Record<string, any>> {
     const res = await this.q(queryable).query<Record<string, any>>(
-      'INSERT INTO customers (name, phone, address) VALUES ($1, $2, $3) RETURNING *',
+      `INSERT INTO customers (name, phone, address) VALUES ($1, $2, $3)
+       ON CONFLICT (phone) DO UPDATE SET updated_at = CURRENT_TIMESTAMP
+       RETURNING *`,
       [name, phone, address]
     );
     return res.rows[0];

--- a/server/tests/concurrency/onlineOrders.concurrency.test.ts
+++ b/server/tests/concurrency/onlineOrders.concurrency.test.ts
@@ -89,6 +89,35 @@ describeWithPostgres('online orders under concurrency (#125, #128)', () => {
     expect(await countRows('online_orders')).toBe(1);
   });
 
+  it('lets two concurrent first orders from one phone share a customer', async () => {
+    // `customers.phone` is UNIQUE and the order path finds-then-creates, so both of
+    // these saw no customer and both inserted. The loser's 23505 is on
+    // `customers_phone_key`, which the document-number retry correctly declines to
+    // re-roll -- so before the upsert it escaped raw and the shopper got a 500.
+    await harness.pool.query('UPDATE products SET stock = 2 WHERE id = 1');
+
+    const outcomes = await Promise.allSettled([
+      service.createOrder(order({ customer_phone: '01555000111' })),
+      service.createOrder(order({ customer_phone: '01555000111' })),
+    ]);
+
+    for (const outcome of outcomes) {
+      expect(outcome.status).toBe('fulfilled');
+    }
+
+    // One phone is one customer, and both orders point at it.
+    const { rows } = await harness.pool.query<{ customer_id: number }>(
+      `SELECT o.customer_id FROM online_orders o
+       JOIN customers c ON c.id = o.customer_id
+       WHERE c.phone = $1`,
+      ['01555000111']
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.customer_id)).size).toBe(1);
+    expect(await countRows('online_orders')).toBe(2);
+    expect(await stockOf(1)).toBe(0);
+  });
+
   it('rolls the order and its items back when a later line is out of stock', async () => {
     await harness.pool.query(
       `INSERT INTO products (id, name, sku, price, cost_price, stock)


### PR DESCRIPTION
## Summary

A latent race on `main`, found by an intermittent failure of the `#125/#128` concurrency suite rather than by the diff that introduced it.

`OnlineOrdersService.createOrder` resolves the shopper with a find-then-create pair:

```ts
const custRes = await this.repo.findCustomerByPhone(data.customer_phone, client);
if (custRes) { customerId = custRes.id; } else { /* INSERT */ }
```

`customers.phone` is `UNIQUE` (`001_initial_schema.sql:100`). Two simultaneous first orders from one phone both see no customer and both insert; the loser gets `23505` on `customers_phone_key`. The document-number retry narrows on `online_orders_order_number_key` — correctly, and there is already a test asserting it must not re-roll on a *different* index — so this violation is rethrown raw and reaches the shopper as the `INTERNAL_ERROR` that #128 set out to remove.

It surfaced in `lets exactly one of three concurrent orders take the last unit`, where all three orders share a phone: one loser was rejected for out-of-stock (`CONFLICT`, as asserted) and the other with a raw `DatabaseError { code: '23505' }`.

## Change

`ON CONFLICT (phone) DO UPDATE SET updated_at = CURRENT_TIMESTAMP RETURNING *` — the insert becomes the only authority, and a concurrent winner's row is returned instead of collided with. The conflicting update deliberately touches nothing else: an existing customer's name and address are theirs, not the incoming order's.

Scope is one call site. `delivery/repository.ts` has a similarly-shaped `createCustomer`, but its caller resolves by id rather than find-or-create by phone, so it is not reachable the same way and is left alone.

## Testing

- New: `lets two concurrent first orders from one phone share a customer` — two concurrent orders, same phone, both fulfil, both point at one customer row. Fails on `main` with the raw `23505`.
- `npm test -- onlineOrders` green; `tsc --noEmit` clean; ESLint clean of errors (only pre-existing `any` warnings, ratchet unmoved).
- The real proof is CI: this invariant cannot be shown on pg-mem, which does not populate `err.constraint`.

## Post-Deploy Monitoring & Validation

- **Log query:** `code=23505 AND constraint=customers_phone_key` — should go to zero for the online-order path.
- **Also watch:** 5xx rate on `POST /api/v1/online-orders`, and `INTERNAL_ERROR` responses carrying an online-order route.
- **Healthy signal:** repeat orders from a known phone still resolve to the existing customer (no duplicate customer rows); `SELECT phone, COUNT(*) FROM customers GROUP BY phone HAVING COUNT(*) > 1` stays empty, as the UNIQUE index guarantees.
- **Failure signal / rollback trigger:** any rise in 4xx/5xx on order creation, or customer rows whose `name`/`address` change unexpectedly after an order (would mean the conflicting update is writing more than `updated_at`). Revert this commit — it is self-contained, with no migration.
- **Window/owner:** first 24h of traffic after deploy, author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN