### PR TITLE
fix(delivery): claim the customer row by upsert, not a blind insert

### DIFF
--- a/server/src/modules/fulfillment/delivery/repository.ts
+++ b/server/src/modules/fulfillment/delivery/repository.ts
@@ -228,6 +228,18 @@ export class DeliveryRepository implements IDeliveryRepository {
     return res.rows[0] || null;
   }
 
+  /**
+   * Claims the customer row for a phone number, whoever gets there first.
+   *
+   * `customers.phone` is UNIQUE and the caller reaches this with no lookup at
+   * all, so a delivery for a phone already in `customers` -- a returning
+   * customer, which is the normal case -- raised 23505 and reached the operator
+   * as a 500. Unlike the online-order path this was not a race but a certainty
+   * (#150; #143 is the same defect one table over).
+   *
+   * The conflicting update deliberately touches nothing but `updated_at`: an
+   * existing customer's name and address are theirs, not the new delivery's.
+   */
   async createCustomer(
     name: string,
     phone: string,
@@ -235,7 +247,9 @@ export class DeliveryRepository implements IDeliveryRepository {
     queryable?: Queryable
   ): Promise<{ id: number }> {
     const res = await this.q(queryable).query<{ id: number }>(
-      'INSERT INTO customers (name, phone, address) VALUES ($1, $2, $3) RETURNING id',
+      `INSERT INTO customers (name, phone, address) VALUES ($1, $2, $3)
+       ON CONFLICT (phone) DO UPDATE SET updated_at = CURRENT_TIMESTAMP
+       RETURNING id`,
       [name, phone, address || null]
     );
     return res.rows[0];

--- a/server/tests/delivery.test.ts
+++ b/server/tests/delivery.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Delivery orders against real PostgreSQL: resolving the customer a delivery is for (#150).
+ *
+ * Real PostgreSQL rather than pg-mem because the defect is entirely a matter of what the
+ * UNIQUE index on `customers.phone` does to an insert that did not look first, and of
+ * what `ON CONFLICT` does about it.
+ */
+import { afterAll, beforeAll, beforeEach, expect, it } from 'vitest';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from './support/realPostgres';
+import { DeliveryRepository } from '../src/modules/fulfillment/delivery/repository';
+import { DeliveryService } from '../src/modules/fulfillment/delivery/service';
+
+const delivery = (overrides: Record<string, unknown> = {}) => ({
+  customer_name: 'Nadia Hassan',
+  phone: '01000000000',
+  address: '12 Nile St, Cairo',
+  items: [{ product_id: 1, quantity: 1, price: 500 }],
+  ...overrides,
+});
+
+describeWithPostgres('delivery orders — resolving the customer (#150)', () => {
+  let harness: RealPostgresHarness;
+  const repo = new DeliveryRepository();
+  const service = new DeliveryService(repo);
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('delivery-customer', { maxConnections: 4 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    await harness.pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 10)`
+    );
+  });
+
+  async function customerRows(phone: string) {
+    const { rows } = await harness.pool.query<{ id: number; name: string; address: string }>(
+      'SELECT id, name, address FROM customers WHERE phone = $1',
+      [phone]
+    );
+    return rows;
+  }
+
+  it('reuses the existing customer when the phone is already known', async () => {
+    // The repro. Before the upsert this raised 23505 on `customers_phone_key`, which
+    // nothing in the module mapped, so the operator got a 500 for a returning customer.
+    const { rows } = await harness.pool.query<{ id: number }>(
+      `INSERT INTO customers (name, phone, address)
+       VALUES ('Nadia H.', '01000000000', '3 Old Address') RETURNING id`
+    );
+    const existingId = rows[0].id;
+
+    const order = await service.createDeliveryOrder(delivery());
+
+    expect(order.customer_id).toBe(existingId);
+    expect(await customerRows('01000000000')).toHaveLength(1);
+  });
+
+  it('leaves the existing customer name and address alone', async () => {
+    // The delivery form's fields describe where this parcel goes, not who the customer
+    // is. Overwriting the customer record from an order would let a typo on one delivery
+    // rewrite the address of every future one.
+    await harness.pool.query(
+      `INSERT INTO customers (name, phone, address)
+       VALUES ('Nadia H.', '01000000000', '3 Old Address')`
+    );
+
+    await service.createDeliveryOrder(
+      delivery({ customer_name: 'N. Hassan', address: '12 Nile St, Cairo' })
+    );
+
+    const [customer] = await customerRows('01000000000');
+    expect(customer.name).toBe('Nadia H.');
+    expect(customer.address).toBe('3 Old Address');
+  });
+
+  it('creates a customer when the phone is new', async () => {
+    const order = await service.createDeliveryOrder(delivery({ phone: '01555000222' }));
+
+    const rows = await customerRows('01555000222');
+    expect(rows).toHaveLength(1);
+    expect(order.customer_id).toBe(rows[0].id);
+    expect(rows[0].name).toBe('Nadia Hassan');
+  });
+
+  it('still validates an explicitly supplied customer_id', async () => {
+    await expect(
+      service.createDeliveryOrder(delivery({ customer_id: 9999 }))
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('reuses the existing customer on update too', async () => {
+    // `updateDeliveryOrder` resolves the customer through the same helper, so it carried
+    // the same defect.
+    const created = await service.createDeliveryOrder(delivery({ phone: '01555000333' }));
+    await harness.pool.query(
+      `INSERT INTO customers (name, phone, address) VALUES ('Someone Else', '01555000444', 'x')`
+    );
+
+    const updated = await service.updateDeliveryOrder(
+      created.id,
+      delivery({ phone: '01555000444', customer_name: 'Someone Else' })
+    );
+
+    const [customer] = await customerRows('01555000444');
+    expect(updated.customer_id).toBe(customer.id);
+    expect(await customerRows('01555000444')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #150.

## The defect

`DeliveryService.resolveCustomer` takes an optional `customer_id`. When one is supplied it is validated; when one is **not**, it goes straight to an insert:

```ts
const newCustomer = await this.repo.createCustomer(customer_name, phone, address || null, queryable);
```

`DeliveryRepository.createCustomer` was a bare `INSERT INTO customers ... RETURNING id`, and `customers.phone` is `UNIQUE` (`001_initial_schema.sql:100`). There was no lookup at all — not even the check-then-insert pair the online-order path had.

So a delivery for a phone already on file raised `23505` on `customers_phone_key`. Nothing in `modules/fulfillment/delivery/` catches a unique violation, so it fell through to `INTERNAL_ERROR` and the operator got a 500 — for a returning customer, which is the normal case for a delivery.

#143 was the same defect one table over, where a find-then-create pair made it a race between two simultaneous first orders. Here it was a certainty.

## The fix

```sql
INSERT INTO customers (name, phone, address) VALUES ($1, $2, $3)
ON CONFLICT (phone) DO UPDATE SET updated_at = CURRENT_TIMESTAMP
RETURNING id
```

The conflicting update deliberately touches nothing else. The delivery form's `customer_name` and `address` describe **where this parcel goes**, not who the customer is — letting an order rewrite the customer record would let one typo on one delivery change the address of every future one. So the existing row is returned unchanged and the delivery links to it, which is what an operator expects when they type a phone number they know.

`updateDeliveryOrder` resolves through the same helper and carried the same defect; it is covered by the same change.

## Testing

New `server/tests/delivery.test.ts`, real PostgreSQL (`describeWithPostgres`) because the defect is entirely about what the UNIQUE index does to an insert that did not look first:

- **the repro** — a delivery for an existing phone reuses that customer, one row, no 500
- the existing customer's name and address are left alone
- a genuinely new phone still creates a customer
- an explicit `customer_id` is still validated (unchanged behaviour)
- the same holds through `updateDeliveryOrder`

`tsc --noEmit` clean. The suite skips locally without `TEST_DATABASE_URL` and runs in CI, which is the real proof.

## Post-Deploy Monitoring & Validation

- **Log query:** `code=23505 AND constraint=customers_phone_key` — should reach zero across delivery *and* online orders now that both paths upsert.
- **Also watch:** 5xx rate on `POST /api/v1/delivery` and `PUT /api/v1/delivery/:id`.
- **Healthy signal:** deliveries for returning customers succeed and link to the existing customer id; `SELECT phone, COUNT(*) FROM customers GROUP BY phone HAVING COUNT(*) > 1` stays empty.
- **Failure signal / rollback trigger:** any customer whose `name` or `address` changes after a delivery is created — that would mean the conflicting update is writing more than `updated_at`. Revert this commit; it is self-contained with no migration.
- **Window/owner:** first 24h of delivery traffic, author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN