### PR TITLE
refactor(sales): make the refund cap a query, not a JSON parse

### DIFF
--- a/server/src/database/migrations/012_refund_items.down.sql
+++ b/server/src/database/migrations/012_refund_items.down.sql
@@ -1,0 +1,7 @@
+-- Reverses 012 by dropping the table it created. A real reversal, not a no-op.
+--
+-- Nothing is lost: 012 derived every row from `refunds.items`, which this migration
+-- never touched and which the application keeps writing, so the same rollback can be
+-- re-applied and produce the same table again. Retiring the blob is a separate change
+-- and must not land before this one is proven.
+DROP TABLE IF EXISTS refund_items;

--- a/server/src/database/migrations/012_refund_items.sql
+++ b/server/src/database/migrations/012_refund_items.sql
@@ -1,0 +1,66 @@
+-- Gives refunded lines a table, so the cumulative refund cap is a query rather than a
+-- JSON parse in a loop.
+--
+-- `refunds.items` is a TEXT column holding JSON and has been the only record of how much
+-- of each sale line has been refunded -- there is no refund_items table, unlike
+-- `exchange_returned_items`, which is a real table with real columns. Two modules ended
+-- up decoding the same blob: `SalesService.executeRefund` to cap a refund against prior
+-- refunds (#120), and `ExchangesRepository.findRefundedQuantitiesBySaleId` to cap an
+-- exchange against them (#122). Nothing constrained the shape either parser expected.
+--
+-- `unit_price` is recorded per line because that is what the refund was actually valued
+-- at, and rows written before #120 landed were valued from the request rather than the
+-- sale. Keeping the figure the refund used means a later reconciliation can see what
+-- happened rather than recompute what should have happened.
+CREATE TABLE IF NOT EXISTS refund_items (
+  id SERIAL PRIMARY KEY,
+  refund_id INTEGER NOT NULL REFERENCES refunds(id) ON DELETE CASCADE,
+  product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE RESTRICT,
+  variant_id INTEGER REFERENCES product_variants(id) ON DELETE RESTRICT,
+  quantity INTEGER NOT NULL CHECK (quantity > 0),
+  unit_price NUMERIC NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_refund_items_refund_id ON refund_items(refund_id);
+CREATE INDEX IF NOT EXISTS idx_refund_items_product ON refund_items(product_id, variant_id);
+
+-- Backfill from the blob every existing refund carries.
+--
+-- Rows whose product no longer exists are skipped rather than failing the migration: the
+-- FK above is RESTRICT, and a historical refund naming a deleted product is a real thing
+-- to find in a database this old. The blob stays in place, so nothing is lost by skipping
+-- -- and #120's guard already treats an unparseable prior refund as a reason to refuse a
+-- new one rather than to count zero.
+--
+-- `jsonb_array_elements` needs the column cast, since it is TEXT. A row whose items are
+-- not a JSON array would raise here, which is the loud failure we want: it would mean the
+-- cumulative cap has been reading something it could not have understood either.
+-- Wrapped in a tagged DO block so the pg-mem shim can strip it, the same way it stubs
+-- 009's catalog repair block. The backfill uses CROSS JOIN LATERAL and
+-- `jsonb_array_elements`, which pg-mem's parser cannot handle -- and every pg-mem suite
+-- runs the whole migration set at startup. Stubbing it there costs nothing: a pg-mem
+-- database is always freshly created, so it has no refunds to backfill. Real PostgreSQL
+-- runs it exactly as written, and `migration012.test.ts` proves the backfill there.
+DO $backfill_012$
+BEGIN
+  INSERT INTO refund_items (refund_id, product_id, variant_id, quantity, unit_price)
+  SELECT
+    r.id,
+    (item->>'product_id')::int,
+    NULLIF(item->>'variant_id', 'null')::int,
+    (item->>'quantity')::int,
+    COALESCE((item->>'unit_price')::numeric, 0)
+  FROM refunds r
+  CROSS JOIN LATERAL jsonb_array_elements(r.items::jsonb) AS item
+  WHERE (item->>'quantity')::int > 0
+    AND EXISTS (SELECT 1 FROM products p WHERE p.id = (item->>'product_id')::int)
+    AND (
+      item->>'variant_id' IS NULL
+      OR item->>'variant_id' = 'null'
+      OR EXISTS (
+        SELECT 1 FROM product_variants v WHERE v.id = NULLIF(item->>'variant_id', 'null')::int
+      )
+    );
+END
+$backfill_012$;

--- a/server/src/modules/pos/exchanges/repository.ts
+++ b/server/src/modules/pos/exchanges/repository.ts
@@ -169,31 +169,33 @@ export class ExchangesRepository implements IExchangesRepository {
   /**
    * Prior refunds of the same sale. #122 notes the double-recovery path between the two
    * routes: capping only exchanges would still let a line be refunded and then exchanged.
-   * `refunds.items` is a TEXT column holding JSON, so it is parsed here at the boundary.
+   *
+   * A `SUM ... GROUP BY` over `refund_items` since #140. It used to decode the
+   * `refunds.items` JSON blob here, which meant this module and the sales module each
+   * carried their own parser for the same undeclared shape and had to agree.
    */
   async findRefundedQuantitiesBySaleId(
     saleId: number,
     queryable?: Queryable
   ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>> {
-    const res = await this.q(queryable).query<{ items: string | unknown }>(
-      'SELECT items FROM refunds WHERE sale_id = $1',
+    const res = await this.q(queryable).query<{
+      product_id: number;
+      variant_id: number | null;
+      quantity: string;
+    }>(
+      `SELECT ri.product_id, ri.variant_id, SUM(ri.quantity)::int AS quantity
+         FROM refund_items ri
+         JOIN refunds r ON r.id = ri.refund_id
+        WHERE r.sale_id = $1
+        GROUP BY ri.product_id, ri.variant_id`,
       [saleId]
     );
 
-    const totals: Array<{ product_id: number; variant_id: number | null; quantity: number }> = [];
-    for (const row of res.rows) {
-      const items = (
-        typeof row.items === 'string' ? JSON.parse(row.items) : (row.items ?? [])
-      ) as Array<{ product_id: number; variant_id?: number | null; quantity: number }>;
-      for (const item of items) {
-        totals.push({
-          product_id: item.product_id,
-          variant_id: item.variant_id ?? null,
-          quantity: Number(item.quantity),
-        });
-      }
-    }
-    return totals;
+    return res.rows.map((row) => ({
+      product_id: row.product_id,
+      variant_id: row.variant_id ?? null,
+      quantity: Number(row.quantity),
+    }));
   }
 
   async createExchange(

--- a/server/src/modules/pos/sales/repository.ts
+++ b/server/src/modules/pos/sales/repository.ts
@@ -14,6 +14,10 @@ export interface ISalesRepository {
     saleId: number | string,
     queryable?: Queryable
   ): Promise<Record<string, any>[]>;
+  findRefundedQuantitiesBySaleId(
+    saleId: number | string,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>>;
   findExchangedQuantitiesBySaleId(
     saleId: number | string,
     queryable?: Queryable
@@ -499,6 +503,14 @@ export class SalesRepository implements ISalesRepository {
     );
   }
 
+  /**
+   * Writes the refund and its lines, in the same transaction the caller is already in.
+   *
+   * The `items` JSON is still written alongside `refund_items` (#140). It is not
+   * belt-and-braces for its own sake: 012 derives the table *from* the blob, so keeping
+   * the blob is what lets that migration be rolled back and re-applied. Retiring it is a
+   * separate change and must not land before this one has been proven in production.
+   */
   async createRefund(
     data: Record<string, any>,
     queryable: Queryable
@@ -515,7 +527,57 @@ export class SalesRepository implements ISalesRepository {
         data.cashier_id,
       ]
     );
-    return res.rows[0];
+    const refund = res.rows[0];
+
+    for (const item of data.items as Array<{
+      product_id: number;
+      variant_id?: number | null;
+      quantity: number;
+      unit_price?: number;
+    }>) {
+      await queryable.query(
+        `INSERT INTO refund_items (refund_id, product_id, variant_id, quantity, unit_price)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [refund.id, item.product_id, item.variant_id ?? null, item.quantity, item.unit_price ?? 0]
+      );
+    }
+
+    return refund;
+  }
+
+  /**
+   * How much of each line of a sale has already been refunded.
+   *
+   * This is what `refunds.items` used to be parsed in a loop to answer (#140). The cap it
+   * feeds is a financial invariant, so it being a `SUM ... GROUP BY` over real rows rather
+   * than a JSON decode is the point: there is now a shape the database enforces, and one
+   * query where there were two decoders that had to agree with each other.
+   *
+   * Grouped on `(product_id, variant_id)` because that is the identity of a sale line --
+   * two variants of one product are two lines and cap independently.
+   */
+  async findRefundedQuantitiesBySaleId(
+    saleId: number | string,
+    queryable?: Queryable
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>> {
+    const res = await this.q(queryable).query<{
+      product_id: number;
+      variant_id: number | null;
+      quantity: string;
+    }>(
+      `SELECT ri.product_id, ri.variant_id, SUM(ri.quantity)::int AS quantity
+         FROM refund_items ri
+         JOIN refunds r ON r.id = ri.refund_id
+        WHERE r.sale_id = $1
+        GROUP BY ri.product_id, ri.variant_id`,
+      [saleId]
+    );
+
+    return res.rows.map((row) => ({
+      product_id: row.product_id,
+      variant_id: row.variant_id ?? null,
+      quantity: Number(row.quantity),
+    }));
   }
 
   async updateSaleRefundStatus(

--- a/server/src/modules/pos/sales/service.ts
+++ b/server/src/modules/pos/sales/service.ts
@@ -972,11 +972,11 @@ export class SalesService {
 
       const saleItems = await this.repo.findItemsBySaleId(saleId, client);
 
-      // Prior refunds are the only record of how much of each line has already gone
-      // back -- `refunds.items` is a JSON blob, not a normalized table (#120) -- so they
-      // are aggregated here, inside the same `FOR UPDATE` lock on `sale` that makes the
-      // read-then-write safe against a sibling refund committing concurrently.
-      const priorRefunds = await this.repo.findRefundsBySaleId(saleId, client);
+      // How much of each line has already gone back. Read inside the same `FOR UPDATE`
+      // lock on `sale` that makes the read-then-write safe against a sibling refund
+      // committing concurrently -- the lock, not the storage, is what makes the cap
+      // sound. What the storage changes is that this is now a SUM over `refund_items`
+      // rather than a JSON blob decoded in a loop (#140).
       const previouslyRefundedByLine = new Map<string, number>();
       const previouslyRefundedByProduct = new Map<number, number>();
 
@@ -993,12 +993,8 @@ export class SalesService {
         );
       };
 
-      for (const priorRefund of priorRefunds) {
-        const items: Array<{ product_id: number; variant_id?: number | null; quantity: number }> =
-          typeof priorRefund.items === 'string' ? JSON.parse(priorRefund.items) : priorRefund.items;
-        for (const item of items) {
-          countAsTaken(item.product_id, item.variant_id, Number(item.quantity));
-        }
+      for (const refunded of await this.repo.findRefundedQuantitiesBySaleId(saleId, client)) {
+        countAsTaken(refunded.product_id, refunded.variant_id, refunded.quantity);
       }
 
       // Exchanges draw on the same sold quantity. A refund and an exchange are two

--- a/server/tests/database/migration009.test.ts
+++ b/server/tests/database/migration009.test.ts
@@ -105,13 +105,14 @@ describeWithPostgres('009 legacy production schema repair', () => {
     `);
     // Only 001-008 were pre-marked applied, so this call also runs every migration after
     // 009 that exists today (010 narrows purchase_orders_status_check; 011 drops the two
-    // duplicate value columns). This list is deliberately exact rather than a length
-    // check -- a migration landing without anyone considering its effect on the legacy
-    // upgrade path is the thing worth failing on.
+    // duplicate value columns; 012 adds refund_items). This list is deliberately exact
+    // rather than a length check -- a migration landing without anyone considering its
+    // effect on the legacy upgrade path is the thing worth failing on.
     expect(await runMigrationsUp(pool, dir)).toEqual([
       migration,
       '010_purchase_order_status_vocabulary.sql',
       '011_retire_duplicate_value_columns.sql',
+      '012_refund_items.sql',
     ]);
     expect(await runMigrationsUp(pool, dir)).toEqual([]);
 

--- a/server/tests/database/migration009.test.ts
+++ b/server/tests/database/migration009.test.ts
@@ -117,17 +117,21 @@ describeWithPostgres('009 legacy production schema repair', () => {
     expect(await runMigrationsUp(pool, dir)).toEqual([]);
 
     // Replaying the raw SQL is how this test proves 009 and 010 are re-runnable. 011 has
-    // to come back off first: 009 backfills `product_bundles.bundle_price` from `price`,
-    // and 011 drops `price`, so replaying 009 on top of 011 fails on a column the schema
-    // no longer has. That is inherent to replaying an older migration after a newer one
+    // to come back off first -- and 012 with it, since it sits above 011. 009 backfills
+    // `product_bundles.bundle_price` from `price`, and 011 drops `price`, so replaying
+    // 009 on top of 011 fails on a column the schema no longer has. That is inherent to replaying an older migration after a newer one
     // removes what it referenced -- the same shape as 009 re-adding its own wider CHECK
     // over 010's narrowed one -- and not a fault in either file.
-    expect(await runMigrationsDown(1, pool, dir)).toEqual([
+    expect(await runMigrationsDown(2, pool, dir)).toEqual([
+      '012_refund_items.sql',
       '011_retire_duplicate_value_columns.sql',
     ]);
     await pool.query(sql);
     await pool.query(nextSql);
-    expect(await runMigrationsUp(pool, dir)).toEqual(['011_retire_duplicate_value_columns.sql']);
+    expect(await runMigrationsUp(pool, dir)).toEqual([
+      '011_retire_duplicate_value_columns.sql',
+      '012_refund_items.sql',
+    ]);
     expect((await pool.query('SELECT favorites FROM users')).rows[0].favorites).toBe('[]');
     expect(
       (await pool.query('SELECT bundle_price FROM product_bundles WHERE id=51')).rows[0]

--- a/server/tests/database/migration012.test.ts
+++ b/server/tests/database/migration012.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Migration 012 — gives refunded lines a table, and backfills it from the blob.
+ *
+ * `refunds.items` was the only record of how much of each sale line had gone back, so
+ * both the refund cap (#120) and the exchange cap (#122) decoded the same undeclared JSON
+ * shape in their own loops. This is the part of #140 that cannot be proven anywhere else:
+ * pg-mem cannot parse the `CROSS JOIN LATERAL jsonb_array_elements` the backfill uses, so
+ * the shim strips the block there and the migration's real behaviour is only observable
+ * against PostgreSQL.
+ */
+import { afterAll, beforeAll, beforeEach, expect, it } from 'vitest';
+import path from 'path';
+import {
+  describeWithPostgres,
+  setupRealPostgres,
+  type RealPostgresHarness,
+} from '../support/realPostgres';
+import {
+  runMigrationsDown,
+  runMigrationsUp,
+  getAppliedMigrations,
+} from '../../src/database/migrate';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/database/migrations');
+const MIGRATION = '012_refund_items.sql';
+
+describeWithPostgres('migration 012 — refund_items', () => {
+  let harness: RealPostgresHarness;
+
+  beforeAll(async () => {
+    harness = await setupRealPostgres('migration-012', { maxConnections: 3 });
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.truncate();
+  });
+
+  /** Rolls 012 off, seeds refunds as they existed before it, and re-applies it. */
+  async function backfillFrom(
+    seed: (pool: RealPostgresHarness['pool']) => Promise<void>
+  ): Promise<RealPostgresHarness> {
+    const db = await setupRealPostgres(`migration-012-${Math.floor(Math.random() * 1e6)}`, {
+      installAsAppPool: false,
+      maxConnections: 2,
+    });
+
+    const applied = await getAppliedMigrations(db.pool);
+    await runMigrationsDown(applied.length - applied.indexOf(MIGRATION), db.pool, MIGRATIONS_DIR);
+    expect(await getAppliedMigrations(db.pool)).not.toContain(MIGRATION);
+
+    await seed(db.pool);
+
+    expect(await runMigrationsUp(db.pool, MIGRATIONS_DIR)).toContain(MIGRATION);
+    return db;
+  }
+
+  async function seedSaleAndRefund(
+    pool: RealPostgresHarness['pool'],
+    items: unknown[]
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 10)`
+    );
+    await pool.query(
+      `INSERT INTO product_variants (id, product_id, sku, price, stock, attributes)
+       VALUES (10, 1, 'SKU-001-RED', 500, 4, '{"color":"Red"}')`
+    );
+    const sale = await pool.query<{ id: number }>(
+      `INSERT INTO sales (subtotal, total, payment_method) VALUES (500, 500, 'Cash') RETURNING id`
+    );
+    await pool.query(
+      `INSERT INTO refunds (sale_id, amount, reason, items, restock)
+       VALUES ($1, 500, 'Returned', $2, 1)`,
+      [sale.rows[0].id, JSON.stringify(items)]
+    );
+  }
+
+  it('creates the table with an index on the refund it belongs to', async () => {
+    const { rows } = await harness.pool.query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM information_schema.tables
+        WHERE table_schema = current_schema() AND table_name = 'refund_items'`
+    );
+    expect(rows[0].n).toBe(1);
+  });
+
+  it('refuses a non-positive quantity', async () => {
+    await harness.pool.query(
+      `INSERT INTO products (id, name, sku, price, cost_price, stock)
+       VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 10)`
+    );
+    const sale = await harness.pool.query<{ id: number }>(
+      `INSERT INTO sales (subtotal, total, payment_method) VALUES (500, 500, 'Cash') RETURNING id`
+    );
+    const refund = await harness.pool.query<{ id: number }>(
+      `INSERT INTO refunds (sale_id, amount, reason, items, restock)
+       VALUES ($1, 500, 'Returned', '[]', 1) RETURNING id`,
+      [sale.rows[0].id]
+    );
+
+    await expect(
+      harness.pool.query(
+        `INSERT INTO refund_items (refund_id, product_id, quantity, unit_price)
+         VALUES ($1, 1, 0, 500)`,
+        [refund.rows[0].id]
+      )
+    ).rejects.toMatchObject({ code: '23514' });
+  });
+
+  it('backfills a plain line from the blob', async () => {
+    const db = await backfillFrom((pool) =>
+      seedSaleAndRefund(pool, [{ product_id: 1, quantity: 2, unit_price: 500 }])
+    );
+
+    try {
+      const { rows } = await db.pool.query(
+        'SELECT product_id, variant_id, quantity, unit_price FROM refund_items'
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ product_id: 1, variant_id: null, quantity: 2 });
+      expect(Number(rows[0].unit_price)).toBe(500);
+    } finally {
+      await db.teardown();
+    }
+  });
+
+  it('carries variant_id through, and reads a JSON null as no variant', async () => {
+    // A pre-#121 refund has no variant_id key at all; one written after it may carry an
+    // explicit JSON `null`. Both mean "not a variant line" and must not become a row
+    // pointing at variant 0.
+    const db = await backfillFrom((pool) =>
+      seedSaleAndRefund(pool, [
+        { product_id: 1, variant_id: 10, quantity: 1, unit_price: 500 },
+        { product_id: 1, variant_id: null, quantity: 1, unit_price: 500 },
+        { product_id: 1, quantity: 1, unit_price: 500 },
+      ])
+    );
+
+    try {
+      const { rows } = await db.pool.query<{ variant_id: number | null }>(
+        'SELECT variant_id FROM refund_items ORDER BY id'
+      );
+      expect(rows.map((r) => r.variant_id)).toEqual([10, null, null]);
+    } finally {
+      await db.teardown();
+    }
+  });
+
+  it('skips a line naming a product that no longer exists rather than failing the migration', async () => {
+    // The FK is RESTRICT, and a refund naming a deleted product is a real thing to find in
+    // a database this old. The blob is untouched, so nothing is lost by skipping it.
+    const db = await backfillFrom((pool) =>
+      seedSaleAndRefund(pool, [
+        { product_id: 1, quantity: 1, unit_price: 500 },
+        { product_id: 9999, quantity: 1, unit_price: 500 },
+      ])
+    );
+
+    try {
+      const { rows } = await db.pool.query<{ product_id: number }>(
+        'SELECT product_id FROM refund_items'
+      );
+      expect(rows.map((r) => r.product_id)).toEqual([1]);
+    } finally {
+      await db.teardown();
+    }
+  });
+
+  it('drops the table on rollback, leaving the blob it was derived from', async () => {
+    const db = await backfillFrom((pool) =>
+      seedSaleAndRefund(pool, [{ product_id: 1, quantity: 1, unit_price: 500 }])
+    );
+
+    try {
+      const applied = await getAppliedMigrations(db.pool);
+      await runMigrationsDown(applied.length - applied.indexOf(MIGRATION), db.pool, MIGRATIONS_DIR);
+
+      await expect(db.pool.query('SELECT 1 FROM refund_items')).rejects.toThrow(/refund_items/);
+
+      // The blob is what 012 derives from, so it must survive for the migration to be
+      // re-appliable at all.
+      const { rows } = await db.pool.query<{ items: string }>('SELECT items FROM refunds');
+      expect(JSON.parse(rows[0].items)).toHaveLength(1);
+
+      expect(await runMigrationsUp(db.pool, MIGRATIONS_DIR)).toContain(MIGRATION);
+      const again = await db.pool.query('SELECT product_id FROM refund_items');
+      expect(again.rows).toHaveLength(1);
+    } finally {
+      await db.teardown();
+    }
+  });
+});

--- a/server/tests/exchanges.validation.test.ts
+++ b/server/tests/exchanges.validation.test.ts
@@ -82,6 +82,36 @@ describe('exchange returned-item validation (#122)', () => {
     condition: 'good' as const,
   });
 
+  /**
+   * A refund as it exists after migration 012: the `refunds.items` blob it was written
+   * with, plus the `refund_items` rows 012's backfill derives from it. A fixture that
+   * writes only the blob describes a database state that no longer occurs, and would let
+   * these caps pass by reading nothing at all.
+   */
+  async function insertHistoricalRefund(
+    saleId: number,
+    amount: number,
+    items: Array<{
+      product_id: number;
+      variant_id?: number | null;
+      quantity: number;
+      unit_price: number;
+    }>
+  ): Promise<void> {
+    const { rows } = await testPool.query<{ id: number }>(
+      `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
+       VALUES ($1, $2, 'Returned', $3, 1, 1) RETURNING id`,
+      [saleId, amount, JSON.stringify(items)]
+    );
+    for (const item of items) {
+      await testPool.query(
+        `INSERT INTO refund_items (refund_id, product_id, variant_id, quantity, unit_price)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [rows[0].id, item.product_id, item.variant_id ?? null, item.quantity, item.unit_price]
+      );
+    }
+  }
+
   async function stockOf(productId: number): Promise<number> {
     const { rows } = await testPool.query<{ stock: number }>(
       'SELECT stock FROM products WHERE id = $1',
@@ -133,11 +163,7 @@ describe('exchange returned-item validation (#122)', () => {
   it('counts an earlier REFUND of the same line against what is left (#122 double recovery)', async () => {
     // The goods came back through the refund endpoint. Exchanging them again would
     // recover the same units twice -- once as cash, once as credit plus stock.
-    await testPool.query(
-      `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
-       VALUES ($1, 1000, 'Returned', $2, 1, 1)`,
-      [saleId, JSON.stringify([{ product_id: 1, quantity: 2, unit_price: 500 }])]
-    );
+    await insertHistoricalRefund(saleId, 1000, [{ product_id: 1, quantity: 2, unit_price: 500 }]);
 
     await expect(service.createExchange(exchange([returned(1, 1)]), 1)).rejects.toThrow(
       /exceeds what remains of product 1 \(0 remaining\)/
@@ -145,11 +171,7 @@ describe('exchange returned-item validation (#122)', () => {
   });
 
   it('allows what genuinely remains after a partial refund', async () => {
-    await testPool.query(
-      `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
-       VALUES ($1, 500, 'Returned', $2, 1, 1)`,
-      [saleId, JSON.stringify([{ product_id: 1, quantity: 1, unit_price: 500 }])]
-    );
+    await insertHistoricalRefund(saleId, 500, [{ product_id: 1, quantity: 1, unit_price: 500 }]);
 
     // One dress of the two is still the customer's to bring back.
     const created = await service.createExchange(exchange([returned(1, 1)]), 1);
@@ -201,12 +223,11 @@ describe('exchange returned-item validation (#122)', () => {
        VALUES ($1, 1, 10, 1, 500)`,
       [variantSaleId]
     );
-    await testPool.query(
-      `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
-       VALUES ($1, 500, 'Returned', $2, 1, 1)`,
-      // No variant_id, exactly as a pre-#121 refund recorded it.
-      [variantSaleId, JSON.stringify([{ product_id: 1, quantity: 1, unit_price: 500 }])]
-    );
+    // No variant_id, exactly as a pre-#121 refund recorded it -- and exactly as 012's
+    // backfill leaves such a row: product_id set, variant_id NULL.
+    await insertHistoricalRefund(variantSaleId, 500, [
+      { product_id: 1, quantity: 1, unit_price: 500 },
+    ]);
 
     await expect(
       service.createExchange(

--- a/server/tests/sales.test.ts
+++ b/server/tests/sales.test.ts
@@ -908,10 +908,19 @@ describe('Sales - PostgreSQL Service & Transaction', () => {
         const sale = await sellVariant(variantId, 1);
         expect(await readVariantStock(variantId)).toBe(3);
 
-        await testPool.query(
+        // Written as a pre-#121 refund recorded it, and carried into `refund_items` the
+        // way 012's backfill does: product_id set, variant_id NULL. A fixture writing only
+        // the blob would describe a state that no longer occurs, and the cap would pass by
+        // reading nothing at all.
+        const legacy = await testPool.query<{ id: number }>(
           `INSERT INTO refunds (sale_id, amount, reason, items, restock, cashier_id)
-           VALUES ($1, 500, 'Legacy refund', $2, 1, 1)`,
+           VALUES ($1, 500, 'Legacy refund', $2, 1, 1) RETURNING id`,
           [sale.id, JSON.stringify([{ product_id: 1, quantity: 1, unit_price: 500 }])]
+        );
+        await testPool.query(
+          `INSERT INTO refund_items (refund_id, product_id, variant_id, quantity, unit_price)
+           VALUES ($1, 1, NULL, 1, 500)`,
+          [legacy.rows[0].id]
         );
 
         await expect(

--- a/server/tests/support/pgMem.ts
+++ b/server/tests/support/pgMem.ts
@@ -25,11 +25,25 @@ import type { Pool as PgPool, PoolClient, QueryResult, QueryResultRow } from 'pg
 /** Matches a trailing `NOT VALID` on an ALTER TABLE ... ADD CONSTRAINT statement. */
 const TRAILING_NOT_VALID = /\s+NOT\s+VALID(?=\s*;|\s*$)/gi;
 
+/**
+ * Matches 012's tagged backfill block, and only it.
+ *
+ * Stripped rather than stubbing the whole file the way `DO $repair_009$` is: 009 is
+ * nothing but its repair block, while 012 also creates `refund_items` and its indexes --
+ * statements pg-mem handles and the suites need. Replacing the file wholesale left every
+ * refund test failing on `relation "refund_items" does not exist`.
+ */
+const BACKFILL_012 = /DO \$backfill_012\$[\s\S]*?\$backfill_012\$;/g;
+
 export function toPgMemCompatibleSql(sql: string): string {
   // 009 upgrades legacy schemas only. pg-mem fixtures start from the corrected 001;
   // its catalog-driven PL/pgSQL repair is exercised on real PostgreSQL instead.
   if (sql.includes('DO $repair_009$')) return 'SELECT 1;';
-  return sql.replace(TRAILING_NOT_VALID, '');
+  // 012 backfills `refund_items` from the `refunds.items` blob with CROSS JOIN LATERAL
+  // and `jsonb_array_elements`, which pg-mem's parser rejects. A pg-mem database is always
+  // freshly created and so has no refunds to backfill, and the CREATE TABLE around it is
+  // kept. The backfill is proven on real PostgreSQL in `tests/database/migration012.test.ts`.
+  return sql.replace(BACKFILL_012, 'SELECT 1;').replace(TRAILING_NOT_VALID, '');
 }
 
 type QueryArgs = [string | { text: string }, unknown[]?];


### PR DESCRIPTION
Closes #140.

## The problem

`refunds.items` is a `TEXT` column holding JSON, and it was the **only** record of how much of each sale line had already gone back — there is no `refund_items` table, unlike `exchange_returned_items`, which is a real table with real columns.

So two modules ended up decoding the same undeclared shape in their own loops:

- `SalesService.executeRefund`, to cap a refund against prior refunds (#120)
- `ExchangesRepository.findRefundedQuantitiesBySaleId`, to cap an exchange against them (#122)

A financial invariant therefore depended on two parsers agreeing with each other, and nothing constrained what either would find. It was *correct* — the `FOR UPDATE` lock on the sale is what makes the cap sound, not the storage — but the lock was doing work a `SUM ... GROUP BY` does for free.

## The change

Migration 012 adds `refund_items` and backfills it from the blob. Both caps become one query over rows the database shapes: `CHECK (quantity > 0)`, real foreign keys, and a nullable `variant_id` that states "not a variant line" as a schema fact rather than a defensive fallback in two places.

**The blob is still written.** 012 derives the table *from* it, so keeping it is what makes the migration rollback-and-re-appliable — the down migration just drops the table. Retiring the column is a separate change that must not land before this one is proven in production.

## Two things worth flagging

**The pg-mem shim.** The backfill uses `CROSS JOIN LATERAL jsonb_array_elements`, which pg-mem's parser rejects outright — and every pg-mem suite runs the whole migration set at startup. The block is tagged `DO $backfill_012$` and the shim strips it, following the precedent already set for 009's repair block. Unlike 009, only the *block* is stripped rather than the whole file, since 012 also creates the table the suites need. A pg-mem database is always freshly created, so it has no refunds to backfill.

**Fixtures that wrote only the blob.** Four tests seeded a historical refund by inserting `refunds.items` directly. Post-012 that describes a state that no longer occurs, and worse, three of them would have gone on passing while reading *nothing at all* — the caps would have been satisfied vacuously. They now write the row the way the backfill leaves it, which is also what the behaviour under test is about: a pre-#121 refund has `variant_id` NULL and must still count against the variant line, through the per-product belt.

## Testing

New `server/tests/database/migration012.test.ts`, real PostgreSQL:

- the table exists, and rejects a non-positive quantity (`23514`)
- a plain line backfills with `variant_id` NULL and its `unit_price` preserved
- **a missing `variant_id` key and an explicit JSON `null` both become NULL** — neither may become a row pointing at variant 0
- a line naming a deleted product is skipped rather than failing the migration (the FK is `RESTRICT`, and the blob is untouched, so nothing is lost)
- rollback drops the table and leaves the blob, and re-applying rebuilds it

Full local suite: **679 passed, 167 skipped, 0 failed.** `tsc --noEmit` clean.

## Post-Deploy Monitoring & Validation

- **Before deploying:** the backfill runs over every historical refund. On a large `refunds` table this is the slow part of the migration — check `SELECT COUNT(*) FROM refunds` and expect the migration to take proportionally longer.
- **Verification query:** compare the two records for a sample of sales —
  `SELECT r.sale_id, jsonb_array_length(r.items::jsonb) AS blob_lines, COUNT(ri.id) AS table_lines FROM refunds r LEFT JOIN refund_items ri ON ri.refund_id = r.id GROUP BY r.id HAVING jsonb_array_length(r.items::jsonb) <> COUNT(ri.id);`
  Rows here are refunds whose lines were skipped — expected only for deleted products or zero quantities. Anything else wants investigating before the blob is retired.
- **Log query:** `VALIDATION_ERROR` on `POST /api/v1/sales/:id/refund` mentioning remaining quantity, and the same on exchanges.
- **Healthy signal:** refund and exchange caps still refuse over-recovery; new refunds write both the blob and `refund_items` rows in step.
- **Failure signal / rollback trigger:** a refund allowed past what was sold (the cap reading zero because rows are missing), or `23514` on `refund_items` during a refund. Roll back 012 — the blob is intact and the previous code reads it.
- **Window/owner:** first week of refund and exchange traffic, author. Do not open #146-style retirement of `refunds.items` until that window is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN