### PR TITLE
docs(plan): point the follow-ups at the issues that already existed

### DIFF
--- a/docs/plans/2026-09-09-001-fix-open-bug-backlog-plan.md
+++ b/docs/plans/2026-09-09-001-fix-open-bug-backlog-plan.md
@@ -990,17 +990,17 @@ a 500 waiting to happen unless something else handles it.
 
 All filed.
 
-1. #144 — stock reservations for the public online-order endpoint, per the original
+1. #137 — stock reservations for the public online-order endpoint, per the original
    published contract (#125 remainder).
-2. #145 — store credit; `payment_method: 'store_credit'` is documented in the exchanges
+2. #138 — store credit; `payment_method: 'store_credit'` is documented in the exchanges
    schema but no code writes any balance (#122 note).
-3. #146 — retire the duplicated dead columns `purchase_orders.total_amount` and
+3. #139 — retire the duplicated dead columns `purchase_orders.total_amount` and
    `product_bundles.price` in one migration.
-4. #147 — normalize `refunds.items` into a `refund_items` table so cumulative quantities are
+4. #140 — normalize `refunds.items` into a `refund_items` table so cumulative quantities are
    a query rather than a JSON parse.
-5. #148 — `GiftCardsService.create`'s check-then-insert loop is TOCTOU-racy; move it to the
+5. #141 — `GiftCardsService.create`'s check-then-insert loop is TOCTOU-racy; move it to the
    catch-and-retry helper from Unit 11.
-6. #149 — a purchase-order status state machine (reject `Received → Draft` and friends).
+6. #142 — a purchase-order status state machine (reject `Received → Draft` and friends).
 7. #150 — `DeliveryService.resolveCustomer` inserts a customer with no lookup at all, so a
    delivery for an already-known phone collides deterministically. Found while fixing #143;
    not part of the original twelve.


### PR DESCRIPTION
## Summary

Corrects wrong issue references I introduced in #151.

#151 recorded the plan's follow-ups as #144–#149. Those were issues I had filed moments earlier — without first listing the repository's open issues, so I did not see that the same six follow-ups had **already** been filed as #137–#142.

The originals are better: they were written with the implementation in hand and are more specific for it (#140 names `findRefundedQuantitiesBySaleId` and the per-product belt; #142 explains why a hand-set status can contradict what `receiveItems` actually took in). They only lacked labels, which I have since added.

So #137–#142 are canonical, my #144–#149 are closed as duplicates pointing at them, and this corrects the plan to name the right numbers.

**#150 stands** — the delivery-path customer collision had no prior issue and is a real defect, deterministic rather than a race.

## Changes

Six reference swaps in the `Follow-Up Issues` list. No other content.

## Testing

None applicable — a Markdown file under `docs/plans/`, referenced by no code and no test.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — documentation-only change with no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN