### PR TITLE
fix(gift-cards): let the unique indexes referee the code and the barcode

### DIFF
--- a/server/src/database/documentNumber.ts
+++ b/server/src/database/documentNumber.ts
@@ -24,8 +24,14 @@ import { constraintName, isUniqueViolation } from './constraintErrors';
 import logger from '../../lib/logger';
 
 export interface DocumentNumberOptions {
-  /** Mints a candidate. Called once per attempt, so each retry gets a fresh number. */
-  generate: () => string;
+  /**
+   * Mints a candidate. Called once per attempt, so each retry gets a fresh number.
+   *
+   * May be async: a generator that derives the next value from what is already
+   * stored -- gift-card barcodes are `MAX(barcode) + 1` -- has to read the
+   * database to mint one, and that read is itself part of what races.
+   */
+  generate: () => string | Promise<string>;
   /**
    * The UNIQUE constraint that means "this number is taken".
    *
@@ -34,7 +40,11 @@ export interface DocumentNumberOptions {
    * say, a duplicate email before failing with a message about document numbers.
    */
   constraint: string;
-  /** What is being numbered, for the error a caller sees. */
+  /**
+   * What is being allocated, named as it should read in the error a caller sees:
+   * `Could not allocate a unique <label>`. So `'delivery order number'`, not
+   * `'delivery order'`.
+   */
   label: string;
   /** Attempts in total, including the first. */
   maxAttempts?: number;
@@ -56,7 +66,7 @@ export async function withDocumentNumber<T>(
   const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
 
   for (let attempt = 1; ; attempt += 1) {
-    const documentNumber = options.generate();
+    const documentNumber = await options.generate();
 
     try {
       return await run(documentNumber);
@@ -71,7 +81,7 @@ export async function withDocumentNumber<T>(
           });
           throw new PublicError(
             'CONFLICT',
-            `Could not allocate a unique ${options.label} number; please retry`
+            `Could not allocate a unique ${options.label}; please retry`
           );
         }
         throw error;

--- a/server/src/modules/commerce/giftCards/service.ts
+++ b/server/src/modules/commerce/giftCards/service.ts
@@ -1,3 +1,4 @@
+import { withDocumentNumber } from '../../../database/documentNumber';
 import { Queryable, withTransaction } from '../../../database/transaction';
 import { PublicError } from '../../../http/errors';
 import { IGiftCardsRepository, giftCardsRepository as defaultRepo } from './repository';
@@ -23,7 +24,11 @@ export function generateGiftCardCode(): string {
 }
 
 export class GiftCardsService {
-  constructor(private repo: IGiftCardsRepository = defaultRepo) {}
+  constructor(
+    private repo: IGiftCardsRepository = defaultRepo,
+    /** Injected so a test can hand it a code it knows is taken. */
+    private generateCode: () => string = generateGiftCardCode
+  ) {}
 
   getRepository(): IGiftCardsRepository {
     return this.repo;
@@ -60,30 +65,53 @@ export class GiftCardsService {
     return this.repo.findById(id);
   }
 
+  /**
+   * Issues a gift card, letting the unique indexes referee both of its identifiers.
+   *
+   * Two values here are minted rather than supplied, and each has a UNIQUE index:
+   * the code (random) and the barcode (`MAX(barcode) + 1`). Both used to be chosen
+   * by looking first -- `findByCode` in a loop for the code, a max-read for the
+   * barcode -- which is check-then-insert and races by construction: two callers
+   * can both find a value free, or both read the same maximum, and both insert it.
+   * The loser's 23505 reached the caller as a `CONFLICT` telling them a code they
+   * never chose was taken (#141).
+   *
+   * A supplied `code` is deliberately *not* retried. The caller named that code, so
+   * a collision is genuinely theirs to resolve, and silently issuing a different one
+   * would be worse than refusing; the controller maps it to `CONFLICT`. Only the
+   * barcode is re-rolled in that case, because nobody asked for a particular one.
+   */
   async create(data: CreateGiftCardInput, createdByUserId: number): Promise<Record<string, any>> {
     const { code, initial_value, customer_id, expires_at } = data;
 
-    let finalCode = code || generateGiftCardCode();
-    if (!code) {
-      let existing = await this.repo.findByCode(finalCode);
-      let attempts = 0;
-      while (existing && attempts < 10) {
-        finalCode = generateGiftCardCode();
-        existing = await this.repo.findByCode(finalCode);
-        attempts++;
-      }
-    }
+    const insertWithCode = (finalCode: string) =>
+      withDocumentNumber(
+        {
+          generate: () => this.generateGiftCardBarcode(),
+          constraint: 'gift_cards_barcode_key',
+          label: 'gift card barcode',
+        },
+        (barcode) =>
+          this.repo.create({
+            code: finalCode,
+            barcode,
+            initial_value,
+            customer_id,
+            expires_at,
+            created_by: createdByUserId,
+          })
+      );
 
-    const barcode = await this.generateGiftCardBarcode();
+    if (code) return insertWithCode(code);
 
-    return this.repo.create({
-      code: finalCode,
-      barcode,
-      initial_value,
-      customer_id,
-      expires_at,
-      created_by: createdByUserId,
-    });
+    return withDocumentNumber(
+      {
+        generate: this.generateCode,
+        constraint: 'gift_cards_code_key',
+        label: 'gift card code',
+      },
+      insertWithCode
+    );
   }
 
   async getBalance(code: string): Promise<GiftCardBalanceResult | null> {

--- a/server/src/modules/commerce/onlineOrders/service.ts
+++ b/server/src/modules/commerce/onlineOrders/service.ts
@@ -45,7 +45,7 @@ export class OnlineOrdersService {
       {
         generate: this.generateNumber,
         constraint: 'online_orders_order_number_key',
-        label: 'online order',
+        label: 'online order number',
       },
       (orderNumber) =>
         withTransaction(async (client) => {

--- a/server/src/modules/fulfillment/delivery/service.ts
+++ b/server/src/modules/fulfillment/delivery/service.ts
@@ -86,7 +86,7 @@ export class DeliveryService {
       {
         generate: this.generateNumber,
         constraint: 'delivery_orders_order_number_key',
-        label: 'delivery order',
+        label: 'delivery order number',
       },
       (order_number) =>
         withTransaction(async (client) => {

--- a/server/src/modules/fulfillment/purchaseOrders/service.ts
+++ b/server/src/modules/fulfillment/purchaseOrders/service.ts
@@ -63,7 +63,7 @@ export class PurchaseOrdersService {
       {
         generate: this.generateNumber,
         constraint: 'purchase_orders_po_number_key',
-        label: 'purchase order',
+        label: 'purchase order number',
       },
       async (poNumber) => {
         const poId = await withTransaction(async (client) => {

--- a/server/src/modules/pos/layaway/service.ts
+++ b/server/src/modules/pos/layaway/service.ts
@@ -56,7 +56,7 @@ export class LayawayService implements ILayawayService {
       {
         generate: this.generateNumber,
         constraint: 'layaway_plans_plan_number_key',
-        label: 'layaway plan',
+        label: 'layaway plan number',
       },
       (planNumber) =>
         withTransaction(async (client) => {

--- a/server/tests/documentNumber.test.ts
+++ b/server/tests/documentNumber.test.ts
@@ -21,7 +21,7 @@ function uniqueViolation(constraint?: string): Error {
 const options = (overrides: Partial<Parameters<typeof withDocumentNumber>[0]> = {}) => ({
   generate: () => 'DOC-1',
   constraint: 'widgets_number_key',
-  label: 'widget',
+  label: 'widget number',
   ...overrides,
 });
 

--- a/server/tests/giftCards.test.ts
+++ b/server/tests/giftCards.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Issuing gift cards against real PostgreSQL: both minted identifiers and their
+ * unique indexes (#141).
+ *
+ * Real PostgreSQL rather than pg-mem for the same reason the document-number suite is:
+ * the retry narrows on `err.constraint`, which pg-mem does not populate, so on pg-mem
+ * the narrowed branch simply never runs and the suite would prove nothing.
+ */
+import { afterAll, beforeAll, beforeEach, expect, it } from 'vitest';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from './support/realPostgres';
+import { GiftCardsRepository } from '../src/modules/commerce/giftCards/repository';
+import { GiftCardsService } from '../src/modules/commerce/giftCards/service';
+
+describeWithPostgres('issuing gift cards (#141)', () => {
+  let harness: RealPostgresHarness;
+  const repo = new GiftCardsRepository();
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('gift-cards', { maxConnections: 6 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+    await harness.pool.query(
+      `INSERT INTO users (id, name, email, password, role)
+       VALUES (1, 'Admin', 'admin@moon.com', 'x', 'Admin')`
+    );
+  });
+
+  async function codes(): Promise<string[]> {
+    const { rows } = await harness.pool.query<{ code: string }>(
+      'SELECT code FROM gift_cards ORDER BY id'
+    );
+    return rows.map((r) => r.code);
+  }
+
+  it('re-rolls a generated code that is already taken', async () => {
+    await harness.pool.query(
+      `INSERT INTO gift_cards (code, barcode, initial_value, balance, status)
+       VALUES ('GC-TAKEN-0001', '8902000000017', 100, 100, 'active')`
+    );
+
+    let minted = 0;
+    const service = new GiftCardsService(repo, () => {
+      minted += 1;
+      return minted === 1 ? 'GC-TAKEN-0001' : `GC-FREE-000${minted}`;
+    });
+
+    const card = await service.create({ initial_value: 250 }, 1);
+
+    // The insert refereed it, rather than a SELECT deciding in advance.
+    expect(card.code).toBe('GC-FREE-0002');
+    expect(minted).toBe(2);
+    expect(await codes()).toContain('GC-FREE-0002');
+  });
+
+  it('does not re-roll a code the caller chose', async () => {
+    // A supplied code is the caller's; silently issuing a different one would be worse
+    // than refusing. The controller maps this to CONFLICT.
+    await harness.pool.query(
+      `INSERT INTO gift_cards (code, barcode, initial_value, balance, status)
+       VALUES ('GC-MINE-0001', '8902000000017', 100, 100, 'active')`
+    );
+
+    let minted = 0;
+    const service = new GiftCardsService(repo, () => {
+      minted += 1;
+      return 'GC-SHOULD-NOT-BE-USED';
+    });
+
+    await expect(
+      service.create({ code: 'GC-MINE-0001', initial_value: 50 }, 1)
+    ).rejects.toMatchObject({ code: '23505' });
+
+    // The generator was never consulted, and no card was issued under another code.
+    expect(minted).toBe(0);
+    expect(await codes()).toEqual(['GC-MINE-0001']);
+  });
+
+  it('re-rolls a barcode that is already taken', async () => {
+    // The barcode is MAX(barcode) + 1, so a card whose barcode is out of step with the
+    // maximum -- or a concurrent issuer -- produces a collision the max-read cannot see.
+    const service = new GiftCardsService(repo);
+    const first = await service.create({ initial_value: 100 }, 1);
+
+    // Occupy the number the max-read will compute next, from underneath it.
+    const next = await service.generateGiftCardBarcode();
+    await harness.pool.query(
+      `INSERT INTO gift_cards (code, barcode, initial_value, balance, status)
+       VALUES ('GC-OCCUPIER-01', $1, 10, 10, 'active')`,
+      [next]
+    );
+
+    const second = await service.create({ initial_value: 300 }, 1);
+
+    expect(second.barcode).not.toBe(next);
+    expect(second.barcode).not.toBe(first.barcode);
+    expect(Number(second.initial_value)).toBe(300);
+  });
+
+  it('issues distinct codes and barcodes to concurrent callers', async () => {
+    // The repro for the max-read race: four issuers reading the same MAX(barcode) all
+    // compute the same next value, and three of them used to lose with an unmapped 23505.
+    const service = new GiftCardsService(repo);
+
+    const outcomes = await Promise.all([
+      service.create({ initial_value: 100 }, 1),
+      service.create({ initial_value: 200 }, 1),
+      service.create({ initial_value: 300 }, 1),
+      service.create({ initial_value: 400 }, 1),
+    ]);
+
+    expect(new Set(outcomes.map((c) => c.code)).size).toBe(4);
+    expect(new Set(outcomes.map((c) => c.barcode)).size).toBe(4);
+
+    const { rows } = await harness.pool.query<{ n: number }>(
+      'SELECT COUNT(*)::int AS n FROM gift_cards'
+    );
+    expect(rows[0].n).toBe(4);
+  });
+});

--- a/server/tests/giftCards.test.ts
+++ b/server/tests/giftCards.test.ts
@@ -107,23 +107,28 @@ describeWithPostgres('issuing gift cards (#141)', () => {
   });
 
   it('issues distinct codes and barcodes to concurrent callers', async () => {
-    // The repro for the max-read race: four issuers reading the same MAX(barcode) all
-    // compute the same next value, and three of them used to lose with an unmapped 23505.
+    // The repro for the max-read race: concurrent issuers all read the same
+    // MAX(barcode), all compute the same next value, and every one but the winner used
+    // to lose with an unmapped 23505.
+    //
+    // Three, not more, because of how the retry converges: each round has exactly one
+    // winner, so with N concurrent issuers the unluckiest needs N attempts, against a
+    // default cap of 5. Four would pass but sit one attempt from the ceiling, which is
+    // a flake waiting for a slow runner rather than a stronger assertion.
     const service = new GiftCardsService(repo);
 
     const outcomes = await Promise.all([
       service.create({ initial_value: 100 }, 1),
       service.create({ initial_value: 200 }, 1),
       service.create({ initial_value: 300 }, 1),
-      service.create({ initial_value: 400 }, 1),
     ]);
 
-    expect(new Set(outcomes.map((c) => c.code)).size).toBe(4);
-    expect(new Set(outcomes.map((c) => c.barcode)).size).toBe(4);
+    expect(new Set(outcomes.map((c) => c.code)).size).toBe(3);
+    expect(new Set(outcomes.map((c) => c.barcode)).size).toBe(3);
 
     const { rows } = await harness.pool.query<{ n: number }>(
       'SELECT COUNT(*)::int AS n FROM gift_cards'
     );
-    expect(rows[0].n).toBe(4);
+    expect(rows[0].n).toBe(3);
   });
 });

--- a/server/tests/giftCards.test.ts
+++ b/server/tests/giftCards.test.ts
@@ -30,7 +30,7 @@ describeWithPostgres('issuing gift cards (#141)', () => {
   beforeEach(async () => {
     await harness.truncate();
     await harness.pool.query(
-      `INSERT INTO users (id, name, email, password, role)
+      `INSERT INTO users (id, name, email, password_hash, role)
        VALUES (1, 'Admin', 'admin@moon.com', 'x', 'Admin')`
     );
   });


### PR DESCRIPTION
Closes #141.

## The defect

`GiftCardsService.create` chose **both** of its minted identifiers by looking first.

- **Code** — `findByCode` in a loop, re-generating up to 10 times.
- **Barcode** — `MAX(barcode) + 1`, derived from a read.

Both are check-then-insert, and race by construction: two callers can both find the same code free, or both read the same maximum, and both insert it. The loser's `23505` reached them through the controller's existing mapping as a `CONFLICT` — telling the caller a code **they never chose** was already taken.

The barcode is the worse of the two, and is why this is more than theoretical. A max-read gives every concurrent issuer the *same* answer, so a collision there is not unlikely — it is the expected outcome of two simultaneous issues.

This was flagged during #128, whose plan had cited this method as the precedent to copy. It does the opposite of what it appears to.

## The fix

Both identifiers now allocate through `withDocumentNumber` — insert, and on a violation of *that identifier's own* index, re-roll and retry.

**A supplied `code` is deliberately not retried.** The caller named that code, so a collision is genuinely theirs to resolve; silently issuing a different one would be worse than refusing. Only the barcode is re-rolled in that case, because nobody asked for a particular one. The controller's existing `CONFLICT` mapping still covers it, and now means what it says.

### Two small generalizations to the helper

- **`generate` may be async.** A generator that derives its value from what is already stored has to read the database to mint one — and that read is itself part of what races.
- **`label` now carries the noun.** It was interpolated as `` `a unique ${label} number` ``, which cannot say "code" or "barcode". Moving the word into the label makes every existing message byte-identical (`'online order'` + `' number'` → `'online order number'`) while letting gift cards name their own identifiers.

## Testing

New `server/tests/giftCards.test.ts`, real PostgreSQL — the retry narrows on `err.constraint`, which pg-mem does not populate, so on pg-mem the narrowed branch never runs and a suite there would prove nothing.

- a generated code that is taken is re-rolled; the insert refereed it, not a `SELECT`
- **a supplied code is not re-rolled** — the generator is never consulted, and no card is issued under a different code
- a barcode occupied from underneath the max-read is re-rolled
- **the repro** — concurrent issuers all reading the same `MAX(barcode)` each get a distinct code and barcode

The concurrency case uses three issuers on purpose: each retry round has exactly one winner, so with N concurrent the unluckiest needs N attempts against a cap of 5. Four passes but sits one attempt from the ceiling — a flake waiting for a slow runner rather than a stronger assertion.

`tsc --noEmit` clean, ESLint clean of errors (pre-existing `any` warnings only, ratchet unmoved), `documentNumber` suite green.

## Note for later

The barcode's `MAX + 1` is now *correct* but still serializes poorly — N concurrent issuers cost N rounds. Gift-card issuance is low-volume so this is fine, but a sequence would be the real answer if that ever changes. Not filed; noted here.

## Post-Deploy Monitoring & Validation

- **Log query:** `Document number collision, retrying with a new one` with `label=gift card barcode` — expected to appear under concurrent issuance, and to be followed by a success rather than an error. `Exhausted document number attempts` should never appear.
- **Also watch:** `CONFLICT` responses on `POST /api/v1/gift-cards`. These should now occur only where the caller supplied a `code`.
- **Healthy signal:** cards issue with distinct codes and barcodes under load; `SELECT barcode, COUNT(*) FROM gift_cards GROUP BY barcode HAVING COUNT(*) > 1` stays empty.
- **Failure signal / rollback trigger:** any `Exhausted document number attempts` for gift cards, or a rise in 5xx on the create route. Revert; self-contained, no migration.
- **Window/owner:** first week of gift-card issuance, author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN