### PR TITLE
feat(purchase-orders): say which status transitions are legal by hand

### DIFF
--- a/server/src/modules/fulfillment/purchaseOrders/schemas.ts
+++ b/server/src/modules/fulfillment/purchaseOrders/schemas.ts
@@ -51,6 +51,11 @@ export const purchaseOrdersRequestContracts = {
     beyondSchema: [
       'Setting a status here does not move stock. Only `receive` does that, which is why ' +
         'marking an order Received by hand leaves the inventory untouched.',
+      'Not every status is reachable from every other. `Received` and `Cancelled` are ' +
+        'final, and `Partially Received` cannot be set here at all -- it is derived from ' +
+        'what has actually arrived, and only `receive` writes it. An illegal move is a ' +
+        '409 `CONFLICT` naming both statuses; re-asserting the order’s current status ' +
+        'is accepted and changes nothing.',
     ],
   }),
 

--- a/server/src/modules/fulfillment/purchaseOrders/service.ts
+++ b/server/src/modules/fulfillment/purchaseOrders/service.ts
@@ -95,6 +95,36 @@ export class PurchaseOrdersService {
     );
   }
 
+  /**
+   * Where a purchase order may be moved to **by hand**.
+   *
+   * Migration 010 made all five statuses writable; it could not say which
+   * transitions are legal, because a CHECK constraint sees one row's new value and
+   * never where that row came from. So `Received -> Draft` was accepted, on an
+   * order whose stock had already moved (#142).
+   *
+   * Two rules, and both are about not letting a hand-set status contradict what
+   * `receiveItems` actually took in:
+   *
+   * - **`Received` and `Cancelled` are final.** They are the states that assert the
+   *   order is done with, and leaving them would strand the stock already received.
+   * - **`Partially Received` is never settable here.** It is derived from what has
+   *   actually arrived, so naming it by hand is always a claim about receipts that
+   *   did not happen. `receiveItems` computes and writes it through the repository,
+   *   below this guard.
+   *
+   * `Sent -> Received` deliberately stays legal: the request contract already
+   * documents that setting a status does not move stock, and it is the path for
+   * goods reconciled outside the system.
+   */
+  private static readonly MANUAL_TRANSITIONS: Record<string, readonly string[]> = {
+    Draft: ['Sent', 'Cancelled'],
+    Sent: ['Received', 'Cancelled'],
+    'Partially Received': ['Received', 'Cancelled'],
+    Received: [],
+    Cancelled: [],
+  };
+
   async updateStatus(
     id: number | string,
     status: string
@@ -102,6 +132,22 @@ export class PurchaseOrdersService {
     const existing = await this.repo.findById(id);
     if (!existing) {
       return null;
+    }
+
+    const from = String(existing.status);
+
+    // Re-asserting the current status changes nothing, so it is not a transition to
+    // refuse -- a retried request should not fail where the first one succeeded.
+    if (from !== status) {
+      const allowed = PurchaseOrdersService.MANUAL_TRANSITIONS[from] ?? [];
+      if (!allowed.includes(status)) {
+        throw new PublicError(
+          'CONFLICT',
+          allowed.length === 0
+            ? `A ${from} purchase order is final and cannot be moved to ${status}`
+            : `Cannot move a purchase order from ${from} to ${status}`
+        );
+      }
     }
 
     await this.repo.updateStatus(id, status);

--- a/server/tests/purchaseOrders.status.test.ts
+++ b/server/tests/purchaseOrders.status.test.ts
@@ -156,4 +156,125 @@ describeWithPostgres('purchase order status vocabulary (#119)', () => {
     expect(error).toMatchObject({ name: 'PublicError', code: 'CONFLICT' });
     spy.mockRestore();
   });
+
+  // --- Which transitions are legal by hand (#142) -------------------------------------
+  //
+  // 010 made all five statuses writable but could not say which moves are legal: a CHECK
+  // sees the new value and never where the row came from.
+
+  async function draftOrder(): Promise<number> {
+    const created = await purchaseOrdersService.create(
+      {
+        distributor_id: distributorId,
+        items: [{ product_id: productId, quantity: 4, cost_price: 10 }],
+      },
+      userId
+    );
+    return created.id;
+  }
+
+  it('refuses to move a Received order back to Draft', async () => {
+    // The issue's repro: the stock has already moved, so there is nothing sensible for
+    // a Draft order to mean afterwards.
+    const id = await draftOrder();
+    await purchaseOrdersService.updateStatus(id, 'Sent');
+    const items = await purchaseOrdersService.getRepository().findItemsByPoId(id);
+    await purchaseOrdersService.receiveItems(
+      id,
+      { items: [{ item_id: items[0].id, quantity: 4 }] },
+      userId
+    );
+    expect((await purchaseOrdersService.findById(id))?.status).toBe('Received');
+
+    await expect(purchaseOrdersService.updateStatus(id, 'Draft')).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+
+    // Refused, not partially applied.
+    expect((await purchaseOrdersService.findById(id))?.status).toBe('Received');
+    expect(await stockOf(productId)).toBe(4);
+  });
+
+  it('refuses to move a Cancelled order anywhere', async () => {
+    const id = await draftOrder();
+    await purchaseOrdersService.updateStatus(id, 'Cancelled');
+
+    await expect(purchaseOrdersService.updateStatus(id, 'Sent')).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    await expect(purchaseOrdersService.updateStatus(id, 'Received')).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    expect((await purchaseOrdersService.findById(id))?.status).toBe('Cancelled');
+  });
+
+  it('never lets Partially Received be set by hand', async () => {
+    // It is derived from what actually arrived, so naming it by hand is a claim about
+    // receipts that did not happen.
+    const id = await draftOrder();
+    await expect(
+      purchaseOrdersService.updateStatus(id, 'Partially Received')
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    await purchaseOrdersService.updateStatus(id, 'Sent');
+    await expect(
+      purchaseOrdersService.updateStatus(id, 'Partially Received')
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect((await purchaseOrdersService.findById(id))?.status).toBe('Sent');
+  });
+
+  it('still lets receiveItems write Partially Received, which the guard sits above', async () => {
+    const id = await draftOrder();
+    await purchaseOrdersService.updateStatus(id, 'Sent');
+    const items = await purchaseOrdersService.getRepository().findItemsByPoId(id);
+
+    const status = await purchaseOrdersService.receiveItems(
+      id,
+      { items: [{ item_id: items[0].id, quantity: 1 }] },
+      userId
+    );
+
+    expect(status).toBe('Partially Received');
+  });
+
+  it('accepts re-asserting the current status as a no-op', async () => {
+    // A retried request must not fail where the first one succeeded.
+    const id = await draftOrder();
+    await purchaseOrdersService.updateStatus(id, 'Sent');
+
+    await expect(purchaseOrdersService.updateStatus(id, 'Sent')).resolves.toMatchObject({
+      status: 'Sent',
+    });
+    expect((await purchaseOrdersService.findById(id))?.status).toBe('Sent');
+  });
+
+  it('keeps Sent -> Received legal, and it still moves no stock', async () => {
+    // The path for goods reconciled outside the system. The request contract already
+    // says setting a status does not move stock; this pins that it stays true.
+    const id = await draftOrder();
+    await purchaseOrdersService.updateStatus(id, 'Sent');
+
+    await expect(purchaseOrdersService.updateStatus(id, 'Received')).resolves.toMatchObject({
+      status: 'Received',
+    });
+    expect(await stockOf(productId)).toBe(0);
+  });
+
+  it('lets a partially received order be cancelled or completed', async () => {
+    const id = await draftOrder();
+    await purchaseOrdersService.updateStatus(id, 'Sent');
+    const items = await purchaseOrdersService.getRepository().findItemsByPoId(id);
+    await purchaseOrdersService.receiveItems(
+      id,
+      { items: [{ item_id: items[0].id, quantity: 1 }] },
+      userId
+    );
+
+    await expect(purchaseOrdersService.updateStatus(id, 'Cancelled')).resolves.toMatchObject({
+      status: 'Cancelled',
+    });
+    // The unit already received stays received; cancelling does not reverse it.
+    expect(await stockOf(productId)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #142.

## The gap

Migration 010 (#119) narrowed `purchase_orders_status_check` to the five statuses the application speaks, which made every status the app writes actually writable. It could not say which **transitions** between them are legal — a CHECK constraint sees one row's new value and never where that row came from.

So `PUT /api/v1/purchase-orders/:id/status` accepted any of the five from any of the five. `Received → Draft` was allowed, on an order whose stock had already moved. So was `Cancelled → Partially Received`.

## The rules

Both are about not letting a hand-set status contradict what `receiveItems` actually took in.

| From | May be moved to |
| --- | --- |
| `Draft` | `Sent`, `Cancelled` |
| `Sent` | `Received`, `Cancelled` |
| `Partially Received` | `Received`, `Cancelled` |
| `Received` | — final |
| `Cancelled` | — final |

- **`Received` and `Cancelled` are final.** They are the states asserting the order is done with; leaving them would strand the stock already received.
- **`Partially Received` is never settable here.** It is derived from what has actually arrived, so naming it by hand is always a claim about receipts that did not happen. `receiveItems` still computes and writes it — through the repository, *below* this guard, which is why the receive path is untouched.

**`Sent → Received` deliberately stays legal.** The request contract already documents that setting a status does not move stock, and this is the path for goods reconciled outside the system. Removing it would have been a behaviour change beyond what the issue describes.

**Re-asserting the current status is a no-op, not a refusal** — a retried request must not fail where the first one succeeded.

An illegal move is a `409 CONFLICT` naming both statuses. The `beyondSchema` contract text is updated, so the published API says this too.

## Scope

This does **not** make receiving reversible, which the issue raised as an adjacent question. Cancelling a partially received order leaves the units already received on the shelf — the new test pins that as the current behaviour rather than quietly changing it. Reversing a receipt is a stock movement with its own adjustment rows and belongs in its own change.

## Testing

Seven cases added to `server/tests/purchaseOrders.status.test.ts` (real PostgreSQL, alongside the existing #119 suite):

- **the repro** — a fully received order refuses `Draft`, and is left untouched, stock intact
- a cancelled order refuses everything
- `Partially Received` is refused by hand from both `Draft` and `Sent`
- **`receiveItems` still writes `Partially Received`** — proving the guard sits above it
- re-asserting the current status resolves as a no-op
- `Sent → Received` still works and still moves no stock
- a partially received order can be cancelled, and the received unit stays received

The existing CHECK-violation test reaches the constraint through `getRepository().updateStatus`, below the guard, so it is unaffected.

`tsc --noEmit` clean; `check:api-docs` green at 204 routes with both ratchets unmoved.

## Post-Deploy Monitoring & Validation

- **Log query:** 409s on `PUT /api/v1/purchase-orders/:id/status` carrying `Cannot move a purchase order from` or `is final and cannot be moved to`.
- **Expected healthy signal:** a low, non-zero rate is fine and is the feature working — it means the UI is offering a move the server now refuses. A *high* rate means the client is offering illegal transitions and its buttons need gating.
- **Failure signal / rollback trigger:** 409s on transitions in the table above (would mean the map is wrong), or any report of an order stuck because a legitimate workflow needed a move now refused — most likely `Received → Cancelled` for return-to-vendor, which was deliberately excluded. Revert; self-contained, no migration.
- **Window/owner:** first two weeks of purchasing activity, author. Worth checking with whoever does receiving that nobody relied on un-receiving an order by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN