### PR TITLE
feat(online-orders): hold stock on order, deduct on fulfilment

### DIFF
--- a/server/src/modules/commerce/onlineOrders/repository.ts
+++ b/server/src/modules/commerce/onlineOrders/repository.ts
@@ -23,6 +23,11 @@ export interface IOnlineOrdersRepository {
     variantId: number | null | undefined,
     queryable?: Queryable
   ): Promise<number | null>;
+  lockStockForUpdate(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable: Queryable
+  ): Promise<number | null>;
   getCatalogLine(
     productId: number,
     variantId: number | null | undefined,
@@ -184,6 +189,34 @@ export class OnlineOrdersRepository implements IOnlineOrdersRepository {
         )
       : await this.q(queryable).query<{ stock: number }>(
           'SELECT stock FROM products WHERE id = $1',
+          [productId]
+        );
+    return res.rows[0] ? Number(res.rows[0].stock) : null;
+  }
+
+  /**
+   * Locks the stock row this line draws on and returns what it holds.
+   *
+   * Reserving is a read-then-write across two tables -- `products.stock` minus the live
+   * rows in `stock_reservations` -- so it cannot be a single guarded UPDATE the way
+   * deducting was. Locking the stock row first is what makes the pair atomic: two
+   * shoppers reaching for the last unit serialize here, and the loser recomputes
+   * availability after the winner's reservation is committed and visible (#137).
+   *
+   * @returns the row's stock, or null when there is no such row.
+   */
+  async lockStockForUpdate(
+    productId: number,
+    variantId: number | null | undefined,
+    queryable: Queryable
+  ): Promise<number | null> {
+    const res = variantId
+      ? await queryable.query<{ stock: number }>(
+          'SELECT stock FROM product_variants WHERE id = $1 FOR UPDATE',
+          [variantId]
+        )
+      : await queryable.query<{ stock: number }>(
+          'SELECT stock FROM products WHERE id = $1 FOR UPDATE',
           [productId]
         );
     return res.rows[0] ? Number(res.rows[0].stock) : null;

--- a/server/src/modules/commerce/onlineOrders/schemas.ts
+++ b/server/src/modules/commerce/onlineOrders/schemas.ts
@@ -40,14 +40,21 @@ export const onlineOrdersRequestContracts = {
     operation: 'createOnlineOrder',
     body: createOnlineOrderSchema,
     beyondSchema: [
-      'Public: a shopper places this without a token. Stock is DEDUCTED when the order ' +
-        'is placed, not reserved — cancelling a pending, processing or shipped order ' +
-        'restores it; a delivered one cannot be cancelled. (Reservation is not ' +
-        'implemented; this text used to describe it, and did not match the code.)',
+      'Public: a shopper places this without a token. Stock is RESERVED when the order ' +
+        'is placed, not deducted: the units stay sellable at the till until the shop ' +
+        'starts fulfilling. Moving the order to processing, shipped or delivered ' +
+        'releases the hold and deducts the stock in one transaction.',
+      'A hold lasts 48 hours. After that it lapses and the units are available again, ' +
+        'while the order stays pending — so processing it later is re-checked against ' +
+        'real stock and can be refused with a 409 if the goods went elsewhere.',
+      'Cancelling releases the hold. It restores stock only if the order had reached a ' +
+        'status that deducted it; a pending order never took its units off the shelf, ' +
+        'so there is nothing to restore. A delivered order cannot be cancelled.',
       "Each line's `price` is accepted and ignored: the order is priced from the " +
         'catalog, since a public endpoint cannot let a caller name its own price.',
-      'An order for more units than are in stock is refused with a 409, naming how ' +
-        'many remain.',
+      'An order for more units than are AVAILABLE — stock on hand minus what other ' +
+        'online orders are already holding — is refused with a 409, naming how many ' +
+        'remain.',
     ],
   }),
 

--- a/server/src/modules/commerce/onlineOrders/service.ts
+++ b/server/src/modules/commerce/onlineOrders/service.ts
@@ -101,6 +101,45 @@ export class OnlineOrdersService {
           const subtotal = priced.reduce((sum, item) => sum + item.price * item.quantity, 0);
           const total = subtotal + shippingFee;
 
+          // Availability is settled BEFORE anything else in this transaction is written.
+          //
+          // Not merely tidy: `online_order_items.product_id` is a foreign key, so writing
+          // a line takes a FOR KEY SHARE lock on the product row. Locking the same row
+          // FOR UPDATE afterwards is a lock upgrade, and two orders for one product each
+          // holding KEY SHARE and each waiting to upgrade is a deadlock -- SQLSTATE
+          // 40P01, reported by the three-concurrent-orders test before this moved.
+          // Taking the strongest lock first gives every transaction the same lock order.
+          //
+          // Within the pass, rows are locked in the one canonical order every stock path
+          // in this repo uses, so two shoppers naming the same products in opposite order
+          // cannot deadlock against each other either.
+          const held = sortForStockWrites(priced);
+          for (const item of held) {
+            const onHand = await this.repo.lockStockForUpdate(
+              item.product_id,
+              item.variant_id,
+              client
+            );
+            if (onHand === null) {
+              throw new PublicError('CONFLICT', `Product not available: ID ${item.product_id}`);
+            }
+
+            // Read after the lock, so a competing order's reservation is either committed
+            // and counted here or still waiting on the lock this transaction holds.
+            const reserved = await this.reservations.getReservedQuantity(
+              item.product_id,
+              item.variant_id,
+              client
+            );
+            const available = onHand - reserved;
+            if (item.quantity > available) {
+              throw new PublicError(
+                'CONFLICT',
+                `Only ${Math.max(0, available)} left of ${item.name}`
+              );
+            }
+          }
+
           // Find or create customer
           let customerId: number | null = null;
           const custRes = await this.repo.findCustomerByPhone(data.customer_phone, client);
@@ -146,41 +185,10 @@ export class OnlineOrdersService {
             );
           }
 
-          // Holds, not deductions (#137). Placing an order no longer takes the goods off
-          // the shelf -- it reserves them, and `updateStatus` deducts when the shop
-          // actually starts fulfilling. Until then the units are still sellable at the
-          // till, which is deliberate: the shop floor has the goods in hand and the web
-          // order is the speculative one.
-          //
-          // Locks are taken in the one canonical order every stock path in this repo
-          // uses. Two shoppers naming the same products in opposite order would otherwise
-          // take their row locks in opposite order and deadlock -- SQLSTATE 40P01, which
-          // reaches the shopper as exactly the 500 #125 set out to remove.
-          for (const item of sortForStockWrites(priced)) {
-            const onHand = await this.repo.lockStockForUpdate(
-              item.product_id,
-              item.variant_id,
-              client
-            );
-            if (onHand === null) {
-              throw new PublicError('CONFLICT', `Product not available: ID ${item.product_id}`);
-            }
-
-            // Read after the lock, so a competing order's reservation is either committed
-            // and counted here or still waiting on the lock we hold.
-            const reserved = await this.reservations.getReservedQuantity(
-              item.product_id,
-              item.variant_id,
-              client
-            );
-            const available = onHand - reserved;
-            if (item.quantity > available) {
-              throw new PublicError(
-                'CONFLICT',
-                `Only ${Math.max(0, available)} left of ${item.name}`
-              );
-            }
-
+          // The holds themselves, now that the order has an id to hang them on. The
+          // stock rows locked above are still held, so nothing can have taken the units
+          // between the check and this write.
+          for (const item of held) {
             await this.reservations.createReservation(
               {
                 product_id: item.product_id,

--- a/server/src/modules/commerce/onlineOrders/service.ts
+++ b/server/src/modules/commerce/onlineOrders/service.ts
@@ -2,6 +2,10 @@ import { withTransaction } from '../../../database/transaction';
 import { withDocumentNumber } from '../../../database/documentNumber';
 import { PublicError } from '../../../http/errors';
 import { sortForStockWrites } from '../../pos/stockWriteOrder';
+import {
+  IReservationsRepository,
+  reservationsRepository as defaultReservations,
+} from '../../pos/reservations/repository';
 import { IOnlineOrdersRepository, onlineOrdersRepository as defaultRepo } from './repository';
 import { CreateOnlineOrderDTO, OnlineOrderFilters, OnlineOrderRecord } from './types';
 
@@ -11,6 +15,29 @@ import { CreateOnlineOrderDTO, OnlineOrderFilters, OnlineOrderRecord } from './t
  * doing so invented inventory out of a data-entry correction (#125).
  */
 const CANCELLABLE_STATUSES = new Set(['pending', 'processing', 'shipped']);
+
+/**
+ * What an online order reserves stock as, in `stock_reservations.source_type`.
+ *
+ * Distinct from the `cart` holds the POS writes, because releasing one must never take
+ * the other with it: both key their `source_id` on a plain numeric id.
+ */
+const RESERVATION_SOURCE = 'online_order';
+
+/**
+ * How long an unprocessed order holds its stock.
+ *
+ * A reservation is a promise to a shopper the shop has not yet acted on, so it cannot be
+ * open-ended -- an abandoned order would hold goods off the shelf forever. Two days is
+ * long enough to cover a weekend before anyone looks at the queue, and short enough that
+ * the hold means something. When it lapses the existing `reservation-cleanup` job removes
+ * the row and the units are simply available again; the order stays `pending` and is
+ * re-checked against real stock when someone processes it.
+ */
+const RESERVATION_MINUTES = 48 * 60;
+
+/** Statuses whose stock has actually left `products.stock` rather than merely being held. */
+const DEDUCTED_STATUSES = new Set(['processing', 'shipped', 'delivered']);
 
 export function generateOnlineOrderNumber(): string {
   const now = new Date();
@@ -29,7 +56,8 @@ export class OnlineOrdersService {
      * taken. Spying on the module export cannot work: the call site closes over the
      * local binding, not the exported property.
      */
-    private generateNumber: () => string = generateOnlineOrderNumber
+    private generateNumber: () => string = generateOnlineOrderNumber,
+    private reservations: IReservationsRepository = defaultReservations
   ) {}
 
   getRepository(): IOnlineOrdersRepository {
@@ -118,29 +146,52 @@ export class OnlineOrdersService {
             );
           }
 
-          // Stock writes in the one canonical order every path in this repo uses, and
-          // in their own pass. Deducting in request order lets two shoppers who name the
-          // same products in opposite order take their row locks in opposite order and
-          // deadlock -- SQLSTATE 40P01, which reaches the shopper as exactly the 500
-          // this issue set out to remove.
+          // Holds, not deductions (#137). Placing an order no longer takes the goods off
+          // the shelf -- it reserves them, and `updateStatus` deducts when the shop
+          // actually starts fulfilling. Until then the units are still sellable at the
+          // till, which is deliberate: the shop floor has the goods in hand and the web
+          // order is the speculative one.
+          //
+          // Locks are taken in the one canonical order every stock path in this repo
+          // uses. Two shoppers naming the same products in opposite order would otherwise
+          // take their row locks in opposite order and deadlock -- SQLSTATE 40P01, which
+          // reaches the shopper as exactly the 500 #125 set out to remove.
           for (const item of sortForStockWrites(priced)) {
-            const remaining = await this.repo.deductStock(
+            const onHand = await this.repo.lockStockForUpdate(
               item.product_id,
               item.variant_id,
-              item.quantity,
               client
             );
-            if (remaining === null) {
-              // The guarded write refuses on both "no such row" and "not enough"; a
-              // re-read is the only way to tell a shopper which.
-              const available = await this.repo.getStock(item.product_id, item.variant_id, client);
+            if (onHand === null) {
+              throw new PublicError('CONFLICT', `Product not available: ID ${item.product_id}`);
+            }
+
+            // Read after the lock, so a competing order's reservation is either committed
+            // and counted here or still waiting on the lock we hold.
+            const reserved = await this.reservations.getReservedQuantity(
+              item.product_id,
+              item.variant_id,
+              client
+            );
+            const available = onHand - reserved;
+            if (item.quantity > available) {
               throw new PublicError(
                 'CONFLICT',
-                available === null
-                  ? `Product not available: ID ${item.product_id}`
-                  : `Only ${available} left of ${item.name}`
+                `Only ${Math.max(0, available)} left of ${item.name}`
               );
             }
+
+            await this.reservations.createReservation(
+              {
+                product_id: item.product_id,
+                variant_id: item.variant_id ?? null,
+                quantity: item.quantity,
+                source_type: RESERVATION_SOURCE,
+                source_id: String(order.id),
+                expiryMinutes: RESERVATION_MINUTES,
+              },
+              client
+            );
           }
 
           return order;
@@ -192,10 +243,46 @@ export class OnlineOrdersService {
       return null;
     }
 
-    // If cancelling, restore inventory -- but only from a status the goods could still
-    // be recovered from. Cancelling a `delivered` order used to put its units back on
-    // the shelf, creating stock that had already left the shop (#125). Cancelling an
-    // already-cancelled order is a no-op rather than a second restore.
+    // Leaving `pending` for a status the shop is actually working is where the hold
+    // becomes a deduction (#137). The reservation is released and the units come off
+    // `products.stock` in the same transaction, so the two can never both count.
+    if (DEDUCTED_STATUSES.has(status) && !DEDUCTED_STATUSES.has(currentOrder.status)) {
+      return withTransaction(async (client) => {
+        const items = await this.repo.getOrderItems(id, client);
+
+        await this.reservations.deleteBySource(RESERVATION_SOURCE, String(id), client);
+
+        for (const item of sortForStockWrites(items)) {
+          const remaining = await this.repo.deductStock(
+            item.product_id,
+            item.variant_id,
+            item.quantity,
+            client
+          );
+          if (remaining === null) {
+            // The hold has lapsed -- `reservation-cleanup` removed it after
+            // RESERVATION_MINUTES -- and the units went to someone else in the meantime.
+            // Refusing is the honest answer; the order stays where it was.
+            const available = await this.repo.getStock(item.product_id, item.variant_id, client);
+            throw new PublicError(
+              'CONFLICT',
+              available === null
+                ? `Product no longer available: ID ${item.product_id}`
+                : `Only ${available} left of product ${item.product_id}; the hold on this order has lapsed`
+            );
+          }
+        }
+
+        return this.repo.updateStatus(id, status, client);
+      });
+    }
+
+    // If cancelling, release whatever the order is holding -- and restore stock only if
+    // it was actually deducted. A `pending` order never took its units off the shelf, so
+    // "restoring" them would invent inventory; before #137 every cancel restored, and
+    // cancelling a `delivered` order put units back that had already left the shop
+    // (#125). Cancelling an already-cancelled order is a no-op rather than a second
+    // restore.
     if (status === 'cancelled' && currentOrder.status !== 'cancelled') {
       if (!CANCELLABLE_STATUSES.has(currentOrder.status)) {
         throw new PublicError(
@@ -204,11 +291,18 @@ export class OnlineOrdersService {
         );
       }
 
+      const wasDeducted = DEDUCTED_STATUSES.has(currentOrder.status);
+
       return withTransaction(async (client) => {
-        const items = await this.repo.getOrderItems(id, client);
-        for (const item of items) {
-          await this.repo.restoreStock(item.product_id, item.variant_id, item.quantity, client);
+        await this.reservations.deleteBySource(RESERVATION_SOURCE, String(id), client);
+
+        if (wasDeducted) {
+          const items = await this.repo.getOrderItems(id, client);
+          for (const item of sortForStockWrites(items)) {
+            await this.repo.restoreStock(item.product_id, item.variant_id, item.quantity, client);
+          }
         }
+
         return this.repo.updateStatus(id, status, client);
       });
     }

--- a/server/src/modules/pos/reservations/repository.ts
+++ b/server/src/modules/pos/reservations/repository.ts
@@ -23,6 +23,7 @@ export interface IReservationsRepository {
   ): Promise<ReservationRow>;
   deleteById(id: number | string, queryable?: Queryable): Promise<boolean>;
   deleteBySourceId(sourceId: string, queryable?: Queryable): Promise<number>;
+  deleteBySource(sourceType: string, sourceId: string, queryable?: Queryable): Promise<number>;
   deleteExpired(queryable?: Queryable): Promise<number>;
 }
 
@@ -109,6 +110,25 @@ export class ReservationsRepository implements IReservationsRepository {
     const res = await this.q(queryable).query(
       'DELETE FROM stock_reservations WHERE source_id = $1 RETURNING id',
       [sourceId]
+    );
+    return res.rowCount || 0;
+  }
+
+  /**
+   * Releases one source's holds, scoped by what kind of source it is.
+   *
+   * `deleteBySourceId` keys on the id alone, which is only safe while one kind of thing
+   * reserves stock. Online orders reserve under their own numeric id (#137), and cart
+   * ids share that space -- so releasing order 7's hold would take cart 7's with it.
+   */
+  async deleteBySource(
+    sourceType: string,
+    sourceId: string,
+    queryable?: Queryable
+  ): Promise<number> {
+    const res = await this.q(queryable).query(
+      'DELETE FROM stock_reservations WHERE source_type = $1 AND source_id = $2 RETURNING id',
+      [sourceType, sourceId]
     );
     return res.rowCount || 0;
   }

--- a/server/tests/concurrency/onlineOrders.concurrency.test.ts
+++ b/server/tests/concurrency/onlineOrders.concurrency.test.ts
@@ -83,10 +83,25 @@ describeWithPostgres('online orders under concurrency (#125, #128)', () => {
       expect((outcome as PromiseRejectedResult).reason).toMatchObject({ code: 'CONFLICT' });
     }
 
-    // Never negative, and never oversold: the guard is in the WHERE clause, so the two
-    // losers' updates matched no row rather than reading a stale count.
-    expect(await stockOf(1)).toBe(0);
+    // Never oversold. Since #137 the winner HOLDS the unit rather than deducting it, so
+    // stock is untouched and the exclusion lives in the reservation: the two losers took
+    // the row lock after the winner committed and saw availability at zero, rather than
+    // each reading a stale count and all three passing.
+    expect(await stockOf(1)).toBe(1);
     expect(await countRows('online_orders')).toBe(1);
+    expect(await countRows('stock_reservations')).toBe(1);
+  });
+
+  it('turns the hold into a deduction when the order is processed', async () => {
+    // The other half of the same invariant: the unit the winner held above comes off the
+    // shelf here, and the hold goes with it, so the two can never both count.
+    const created = await service.createOrder(order());
+    expect(await stockOf(1)).toBe(1);
+
+    await service.updateStatus(created.id, 'processing');
+
+    expect(await stockOf(1)).toBe(0);
+    expect(await countRows('stock_reservations')).toBe(0);
   });
 
   it('lets two concurrent first orders from one phone share a customer', async () => {
@@ -135,11 +150,12 @@ describeWithPostgres('online orders under concurrency (#125, #128)', () => {
       )
     ).rejects.toMatchObject({ code: 'CONFLICT' });
 
-    // The first line's deduction happened before the second line refused; only a real
-    // rollback puts it back.
+    // The first line's reservation was written before the second line refused; only a
+    // real rollback removes it. Stock was never touched either way since #137.
     expect(await stockOf(1)).toBe(1);
     expect(await countRows('online_orders')).toBe(0);
     expect(await countRows('online_order_items')).toBe(0);
+    expect(await countRows('stock_reservations')).toBe(0);
   });
 
   /** Seeds an order that already owns `number`, so the next attempt at it collides. */

--- a/server/tests/concurrency/onlineOrders.concurrency.test.ts
+++ b/server/tests/concurrency/onlineOrders.concurrency.test.ts
@@ -130,7 +130,9 @@ describeWithPostgres('online orders under concurrency (#125, #128)', () => {
     expect(rows).toHaveLength(2);
     expect(new Set(rows.map((r) => r.customer_id)).size).toBe(1);
     expect(await countRows('online_orders')).toBe(2);
-    expect(await stockOf(1)).toBe(0);
+    // Both units are held, not taken: since #137 placing an order reserves.
+    expect(await stockOf(1)).toBe(2);
+    expect(await countRows('stock_reservations')).toBe(2);
   });
 
   it('rolls the order and its items back when a later line is out of stock', async () => {

--- a/server/tests/onlineOrders.test.ts
+++ b/server/tests/onlineOrders.test.ts
@@ -45,6 +45,7 @@ describe('online orders (#125)', () => {
   });
 
   beforeEach(async () => {
+    await testPool.query('DELETE FROM stock_reservations');
     await testPool.query('DELETE FROM online_order_items');
     await testPool.query('DELETE FROM online_orders');
     await testPool.query('DELETE FROM product_variants');
@@ -56,6 +57,27 @@ describe('online orders (#125)', () => {
        VALUES (1, 'Silk Dress', 'SKU-001', 500, 250, 5)`
     );
   });
+
+  /** What an order is currently holding, as `stock_reservations` records it. */
+  async function reservedFor(
+    orderId: number | string
+  ): Promise<Array<{ product_id: number; variant_id: number | null; quantity: number }>> {
+    const { rows } = await testPool.query<{
+      product_id: number;
+      variant_id: number | null;
+      quantity: number;
+    }>(
+      `SELECT product_id, variant_id, quantity FROM stock_reservations
+        WHERE source_type = 'online_order' AND source_id = $1
+        ORDER BY id`,
+      [String(orderId)]
+    );
+    return rows.map((r) => ({
+      product_id: Number(r.product_id),
+      variant_id: r.variant_id === null ? null : Number(r.variant_id),
+      quantity: Number(r.quantity),
+    }));
+  }
 
   async function stockOf(productId: number): Promise<number> {
     const { rows } = await testPool.query<{ stock: number }>(
@@ -106,9 +128,41 @@ describe('online orders (#125)', () => {
     ).rejects.toThrow(/Only 5 left of Silk Dress/);
   });
 
-  it('deducts exactly the ordered quantity when it fits', async () => {
-    await service.createOrder(order({ items: [{ product_id: 1, quantity: 2, price: 500 }] }));
+  it('holds the ordered quantity without taking it off the shelf (#137)', async () => {
+    const created = await service.createOrder(
+      order({ items: [{ product_id: 1, quantity: 2, price: 500 }] })
+    );
+
+    // Placing an order reserves; it no longer deducts. The units stay sellable at the
+    // till until the shop starts fulfilling.
+    expect(await stockOf(1)).toBe(5);
+    expect(await reservedFor(created.id)).toEqual([
+      { product_id: 1, variant_id: null, quantity: 2 },
+    ]);
+  });
+
+  it('deducts and releases the hold when the order moves to processing (#137)', async () => {
+    const created = await service.createOrder(
+      order({ items: [{ product_id: 1, quantity: 2, price: 500 }] })
+    );
+
+    await service.updateStatus(created.id, 'processing');
+
     expect(await stockOf(1)).toBe(3);
+    expect(await reservedFor(created.id)).toEqual([]);
+  });
+
+  it("counts another order's hold against what is available (#137)", async () => {
+    await service.createOrder(order({ items: [{ product_id: 1, quantity: 4, price: 500 }] }));
+
+    // 5 on hand, 4 held: only one left to promise, even though nothing has been deducted.
+    await expect(
+      service.createOrder(order({ items: [{ product_id: 1, quantity: 2, price: 500 }] }))
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    await expect(
+      service.createOrder(order({ items: [{ product_id: 1, quantity: 1, price: 500 }] }))
+    ).resolves.toBeTruthy();
   });
 
   it('refuses a product that does not exist rather than pricing it at nothing', async () => {
@@ -125,12 +179,30 @@ describe('online orders (#125)', () => {
       );
     });
 
-    it('prices and deducts from the variant, not its parent product', async () => {
+    it('prices from the variant and holds against it, not its parent product', async () => {
       const created = await service.createOrder(
         order({ items: [{ product_id: 1, variant_id: 10, quantity: 1, price: 1 }] })
       );
 
       expect(Number(created.subtotal)).toBe(550);
+      expect(await reservedFor(created.id)).toEqual([
+        { product_id: 1, variant_id: 10, quantity: 1 },
+      ]);
+
+      // Nothing is deducted yet, from either row.
+      const { rows } = await testPool.query<{ stock: number }>(
+        'SELECT stock FROM product_variants WHERE id = 10'
+      );
+      expect(Number(rows[0].stock)).toBe(2);
+      expect(await stockOf(1)).toBe(5);
+    });
+
+    it('deducts the variant row, not its parent, once processing starts', async () => {
+      const created = await service.createOrder(
+        order({ items: [{ product_id: 1, variant_id: 10, quantity: 1, price: 1 }] })
+      );
+
+      await service.updateStatus(created.id, 'processing');
 
       const { rows } = await testPool.query<{ stock: number }>(
         'SELECT stock FROM product_variants WHERE id = 10'
@@ -156,8 +228,21 @@ describe('online orders (#125)', () => {
       return created.id;
     }
 
-    it('restores stock once when a pending order is cancelled', async () => {
+    it('releases the hold and restores nothing when a pending order is cancelled (#137)', async () => {
       const id = await place();
+      // Never deducted, so there is nothing to give back -- restoring here would invent
+      // inventory, which is what every cancel used to do.
+      expect(await stockOf(1)).toBe(5);
+
+      await service.updateStatus(id, 'cancelled');
+
+      expect(await stockOf(1)).toBe(5);
+      expect(await reservedFor(id)).toEqual([]);
+    });
+
+    it('restores stock once when an order that had been processing is cancelled', async () => {
+      const id = await place();
+      await service.updateStatus(id, 'processing');
       expect(await stockOf(1)).toBe(3);
 
       await service.updateStatus(id, 'cancelled');
@@ -166,6 +251,7 @@ describe('online orders (#125)', () => {
 
     it('does not restore twice when an already-cancelled order is cancelled again', async () => {
       const id = await place();
+      await service.updateStatus(id, 'processing');
       await service.updateStatus(id, 'cancelled');
       await service.updateStatus(id, 'cancelled');
 


### PR DESCRIPTION
Closes #137.

## What changed

Placing an online order **deducted** stock outright, so a web order took goods off the shelf the moment a shopper clicked — and every cancel put them back, including a cancel of an order that had never deducted anything.

Orders now reserve. `stock_reservations` already existed with exactly the right shape (`product_id`, `variant_id`, `quantity`, `source_type`, `source_id`, `expires_at`) and the `reservation-cleanup` job already swept it every five minutes. Nothing outside its own module had ever read it — `getReservedQuantity` had no callers.

| Event | Effect |
| --- | --- |
| Order created | Reservation rows written; `products.stock` untouched |
| → `processing` / `shipped` / `delivered` | Hold released **and** stock deducted, in one transaction |
| → `cancelled` | Hold released; stock restored **only** if it had actually been deducted |
| Hold expires (48h) | The existing sweep removes it; the order stays `pending` |

## Scope: online orders only

Availability at the public endpoint is `stock − live holds`. **The POS still sells off `products.stock`,** so a till can still sell a reserved unit. That is deliberate: the shop floor has the goods in hand and the web order is the speculative one. Making reservations global would mean a till refusing to sell an item physically on the counter.

## Why a lock, not a guarded UPDATE

Deducting was a single atomic statement — `UPDATE ... WHERE stock >= $1`. Reserving is a read-then-write across *two* tables (`products.stock` minus live rows in `stock_reservations`), so no single statement expresses it. The stock row is locked `FOR UPDATE` first, which is what makes the pair atomic: two shoppers reaching for the last unit serialize on the lock, and the loser recomputes availability against the winner's committed reservation rather than a stale count.

Locks are taken in the repo's one canonical stock-write order, so two shoppers naming the same products in opposite order cannot deadlock into a 40P01.

## The 48-hour window

A hold cannot be open-ended or an abandoned order keeps goods off the shelf forever. Two days covers a weekend before anyone looks at the queue. When it lapses the units are simply available again and the order stays `pending` — processing it later is re-checked against real stock and refused with a typed 409 if the goods went elsewhere.

## A latent trap fixed on the way

`deleteBySourceId` keys on the source id **alone**, which was only safe while one kind of thing reserved stock. Online orders reserve under their own numeric id, and cart holds share that space — so releasing order 7's hold would have taken cart 7's with it. Added `deleteBySource(sourceType, sourceId)` and used that.

## Testing

`server/tests/onlineOrders.test.ts` — three tests changed behaviour deliberately and are rewritten rather than deleted:

- placing an order **holds** without deducting
- moving to `processing` deducts and releases the hold
- **another order's hold counts against availability** — 5 on hand, 4 held, a 2-unit order is refused and a 1-unit order succeeds
- a variant line holds against the variant row, and deducts from it (not the parent) on processing
- **cancelling a pending order restores nothing** — it never deducted, so restoring would invent inventory, which is what every cancel used to do
- cancelling an order that reached `processing` does restore

`server/tests/concurrency/onlineOrders.concurrency.test.ts` — the last-unit race now proves exclusion through the reservation rather than the guarded write, and the rollback test additionally asserts no reservation survives.

Full local suite: **683 passed, 162 skipped, 0 failed.** `tsc --noEmit` clean; `check:api-docs` green at 204 routes, both ratchets unmoved. The `beyondSchema` contract text — which #134 had corrected to say reservations were *not* implemented — now describes the hold, the 48-hour window, and the cancel semantics.

## Post-Deploy Monitoring & Validation

- **Behaviour change worth announcing to staff:** the Inventory figure no longer drops when a web order arrives. It drops when someone starts fulfilling. Anyone reconciling stock against the order queue will notice this first.
- **Query:** `SELECT source_type, COUNT(*), MIN(expires_at) FROM stock_reservations GROUP BY source_type;` — `online_order` rows should appear, and the oldest should never be more than 48h old (the sweep runs every 5 minutes).
- **Log query:** `the hold on this order has lapsed` — an order processed after its hold expired and the goods had gone. A steady trickle means the 48h window is too short for the shop's actual turnaround and should be raised.
- **Healthy signal:** reservations are created on order and gone after processing or cancelling; `SELECT COUNT(*) FROM stock_reservations WHERE source_type = 'online_order'` roughly tracks the pending-order count.
- **Failure signal / rollback trigger:** reservations accumulating without matching pending orders (a release path missed), stock going negative, or the sweep deleting cart holds alongside order holds. Revert; no migration, so the only residue is `online_order` rows in `stock_reservations`, which the sweep clears within 48h.
- **Window/owner:** first two weeks of online-order traffic, author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5vRRnt4rqd6RdxCmFZzFN